### PR TITLE
chore: add optional local CodeQL scanning script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ bun.lockb
 *.pem
 *.key
 
+# CodeQL
+.codeql-db/
+.codeql-results/
+
 # Testing
 coverage/
 .nyc_output/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:fix": "prettier --write .",
     "clean": "turbo clean",
     "roadmap": "beans roadmap > docs/roadmap.md",
+    "codeql": "bash scripts/codeql.sh",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/codeql.sh
+++ b/scripts/codeql.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v codeql &>/dev/null; then
+  echo "CodeQL CLI not found. Install from: https://github.com/github/codeql-cli-binaries/releases"
+  echo "Skipping analysis."
+  exit 0
+fi
+
+DB_DIR=".codeql-db"
+RESULTS_DIR=".codeql-results"
+
+rm -rf "$DB_DIR" "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+
+echo "Creating CodeQL database..."
+codeql database create "$DB_DIR" --language=javascript --overwrite --source-root=.
+
+echo "Running analysis..."
+codeql database analyze "$DB_DIR" \
+  --format=sarif-latest \
+  --output="$RESULTS_DIR/results.sarif" \
+  -- codeql/javascript-queries:codeql-suites/javascript-security-and-quality-query-suite.qls
+
+echo "Results written to $RESULTS_DIR/results.sarif"
+
+# Print summary of any findings
+if command -v jq &>/dev/null; then
+  count=$(jq '[.runs[].results[]] | length' "$RESULTS_DIR/results.sarif")
+  echo "Found $count issue(s)."
+else
+  echo "Install jq to see a summary of results."
+fi


### PR DESCRIPTION
## Summary

Adds `pnpm codeql` for running CodeQL analysis locally.

## Changes

- Adds `scripts/codeql.sh` that creates a JS/TS CodeQL database and runs the security-and-quality suite
- Exits gracefully with install instructions if the CodeQL CLI is not found
- Adds `codeql` script to root package.json
- Adds `.codeql-db/` and `.codeql-results/` to .gitignore

## Deferred Items

- None