### PR TITLE
fix(api): add per-category rate limits for read endpoints

### DIFF
--- a/.beans/api-mq36--add-per-category-rate-limits-for-read-endpoints.md
+++ b/.beans/api-mq36--add-per-category-rate-limits-for-read-endpoints.md
@@ -1,0 +1,9 @@
+---
+# api-mq36
+title: Add per-category rate limits for read endpoints
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-18T14:08:15Z
+updated_at: 2026-03-18T14:26:36Z
+---

--- a/apps/api/src/__tests__/routes/blobs/download-url.test.ts
+++ b/apps/api/src/__tests__/routes/blobs/download-url.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getDownloadUrl } = await import("../../../services/blob.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -97,5 +98,9 @@ describe("GET /systems/:systemId/blobs/:blobId/download-url", () => {
     const res = await app.request(invalidUrl);
 
     expect(res.status).toBe(400);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/blobs/get.test.ts
+++ b/apps/api/src/__tests__/routes/blobs/get.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getBlob } = await import("../../../services/blob.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -102,5 +103,9 @@ describe("GET /systems/:systemId/blobs/:blobId", () => {
     const res = await app.request(invalidUrl);
 
     expect(res.status).toBe(400);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/buckets/rotations/progress.test.ts
+++ b/apps/api/src/__tests__/routes/buckets/rotations/progress.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getRotationProgress } = await import("../../../../services/key-rotation.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -100,6 +101,10 @@ describe("GET /systems/:id/buckets/:bucketId/rotations/:rotationId", () => {
     );
 
     expect(res.status).toBe(400);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("calls service without audit writer", async () => {

--- a/apps/api/src/__tests__/routes/custom-fronts/crud.test.ts
+++ b/apps/api/src/__tests__/routes/custom-fronts/crud.test.ts
@@ -37,6 +37,7 @@ const {
   updateCustomFront,
   deleteCustomFront,
 } = await import("../../../services/custom-front.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -226,5 +227,11 @@ describe("DELETE /systems/:id/custom-fronts/:customFrontId", () => {
     expect(res.status).toBe(409);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("HAS_DEPENDENTS");
+  });
+});
+
+describe("read rate limits", () => {
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/fields/get.test.ts
+++ b/apps/api/src/__tests__/routes/fields/get.test.ts
@@ -35,6 +35,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getFieldDefinition } = await import("../../../services/field-definition.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -94,6 +95,10 @@ describe("GET /systems/:systemId/fields/:fieldId", () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/fields/list.test.ts
+++ b/apps/api/src/__tests__/routes/fields/list.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listFieldDefinitions } = await import("../../../services/field-definition.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -148,6 +149,10 @@ describe("GET /systems/:systemId/fields", () => {
       MOCK_AUTH,
       { cursor: undefined, limit: 25, includeArchived: false },
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/groups/get.test.ts
+++ b/apps/api/src/__tests__/routes/groups/get.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../../middleware/rate-limit.js", () => mockRateLimitFactory());
 vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 
 const { getGroup } = await import("../../../services/group.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 const createApp = () => createRouteApp("/systems", systemRoutes);
@@ -86,6 +87,10 @@ describe("GET /systems/:id/groups/:groupId", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/groups/list.test.ts
+++ b/apps/api/src/__tests__/routes/groups/list.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../../middleware/rate-limit.js", () => mockRateLimitFactory());
 vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 
 const { listGroups } = await import("../../../services/group.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 const createApp = () => createRouteApp("/systems", systemRoutes);
@@ -63,6 +64,10 @@ describe("GET /systems/:id/groups", () => {
       "grp_abc",
       10,
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/groups/members/list.test.ts
+++ b/apps/api/src/__tests__/routes/groups/members/list.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../../../middleware/rate-limit.js", () => mockRateLimitFactory());
 vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 
 const { listGroupMembers } = await import("../../../../services/group-membership.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 const createApp = () => createRouteApp("/systems", systemRoutes);
@@ -43,6 +44,10 @@ describe("GET /systems/:id/groups/:groupId/members", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as typeof EMPTY_PAGE;
     expect(body.items).toEqual([]);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/groups/tree.test.ts
+++ b/apps/api/src/__tests__/routes/groups/tree.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../../middleware/rate-limit.js", () => mockRateLimitFactory());
 vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 
 const { getGroupTree } = await import("../../../services/group.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 const createApp = () => createRouteApp("/systems", systemRoutes);
@@ -41,6 +42,10 @@ describe("GET /systems/:id/groups/tree", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as unknown[];
     expect(body).toEqual([]);
+  });
+
+  it("applies the readHeavy rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readHeavy");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/innerworld/canvas/canvas.test.ts
+++ b/apps/api/src/__tests__/routes/innerworld/canvas/canvas.test.ts
@@ -29,6 +29,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 
 const { getCanvas, upsertCanvas } =
   await import("../../../../services/innerworld-canvas.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -137,8 +138,15 @@ describe("PUT /systems/:id/innerworld/canvas", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(VALID_BODY),
     });
+
     expect(res.status).toBe(409);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("CONFLICT");
+  });
+});
+
+describe("read rate limit", () => {
+  it("applies the readDefault rate limit category to the canvas GET route", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/innerworld/entities/get.test.ts
+++ b/apps/api/src/__tests__/routes/innerworld/entities/get.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getEntity } = await import("../../../../services/innerworld-entity.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -87,5 +88,9 @@ describe("GET /systems/:id/innerworld/entities/:entityId", () => {
     const res = await createApp().request(`${BASE_URL}/not-valid`);
 
     expect(res.status).toBe(400);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/innerworld/entities/list.test.ts
+++ b/apps/api/src/__tests__/routes/innerworld/entities/list.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listEntities } = await import("../../../../services/innerworld-entity.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -93,5 +94,9 @@ describe("GET /systems/:id/innerworld/entities", () => {
 
     expect(res.status).toBe(200);
     expect(vi.mocked(listEntities)).toHaveBeenCalledOnce();
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/innerworld/regions/get.test.ts
+++ b/apps/api/src/__tests__/routes/innerworld/regions/get.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getRegion } = await import("../../../../services/innerworld-region.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -87,5 +88,9 @@ describe("GET /systems/:id/innerworld/regions/:regionId", () => {
     const res = await createApp().request(`${BASE_URL}/not-valid`);
 
     expect(res.status).toBe(400);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/innerworld/regions/list.test.ts
+++ b/apps/api/src/__tests__/routes/innerworld/regions/list.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listRegions } = await import("../../../../services/innerworld-region.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -91,5 +92,9 @@ describe("GET /systems/:id/innerworld/regions", () => {
 
     expect(res.status).toBe(200);
     expect(vi.mocked(listRegions)).toHaveBeenCalledOnce();
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });

--- a/apps/api/src/__tests__/routes/layers.test.ts
+++ b/apps/api/src/__tests__/routes/layers.test.ts
@@ -34,6 +34,7 @@ vi.mock("../../middleware/auth.js", () => mockAuthFactory());
 
 const { createLayer, listLayers, getLayer, updateLayer, deleteLayer, archiveLayer, restoreLayer } =
   await import("../../services/layer.service.js");
+const { createCategoryRateLimiter } = await import("../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -137,6 +138,10 @@ describe("GET /systems/:id/layers", () => {
       undefined,
       expect.any(Number),
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });
 

--- a/apps/api/src/__tests__/routes/lifecycle-events.test.ts
+++ b/apps/api/src/__tests__/routes/lifecycle-events.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../middleware/auth.js", () => mockAuthFactory());
 
 const { createLifecycleEvent, listLifecycleEvents, getLifecycleEvent } =
   await import("../../services/lifecycle-event.service.js");
+const { createCategoryRateLimiter } = await import("../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -134,6 +135,10 @@ describe("GET /systems/:id/lifecycle-events", () => {
       expect.any(Number),
       undefined,
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });
 

--- a/apps/api/src/__tests__/routes/members/fields/list.test.ts
+++ b/apps/api/src/__tests__/routes/members/fields/list.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listFieldValues } = await import("../../../../services/field-value.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -103,6 +104,10 @@ describe("GET /systems/:systemId/members/:memberId/fields", () => {
       MEM_ID,
       MOCK_AUTH,
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/members/get.test.ts
+++ b/apps/api/src/__tests__/routes/members/get.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getMember } = await import("../../../services/member.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -119,6 +120,10 @@ describe("GET /systems/:systemId/members/:memberId", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/members/list.test.ts
+++ b/apps/api/src/__tests__/routes/members/list.test.ts
@@ -38,6 +38,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listMembers } = await import("../../../services/member.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -168,6 +169,10 @@ describe("GET /systems/:systemId/members", () => {
       limit: 25,
       includeArchived: true,
     });
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/members/memberships.test.ts
+++ b/apps/api/src/__tests__/routes/members/memberships.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listAllMemberMemberships } = await import("../../../services/member.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -104,6 +105,10 @@ describe("GET /systems/:systemId/members/:memberId/memberships", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/members/photos/list.test.ts
+++ b/apps/api/src/__tests__/routes/members/photos/list.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listMemberPhotos } = await import("../../../../services/member-photo.service.js");
+const { createCategoryRateLimiter } = await import("../../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -102,6 +103,10 @@ describe("GET /systems/:systemId/members/:memberId/photos", () => {
       MEM_ID,
       MOCK_AUTH,
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/relationships.test.ts
+++ b/apps/api/src/__tests__/routes/relationships.test.ts
@@ -41,6 +41,7 @@ const {
   archiveRelationship,
   restoreRelationship,
 } = await import("../../services/relationship.service.js");
+const { createCategoryRateLimiter } = await import("../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -150,6 +151,10 @@ describe("GET /systems/:id/relationships", () => {
       expect.any(Number),
       undefined,
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });
 

--- a/apps/api/src/__tests__/routes/side-systems.test.ts
+++ b/apps/api/src/__tests__/routes/side-systems.test.ts
@@ -41,6 +41,7 @@ const {
   archiveSideSystem,
   restoreSideSystem,
 } = await import("../../services/side-system.service.js");
+const { createCategoryRateLimiter } = await import("../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -145,6 +146,10 @@ describe("GET /systems/:id/side-systems", () => {
       undefined,
       expect.any(Number),
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });
 

--- a/apps/api/src/__tests__/routes/structure-links.test.ts
+++ b/apps/api/src/__tests__/routes/structure-links.test.ts
@@ -45,6 +45,7 @@ const {
   deleteSideSystemLayerLink,
   listSideSystemLayerLinks,
 } = await import("../../services/structure-link.service.js");
+const { createCategoryRateLimiter } = await import("../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -113,6 +114,10 @@ describe("GET /systems/:id/structure-links/subsystem-layer", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { items: unknown[] };
     expect(body.items).toHaveLength(1);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });
 

--- a/apps/api/src/__tests__/routes/structure-memberships.test.ts
+++ b/apps/api/src/__tests__/routes/structure-memberships.test.ts
@@ -65,6 +65,7 @@ vi.mock("../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const service = await import("../../services/structure-membership.service.js");
+const { createCategoryRateLimiter } = await import("../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
 const { ApiHttpError } = await import("../../lib/api-error.js");
 
@@ -373,6 +374,10 @@ for (const variant of VARIANTS) {
       expect(res.status).toBe(400);
       const body = (await res.json()) as ApiErrorResponse;
       expect(body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("applies the readDefault rate limit category", () => {
+      expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
     });
 
     it("returns 500 for unexpected errors", async () => {

--- a/apps/api/src/__tests__/routes/subsystems.test.ts
+++ b/apps/api/src/__tests__/routes/subsystems.test.ts
@@ -41,6 +41,7 @@ const {
   archiveSubsystem,
   restoreSubsystem,
 } = await import("../../services/subsystem.service.js");
+const { createCategoryRateLimiter } = await import("../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -149,6 +150,10 @@ describe("GET /systems/:id/subsystems", () => {
       undefined,
       expect.any(Number),
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 });
 

--- a/apps/api/src/__tests__/routes/systems/get.test.ts
+++ b/apps/api/src/__tests__/routes/systems/get.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { getSystemProfile } = await import("../../../services/system.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -103,6 +104,10 @@ describe("GET /systems/:id", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/systems/list.test.ts
+++ b/apps/api/src/__tests__/routes/systems/list.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 // ── Imports after mocks ──────────────────────────────────────────
 
 const { listSystems } = await import("../../../services/system.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { systemRoutes } = await import("../../../routes/systems/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -180,6 +181,10 @@ describe("GET /systems", () => {
       undefined,
       25,
     );
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/systems/nomenclature.test.ts
+++ b/apps/api/src/__tests__/routes/systems/nomenclature.test.ts
@@ -29,6 +29,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 
 const { getNomenclatureSettings, updateNomenclatureSettings } =
   await import("../../../services/nomenclature.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { nomenclatureRoutes } = await import("../../../routes/systems/nomenclature/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -66,6 +67,10 @@ describe("GET /:id/nomenclature", () => {
     const body = (await res.json()) as typeof MOCK_RESULT;
     expect(body.systemId).toBe(SYS_ID);
     expect(body.version).toBe(1);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors", async () => {

--- a/apps/api/src/__tests__/routes/systems/settings.test.ts
+++ b/apps/api/src/__tests__/routes/systems/settings.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 
 const { getSystemSettings, updateSystemSettings } =
   await import("../../../services/system-settings.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { settingsRoutes } = await import("../../../routes/systems/settings/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -77,6 +78,10 @@ describe("GET /:id/settings", () => {
     const body = (await res.json()) as typeof MOCK_SETTINGS;
     expect(body.id).toBe("sset_abc");
     expect(body.locale).toBe("en-US");
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors", async () => {

--- a/apps/api/src/__tests__/routes/systems/setup.test.ts
+++ b/apps/api/src/__tests__/routes/systems/setup.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../../middleware/auth.js", () => mockAuthFactory());
 
 const { getSetupStatus, setupNomenclatureStep, setupProfileStep, setupComplete } =
   await import("../../../services/setup.service.js");
+const { createCategoryRateLimiter } = await import("../../../middleware/rate-limit.js");
 const { setupRoutes } = await import("../../../routes/systems/setup/index.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -81,6 +82,10 @@ describe("GET /:id/setup/status", () => {
     const body = (await res.json()) as typeof MOCK_STATUS;
     expect(body.isComplete).toBe(false);
     expect(body.nomenclatureComplete).toBe(false);
+  });
+
+  it("applies the readDefault rate limit category", () => {
+    expect(vi.mocked(createCategoryRateLimiter)).toHaveBeenCalledWith("readDefault");
   });
 
   it("re-throws unexpected errors", async () => {

--- a/apps/api/src/routes/blobs/download-url.ts
+++ b/apps/api/src/routes/blobs/download-url.ts
@@ -4,12 +4,14 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
 import { getStorageAdapter } from "../../lib/storage.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getDownloadUrl } from "../../services/blob.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const downloadUrlRoute = new Hono<AuthEnv>();
 
+downloadUrlRoute.use("*", createCategoryRateLimiter("readDefault"));
 downloadUrlRoute.get("/:blobId/download-url", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/blobs/get.ts
+++ b/apps/api/src/routes/blobs/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getBlob } from "../../services/blob.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:blobId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/buckets/rotations/progress.ts
+++ b/apps/api/src/routes/buckets/rotations/progress.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { getRotationProgress } from "../../../services/key-rotation.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const progressRoute = new Hono<AuthEnv>();
 
+progressRoute.use("*", createCategoryRateLimiter("readDefault"));
 progressRoute.get("/:rotationId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/custom-fronts/get.ts
+++ b/apps/api/src/routes/custom-fronts/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getCustomFront } from "../../services/custom-front.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:customFrontId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/custom-fronts/list.ts
+++ b/apps/api/src/routes/custom-fronts/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listCustomFronts } from "../../services/custom-front.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/fields/get.ts
+++ b/apps/api/src/routes/fields/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getFieldDefinition } from "../../services/field-definition.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:fieldId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/fields/list.ts
+++ b/apps/api/src/routes/fields/list.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { listFieldDefinitions } from "../../services/field-definition.service.js";
 
 import { DEFAULT_FIELD_LIMIT, MAX_FIELD_LIMIT } from "./fields.constants.js";
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/groups/get.ts
+++ b/apps/api/src/routes/groups/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getGroup } from "../../services/group.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:groupId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/groups/list.ts
+++ b/apps/api/src/routes/groups/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listGroups } from "../../services/group.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/groups/members/list.ts
+++ b/apps/api/src/routes/groups/members/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
 import { parsePaginationLimit } from "../../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../../service.constants.js";
 import { listGroupMembers } from "../../../services/group-membership.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/groups/tree.ts
+++ b/apps/api/src/routes/groups/tree.ts
@@ -3,11 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getGroupTree } from "../../services/group.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const treeRoute = new Hono<AuthEnv>();
+
+treeRoute.use("*", createCategoryRateLimiter("readHeavy"));
 
 treeRoute.get("/tree", async (c) => {
   const auth = c.get("auth");

--- a/apps/api/src/routes/innerworld/canvas/index.ts
+++ b/apps/api/src/routes/innerworld/canvas/index.ts
@@ -12,7 +12,10 @@ import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const canvasRoutes = new Hono<AuthEnv>();
 
-canvasRoutes.get("/", async (c) => {
+const canvasReadRoutes = new Hono<AuthEnv>();
+canvasReadRoutes.use("*", createCategoryRateLimiter("readDefault"));
+
+canvasReadRoutes.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
 
@@ -20,6 +23,8 @@ canvasRoutes.get("/", async (c) => {
   const result = await getCanvas(db, systemId, auth);
   return c.json(result);
 });
+
+canvasRoutes.route("/", canvasReadRoutes);
 
 const canvasWriteRoutes = new Hono<AuthEnv>();
 canvasWriteRoutes.use("*", createCategoryRateLimiter("write"));

--- a/apps/api/src/routes/innerworld/entities/get.ts
+++ b/apps/api/src/routes/innerworld/entities/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { getEntity } from "../../../services/innerworld-entity.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:entityId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/innerworld/entities/list.ts
+++ b/apps/api/src/routes/innerworld/entities/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
 import { parsePaginationLimit } from "../../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { listEntities } from "../../../services/innerworld-entity.service.js";
 
 import { DEFAULT_ENTITY_LIMIT, MAX_ENTITY_LIMIT } from "./entities.constants.js";
@@ -13,6 +14,7 @@ import type { InnerWorldRegionId } from "@pluralscape/types";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/innerworld/regions/get.ts
+++ b/apps/api/src/routes/innerworld/regions/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { getRegion } from "../../../services/innerworld-region.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:regionId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/innerworld/regions/list.ts
+++ b/apps/api/src/routes/innerworld/regions/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
 import { parsePaginationLimit } from "../../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { listRegions } from "../../../services/innerworld-region.service.js";
 
 import { DEFAULT_REGION_LIMIT, MAX_REGION_LIMIT } from "./regions.constants.js";
@@ -12,6 +13,7 @@ import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/layers/get.ts
+++ b/apps/api/src/routes/layers/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getLayer } from "../../services/layer.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:layerId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/layers/list.ts
+++ b/apps/api/src/routes/layers/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listLayers } from "../../services/layer.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/layers/memberships/index.ts
+++ b/apps/api/src/routes/layers/memberships/index.ts
@@ -47,6 +47,7 @@ removeRoute.delete("/:membershipId", async (c) => {
 });
 
 const listRoute = new Hono<AuthEnv>();
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/lifecycle-events/get.ts
+++ b/apps/api/src/routes/lifecycle-events/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getLifecycleEvent } from "../../services/lifecycle-event.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:eventId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/lifecycle-events/list.ts
+++ b/apps/api/src/routes/lifecycle-events/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listLifecycleEvents } from "../../services/lifecycle-event.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/members/fields/list.ts
+++ b/apps/api/src/routes/members/fields/list.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { listFieldValues } from "../../../services/field-value.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/members/get.ts
+++ b/apps/api/src/routes/members/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getMember } from "../../services/member.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:memberId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/members/list.ts
+++ b/apps/api/src/routes/members/list.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { listMembers } from "../../services/member.service.js";
 
 import { DEFAULT_MEMBER_LIMIT, MAX_MEMBER_LIMIT } from "./members.constants.js";
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/members/memberships.ts
+++ b/apps/api/src/routes/members/memberships.ts
@@ -3,11 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { listAllMemberMemberships } from "../../services/member.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const membershipsRoute = new Hono<AuthEnv>();
+
+membershipsRoute.use("*", createCategoryRateLimiter("readDefault"));
 
 membershipsRoute.get("/", async (c) => {
   const auth = c.get("auth");

--- a/apps/api/src/routes/members/photos/list.ts
+++ b/apps/api/src/routes/members/photos/list.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { listMemberPhotos } from "../../../services/member-photo.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/relationships/get.ts
+++ b/apps/api/src/routes/relationships/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getRelationship } from "../../services/relationship.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:relationshipId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/relationships/list.ts
+++ b/apps/api/src/routes/relationships/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listRelationships } from "../../services/relationship.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/side-systems/get.ts
+++ b/apps/api/src/routes/side-systems/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getSideSystem } from "../../services/side-system.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:sideSystemId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/side-systems/list.ts
+++ b/apps/api/src/routes/side-systems/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listSideSystems } from "../../services/side-system.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/side-systems/memberships/index.ts
+++ b/apps/api/src/routes/side-systems/memberships/index.ts
@@ -51,6 +51,7 @@ removeRoute.delete("/:membershipId", async (c) => {
 });
 
 const listRoute = new Hono<AuthEnv>();
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/structure-links/index.ts
+++ b/apps/api/src/routes/structure-links/index.ts
@@ -54,6 +54,7 @@ slDelete.delete("/subsystem-layer/:linkId", async (c) => {
 });
 
 const slList = new Hono<AuthEnv>();
+slList.use("*", createCategoryRateLimiter("readDefault"));
 slList.get("/subsystem-layer", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
@@ -104,6 +105,7 @@ ssDelete.delete("/subsystem-side-system/:linkId", async (c) => {
 });
 
 const ssList = new Hono<AuthEnv>();
+ssList.use("*", createCategoryRateLimiter("readDefault"));
 ssList.get("/subsystem-side-system", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
@@ -154,6 +156,7 @@ sslDelete.delete("/side-system-layer/:linkId", async (c) => {
 });
 
 const sslList = new Hono<AuthEnv>();
+sslList.use("*", createCategoryRateLimiter("readDefault"));
 sslList.get("/side-system-layer", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/subsystems/get.ts
+++ b/apps/api/src/routes/subsystems/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getSubsystem } from "../../services/subsystem.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:subsystemId", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/subsystems/list.ts
+++ b/apps/api/src/routes/subsystems/list.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listSubsystems } from "../../services/subsystem.service.js";
 
@@ -11,6 +12,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/subsystems/memberships/index.ts
+++ b/apps/api/src/routes/subsystems/memberships/index.ts
@@ -51,6 +51,7 @@ removeRoute.delete("/:membershipId", async (c) => {
 });
 
 const listRoute = new Hono<AuthEnv>();
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/systems/get.ts
+++ b/apps/api/src/routes/systems/get.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parseIdParam } from "../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { getSystemProfile } from "../../services/system.service.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const getRoute = new Hono<AuthEnv>();
 
+getRoute.use("*", createCategoryRateLimiter("readDefault"));
 getRoute.get("/:id", async (c) => {
   const auth = c.get("auth");
   const systemId = parseIdParam(c.req.param("id"), ID_PREFIXES.system);

--- a/apps/api/src/routes/systems/list.ts
+++ b/apps/api/src/routes/systems/list.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 
 import { getDb } from "../../lib/db.js";
 import { parsePaginationLimit } from "../../lib/pagination.js";
+import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { listSystems } from "../../services/system.service.js";
 
@@ -10,6 +11,7 @@ import type { AuthEnv } from "../../lib/auth-context.js";
 
 export const listRoute = new Hono<AuthEnv>();
 
+listRoute.use("*", createCategoryRateLimiter("readDefault"));
 listRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const cursorParam = c.req.query("cursor");

--- a/apps/api/src/routes/systems/nomenclature/get-nomenclature.ts
+++ b/apps/api/src/routes/systems/nomenclature/get-nomenclature.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { getNomenclatureSettings } from "../../../services/nomenclature.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const getNomenclatureRoute = new Hono<AuthEnv>();
 
+getNomenclatureRoute.use("*", createCategoryRateLimiter("readDefault"));
 getNomenclatureRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/systems/settings/get-settings.ts
+++ b/apps/api/src/routes/systems/settings/get-settings.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { getSystemSettings } from "../../../services/system-settings.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const getSettingsRoute = new Hono<AuthEnv>();
 
+getSettingsRoute.use("*", createCategoryRateLimiter("readDefault"));
 getSettingsRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/apps/api/src/routes/systems/setup/status.ts
+++ b/apps/api/src/routes/systems/setup/status.ts
@@ -3,12 +3,14 @@ import { Hono } from "hono";
 
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
+import { createCategoryRateLimiter } from "../../../middleware/rate-limit.js";
 import { getSetupStatus } from "../../../services/setup.service.js";
 
 import type { AuthEnv } from "../../../lib/auth-context.js";
 
 export const setupStatusRoute = new Hono<AuthEnv>();
 
+setupStatusRoute.use("*", createCategoryRateLimiter("readDefault"));
 setupStatusRoute.get("/", async (c) => {
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);

--- a/packages/types/src/api-constants.ts
+++ b/packages/types/src/api-constants.ts
@@ -51,6 +51,8 @@ const RATE_LIMIT_AUTH_HEAVY = 5;
 const RATE_LIMIT_AUTH_LIGHT = 20;
 const RATE_LIMIT_DEVICE_TRANSFER = 10;
 const RATE_LIMIT_WRITE = 60;
+const RATE_LIMIT_READ_DEFAULT = 60;
+const RATE_LIMIT_READ_HEAVY = 30;
 const RATE_LIMIT_BLOB_UPLOAD = 20;
 const RATE_LIMIT_WEBHOOK = 20;
 const RATE_LIMIT_EXPORT_IMPORT = 2;
@@ -65,6 +67,8 @@ export const RATE_LIMITS = {
   authLight: { limit: RATE_LIMIT_AUTH_LIGHT, windowMs: MS_PER_MINUTE },
   deviceTransfer: { limit: RATE_LIMIT_DEVICE_TRANSFER, windowMs: MS_PER_MINUTE },
   write: { limit: RATE_LIMIT_WRITE, windowMs: MS_PER_MINUTE },
+  readDefault: { limit: RATE_LIMIT_READ_DEFAULT, windowMs: MS_PER_MINUTE },
+  readHeavy: { limit: RATE_LIMIT_READ_HEAVY, windowMs: MS_PER_MINUTE },
   blobUpload: { limit: RATE_LIMIT_BLOB_UPLOAD, windowMs: MS_PER_MINUTE },
   webhookManagement: { limit: RATE_LIMIT_WEBHOOK, windowMs: MS_PER_MINUTE },
   dataExport: { limit: RATE_LIMIT_EXPORT_IMPORT, windowMs: MS_PER_HOUR },


### PR DESCRIPTION
## Summary

Addresses audit 012 finding S-10: many GET/read endpoints only relied on the global 100/min rate limit. This adds dedicated per-category rate limits to all unprotected read routes, giving finer-grained control over read traffic.

## Changes

- Adds two new rate limit categories in `packages/types/src/api-constants.ts`:
  - `readDefault` (60 requests/min) for standard CRUD reads
  - `readHeavy` (30 requests/min) for expensive operations like tree traversals
- Applies `readDefault` to all get-by-id, list, settings, membership, and structure-link read endpoints across every domain (members, groups, fields, layers, blobs, custom-fronts, relationships, side-systems, subsystems, lifecycle events, innerworld, systems)
- Applies `readHeavy` to the groups/tree endpoint
- Adds rate limit category assertions to all 32 affected route test files

## Test Plan

- [x] All 1503 API tests pass (158 test files)
- [x] Each new rate limit has a corresponding test asserting `createCategoryRateLimiter` is called with the correct category
- [x] TypeScript typecheck passes
- [x] ESLint passes with zero warnings
- [x] Prettier formatting clean

## Review Checklist

- [x] Privacy: new data defaults to maximum restriction (fail-closed)
- [x] Offline: works correctly without network connectivity
- [x] Data lifecycle: deletions are intentional, confirmed, and handle cascading references
- [x] Accessibility: UI changes meet WCAG guidelines
- [x] Domain terms used correctly (community terminology, not clinical language)

## Deferred Items

- None