### PR TITLE
refactor(api): improve hierarchy services, batch queries, and add group copy

### DIFF
--- a/.beans/api-kmto--consolidate-deletesubsystem-count-queries-into-sin.md
+++ b/.beans/api-kmto--consolidate-deletesubsystem-count-queries-into-sin.md
@@ -1,0 +1,9 @@
+---
+# api-kmto
+title: Consolidate deleteSubsystem count queries into single query
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-18T13:11:44Z
+updated_at: 2026-03-18T13:16:17Z
+---

--- a/apps/api/src/__tests__/services/subsystem.service.test.ts
+++ b/apps/api/src/__tests__/services/subsystem.service.test.ts
@@ -499,14 +499,12 @@ describe("deleteSubsystem", () => {
 
   it("deletes a subsystem with no dependents", async () => {
     const { db, chain } = mockDb();
-    // exists check → chains to .limit()
-    chain.where
-      .mockReturnValueOnce(chain) // existence check → chains to .limit()
-      .mockResolvedValueOnce([{ count: 0 }]) // child subsystems count
-      .mockResolvedValueOnce([{ count: 0 }]) // memberships count
-      .mockResolvedValueOnce([{ count: 0 }]) // layer link count
-      .mockResolvedValueOnce([{ count: 0 }]); // side system link count
-    chain.limit.mockResolvedValueOnce([{ id: SUBSYSTEM_ID }]); // exists check
+    // exists check: select().from().where().limit()
+    chain.limit.mockResolvedValueOnce([{ id: SUBSYSTEM_ID }]);
+    // dependents check: select({subqueries}).from(sql) — from() is terminal
+    chain.from
+      .mockReturnValueOnce(chain) // existence check from() → chains to .where()
+      .mockResolvedValueOnce([{ children: 0, memberships: 0, layerLinks: 0, sideSystemLinks: 0 }]);
 
     await deleteSubsystem(db, SYSTEM_ID, SUBSYSTEM_ID, AUTH, mockAudit);
 
@@ -519,13 +517,12 @@ describe("deleteSubsystem", () => {
 
   it("throws 409 when subsystem has dependents", async () => {
     const { db, chain } = mockDb();
-    chain.where
-      .mockReturnValueOnce(chain) // existence check → chains to .limit()
-      .mockResolvedValueOnce([{ count: 3 }]) // child subsystems
-      .mockResolvedValueOnce([{ count: 0 }]) // memberships
-      .mockResolvedValueOnce([{ count: 0 }]) // layer links
-      .mockResolvedValueOnce([{ count: 0 }]); // side system links
+    // exists check: select().from().where().limit()
     chain.limit.mockResolvedValueOnce([{ id: SUBSYSTEM_ID }]);
+    // dependents check: select({subqueries}).from(sql) — from() is terminal
+    chain.from
+      .mockReturnValueOnce(chain) // existence check from() → chains to .where()
+      .mockResolvedValueOnce([{ children: 3, memberships: 0, layerLinks: 0, sideSystemLinks: 0 }]);
 
     await expect(deleteSubsystem(db, SYSTEM_ID, SUBSYSTEM_ID, AUTH, mockAudit)).rejects.toThrow(
       expect.objectContaining({ status: 409, code: "HAS_DEPENDENTS" }),

--- a/apps/api/src/services/subsystem.service.ts
+++ b/apps/api/src/services/subsystem.service.ts
@@ -6,7 +6,7 @@ import {
 } from "@pluralscape/db/pg";
 import { ID_PREFIXES, createId, now } from "@pluralscape/types";
 import { CreateSubsystemBodySchema, UpdateSubsystemBodySchema } from "@pluralscape/validation";
-import { and, count, eq, gt, sql } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 
 import { HTTP_BAD_REQUEST, HTTP_CONFLICT, HTTP_NOT_FOUND } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
@@ -336,56 +336,46 @@ export async function deleteSubsystem(
       throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Subsystem not found");
     }
 
-    // Check for child subsystems
-    const [childCount] = await tx
-      .select({ count: count() })
-      .from(subsystems)
-      .where(
-        and(
-          eq(subsystems.parentSubsystemId, subsystemId),
-          eq(subsystems.systemId, systemId),
-          eq(subsystems.archived, false),
-        ),
-      );
+    // Check all dependents in a single query using subselects
+    const [dependents] = await tx
+      .select({
+        children: sql<number>`(
+          SELECT count(*)
+          FROM ${subsystems}
+          WHERE ${subsystems.parentSubsystemId} = ${subsystemId}
+            AND ${subsystems.systemId} = ${systemId}
+            AND ${subsystems.archived} = false
+        )`.mapWith(Number),
+        memberships: sql<number>`(
+          SELECT count(*)
+          FROM ${subsystemMemberships}
+          WHERE ${subsystemMemberships.subsystemId} = ${subsystemId}
+            AND ${subsystemMemberships.systemId} = ${systemId}
+        )`.mapWith(Number),
+        layerLinks: sql<number>`(
+          SELECT count(*)
+          FROM ${subsystemLayerLinks}
+          WHERE ${subsystemLayerLinks.subsystemId} = ${subsystemId}
+            AND ${subsystemLayerLinks.systemId} = ${systemId}
+        )`.mapWith(Number),
+        sideSystemLinks: sql<number>`(
+          SELECT count(*)
+          FROM ${subsystemSideSystemLinks}
+          WHERE ${subsystemSideSystemLinks.subsystemId} = ${subsystemId}
+            AND ${subsystemSideSystemLinks.systemId} = ${systemId}
+        )`.mapWith(Number),
+      })
+      .from(sql`(SELECT 1) AS _`);
 
-    // Check for memberships
-    const [membershipCount] = await tx
-      .select({ count: count() })
-      .from(subsystemMemberships)
-      .where(
-        and(
-          eq(subsystemMemberships.subsystemId, subsystemId),
-          eq(subsystemMemberships.systemId, systemId),
-        ),
-      );
-
-    // Check for cross-structure links (subsystem-layer + subsystem-side-system)
-    const [layerLinkCount] = await tx
-      .select({ count: count() })
-      .from(subsystemLayerLinks)
-      .where(
-        and(
-          eq(subsystemLayerLinks.subsystemId, subsystemId),
-          eq(subsystemLayerLinks.systemId, systemId),
-        ),
-      );
-
-    const [sideSystemLinkCount] = await tx
-      .select({ count: count() })
-      .from(subsystemSideSystemLinks)
-      .where(
-        and(
-          eq(subsystemSideSystemLinks.subsystemId, subsystemId),
-          eq(subsystemSideSystemLinks.systemId, systemId),
-        ),
-      );
-
-    if (!childCount || !membershipCount || !layerLinkCount || !sideSystemLinkCount) {
-      throw new Error("Unexpected: count query returned no rows");
+    if (!dependents) {
+      throw new Error("Unexpected: dependent count query returned no rows");
     }
 
     const totalDependents =
-      childCount.count + membershipCount.count + layerLinkCount.count + sideSystemLinkCount.count;
+      dependents.children +
+      dependents.memberships +
+      dependents.layerLinks +
+      dependents.sideSystemLinks;
 
     if (totalDependents > 0) {
       throw new ApiHttpError(


### PR DESCRIPTION
## Summary

Addresses audit 012 findings for hierarchy service quality (Worktree 4).

- **P-5 (archiveRegion batch UPDATE)**: Already resolved -- `archiveRegion` uses `inArray` for batch updates and `sql.join` for frontier child lookups. No changes needed.
- **P-12 (deduplicate MAX_ANCESTOR_DEPTH)**: Already resolved -- `MAX_ANCESTOR_DEPTH` is defined only in `service.constants.ts` and imported by `hierarchy.ts`. No inline duplicate exists in `subsystem.service.ts`.
- **P-14 (shared ancestor-walk helper)**: Already resolved -- `detectAncestorCycle` in `lib/hierarchy.ts` is already used by both `group.service.ts` and `subsystem.service.ts`.
- **P-15 (consolidate count queries in deleteSubsystem)**: Replaced 4 separate COUNT queries with a single SELECT using scalar subselects, reducing database round trips from 4 to 1 when checking for child subsystems, memberships, layer links, and side-system links before deletion.
- **F-3 (POST /groups/:groupId/copy)**: Already resolved -- the `copyGroup` service method, route handler, validation schema, and tests all exist.

## Test plan

- [x] All 1372 API tests pass (`pnpm test -- --project api`)
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] ESLint passes with zero warnings (`pnpm lint`)
- [x] Updated mock expectations in `subsystem.service.test.ts` to match consolidated query pattern