### PR TITLE
ci: add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Resolves both open CodeQL alerts (actions/missing-workflow-permissions).

## Changes

- Adds top-level `permissions: contents: read` to the CI workflow
- This is the minimum permission needed for checkout, install, lint, and typecheck

## Deferred Items

- None