### PR TITLE
fix(deps): override flatted to >=3.4.0 to resolve DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "pnpm": {
     "overrides": {
-      "esbuild": ">=0.25.0"
+      "esbuild": ">=0.25.0",
+      "flatted": ">=3.4.0"
     }
   },
   "prettier": "@pluralscape/prettier-config",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: '>=0.25.0'
+  flatted: '>=3.4.0'
 
 importers:
 
@@ -3121,8 +3122,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.4:
-    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
@@ -8011,10 +8012,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.4
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.3.4: {}
+  flatted@3.4.1: {}
 
   flow-enums-runtime@0.0.6: {}
 


### PR DESCRIPTION
## What

- Adds a `pnpm` override pinning `flatted` to `>=3.4.0` (resolved: `3.4.1`)
- Fixes Dependabot security alert #8 (high severity)

`flatted` is a transitive dev-only dependency: `eslint` → `flat-cache@4.0.1` → `flatted@3.3.4`. It is not included in any production bundle.

## Why

- `flatted@3.3.4` is vulnerable to unbounded recursion DoS in its `parse()` revive phase — a maliciously crafted input can exhaust the call stack
- The fix (`3.4.0+`) was released upstream; `flat-cache@4.0.1` allows `^3.2.9` so the override is semver-compatible and non-breaking
- This is dev tooling only — no runtime exposure, but resolves the Dependabot alert cleanly

## How to validate

1. Check `flatted` version: `pnpm why flatted` — should show `3.4.1` everywhere
2. Verify ESLint still works: `pnpm lint` — should pass with zero warnings
3. Confirm the Dependabot alert resolves after merge (alert #8 in the Security tab)

## Related links

- https://github.com/ThePrismSystem/pluralscape-mono/security/dependabot/8