### PR TITLE
test(api): add route and lib tests for medium-severity coverage gaps

### DIFF
--- a/.beans/api-4l87--add-route-and-lib-tests-for-medium-severity-covera.md
+++ b/.beans/api-4l87--add-route-and-lib-tests-for-medium-severity-covera.md
@@ -1,0 +1,9 @@
+---
+# api-4l87
+title: Add route and lib tests for medium-severity coverage gaps
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-18T13:11:22Z
+updated_at: 2026-03-18T13:18:14Z
+---

--- a/apps/api/src/__tests__/lib/member-helpers.test.ts
+++ b/apps/api/src/__tests__/lib/member-helpers.test.ts
@@ -42,6 +42,34 @@ describe("assertMemberActive", () => {
     expect(err).toMatchObject({ status: 404, code: "NOT_FOUND" });
     expect((err as ApiHttpError).message).toContain("Member");
   });
+
+  it("throws ApiHttpError with exact message 'Member not found'", async () => {
+    const { db, chain } = mockDb();
+    chain.limit.mockResolvedValueOnce([]);
+
+    const err = await assertMemberActive(db, SYSTEM_ID, "mem_gone" as MemberId).catch(
+      (e: unknown) => e,
+    );
+
+    expect((err as ApiHttpError).message).toBe("Member not found");
+  });
+
+  it("queries with the correct systemId and memberId combination", async () => {
+    const { db, chain } = mockDb();
+    const otherSystemId = "sys_other-system" as SystemId;
+    const memberId = "mem_specific" as MemberId;
+    chain.limit.mockResolvedValueOnce([{ id: memberId }]);
+
+    await assertMemberActive(db, otherSystemId, memberId);
+
+    expect(chain.where).toHaveBeenCalledWith(
+      and(
+        eq(members.id, memberId),
+        eq(members.systemId, otherSystemId),
+        eq(members.archived, false),
+      ),
+    );
+  });
 });
 
 describe("assertFieldDefinitionActive", () => {
@@ -81,5 +109,35 @@ describe("assertFieldDefinitionActive", () => {
     expect(err).toBeInstanceOf(ApiHttpError);
     expect(err).toMatchObject({ status: 404, code: "NOT_FOUND" });
     expect((err as ApiHttpError).message).toContain("Field definition");
+  });
+
+  it("throws ApiHttpError with exact message 'Field definition not found'", async () => {
+    const { db, chain } = mockDb();
+    chain.limit.mockResolvedValueOnce([]);
+
+    const err = await assertFieldDefinitionActive(
+      db,
+      SYSTEM_ID,
+      "fd_missing" as FieldDefinitionId,
+    ).catch((e: unknown) => e);
+
+    expect((err as ApiHttpError).message).toBe("Field definition not found");
+  });
+
+  it("queries with the correct systemId and fieldDefId combination", async () => {
+    const { db, chain } = mockDb();
+    const otherSystemId = "sys_other-system" as SystemId;
+    const fieldDefId = "fd_specific" as FieldDefinitionId;
+    chain.limit.mockResolvedValueOnce([{ id: fieldDefId }]);
+
+    await assertFieldDefinitionActive(db, otherSystemId, fieldDefId);
+
+    expect(chain.where).toHaveBeenCalledWith(
+      and(
+        eq(fieldDefinitions.id, fieldDefId),
+        eq(fieldDefinitions.systemId, otherSystemId),
+        eq(fieldDefinitions.archived, false),
+      ),
+    );
   });
 });

--- a/apps/api/src/__tests__/lib/occ-update.test.ts
+++ b/apps/api/src/__tests__/lib/occ-update.test.ts
@@ -25,6 +25,7 @@ describe("assertOccUpdated", () => {
 
     expect(err).toBeInstanceOf(ApiHttpError);
     expect(err).toMatchObject({ status: 409, code: "CONFLICT" });
+    expect((err as ApiHttpError).message).toBe("Version conflict");
     expect(existsFn).toHaveBeenCalledOnce();
   });
 
@@ -48,5 +49,30 @@ describe("assertOccUpdated", () => {
     const result = await assertOccUpdated(rows, existsFn, "System");
 
     expect(result).toBe(rows[0]);
+  });
+
+  it("includes entity name in the 404 message", async () => {
+    const existsFn = vi.fn().mockResolvedValue(undefined);
+
+    const err = await assertOccUpdated([], existsFn, "Layer").catch((e: unknown) => e);
+
+    expect((err as ApiHttpError).message).toBe("Layer not found");
+  });
+
+  it("propagates errors thrown by existsFn", async () => {
+    const dbError = new Error("Database connection lost");
+    const existsFn = vi.fn().mockRejectedValue(dbError);
+
+    await expect(assertOccUpdated([], existsFn, "System")).rejects.toThrow(
+      "Database connection lost",
+    );
+  });
+
+  it("does not call existsFn when rows are returned", async () => {
+    const existsFn = vi.fn();
+
+    await assertOccUpdated([{ id: "x" }], existsFn, "System");
+
+    expect(existsFn).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/__tests__/lib/system-ownership.test.ts
+++ b/apps/api/src/__tests__/lib/system-ownership.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { ApiHttpError } from "../../lib/api-error.js";
+
 import type { AuthContext } from "../../lib/auth-context.js";
 import type { SystemId } from "@pluralscape/types";
 
@@ -10,6 +12,7 @@ const { assertSystemOwnership } = await import("../../lib/system-ownership.js");
 // ── Fixtures ─────────────────────────────────────────────────────────
 
 const SYSTEM_ID = "sys_test-system" as SystemId;
+const OTHER_SYSTEM_ID = "sys_other-system" as SystemId;
 
 const AUTH: AuthContext = {
   accountId: "acct_test-account" as AuthContext["accountId"],
@@ -47,6 +50,37 @@ describe("assertSystemOwnership", () => {
     };
     expect(() => {
       assertSystemOwnership(SYSTEM_ID, emptyAuth);
+    }).toThrow(
+      expect.objectContaining({
+        status: 404,
+        code: "NOT_FOUND",
+      }),
+    );
+  });
+
+  it("does not throw when checking one of multiple owned systems", () => {
+    const multiAuth: AuthContext = {
+      ...AUTH,
+      ownedSystemIds: new Set([SYSTEM_ID, OTHER_SYSTEM_ID]),
+    };
+    expect(() => {
+      assertSystemOwnership(OTHER_SYSTEM_ID, multiAuth);
+    }).not.toThrow();
+  });
+
+  it("throws ApiHttpError (not a generic Error)", () => {
+    expect(() => {
+      assertSystemOwnership("sys_unowned" as SystemId, AUTH);
+    }).toThrow(ApiHttpError);
+  });
+
+  it("throws for the second system when only one is owned", () => {
+    const singleAuth: AuthContext = {
+      ...AUTH,
+      ownedSystemIds: new Set([OTHER_SYSTEM_ID]),
+    };
+    expect(() => {
+      assertSystemOwnership(SYSTEM_ID, singleAuth);
     }).toThrow(
       expect.objectContaining({
         status: 404,

--- a/apps/api/src/__tests__/routes/structure-memberships.test.ts
+++ b/apps/api/src/__tests__/routes/structure-memberships.test.ts
@@ -66,16 +66,19 @@ vi.mock("../../middleware/auth.js", () => mockAuthFactory());
 
 const service = await import("../../services/structure-membership.service.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
+const { ApiHttpError } = await import("../../lib/api-error.js");
 
 // ── Variant definitions ──────────────────────────────────────────
 
 const SYS_ID = "sys_550e8400-e29b-41d4-a716-446655440000";
+const INVALID_SYS_ID = "not-a-system-id";
 
 interface MembershipVariant {
   label: string;
   urlSegment: string;
   entityId: string;
   membershipId: string;
+  invalidMembershipId: string;
   invalidParamSegment: string;
   addFn: keyof typeof service;
   removeFn: keyof typeof service;
@@ -88,6 +91,7 @@ const VARIANTS: MembershipVariant[] = [
     urlSegment: "layers",
     entityId: "lyr_550e8400-e29b-41d4-a716-446655440001",
     membershipId: "lyrm_550e8400-e29b-41d4-a716-446655440002",
+    invalidMembershipId: "not-a-membership-id",
     invalidParamSegment: "layers/not-valid/memberships",
     addFn: "addLayerMembership",
     removeFn: "removeLayerMembership",
@@ -98,6 +102,7 @@ const VARIANTS: MembershipVariant[] = [
     urlSegment: "side-systems",
     entityId: "ss_550e8400-e29b-41d4-a716-446655440001",
     membershipId: "ssm_550e8400-e29b-41d4-a716-446655440002",
+    invalidMembershipId: "not-a-membership-id",
     invalidParamSegment: "side-systems/not-valid/memberships",
     addFn: "addSideSystemMembership",
     removeFn: "removeSideSystemMembership",
@@ -108,6 +113,7 @@ const VARIANTS: MembershipVariant[] = [
     urlSegment: "subsystems",
     entityId: "sub_550e8400-e29b-41d4-a716-446655440001",
     membershipId: "subm_550e8400-e29b-41d4-a716-446655440002",
+    invalidMembershipId: "not-a-membership-id",
     invalidParamSegment: "subsystems/not-valid/memberships",
     addFn: "addSubsystemMembership",
     removeFn: "removeSubsystemMembership",
@@ -128,6 +134,7 @@ for (const variant of VARIANTS) {
     urlSegment,
     entityId,
     membershipId,
+    invalidMembershipId,
     invalidParamSegment,
     addFn,
     removeFn,
@@ -189,11 +196,7 @@ for (const variant of VARIANTS) {
 
     it("returns 400 for empty object body", async () => {
       addMock().mockRejectedValueOnce(
-        new (await import("../../lib/api-error.js")).ApiHttpError(
-          400,
-          "VALIDATION_ERROR",
-          "Missing required fields",
-        ),
+        new ApiHttpError(400, "VALIDATION_ERROR", "Missing required fields"),
       );
 
       const res = await createApp().request(baseUrl, {
@@ -203,6 +206,46 @@ for (const variant of VARIANTS) {
       });
 
       expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid systemId param format", async () => {
+      const badUrl = `/systems/${INVALID_SYS_ID}/${urlSegment}/${entityId}/memberships`;
+      const res = await createApp().request(badUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_BODY),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ApiErrorResponse;
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 409 when service throws CONFLICT", async () => {
+      addMock().mockRejectedValueOnce(new ApiHttpError(409, "CONFLICT", "Duplicate membership"));
+
+      const res = await createApp().request(baseUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_BODY),
+      });
+
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as ApiErrorResponse;
+      expect(body.error.code).toBe("CONFLICT");
+    });
+
+    it("returns 500 for unexpected errors", async () => {
+      addMock().mockRejectedValueOnce(new Error("DB timeout"));
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const res = await createApp().request(baseUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(VALID_BODY),
+      });
+
+      expect(res.status).toBe(500);
     });
   });
 
@@ -218,8 +261,21 @@ for (const variant of VARIANTS) {
       expect(res.status).toBe(204);
     });
 
+    it("forwards systemId, membershipId, auth, and audit to service", async () => {
+      removeMock().mockResolvedValueOnce(undefined);
+
+      await createApp().request(`${baseUrl}/${membershipId}`, { method: "DELETE" });
+
+      expect(removeMock()).toHaveBeenCalledWith(
+        expect.anything(),
+        SYS_ID,
+        membershipId,
+        MOCK_AUTH,
+        expect.any(Function),
+      );
+    });
+
     it("returns 404 when membership not found", async () => {
-      const { ApiHttpError } = await import("../../lib/api-error.js");
       removeMock().mockRejectedValueOnce(
         new ApiHttpError(404, "NOT_FOUND", "Membership not found"),
       );
@@ -229,6 +285,25 @@ for (const variant of VARIANTS) {
       expect(res.status).toBe(404);
       const body = (await res.json()) as ApiErrorResponse;
       expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns 400 for invalid membershipId param format", async () => {
+      const res = await createApp().request(`${baseUrl}/${invalidMembershipId}`, {
+        method: "DELETE",
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ApiErrorResponse;
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 500 for unexpected errors", async () => {
+      removeMock().mockRejectedValueOnce(new Error("Connection lost"));
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const res = await createApp().request(`${baseUrl}/${membershipId}`, { method: "DELETE" });
+
+      expect(res.status).toBe(500);
     });
   });
 
@@ -255,12 +330,58 @@ for (const variant of VARIANTS) {
       expect(body.nextCursor).toBe("cursor_next");
     });
 
+    it("forwards systemId, entityId, auth, cursor, and limit to service", async () => {
+      const emptyPage = { items: [], nextCursor: null, hasMore: false, totalCount: null };
+      listMock().mockResolvedValueOnce(emptyPage);
+
+      await createApp().request(`${baseUrl}?cursor=cur_abc&limit=5`);
+
+      expect(listMock()).toHaveBeenCalledWith(
+        expect.anything(),
+        SYS_ID,
+        entityId,
+        MOCK_AUTH,
+        "cur_abc",
+        5,
+      );
+    });
+
+    it("returns 200 with empty list when no memberships exist", async () => {
+      const emptyPage = { items: [], nextCursor: null, hasMore: false, totalCount: null };
+      listMock().mockResolvedValueOnce(emptyPage);
+
+      const res = await createApp().request(baseUrl);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { items: unknown[]; hasMore: boolean };
+      expect(body.items).toHaveLength(0);
+      expect(body.hasMore).toBe(false);
+    });
+
     it(`returns 400 for invalid ${label}Id param format`, async () => {
       const res = await createApp().request(`/systems/${SYS_ID}/${invalidParamSegment}`);
 
       expect(res.status).toBe(400);
       const body = (await res.json()) as ApiErrorResponse;
       expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 400 for invalid systemId param format", async () => {
+      const badUrl = `/systems/${INVALID_SYS_ID}/${urlSegment}/${entityId}/memberships`;
+      const res = await createApp().request(badUrl);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ApiErrorResponse;
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("returns 500 for unexpected errors", async () => {
+      listMock().mockRejectedValueOnce(new Error("Query failed"));
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const res = await createApp().request(baseUrl);
+
+      expect(res.status).toBe(500);
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes medium-severity coverage gaps identified in audit 012 (findings T-6 and T-7) by strengthening existing test suites for structure membership routes and lib utilities.

## Changes

- **Structure membership routes (T-6)**: Adds tests for invalid systemId/membershipId param validation, 409 conflict handling, 500 error propagation, service argument forwarding on DELETE and GET list, pagination query param forwarding (cursor/limit), and empty list responses -- across all 3 domains (layers, side-systems, subsystems)
- **occ-update (T-7)**: Adds tests for existsFn error propagation, entity name in 404 message, and explicit conflict message verification
- **system-ownership (T-7)**: Adds tests for multiple owned systems, ApiHttpError type assertion, and single-owned-system rejection
- **member-helpers (T-7)**: Adds tests for exact error messages and cross-system query parameter verification

## Test Plan

- [x] `pnpm vitest run --project api` -- all 1412 tests pass (152 files)
- [x] `pnpm typecheck` -- passes
- [x] `pnpm lint` -- passes with zero warnings

## Review Checklist

- [x] Privacy: new data defaults to maximum restriction (fail-closed)
- [x] Offline: works correctly without network connectivity
- [x] Data lifecycle: deletions are intentional, confirmed, and handle cascading references
- [x] Accessibility: UI changes meet WCAG guidelines
- [x] Domain terms used correctly (community terminology, not clinical language)

N/A -- this PR is test-only with no source changes.

## Deferred Items

- None