### PR TITLE
docs(security): use GitHub private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,17 +8,16 @@ Pluralscape handles deeply sensitive psychiatric and personal data — trauma jo
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Please report vulnerabilities privately via one of:
+Please report vulnerabilities privately through [GitHub's private vulnerability reporting](https://github.com/ThePrismSystem/pluralscape-mono/security/advisories/new). This keeps the report confidential and allows us to coordinate a fix before public disclosure.
 
-- **GitHub Security Advisories**: Use the "Report a vulnerability" button on the Security tab of this repository
-- **Email**: pluralscape@proton.me
-
-Include:
+When filing a report, include:
 
 - Description of the vulnerability
 - Steps to reproduce
 - Potential impact
 - Suggested fix (if you have one)
+
+You will receive updates directly through the advisory as we investigate and resolve the issue.
 
 ## Response Timeline
 


### PR DESCRIPTION
## Summary

Replaces email-based vulnerability reporting with GitHub's built-in private vulnerability reporting.

## Changes

- Removes email address (pluralscape@proton.me) as a reporting channel
- Links directly to the GitHub security advisory creation page
- Adds note about receiving updates through the advisory

## Review Checklist

- [x] Privacy: new data defaults to maximum restriction (fail-closed)
- [x] Offline: works correctly without network connectivity
- [x] Non-destructive: no user data is permanently deleted
- [x] Accessibility: UI changes meet WCAG guidelines
- [x] Domain terms used correctly (community terminology, not clinical language)

## Deferred Items

- None