### PR TITLE
docs: comprehensive documentation update for current project state

### DIFF
--- a/.beans/db-ki5y--support-deletionarchival-for-all-entity-types.md
+++ b/.beans/db-ki5y--support-deletionarchival-for-all-entity-types.md
@@ -5,7 +5,7 @@ status: in-progress
 type: feature
 priority: high
 created_at: 2026-03-13T23:47:17Z
-updated_at: 2026-03-14T03:44:07Z
+updated_at: 2026-03-14T04:39:03Z
 ---
 
 All entity types need a user-facing way to remove accidentally created entries. Currently only 9 entities support archival (members, custom fronts, journal entries, wiki pages, groups, channels, messages, notes, field definitions). All other entities can only be removed via system-level CASCADE (account deletion), which means accidental entries are permanently stuck.
@@ -118,4 +118,17 @@ Added soft-archival support to all 24 non-audit entity tables across PG and SQLi
 
 PR: https://github.com/ThePrismSystem/pluralscape-mono/pull/103
 
-## PR Review Fix Implementation\n\nAddressing all 8 items from PR #103 review:\n- [ ] Commit 1: Add partial filter to friend_notification_preferences and wiki_pages unique indexes\n- [ ] Commit 2: Regenerate migrations\n- [ ] Commit 3: Make Archived<T> distributive and fix ServerRelationship comment\n- [ ] Commit 4: Extract archivableConsistencyCheckFor helper\n- [ ] Commit 5: Add afterEach cleanup, UPDATE path tests, and partial index tests
+## PR Review Fix Implementation\n\nAddressing all 8 items from PR #103 review:\n- [x] Commit 1: Add partial filter to friend_notification_preferences and wiki_pages unique indexes\n- [x] Commit 2: Regenerate migrations\n- [x] Commit 3: Make Archived<T> distributive and fix ServerRelationship comment\n- [x] Commit 4: Extract archivableConsistencyCheckFor helper\n- [x] Commit 5: Add afterEach cleanup, UPDATE path tests, and partial index tests
+
+## PR #103 Review Changes (2026-03-14)
+
+Addressed 6 of 8 review suggestions (2 were invalid):
+
+- [x] Standardized archived index naming: removed redundant `_id` from timer_configs and webhook_configs indexes
+- [x] Converted friend_codes.code from UNIQUE constraint to partial unique index (active rows only)
+- [x] Regenerated PG and SQLite migrations (0003_fuzzy_blizzard, 0003_cynical_warbird)
+- [x] Added bucket unarchival tests (true→false) for PG and SQLite
+- [x] Added check_in_records partial index tests for both platforms
+- [x] Added friend_codes partial index tests (duplicate archived codes, code reuse) for both platforms
+- [x] Added switches archival comment explaining data-correction rationale
+- [x] Renamed 10 communication test descriptions to include archivedAt assertion

--- a/.beans/ps-dok1--comprehensive-documentation-update.md
+++ b/.beans/ps-dok1--comprehensive-documentation-update.md
@@ -1,0 +1,37 @@
+---
+# ps-dok1
+title: Comprehensive documentation update
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-14T05:03:35Z
+updated_at: 2026-03-14T05:06:27Z
+---
+
+Update README, CHANGELOG, database-schema, and milestones docs to reflect current project state: 2889 tests, 22 ADRs, entity archival, launch features, coverage numbers, and consistency fixes.
+
+## Summary of Changes
+
+### README.md
+
+- Test count: 2,338 → 2,889 (across 132 → 144 files)
+- Coverage: statements 95.01→96.46%, branches 83.77→86.29%, functions 98.48→99.03%, lines 94.97→96.43%
+- ADR count: 18 → 22
+- Added 5 completed epics to status section (launch features, entity archival, RLS, SQLCipher, schema docs)
+
+### CHANGELOG.md
+
+- ADR count: 18 → 22, added ADRs 019-022 to list
+- Added 8 new entries under Added (RLS, SQLCipher, launch features, entity archival, archival FK audit, future feature specs, blob/notification/webhook tests)
+- Added Fixed section (flatted DoS, audit 005/008 findings, composite FK fixes)
+
+### database-schema.md
+
+- Removed `boolean archived` from 9 individual table diagrams (members, groups, channels, messages, notes, custom_fronts, field_definitions, journal_entries, wiki_pages) — now covered by convention note since archival is universal
+
+### milestones.md
+
+- ADR count: 20 → 22
+- Added ADRs 019 (fronting sessions partitioning) and 020 (RLS denormalization) to list
+- Marked 5 epics as completed: launch features L2-L10, entity archival, RLS bootstrapping, SQLCipher, schema docs
+- Removed 'ER diagram pending' note

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Community files: Code of Conduct, Contributing guide, Security policy
 - PR template with review checklist
 - `.gitignore`, `.editorconfig`
-- Architecture Decision Records (18 total):
+- Architecture Decision Records (22 total):
   - ADR 001: AGPL-3.0 license
   - ADR 002: Frontend framework (Expo / React Native)
   - ADR 003: API framework (Hono + tRPC + REST on Bun)
@@ -32,6 +32,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - ADR 016: Hash-based message table partitioning
   - ADR 017: Time-based audit log partitioning
   - ADR 018: Encryption-at-rest DB layer boundary
+  - ADR 019: Fronting sessions time-based partitioning
+  - ADR 020: RLS denormalization (cached system_id/account_id)
+  - ADR 021: Non-system account model (viewer accounts)
+  - ADR 022: System structure snapshots
 - Encryption architecture research (`docs/planning/encryption-research.md`)
 - Audits:
   - License compatibility audit (`docs/audits/001-license-compatibility.md`)
@@ -41,8 +45,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `@pluralscape/db` package — Drizzle ORM schema for PostgreSQL and SQLite dual-dialect with 40+ tables, row-level security, common views, query helpers, and encryption contract hardening
 - `@pluralscape/crypto` package — libsodium cross-platform bindings (WASM + React Native), master key derivation, symmetric encryption/decryption, identity keypair generation, and signature operations
 - `@pluralscape/sync` package — encrypted CRDT relay proof-of-concept with Automerge, sync session management, and document topology design
-- Test framework — Vitest workspace configuration with coverage enforcement, test factories, and shared utilities (2,338 tests across 132 files)
+- Test framework — Vitest workspace configuration with coverage enforcement, test factories, and shared utilities (2,889 tests across 144 files)
 - Database schema hardening — 29 optimization tasks: performance indexes (composites, partials, covering), non-critical encryption (API keys, sessions, webhooks, wiki slugs), sync queue fixes, full-text search, and varchar right-sizing
+- RLS policy bootstrapping — row-level security policies for all tenant-scoped tables with session-based isolation
+- SQLCipher encryption-at-rest — encrypted SQLite for self-hosted deployments
+- Launch feature types and schema (L2-L10) — non-system accounts, fronting snapshots, member duplication, outtrigger, multi-system verification, system duplication, lifecycle events (structure-move, innerworld-move), system snapshots
+- Entity archival support — archived/archived_at columns across all non-audit entity types with consistency checks and partial indexes
+- Entity archival FK audit (`docs/audits/011-entity-archival-fk-audit.md`) — complete FK dependency map for 26+ archivable entities
+- 12 future feature specifications (`docs/future-features/`) — widgets, cosmetics, client SDKs, onboarding, linked fronting, outtrigger analytics, traumaversary tracking, therapist reports, journal custom fields, journal fronting context, member templates, custom lifecycle events
+- Blob metadata, notification, and webhook integration tests (PG + SQLite)
 - Work tracking with beans (CLI-based issue tracker committed alongside code)
 - Roadmap generation from beans (`pnpm roadmap`)
 - CodeQL security analysis integration (`pnpm codeql`)
+
+### Fixed
+
+- Security: overridden flatted to >=3.4.0 to resolve DoS vulnerability
+- Schema audit 005 critical and high findings (C3, H1, H2)
+- Schema audit 008 findings across schema, queries, and RLS
+- Composite FK constraints and view join correctness

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Milestone 0 (infrastructure and governance) is complete. Within Milestone 1, the
 - Test framework setup — Vitest workspace with coverage enforcement
 - Encryption primitives (`@pluralscape/crypto`) — master key derivation, symmetric encryption, identity keypairs, libsodium cross-platform bindings
 - Sync proof-of-concept (`@pluralscape/sync`) — encrypted CRDT relay with Automerge
+- Launch feature types — fronting snapshots, outtrigger, member duplication, lifecycle events, system snapshots (L2-L10)
+- Entity archival — archived/archived_at columns across all non-audit entity types with consistency checks and partial indexes
+- RLS policy bootstrapping — row-level security policies for all tenant-scoped tables
+- SQLCipher encryption-at-rest — encrypted SQLite for self-hosted deployments
+- Database schema documentation — full ER diagrams for all 40+ tables
 
 Remaining M1 work: encryption layer completion (key recovery, per-bucket keys, rotation), sync protocol design, blob storage, background jobs, i18n, and nomenclature system.
 
@@ -23,14 +28,14 @@ See the full [milestone roadmap](docs/planning/milestones.md) and [feature speci
 
 ## Test Suite
 
-2,338 tests across 132 test files — all passing.
+2,889 tests across 144 test files — all passing.
 
 | Metric     | Coverage |
 | ---------- | -------- |
-| Statements | 95.01%   |
-| Branches   | 83.77%   |
-| Functions  | 98.48%   |
-| Lines      | 94.97%   |
+| Statements | 96.46%   |
+| Branches   | 86.29%   |
+| Functions  | 99.03%   |
+| Lines      | 96.43%   |
 
 Coverage by package:
 
@@ -185,7 +190,7 @@ Domain prefixes: `ps-`, `api-`, `mobile-`, `db-`, `crypto-`, `sync-`, `types-`, 
 
 ## Architecture Decision Records
 
-Major technical decisions are documented as ADRs in [`docs/adr/`](docs/adr/). 18 accepted ADRs cover the full stack from licensing through encryption-at-rest boundaries. See the [ADR template](docs/adr/000-template.md) for the format.
+Major technical decisions are documented as ADRs in [`docs/adr/`](docs/adr/). 22 accepted ADRs cover the full stack from licensing through system snapshots. See the [ADR template](docs/adr/000-template.md) for the format.
 
 ## License
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -152,7 +152,6 @@ erDiagram
         varchar id PK
         varchar system_id FK
         blob encrypted_data "T1"
-        boolean archived
     }
 
     member_photos {
@@ -169,7 +168,6 @@ erDiagram
         varchar parent_group_id FK "self-ref, nullable"
         integer sort_order
         blob encrypted_data "T1"
-        boolean archived
     }
 
     group_memberships {
@@ -314,7 +312,6 @@ erDiagram
         varchar parent_id FK "self-ref, nullable"
         integer sort_order
         blob encrypted_data "T1"
-        boolean archived
     }
 
     messages {
@@ -325,7 +322,6 @@ erDiagram
         timestamp timestamp
         timestamp edited_at
         blob encrypted_data "T1"
-        boolean archived
     }
 
     board_messages {
@@ -341,7 +337,6 @@ erDiagram
         varchar system_id FK
         varchar member_id FK "nullable"
         blob encrypted_data "T1"
-        boolean archived
     }
 
     polls {
@@ -414,7 +409,6 @@ erDiagram
         varchar id PK
         varchar system_id FK
         blob encrypted_data "T1"
-        boolean archived
     }
 
     fronting_sessions {
@@ -594,7 +588,6 @@ erDiagram
         varchar system_id FK
         varchar fronting_session_id FK "nullable"
         blob encrypted_data "T1"
-        boolean archived
     }
 
     wiki_pages {
@@ -602,7 +595,6 @@ erDiagram
         varchar system_id FK
         varchar slug_hash "64-char hash, unique per system"
         blob encrypted_data "T1"
-        boolean archived
     }
 
     systems ||--o{ journal_entries : "has"
@@ -675,7 +667,6 @@ erDiagram
         boolean required
         integer sort_order
         blob encrypted_data "T1"
-        boolean archived
     }
 
     field_values {

--- a/docs/planning/milestones.md
+++ b/docs/planning/milestones.md
@@ -24,7 +24,11 @@ Epics:
 - ~~Database schema (`packages/db`)~~ [COMPLETED] — 40+ tables, dual-dialect (PG + SQLite), RLS, constraint closure, encryption contracts
 - ~~Database schema hardening~~ [COMPLETED] — 29 tasks: indexes, encryption, sync queue fixes, full-text search, varchar right-sizing
 - ~~Test framework setup~~ [COMPLETED] — Vitest workspace, coverage enforcement, test factories (2,338 tests)
-- Launch feature types: fronting snapshot types (L3), outtrigger types (L5), lifecycle event types for structure-move and innerworld-move (L8/L9), system snapshot types and table (L10)
+- ~~Launch feature types (L2-L10)~~ [COMPLETED] — non-system accounts, fronting snapshots, member duplication, outtrigger, multi-system verification, system duplication, lifecycle events, innerworld-move, system snapshots
+- ~~Entity archival~~ [COMPLETED] — archived/archived_at columns across all non-audit entity types with consistency checks and partial indexes
+- ~~RLS policy bootstrapping~~ [COMPLETED] — row-level security policies for all tenant-scoped tables
+- ~~SQLCipher encryption-at-rest~~ [COMPLETED] — encrypted SQLite for self-hosted deployments
+- ~~Database schema documentation~~ [COMPLETED] — full ER diagrams for all 40+ tables
 - Encryption layer (`packages/crypto`) — ADR 006 (foundation complete: key derivation, symmetric crypto, identity keypairs; remaining: per-bucket keys, key rotation, recovery)
 - Sync protocol design (`packages/sync`) — ADR 005 (encrypted CRDT relay PoC complete; remaining: document topology, conflict resolution, partial replication)
 - Blob storage strategy — ADR 009
@@ -32,7 +36,6 @@ Epics:
 - Key recovery protocol — ADR 011
 - i18n infrastructure (features.md section 11)
 - Nomenclature system (features.md section 12)
-- Database schema documentation (ER diagram pending)
 
 ## Milestone 2: API Core
 
@@ -183,7 +186,7 @@ These features are tracked but may be deferred past initial launch. Each has a d
 
 ## Architecture Decision Records
 
-20 accepted ADRs cover the full stack:
+22 accepted ADRs cover the full stack:
 
 - [ADR 001: AGPL-3.0 License](../adr/001-agpl-3-license.md)
 - [ADR 002-008](../adr/) — Foundation decisions (frontend, API, database, sync, encryption, real-time, runtime)
@@ -197,6 +200,8 @@ These features are tracked but may be deferred past initial launch. Each has a d
 - [ADR 016: Messages Partitioning](../adr/016-messages-partitioning.md) — hash-based partitioning for the messages table
 - [ADR 017: Audit Log Partitioning](../adr/017-audit-log-partitioning.md) — time-based partitioning with automated retention
 - [ADR 018: Encryption-at-Rest Boundary](../adr/018-encryption-at-rest-boundary.md) — DB-layer encryption boundary for tier-2/tier-3 data
+- [ADR 019: Fronting Sessions Partitioning](../adr/019-fronting-sessions-partitioning.md) — time-based partitioning for active fronting session performance
+- [ADR 020: RLS Denormalization](../adr/020-rls-denormalization.md) — cached system_id/account_id on all tables for RLS policy efficiency
 - [ADR 021: Non-System Account Model](../adr/021-non-system-accounts.md) — viewer accounts, account-level friend connections
 - [ADR 022: System Structure Snapshots](../adr/022-system-snapshots.md) — point-in-time structure captures, manual and scheduled triggers
 


### PR DESCRIPTION
## Summary

Updates README, CHANGELOG, database-schema, and milestones to reflect all work completed since the last documentation pass (PRs #81-#103). Fixes stale test counts, coverage numbers, ADR counts, and milestone status across four docs.

## Changes

- **README**: Updates test count (2,338 to 2,889 across 132 to 144 files), coverage numbers (+1-2% across all metrics), ADR count (18 to 22), and adds 5 completed M1 epics to the status section (launch features, entity archival, RLS, SQLCipher, schema docs)
- **CHANGELOG**: Adds ADRs 019-022 to the list, adds 8 new entries under Added (RLS, SQLCipher, launch features, entity archival, FK audit, future feature specs, integration tests), and adds a new Fixed section with 4 entries
- **database-schema**: Removes `boolean archived` from 9 individual table diagrams for consistency -- archival is now universal across all entity types and the convention note at the top already documents this
- **milestones**: Updates ADR count (20 to 22), adds ADRs 019/020, marks 5 epics as completed, removes stale "ER diagram pending" note

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] All 2,889 tests pass
- [ ] Mermaid diagrams render correctly in GitHub (spot-check database-schema.md)

## Review Checklist

- [x] Privacy: new data defaults to maximum restriction (fail-closed)
- [x] Offline: works correctly without network connectivity
- [x] Non-destructive: no user data is permanently deleted
- [x] Accessibility: UI changes meet WCAG guidelines
- [x] Domain terms used correctly (community terminology, not clinical language)

## Deferred Items

- None