### PR TITLE
chore: add STRIDE/OWASP security audit report

### DIFF
--- a/.beans/ps-6976--security-audit-address-strideowasp-findings.md
+++ b/.beans/ps-6976--security-audit-address-strideowasp-findings.md
@@ -1,0 +1,12 @@
+---
+# ps-6976
+title: 'Security audit: address STRIDE/OWASP findings'
+status: todo
+type: task
+priority: normal
+created_at: 2026-03-15T08:45:52Z
+updated_at: 2026-03-15T08:58:51Z
+parent: ps-vtws
+---
+
+Address findings from security/260315-0835-stride-owasp-full-audit. See recommendations.md for prioritized mitigations.

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ docs/local-audits/
 # Agent config (per-contributor)
 CLAUDE.md
 
+# Security audit working files
+security-audit-results.tsv
+
 # Temporary files
 .tmp/
 *.log

--- a/security/260315-0835-stride-owasp-full-audit/attack-surface-map.md
+++ b/security/260315-0835-stride-owasp-full-audit/attack-surface-map.md
@@ -1,0 +1,130 @@
+# Attack Surface Map — Pluralscape
+
+## Entry Points
+
+### HTTP API (Hono on Bun)
+
+| Endpoint | Method | Auth Required | Notes |
+|----------|--------|--------------|-------|
+| `/` | GET | No | Returns `{ status: "ok", service: "pluralscape-api" }` |
+| `/health` | GET | No | Returns `{ status: "healthy" }` |
+
+**Note:** The API is in early development. Only 2 routes exist. No auth, CRUD, or tRPC endpoints are implemented yet. tRPC and Zod dependencies are installed but unused.
+
+### Sync Protocol (WebSocket)
+
+| Message | Direction | Auth | Notes |
+|---------|-----------|------|-------|
+| AuthenticateRequest | Client->Server | sessionToken | Initiates sync session |
+| ManifestRequest | Client->Server | Authenticated | Lists available documents |
+| SubscribeRequest | Client->Server | Authenticated | Real-time updates for documents |
+| SubmitChangeRequest | Client->Server | Authenticated | Submit encrypted CRDT change |
+| SubmitSnapshotRequest | Client->Server | Authenticated | Submit encrypted snapshot |
+| FetchChangesRequest | Client->Server | Authenticated | Pull changes since seq |
+| FetchSnapshotRequest | Client->Server | Authenticated | Pull latest snapshot |
+| DocumentLoadRequest | Client->Server | Authenticated | On-demand document loading |
+
+### Client-Side Entry Points
+
+| Surface | Input Type | Validation |
+|---------|-----------|------------|
+| Password entry | String | Non-empty check only (no complexity validation in crypto layer) |
+| Recovery key entry | String (base32) | Format validation: 13 groups of 4 chars (A-Z, 2-7) |
+| Transfer code entry | String (8 digits) | Pattern validation: `/^\d{8}$/` |
+| QR code scan | JSON string | Schema validation: requestId, code, salt fields; hex salt parsing |
+| Friend code | String (8+ chars) | Minimum length check in schema |
+
+## Data Flows
+
+### Authentication Flow (Designed, Not Implemented)
+```
+Password -> TextEncoder -> Argon2id(password, salt, profile) -> passwordKey (KEK)
+                                                                      |
+                                                              unwrapMasterKey(encryptedMasterKey, KEK)
+                                                                      |
+                                                              masterKey (DEK) -> KDF subkeys
+                                                                      |
+                                                    +--------+--------+--------+
+                                                    |        |        |        |
+                                              identity   data-encr   sync    bucket
+                                              keys       T1 key     key     keys
+```
+
+### Device Transfer Flow
+```
+Source Device:                           Target Device:
+  generateTransferCode()                   [scan QR or enter code]
+  -> verificationCode (8 digits)              |
+  -> codeSalt (16 bytes random)           decodeQRPayload(data)
+  -> requestId (UUID v4)                      |
+       |                                  deriveTransferKey(code, salt)
+  encodeQRPayload(init)                       |
+  -> JSON { requestId, code, salt }       decryptFromTransfer(payload, transferKey)
+       |                                      |
+  deriveTransferKey(code, salt)           masterKey recovered
+       |                                      |
+  encryptForTransfer(masterKey, transferKey)   transferKey memzeroed
+       |
+  transferKey memzeroed
+```
+
+### Sync Encryption Flow
+```
+Automerge.change(doc)
+  -> change bytes
+  -> AEAD encrypt(change, encryptionKey, AAD=documentId)
+  -> Ed25519 signDetached(ciphertext, signingKey)
+  -> EncryptedChangeEnvelope { ciphertext, nonce, signature, authorPublicKey }
+  -> relay/network
+
+Receiving:
+  -> verifySignature(envelope.signature, envelope.ciphertext, envelope.authorPublicKey)
+  -> AEAD decrypt(ciphertext, nonce, AAD=documentId, encryptionKey)
+  -> Automerge.applyChanges(doc, change)
+```
+
+### Key Grant Flow (Friend Sharing)
+```
+Owner:
+  buildEnvelope(bucketId, keyVersion, bucketKey)
+  -> crypto_box(envelope, recipientPublicKey, senderSecretKey)
+  -> [24B nonce || ciphertext] stored in keyGrants table
+
+Friend:
+  boxOpenEasy(ciphertext, nonce, senderPublicKey, recipientSecretKey)
+  -> parseEnvelope(plaintext, expectedBucketId, expectedKeyVersion)
+  -> bucketKey recovered
+```
+
+## Abuse Paths
+
+### 1. Missing Auth Middleware -> Full API Access
+**Current State:** API has no authentication middleware. When routes are added, any unauthenticated client can access them unless auth is implemented first.
+**Chain:** Unauthenticated request -> Hono route handler -> Database query -> Data exposure
+**Impact:** Critical (when API endpoints are implemented)
+
+### 2. Transfer Code Brute Force
+**Scenario:** Attacker intercepts requestId from relay, brute-forces 8-digit code offline with captured salt.
+**Chain:** Capture salt + requestId -> Offline Argon2id brute force (10^8 possibilities) -> Decrypt master key
+**Mitigations:** Argon2id (mobile: 2 ops, 32 MiB), 5-minute session timeout
+**Impact:** High (master key compromise if salt is captured)
+
+### 3. Webhook Secret Compromise -> Signature Forgery
+**Scenario:** Database breach exposes T3 webhook secrets.
+**Chain:** DB compromise -> Read webhookConfigs.secret -> Forge HMAC signatures -> Inject fake webhook payloads to consumers
+**Impact:** Medium (depends on webhook consumer trust)
+
+### 4. RLS Bypass via Missing Context
+**Scenario:** API handler forgets to call setTenantContext() before query.
+**Chain:** Missing setTenantContext() -> GUC vars are NULL -> RLS policies return no rows (fail-closed)
+**Impact:** Low (fail-closed design prevents data leakage; results in denial of service for that request)
+
+### 5. SQLite Application-Layer Isolation Bypass
+**Scenario:** Bug in mobile app skips accountScope/systemScope filtering.
+**Chain:** Missing scope filter -> Query returns all rows in local DB -> Cross-system data exposure
+**Impact:** Medium (limited to local device; multi-system scenarios only)
+
+### 6. Key Version Mismatch
+**Scenario:** Crypto layer accepts keyVersion=0 but DB requires >= 1.
+**Chain:** Create key grant with version 0 -> Crypto succeeds -> DB insert fails or creates inconsistency
+**Impact:** Low (would cause errors, not security breach)

--- a/security/260315-0835-stride-owasp-full-audit/dependency-audit.md
+++ b/security/260315-0835-stride-owasp-full-audit/dependency-audit.md
@@ -1,0 +1,56 @@
+# Dependency Audit — Pluralscape
+
+## pnpm audit
+
+**Run date:** 2026-03-15
+**Total dependencies:** 976
+**Advisories:** 0
+
+```json
+{
+  "vulnerabilities": {
+    "info": 0,
+    "low": 0,
+    "moderate": 0,
+    "high": 0,
+    "critical": 0
+  }
+}
+```
+
+## Key Dependencies
+
+| Package | Version | Purpose | Notes |
+|---------|---------|---------|-------|
+| hono | ^4.12.7 | HTTP framework | Well-maintained, Cloudflare-backed |
+| drizzle-orm | ^0.45.1 | ORM | Parameterized queries prevent SQL injection |
+| postgres | ^3.4.5 | PG client | Maintained by porsager |
+| better-sqlite3-multiple-ciphers | ^12.6.2 | SQLite + SQLCipher | Fork with encryption support |
+| libsodium-wrappers-sumo | ^0.8.2 | Cryptography | Maintained by jedisct1; sumo build includes all algorithms |
+| @automerge/automerge | ^3.2.4 | CRDT library | For encrypted sync protocol |
+| zod | ^4.3.6 | Schema validation | Used with tRPC (not yet implemented) |
+| @trpc/server | ^11.0.0-rc.730 | API framework | RC version (pre-release) |
+
+## Dependency Overrides
+
+```json
+{
+  "esbuild": ">=0.25.0",
+  "flatted": ">=3.4.0"
+}
+```
+
+These overrides pin transitive dependencies to versions that resolve known issues.
+
+## Dependabot Configuration
+
+- **Schedule:** Weekly (Monday)
+- **Ecosystems:** npm, GitHub Actions
+- **Groups:** Dev dependencies grouped for minor/patch updates
+- **PR limit:** 10 open PRs
+
+## Observations
+
+1. **@trpc/server is a release candidate** (rc.730). While not a security issue, RC versions may have breaking changes. Monitor for stable release.
+2. **No lock file integrity verification** in CI beyond `pnpm install --frozen-lockfile`. Consider adding `npm audit --audit-level=moderate` to CI.
+3. **All critical cryptographic operations** use libsodium, which is the gold standard for a NaCl/libsodium binding.

--- a/security/260315-0835-stride-owasp-full-audit/findings.md
+++ b/security/260315-0835-stride-owasp-full-audit/findings.md
@@ -1,0 +1,366 @@
+# Security Findings — Pluralscape
+
+Findings ranked by severity (descending). Each finding includes code evidence, attack scenario, and mitigation.
+
+---
+
+## [HIGH] Finding 1: No Authentication or Authorization Middleware
+
+- **OWASP:** A07 — Identification and Authentication Failures
+- **STRIDE:** Elevation of Privilege
+- **Location:** `apps/api/src/index.ts:1-21`
+- **Confidence:** Confirmed
+
+### Description
+
+The Hono API application has no authentication or authorization middleware. The only middleware is `requireSelfHosted` (deployment guard), which is not currently applied to any route. When API endpoints are added (tRPC routers, CRUD operations), they will be accessible without authentication unless auth middleware is implemented first.
+
+### Code Evidence
+
+```typescript
+// apps/api/src/index.ts — entire file
+import { Hono } from "hono";
+
+const DEFAULT_PORT = 10045;
+const port = Number(process.env["API_PORT"]) || DEFAULT_PORT;
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  return c.json({ status: "ok", service: "pluralscape-api" });
+});
+
+app.get("/health", (c) => {
+  return c.json({ status: "healthy" });
+});
+
+Bun.serve({ port, fetch: app.fetch });
+```
+
+No `app.use()` calls for auth, CORS, rate limiting, or security headers.
+
+### Attack Scenario
+
+1. Developer adds a new route (e.g., `POST /api/systems`) without auth middleware
+2. Unauthenticated HTTP request reaches the handler
+3. Handler executes DB queries without tenant context
+4. Data exposure or modification without authorization
+
+### Mitigation
+
+```typescript
+import { cors } from "hono/cors";
+import { secureHeaders } from "hono/secure-headers";
+
+// Apply global middleware BEFORE route definitions
+app.use("*", cors({ origin: ["https://your-domain.com"] }));
+app.use("*", secureHeaders());
+app.use("/api/*", authMiddleware); // verify session/JWT/API key
+app.use("/api/*", rateLimiter({ windowMs: 60_000, max: 100 }));
+```
+
+### References
+
+- CWE-306: Missing Authentication for Critical Function
+- CWE-862: Missing Authorization
+
+---
+
+## [MEDIUM] Finding 2: No Security Headers
+
+- **OWASP:** A05 — Security Misconfiguration
+- **STRIDE:** Information Disclosure
+- **Location:** `apps/api/src/index.ts:6`
+- **Confidence:** Confirmed
+
+### Description
+
+The Hono application does not configure any security response headers. Missing headers include CSP, HSTS, X-Content-Type-Options, X-Frame-Options, and Permissions-Policy.
+
+### Mitigation
+
+```typescript
+import { secureHeaders } from "hono/secure-headers";
+
+app.use("*", secureHeaders({
+  contentSecurityPolicy: { defaultSrc: ["'self'"] },
+  strictTransportSecurity: "max-age=63072000; includeSubDomains",
+  xContentTypeOptions: "nosniff",
+  xFrameOptions: "DENY",
+}));
+```
+
+### References
+
+- CWE-693: Protection Mechanism Failure
+
+---
+
+## [MEDIUM] Finding 3: No Rate Limiting
+
+- **OWASP:** A04 — Insecure Design
+- **STRIDE:** Denial of Service
+- **Location:** `apps/api/src/index.ts:6`
+- **Confidence:** Confirmed
+
+### Description
+
+No rate limiting middleware is configured. Critical for authentication endpoints (login, password reset, device transfer) which are computationally expensive (Argon2id) and brute-force targets.
+
+### Attack Scenario
+
+1. Attacker sends rapid login requests with different passwords
+2. Each triggers Argon2id (2-3 ops, 32-64 MiB) on the server
+3. CPU and memory exhaustion, denying service to legitimate users
+
+### Mitigation
+
+Use Hono's rate limiter or a Redis-backed solution:
+
+```typescript
+app.use("/api/auth/*", rateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // 10 attempts per window
+  keyGenerator: (c) => c.req.header("x-forwarded-for") ?? "unknown",
+}));
+```
+
+### References
+
+- CWE-770: Allocation of Resources Without Limits
+
+---
+
+## [MEDIUM] Finding 4: No CORS Configuration
+
+- **OWASP:** A05 — Security Misconfiguration
+- **STRIDE:** Spoofing
+- **Location:** `apps/api/src/index.ts:6`
+- **Confidence:** Confirmed
+
+### Description
+
+No CORS middleware is configured. The Hono app will accept requests from any origin by default. When API endpoints are added, cross-origin requests from malicious sites could access authenticated endpoints.
+
+### Mitigation
+
+```typescript
+import { cors } from "hono/cors";
+
+app.use("*", cors({
+  origin: ["https://your-domain.com"],
+  allowMethods: ["GET", "POST", "PUT", "DELETE"],
+  credentials: true,
+}));
+```
+
+### References
+
+- CWE-942: Overly Permissive Cross-domain Whitelist
+
+---
+
+## [MEDIUM] Finding 5: SQLite Foreign Keys Not Enforced
+
+- **OWASP:** A04 — Insecure Design
+- **STRIDE:** Tampering
+- **Location:** `packages/db/src/client/factory.ts:57-69`
+- **Confidence:** Confirmed
+
+### Description
+
+The `createDatabase()` factory for SQLite sets `journal_mode = WAL` and optionally configures SQLCipher encryption, but does not enable `PRAGMA foreign_keys = ON`. Without this pragma, SQLite ignores all foreign key constraints, allowing orphaned records and referential integrity violations. Tests explicitly set this pragma, masking the issue.
+
+### Code Evidence
+
+```typescript
+// packages/db/src/client/factory.ts:57-69
+const client = new Database(config.filename);
+try {
+  if (config.encryptionKey) {
+    client.pragma(`cipher='sqlcipher'`);
+    client.pragma(`key="x'${config.encryptionKey}'"`);
+  }
+  client.pragma("journal_mode = WAL");
+  // Missing: client.pragma("foreign_keys = ON");
+} catch (err) {
+  client.close();
+  throw err;
+}
+```
+
+### Attack Scenario
+
+1. Application creates a member record with a non-existent systemId
+2. SQLite accepts the insert (FK not enforced)
+3. Member exists without a parent system, breaking data integrity
+4. In multi-system scenarios, could lead to data leaking between systems
+
+### Mitigation
+
+```typescript
+client.pragma("foreign_keys = ON");
+```
+
+Add this line after WAL mode setup, before returning the client.
+
+### References
+
+- CWE-20: Improper Input Validation
+
+---
+
+## [MEDIUM] Finding 6: No Password Complexity Enforcement
+
+- **OWASP:** A07 — Identification and Authentication Failures
+- **STRIDE:** Spoofing
+- **Location:** `packages/crypto/src/master-key-wrap.ts:37-39`
+- **Confidence:** Confirmed
+
+### Description
+
+The `derivePasswordKey()` function only validates that the password is non-empty. No minimum length, character diversity, or password policy is enforced at the crypto layer. While enforcement could happen at the application layer, no such enforcement exists anywhere in the codebase.
+
+### Code Evidence
+
+```typescript
+// packages/crypto/src/master-key-wrap.ts:37-39
+export function derivePasswordKey(password: string, salt: PwhashSalt, profile: PwhashProfile): Promise<AeadKey> {
+  if (password.length === 0) {
+    throw new InvalidInputError("Password must not be empty.");
+  }
+  // No length/complexity check — "a" is a valid password
+```
+
+### Mitigation
+
+Enforce at the application layer (not crypto):
+
+```typescript
+function validatePasswordPolicy(password: string): void {
+  if (password.length < 12) throw new Error("Password must be at least 12 characters");
+  // Consider zxcvbn for strength estimation
+}
+```
+
+### References
+
+- CWE-521: Weak Password Requirements
+
+---
+
+## [MEDIUM] Finding 7: Webhook Secret Stored as T3 (Server-Readable)
+
+- **OWASP:** A02 — Cryptographic Failures
+- **STRIDE:** Information Disclosure
+- **Location:** `packages/db/src/schema/*/webhooks.ts` (webhookConfigs.secret column)
+- **Confidence:** Confirmed
+
+### Description
+
+Webhook HMAC signing secrets are stored as `binary` columns without E2E encryption (T3 tier — server-readable). If the database is compromised, an attacker can read all webhook secrets and forge HMAC signatures for webhook payloads, potentially injecting fake events into downstream systems.
+
+### Mitigation
+
+This is a design trade-off: the server must read webhook secrets to sign outgoing deliveries, so E2E encryption is not possible for this field. Mitigations:
+
+1. Encrypt at rest via database-level encryption (PG TDE, SQLCipher)
+2. Rotate webhook secrets periodically
+3. Allow users to verify webhook signatures with a test endpoint
+
+### References
+
+- CWE-312: Cleartext Storage of Sensitive Information
+
+---
+
+## [MEDIUM] Finding 8: No Global Error Handler
+
+- **OWASP:** A05 — Security Misconfiguration
+- **STRIDE:** Information Disclosure
+- **Location:** `apps/api/src/index.ts:6`
+- **Confidence:** Confirmed
+
+### Description
+
+The Hono app has no global error handler (`.onError()`). Unhandled exceptions will produce default error responses that may include stack traces, internal module paths, or sensitive error messages in production.
+
+### Mitigation
+
+```typescript
+app.onError((err, c) => {
+  console.error(err);
+  return c.json({ error: "Internal server error" }, 500);
+});
+```
+
+### References
+
+- CWE-209: Generation of Error Message Containing Sensitive Information
+
+---
+
+## [LOW] Finding 9: Transfer Code Entropy
+
+- **OWASP:** A02 — Cryptographic Failures
+- **STRIDE:** Spoofing
+- **Location:** `packages/crypto/src/device-transfer.ts:12-13`
+- **Confidence:** Likely
+
+### Description
+
+The device transfer code uses 8 decimal digits (~26.5 bits of entropy). While protected by Argon2id with the "mobile" profile (2 ops, 32 MiB) and a 5-minute session timeout, an attacker who captures the salt could attempt offline brute force. At ~1ms per Argon2id hash on a modern GPU, the full keyspace could be exhausted in ~28 hours. The code comments acknowledge this trade-off.
+
+### Mitigation
+
+The 5-minute timeout effectively prevents online brute force. For higher security:
+- Increase to 10-12 digits (adds ~7-13 bits)
+- Use the "server" profile (3 ops, 64 MiB) for the transfer KDF
+- Add attempt limiting on the server relay
+
+### References
+
+- CWE-330: Use of Insufficiently Random Values
+
+---
+
+## [LOW] Finding 10: Audit Log PII in Plaintext
+
+- **OWASP:** A09 — Security Logging & Monitoring Failures
+- **STRIDE:** Information Disclosure
+- **Location:** `packages/db/src/schema/*/audit-log.ts` (ipAddress, userAgent columns)
+- **Confidence:** Confirmed
+
+### Description
+
+The audit log stores IP addresses and user agent strings as plaintext varchar columns. These are GDPR personal data. While the schema comments mention retention policies and the code references ADR 017, no schema-level enforcement (e.g., TTL column, auto-expiry) exists. Retention must be enforced at the application layer.
+
+### Mitigation
+
+The audit-log cleanup query functions exist in `packages/db/src/queries/audit-log-cleanup.ts`. Ensure they are scheduled to run regularly via the job queue.
+
+### References
+
+- CWE-532: Insertion of Sensitive Information into Log File
+
+---
+
+## [INFO] Positive Findings
+
+The following areas were tested and found to be well-implemented:
+
+| Area | Finding | Location |
+|------|---------|----------|
+| Dependencies | 0 known CVEs across 976 packages | pnpm audit |
+| SQL Injection | Drizzle ORM parameterized queries throughout; RLS uses set_config() | All query code |
+| Command Injection | No exec/spawn calls in production code | All source files |
+| Prototype Pollution | No __proto__ or prototype manipulation | All source files |
+| XSS | No dangerouslySetInnerHTML, innerHTML, or eval in production | All source files |
+| RLS Fail-Closed | NULLIF(current_setting(..., true), '') prevents leaks on unset vars | `packages/db/src/rls/policies.ts:17-19` |
+| Key Zeroing | All key derivation functions memzero in finally blocks | All crypto modules |
+| Sync Integrity | AEAD + Ed25519 signatures on all sync envelopes | `packages/sync/src/encrypted-sync.ts` |
+| Encryption Algorithms | XChaCha20-Poly1305 (AEAD), Ed25519, Argon2id — all modern, well-chosen | `packages/crypto/` |
+| Key Derivation | KEK/DEK pattern, deterministic identity from master key, isolated KDF contexts | `packages/crypto/src/master-key-wrap.ts`, `identity.ts` |
+| Stream Encryption | Chunk AAD prevents reordering/truncation attacks | `packages/crypto/src/symmetric.ts:64-70` |
+| Key Grants | Authenticated envelope encryption binds bucketId + keyVersion | `packages/crypto/src/key-grants.ts` |
+| SSRF | No outbound HTTP requests in production code | All source files |

--- a/security/260315-0835-stride-owasp-full-audit/overview.md
+++ b/security/260315-0835-stride-owasp-full-audit/overview.md
@@ -1,0 +1,76 @@
+# Security Audit — Comprehensive STRIDE + OWASP Full Audit
+
+**Date:** 2026-03-15 08:35
+**Scope:** Full codebase (apps/api, packages/crypto, packages/db, packages/sync, packages/storage, packages/queue, packages/types)
+**Focus:** Comprehensive — all STRIDE categories and OWASP Top 10
+**Iterations:** 21
+**Mode:** Unbounded (autonomous loop)
+
+## Summary
+
+- **Total Findings:** 8 actionable (excluding Info-level positive confirmations)
+  - Critical: 0 | High: 1 | Medium: 6 | Low: 2 | Info: 9 (positive confirmations)
+- **STRIDE Coverage:** 6/6 categories tested
+- **OWASP Coverage:** 10/10 categories tested
+- **Confirmed:** 17 | Likely: 1 | Possible: 0
+
+## Overall Assessment
+
+Pluralscape's **cryptographic layer is excellent** — strong algorithm choices (XChaCha20-Poly1305, Ed25519, Argon2id), consistent key zeroing, proper KDF context separation, and authenticated encryption throughout. The **database layer is well-designed** with E2E encryption, RLS fail-closed policies, and parameterized queries.
+
+The primary risk area is the **API layer**, which is in early development and lacks security middleware (auth, CORS, rate limiting, security headers, error handling). These are not yet exploitable since only health-check endpoints exist, but must be addressed **before adding authenticated routes**.
+
+## Top Findings
+
+1. **[HIGH] No Authentication Middleware** — API has no auth, CORS, rate limiting, or security headers ([findings.md#finding-1](./findings.md#high-finding-1-no-authentication-or-authorization-middleware))
+2. **[MEDIUM] SQLite FK Not Enforced** — Production factory missing `PRAGMA foreign_keys = ON` ([findings.md#finding-5](./findings.md#medium-finding-5-sqlite-foreign-keys-not-enforced))
+3. **[MEDIUM] No Password Policy** — Only checks non-empty, no minimum length/complexity ([findings.md#finding-6](./findings.md#medium-finding-6-no-password-complexity-enforcement))
+
+## Files in This Report
+
+- [Threat Model](./threat-model.md) — STRIDE analysis, assets, trust boundaries
+- [Attack Surface Map](./attack-surface-map.md) — entry points, data flows, abuse paths
+- [Findings](./findings.md) — all findings ranked by severity
+- [OWASP Coverage](./owasp-coverage.md) — per-category test results
+- [Dependency Audit](./dependency-audit.md) — known CVEs in dependencies
+- [Recommendations](./recommendations.md) — prioritized mitigations with code snippets
+- [Iteration Log](./security-audit-results.tsv) — raw data from every iteration
+
+## Coverage Matrix
+
+### STRIDE
+
+| Category | Tested | Findings |
+|----------|--------|----------|
+| Spoofing | Yes | 3 (auth middleware, CORS, transfer code) |
+| Tampering | Yes | 1 (SQLite FK) |
+| Repudiation | Yes | 0 (audit logging well-designed) |
+| Information Disclosure | Yes | 3 (headers, webhook secret, audit PII) |
+| Denial of Service | Yes | 1 (rate limiting) |
+| Elevation of Privilege | Yes | 1 (auth middleware) |
+
+### OWASP Top 10
+
+| Category | Status |
+|----------|--------|
+| A01 Broken Access Control | Pass (RLS fail-closed) |
+| A02 Cryptographic Failures | Partial (strong crypto; webhook secret + transfer code gaps) |
+| A03 Injection | Pass (no injection vectors found) |
+| A04 Insecure Design | Issues (rate limiting, SQLite FK, QR design) |
+| A05 Security Misconfiguration | Issues (no middleware configured) |
+| A06 Vulnerable Components | Pass (0 CVEs) |
+| A07 Auth Failures | Issues (no auth middleware, no password policy) |
+| A08 Data Integrity | Pass (Ed25519 + AEAD on all sync data) |
+| A09 Logging Failures | Partial (good events, PII retention gap) |
+| A10 SSRF | Pass (no outbound HTTP) |
+
+## Key Strengths
+
+- E2E encryption with XChaCha20-Poly1305 + Ed25519 signatures
+- KEK/DEK master key wrapping (survives password reset)
+- Fail-closed RLS policies for PostgreSQL multi-tenancy
+- Comprehensive audit event taxonomy (21 event types)
+- Tiered privacy model (T1 zero-knowledge, T2 per-bucket, T3 server-readable)
+- Proper key lifecycle management with memzero and state machine
+- Clean dependency posture (0 CVEs, Dependabot monitoring)
+- CodeQL static analysis configured

--- a/security/260315-0835-stride-owasp-full-audit/owasp-coverage.md
+++ b/security/260315-0835-stride-owasp-full-audit/owasp-coverage.md
@@ -1,0 +1,87 @@
+# OWASP Top 10 Coverage — Pluralscape Security Audit
+
+## Coverage Matrix
+
+| ID | Category | Tested | Findings | Status |
+|----|----------|--------|----------|--------|
+| A01 | Broken Access Control | Yes | 1 (Info: RLS fail-closed) | Pass (RLS well-designed; API auth not yet needed) |
+| A02 | Cryptographic Failures | Yes | 2 (Medium: webhook secret T3; Low: transfer code entropy) | Partial (strong crypto, minor design gaps) |
+| A03 | Injection | Yes | 0 | Pass (Drizzle ORM, no exec/eval/innerHTML) |
+| A04 | Insecure Design | Yes | 3 (Medium: rate limiting, SQLite FK, QR code design) | Issues (early-stage gaps) |
+| A05 | Security Misconfiguration | Yes | 3 (Medium: headers, CORS, error handler) | Issues (no middleware configured) |
+| A06 | Vulnerable Components | Yes | 0 | Pass (0 npm audit advisories) |
+| A07 | Auth & Identification Failures | Yes | 2 (High: no auth middleware; Medium: no password policy) | Issues (not yet implemented) |
+| A08 | Software & Data Integrity Failures | Yes | 0 (Info: sync integrity verified) | Pass (Ed25519 signatures, AEAD) |
+| A09 | Security Logging & Monitoring | Yes | 1 (Low: audit log PII in plaintext) | Partial (good audit events, PII retention gap) |
+| A10 | Server-Side Request Forgery | Yes | 0 | Pass (no outbound HTTP in production code) |
+
+## Per-Category Detail
+
+### A01 — Broken Access Control
+- [x] IDOR on parameterized routes: N/A (no parameterized routes exist)
+- [x] Missing authorization middleware: Confirmed (Finding 1 — no auth middleware)
+- [x] Horizontal privilege escalation: N/A (no multi-user routes exist)
+- [x] Vertical privilege escalation: N/A (no role-based routes exist)
+- [x] Directory traversal: Not applicable (storage keys use branded IDs)
+- [x] CORS misconfiguration: Confirmed (Finding 4)
+- [x] RLS fail-closed design: Verified (NULLIF pattern)
+
+### A02 — Cryptographic Failures
+- [x] Sensitive data in plaintext: Webhook secrets are T3 (Finding 7)
+- [x] Weak hashing: Not found (Argon2id, BLAKE2b)
+- [x] Hardcoded secrets: Not found
+- [x] Missing encryption at rest: SQLCipher for mobile, PG TDE recommended
+- [x] Weak PRNG: Not found (libsodium randombytes)
+- [x] Exposed .env files: .env gitignored, .env.example has no secrets
+
+### A03 — Injection
+- [x] SQL injection: Not found (Drizzle ORM parameterized queries)
+- [x] Command injection: Not found (no exec/spawn in production)
+- [x] XSS: Not found (no innerHTML/eval/dangerouslySetInnerHTML in production)
+- [x] Template injection: Not applicable
+- [x] Path injection: Not applicable (branded storage keys)
+
+### A04 — Insecure Design
+- [x] Missing rate limiting: Confirmed (Finding 3)
+- [x] No account lockout: N/A (auth not implemented)
+- [x] Predictable identifiers: Not found (UUIDs with prefix)
+- [x] Race conditions: Not testable (no concurrent-write endpoints)
+- [x] Missing CSRF: N/A (API-only, no cookie-based auth yet)
+- [x] SQLite FK enforcement: Missing (Finding 5)
+
+### A05 — Security Misconfiguration
+- [x] Debug mode: Not found
+- [x] Default credentials: Not found
+- [x] Verbose errors: Risk present (Finding 8 — no error handler)
+- [x] Missing security headers: Confirmed (Finding 2)
+- [x] Unnecessary HTTP methods: Not testable (minimal routes)
+
+### A06 — Vulnerable Components
+- [x] Known CVEs: 0 advisories (pnpm audit)
+- [x] Outdated frameworks: Up to date
+- [x] Prototype pollution deps: Not found
+
+### A07 — Auth & Identification Failures
+- [x] Weak password policy: Confirmed (Finding 6)
+- [x] Missing MFA: N/A (auth not implemented)
+- [x] Session fixation: N/A (session management exists in schema only)
+- [x] JWT vulnerabilities: N/A (no JWT usage found)
+- [x] Session invalidation: Schema supports revocation (sessions.revoked)
+
+### A08 — Software & Data Integrity Failures
+- [x] CI/CD integrity: GitHub Actions with actions/checkout, CodeQL
+- [x] Unsigned dependencies: Dependabot monitors weekly
+- [x] Insecure deserialization: JSON.parse on decrypted data (safe context)
+- [x] Sync integrity: Ed25519 + AEAD verified
+
+### A09 — Security Logging & Monitoring
+- [x] Audit logging: 21 event types defined
+- [x] Failed auth logging: `auth.login-failed` event type exists
+- [x] Sensitive data in logs: IP/UA in plaintext (Finding 10)
+- [x] Log injection: Not applicable (structured audit log table)
+
+### A10 — Server-Side Request Forgery
+- [x] Unvalidated URLs: No outbound HTTP in production
+- [x] DNS rebinding: N/A
+- [x] Missing allowlist: N/A
+- [x] Proxy endpoints: None exist

--- a/security/260315-0835-stride-owasp-full-audit/recommendations.md
+++ b/security/260315-0835-stride-owasp-full-audit/recommendations.md
@@ -1,0 +1,153 @@
+# Security Recommendations — Pluralscape
+
+Prioritized mitigations for findings from the security audit.
+
+## Priority 1 — High (Address Before Adding API Routes)
+
+### 1. Add Authentication Middleware
+
+**Finding:** [No Authentication or Authorization Middleware](./findings.md#high-finding-1-no-authentication-or-authorization-middleware)
+**Effort:** Medium (depends on auth strategy)
+
+Before adding any authenticated API routes, implement:
+
+```typescript
+// apps/api/src/middleware/auth.ts
+import type { MiddlewareHandler } from "hono";
+
+export const requireAuth: MiddlewareHandler = async (c, next) => {
+  const token = c.req.header("Authorization")?.replace("Bearer ", "");
+  if (!token) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  // Validate session token or API key against DB
+  // Set tenant context for RLS: setTenantContext(db, { systemId, accountId })
+  await next();
+};
+```
+
+### 2. Add Security Headers
+
+**Finding:** [No Security Headers](./findings.md#medium-finding-2-no-security-headers)
+**Effort:** 5 minutes
+
+```typescript
+import { secureHeaders } from "hono/secure-headers";
+app.use("*", secureHeaders());
+```
+
+### 3. Configure CORS
+
+**Finding:** [No CORS Configuration](./findings.md#medium-finding-4-no-cors-configuration)
+**Effort:** 5 minutes
+
+```typescript
+import { cors } from "hono/cors";
+app.use("*", cors({
+  origin: (origin) => allowedOrigins.includes(origin) ? origin : null,
+  credentials: true,
+}));
+```
+
+### 4. Add Error Handler
+
+**Finding:** [No Global Error Handler](./findings.md#medium-finding-8-no-global-error-handler)
+**Effort:** 5 minutes
+
+```typescript
+app.onError((err, c) => {
+  console.error(err);
+  return c.json({ error: "Internal server error" }, 500);
+});
+```
+
+## Priority 2 — High (Fix This Sprint)
+
+### 5. Enable SQLite Foreign Keys
+
+**Finding:** [SQLite Foreign Keys Not Enforced](./findings.md#medium-finding-5-sqlite-foreign-keys-not-enforced)
+**Effort:** 1 minute
+
+```typescript
+// packages/db/src/client/factory.ts — after WAL mode line
+client.pragma("foreign_keys = ON");
+```
+
+### 6. Add Rate Limiting
+
+**Finding:** [No Rate Limiting](./findings.md#medium-finding-3-no-rate-limiting)
+**Effort:** Low-Medium
+
+When auth endpoints are implemented:
+
+```typescript
+// Rate limit auth endpoints more aggressively
+app.use("/api/auth/*", rateLimiter({ windowMs: 15 * 60 * 1000, max: 10 }));
+app.use("/api/*", rateLimiter({ windowMs: 60 * 1000, max: 100 }));
+```
+
+## Priority 3 — Medium (Plan for Next Sprint)
+
+### 7. Enforce Password Policy
+
+**Finding:** [No Password Complexity Enforcement](./findings.md#medium-finding-6-no-password-complexity-enforcement)
+**Effort:** Low
+
+Add validation at the application layer (not crypto layer):
+
+```typescript
+function validatePassword(password: string): void {
+  if (password.length < 12) {
+    throw new Error("Password must be at least 12 characters");
+  }
+  // Consider using zxcvbn for strength estimation
+}
+```
+
+### 8. Schedule Audit Log Cleanup
+
+**Finding:** [Audit Log PII in Plaintext](./findings.md#low-finding-10-audit-log-pii-in-plaintext)
+**Effort:** Low
+
+The cleanup functions already exist. Schedule them via the job queue:
+
+```typescript
+// Schedule weekly cleanup
+await jobQueue.enqueue({
+  type: "audit-log-cleanup",
+  idempotencyKey: `audit-cleanup-${weekNumber}`,
+  payload: { retentionDays: 90 },
+});
+```
+
+### 9. Fix Key Version Validation Inconsistency
+
+**Finding:** [Key Version 0 Accepted](./findings.md#info-positive-findings)
+**Effort:** 1 minute
+
+```typescript
+// packages/crypto/src/validation.ts
+export function validateKeyVersion(keyVersion: number): number {
+  if (!Number.isSafeInteger(keyVersion) || keyVersion < 1) { // Changed from 0 to 1
+    throw new InvalidInputError(
+      `keyVersion must be a positive safe integer, got ${String(keyVersion)}`,
+    );
+  }
+  return keyVersion;
+}
+```
+
+## Priority 4 — Low (Track as Hardening)
+
+### 10. Consider Increasing Transfer Code Length
+
+**Finding:** [Transfer Code Entropy](./findings.md#low-finding-9-transfer-code-entropy)
+**Effort:** Low
+
+If threat model warrants it, increase from 8 to 10-12 digits. Current mitigations (Argon2id + 5-min timeout) are adequate for most scenarios.
+
+### 11. Add Security Audit to CI
+
+**Effort:** Medium
+
+Add `pnpm audit --audit-level=moderate` to the CI pipeline. The CodeQL setup already exists; consider adding it as a GitHub Actions workflow that runs on PRs.

--- a/security/260315-0835-stride-owasp-full-audit/threat-model.md
+++ b/security/260315-0835-stride-owasp-full-audit/threat-model.md
@@ -1,0 +1,136 @@
+# Threat Model — Pluralscape
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| API | Hono on Bun (TypeScript) |
+| Mobile | Expo + React Native |
+| Database | PostgreSQL (server) + SQLite/SQLCipher (mobile) |
+| ORM | Drizzle |
+| Crypto | libsodium (WASM + RN JSI) |
+| Sync | Automerge CRDTs, encrypted relay |
+| Queue | Custom job queue interface |
+| Storage | Abstract blob adapter (presigned URLs) |
+| CI | GitHub Actions, CodeQL |
+| Auth | Password + Argon2id KDF + KEK/DEK master key wrapping |
+
+## Asset Inventory
+
+| Asset | Type | Sensitivity | Location |
+|-------|------|------------|----------|
+| Master encryption key | Cryptographic key | **Critical** | Client-side memory, encrypted at rest (accounts.encryptedMasterKey) |
+| User password hash | KDF output (Argon2id) | **Critical** | accounts.passwordHash |
+| Identity keypairs (X25519 + Ed25519) | Cryptographic keys | **Critical** | Derived from master key; encrypted private keys in authKeys table |
+| Recovery key | 256-bit random (base32 display) | **Critical** | User responsibility; encrypted master key backup in recoveryKeys table |
+| Bucket encryption keys | AeadKey (32 bytes) | **Critical** | Encrypted in keyGrants, managed via bucket-keys module |
+| Session data | Encrypted blob | **High** | sessions table, E2E encrypted |
+| Member profiles | Encrypted blob | **High** | members.encryptedData, E2E encrypted |
+| System profiles | Encrypted blob | **High** | systems.encryptedData, E2E encrypted |
+| Fronting history | CRDT documents | **High** | Encrypted sync documents |
+| Journal entries | CRDT documents | **High** | Encrypted sync documents |
+| Chat messages | CRDT documents | **High** | Encrypted sync documents |
+| Audit log (IP, UA) | GDPR personal data | **Medium** | auditLog table, plaintext |
+| API key tokens | Hashed tokens | **High** | apiKeys.tokenHash |
+| Webhook HMAC secrets | Binary (T3 server-readable) | **Medium** | webhookConfigs.secret |
+| Device push tokens | Platform tokens | **Medium** | deviceTokens.token |
+| Friend codes | 8+ char codes | **Low** | friendCodes.code |
+| Email hash + salt | Salted hash | **Medium** | accounts.emailHash + accounts.emailSalt |
+| Device transfer code | 8 decimal digits | **Medium** | Transient (5-min TTL) |
+
+## Trust Boundaries
+
+```
+Trust Boundaries:
+  +-- Mobile App <--E2E Encrypted--> API Server
+  |   +-- User input (forms, QR scan) --> Crypto layer (client-side)
+  |   +-- Key lifecycle state machine (locked/unlocked/grace)
+  |   +-- Biometric gate --> Key access
+  |
+  +-- API Server <--TLS--> PostgreSQL
+  |   +-- RLS policies (GUC session vars: app.current_system_id, app.current_account_id)
+  |   +-- Application-layer auth (not yet implemented)
+  |
+  +-- API Server <--TLS--> External Services
+  |   +-- Webhook delivery (HMAC-signed)
+  |   +-- Push notifications (APNs/FCM)
+  |   +-- Blob storage (presigned URLs)
+  |
+  +-- Sync Layer
+  |   +-- Client <--WebSocket/TLS--> Sync Relay
+  |   +-- Encrypted CRDT envelopes (AEAD + Ed25519 signatures)
+  |   +-- Document key resolution (master key vs bucket key)
+  |
+  +-- Friend Sharing
+  |   +-- Key grants (XSalsa20-Poly1305 crypto_box)
+  |   +-- Bucket-scoped access control
+  |   +-- Privacy tiers (T1 zero-knowledge, T2 per-bucket, T3 plaintext)
+  |
+  +-- CI/CD <--> Production
+      +-- GitHub Actions
+      +-- CodeQL analysis
+      +-- Dependabot
+```
+
+## STRIDE Threat Analysis
+
+### S — Spoofing
+
+| Threat | Asset/Boundary | Risk | Status |
+|--------|---------------|------|--------|
+| Password brute force | Auth endpoint | High | No rate limiting middleware exists |
+| Session token theft | Client-server | High | Sessions exist in schema but no auth middleware implemented |
+| Transfer code brute force | Device transfer | Medium | 8 digits (~26.5 bits); Argon2id protects offline; 5-min timeout limits online |
+| API key impersonation | API key auth | High | Token hash stored but no verification middleware |
+| Sync session spoofing | Sync relay | Medium | Auth protocol defined but relies on sessionToken validation |
+| Recovery key theft | Master key recovery | High | Physical/social engineering vector; key format is 52 base32 chars |
+
+### T — Tampering
+
+| Threat | Asset/Boundary | Risk | Status |
+|--------|---------------|------|--------|
+| CRDT data tampering | Sync layer | Low | Every envelope is AEAD-encrypted + Ed25519 signed; AAD binds to documentId |
+| Webhook payload tampering | Webhook delivery | Low | HMAC-signed payloads |
+| Bucket key grant tampering | Friend sharing | Low | crypto_box authenticated encryption + envelope binding validation |
+| Encrypted blob tampering | Data at rest | Low | XChaCha20-Poly1305 provides authentication |
+| Stream chunk reordering | Streaming encryption | Low | Chunk AAD includes index + total count |
+| Snapshot version manipulation | Sync snapshots | Low | AAD includes documentId + snapshotVersion |
+
+### R — Repudiation
+
+| Threat | Asset/Boundary | Risk | Status |
+|--------|---------------|------|--------|
+| Unlogged auth events | Audit system | Low | Comprehensive audit event types defined |
+| Missing audit for data access | Data queries | Medium | Audit events for mutations defined; read access not logged |
+| Unsigned sync changes | Sync relay | Low | All changes are Ed25519 signed with authorPublicKey |
+| Missing webhook delivery tracking | Webhook system | Low | webhookDeliveries table tracks status and attempts |
+
+### I — Information Disclosure
+
+| Threat | Asset/Boundary | Risk | Status |
+|--------|---------------|------|--------|
+| Error stack traces in responses | API | Medium | No error handling middleware configured |
+| Audit log PII (IP, UA) | Audit system | Medium | Stored in plaintext; retention policy not enforced in schema |
+| Webhook secret in DB | Webhook config | Medium | Stored as T3 (server-readable binary), not E2E encrypted |
+| Device push tokens in plaintext | Notifications | Low | Required by push services; standard practice |
+| Email hash reversibility | Account data | Low | Salted hash; salt stored per-account |
+
+### D — Denial of Service
+
+| Threat | Asset/Boundary | Risk | Status |
+|--------|---------------|------|--------|
+| No rate limiting on API | All endpoints | High | No rate limiting middleware exists |
+| Argon2id CPU exhaustion | Auth/transfer | Medium | Password hashing is intentionally expensive; no concurrent request limiting |
+| Large blob uploads | Storage | Low | BlobTooLargeError exists in adapter; server-side limit enforcement TBD |
+| Sync document size growth | Sync layer | Low | Storage budget + compaction + time-split mechanisms exist |
+| CRDT state explosion | Sync documents | Low | Document size limits defined (DOCUMENT_SIZE_LIMITS) |
+
+### E — Elevation of Privilege
+
+| Threat | Asset/Boundary | Risk | Status |
+|--------|---------------|------|--------|
+| Missing auth middleware | API routes | **Critical** | No authentication/authorization middleware implemented |
+| RLS bypass (SQLite) | Mobile DB | Medium | SQLite has no RLS; relies on application-layer scoping |
+| API scope bypass | API keys | Medium | Scopes defined but no enforcement middleware |
+| Cross-system data access | Multi-tenant | High | RLS policies exist for PG; fail-closed (NULL = no access) |
+| Key version 0 acceptance | Crypto layer | Low | validateKeyVersion accepts 0; DB schema requires >= 1 |


### PR DESCRIPTION
## Summary

Comprehensive security audit covering all 10 OWASP Top 10 categories and all 6 STRIDE threat categories. Audited the full codebase: API layer, crypto package, database schemas/RLS, sync protocol, storage, and queue packages. 21 iterations with code-evidenced findings.

## Changes

- Adds full security audit report under `security/260315-0835-stride-owasp-full-audit/` with threat model, attack surface map, severity-ranked findings, OWASP coverage matrix, dependency audit, and prioritized recommendations
- Adds `security-audit-results.tsv` to `.gitignore` (working file, not committed)
- Creates bean ps-6976 (child of Milestone 1) to track remediation of findings

**Key results:** 0 Critical, 1 High, 6 Medium, 2 Low, 9 Info (positive confirmations). Cryptographic and database layers are strong. Primary gap is the API layer which lacks security middleware (auth, CORS, rate limiting, headers) — not yet exploitable since only health-check routes exist, but must be addressed before adding authenticated routes. One concrete fix identified: SQLite factory missing `PRAGMA foreign_keys = ON`.

## Test Plan

- [x] Report files are self-contained markdown — no code changes, no tests needed
- [x] `.gitignore` change verified: TSV iteration log excluded from staging

## Review Checklist

- [x] Privacy: new data defaults to maximum restriction (fail-closed)
- [x] Offline: works correctly without network connectivity
- [x] Non-destructive: no user data is permanently deleted
- [ ] ~~Accessibility: UI changes meet WCAG guidelines~~ N/A
- [x] Domain terms used correctly (community terminology, not clinical language)

## Deferred Items

- ps-6976: Address all actionable findings (1 High, 6 Medium, 2 Low) per `recommendations.md` priority order