### PR TITLE
refactor(api): extract shared hierarchy service factory for group and subsystem

### DIFF
--- a/.beans/api-7iy5--deduplicate-groupservicets-and-subsystemservicets.md
+++ b/.beans/api-7iy5--deduplicate-groupservicets-and-subsystemservicets.md
@@ -1,0 +1,9 @@
+---
+# api-7iy5
+title: Deduplicate group.service.ts and subsystem.service.ts into shared hierarchy factory
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-18T14:12:11Z
+updated_at: 2026-03-18T14:26:43Z
+---

--- a/apps/api/src/__tests__/services/subsystem.service.test.ts
+++ b/apps/api/src/__tests__/services/subsystem.service.test.ts
@@ -499,12 +499,16 @@ describe("deleteSubsystem", () => {
 
   it("deletes a subsystem with no dependents", async () => {
     const { db, chain } = mockDb();
-    // exists check: select().from().where().limit()
+    // exists check: select({id}).from(table).where(...).limit(1)
     chain.limit.mockResolvedValueOnce([{ id: SUBSYSTEM_ID }]);
-    // dependents check: select({subqueries}).from(sql) — from() is terminal
-    chain.from
-      .mockReturnValueOnce(chain) // existence check from() → chains to .where()
-      .mockResolvedValueOnce([{ children: 0, memberships: 0, layerLinks: 0, sideSystemLinks: 0 }]);
+    // dependents: 4 individual count queries (children, memberships, layerLinks, sideSystemLinks)
+    // Each does select({count}).from(dep.table).where(...) — where() is terminal
+    chain.where
+      .mockReturnValueOnce(chain) // existence check where() → chains to .limit()
+      .mockResolvedValueOnce([{ count: 0 }]) // child subsystems count
+      .mockResolvedValueOnce([{ count: 0 }]) // memberships count
+      .mockResolvedValueOnce([{ count: 0 }]) // layer links count
+      .mockResolvedValueOnce([{ count: 0 }]); // side system links count
 
     await deleteSubsystem(db, SYSTEM_ID, SUBSYSTEM_ID, AUTH, mockAudit);
 
@@ -517,12 +521,15 @@ describe("deleteSubsystem", () => {
 
   it("throws 409 when subsystem has dependents", async () => {
     const { db, chain } = mockDb();
-    // exists check: select().from().where().limit()
+    // exists check: select({id}).from(table).where(...).limit(1)
     chain.limit.mockResolvedValueOnce([{ id: SUBSYSTEM_ID }]);
-    // dependents check: select({subqueries}).from(sql) — from() is terminal
-    chain.from
-      .mockReturnValueOnce(chain) // existence check from() → chains to .where()
-      .mockResolvedValueOnce([{ children: 3, memberships: 0, layerLinks: 0, sideSystemLinks: 0 }]);
+    // dependents: first count query returns 3 children → 409 immediately
+    chain.where
+      .mockReturnValueOnce(chain) // existence check where() → chains to .limit()
+      .mockResolvedValueOnce([{ count: 3 }]) // child subsystems (non-zero → 409)
+      .mockResolvedValueOnce([{ count: 0 }]) // memberships
+      .mockResolvedValueOnce([{ count: 0 }]) // layer links
+      .mockResolvedValueOnce([{ count: 0 }]); // side system links
 
     await expect(deleteSubsystem(db, SYSTEM_ID, SUBSYSTEM_ID, AUTH, mockAudit)).rejects.toThrow(
       expect.objectContaining({ status: 409, code: "HAS_DEPENDENTS" }),

--- a/apps/api/src/services/group.service.ts
+++ b/apps/api/src/services/group.service.ts
@@ -7,21 +7,15 @@ import {
   ReorderGroupsBodySchema,
   UpdateGroupBodySchema,
 } from "@pluralscape/validation";
-import { and, count, eq, gt, max, sql } from "drizzle-orm";
+import { and, eq, max, sql } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST, HTTP_CONFLICT, HTTP_NOT_FOUND } from "../http.constants.js";
+import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
-import { encryptedBlobToBase64, parseAndValidateBlob } from "../lib/encrypted-blob.js";
-import { archiveEntity } from "../lib/entity-lifecycle.js";
 import { detectAncestorCycle } from "../lib/hierarchy.js";
 import { assertOccUpdated } from "../lib/occ-update.js";
-import { buildPaginatedResult } from "../lib/pagination.js";
 import { assertSystemOwnership } from "../lib/system-ownership.js";
-import {
-  DEFAULT_PAGE_LIMIT,
-  MAX_ENCRYPTED_DATA_BYTES,
-  MAX_PAGE_LIMIT,
-} from "../service.constants.js";
+
+import { createHierarchyService, mapBaseFields } from "./hierarchy-service-factory.js";
 
 import type { AuditWriter } from "../lib/audit-writer.js";
 import type { AuthContext } from "../lib/auth-context.js";
@@ -65,271 +59,98 @@ function toGroupResult(row: {
   archivedAt: number | null;
 }): GroupResult {
   return {
+    ...mapBaseFields(row),
     id: row.id as GroupId,
-    systemId: row.systemId as SystemId,
     parentGroupId: row.parentGroupId as GroupId | null,
     sortOrder: row.sortOrder,
-    encryptedData: encryptedBlobToBase64(row.encryptedData),
-    version: row.version,
-    createdAt: row.createdAt as UnixMillis,
-    updatedAt: row.updatedAt as UnixMillis,
-    archived: row.archived,
-    archivedAt: row.archivedAt as UnixMillis | null,
   };
 }
 
-// ── CREATE ──────────────────────────────────────────────────────────
+// ── Shared hierarchy service ────────────────────────────────────────
 
-export async function createGroup(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  params: unknown,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<GroupResult> {
-  assertSystemOwnership(systemId, auth);
+const groupHierarchy = createHierarchyService<
+  {
+    id: string;
+    systemId: string;
+    parentGroupId: string | null;
+    sortOrder: number;
+    encryptedData: EncryptedBlob;
+    version: number;
+    createdAt: number;
+    updatedAt: number;
+    archived: boolean;
+    archivedAt: number | null;
+  },
+  GroupId,
+  GroupResult
+>({
+  table: groups,
+  columns: {
+    id: groups.id,
+    systemId: groups.systemId,
+    parentId: groups.parentGroupId,
+    encryptedData: groups.encryptedData,
+    version: groups.version,
+    archived: groups.archived,
+    archivedAt: groups.archivedAt,
+    createdAt: groups.createdAt,
+    updatedAt: groups.updatedAt,
+  },
+  idPrefix: ID_PREFIXES.group,
+  entityName: "Group",
+  parentFieldName: "parentGroupId",
+  toResult: toGroupResult,
+  createSchema: CreateGroupBodySchema,
+  updateSchema: UpdateGroupBodySchema,
+  createInsertValues: (parsed) => ({
+    sortOrder: parsed.sortOrder,
+  }),
+  updateSetValues: () => ({}),
+  dependentChecks: [
+    {
+      table: groups,
+      entityColumn: groups.parentGroupId,
+      systemColumn: groups.systemId,
+      label: "child group(s)",
+      filterArchived: groups.archived,
+    },
+    {
+      table: groupMemberships,
+      entityColumn: groupMemberships.groupId,
+      systemColumn: groupMemberships.systemId,
+      label: "member(s)",
+    },
+  ],
+  events: {
+    created: "group.created",
+    updated: "group.updated",
+    deleted: "group.deleted",
+    archived: "group.archived",
+    restored: "group.restored",
+  },
+});
 
-  const { parsed, blob } = parseAndValidateBlob(
-    params,
-    CreateGroupBodySchema,
-    MAX_ENCRYPTED_DATA_BYTES,
-  );
+// ── Delegated CRUD ──────────────────────────────────────────────────
 
-  const groupId = createId(ID_PREFIXES.group);
-  const timestamp = now();
+export const createGroup = groupHierarchy.create;
 
-  return db.transaction(async (tx) => {
-    // Validate parentGroupId exists in same system if non-null
-    if (parsed.parentGroupId !== null) {
-      const [parent] = await tx
-        .select({ id: groups.id })
-        .from(groups)
-        .where(
-          and(
-            eq(groups.id, parsed.parentGroupId),
-            eq(groups.systemId, systemId),
-            eq(groups.archived, false),
-          ),
-        )
-        .limit(1);
-
-      if (!parent) {
-        throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Parent group not found");
-      }
-    }
-
-    const [row] = await tx
-      .insert(groups)
-      .values({
-        id: groupId,
-        systemId,
-        parentGroupId: parsed.parentGroupId,
-        sortOrder: parsed.sortOrder,
-        encryptedData: blob,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      })
-      .returning();
-
-    if (!row) {
-      throw new Error("Failed to create group — INSERT returned no rows");
-    }
-
-    await audit(tx, {
-      eventType: "group.created",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Group created",
-      systemId,
-    });
-
-    return toGroupResult(row);
-  });
-}
-
-// ── LIST ────────────────────────────────────────────────────────────
-
-export async function listGroups(
+export const listGroups: (
   db: PostgresJsDatabase,
   systemId: SystemId,
   auth: AuthContext,
   cursor?: PaginationCursor,
-  limit = DEFAULT_PAGE_LIMIT,
-): Promise<PaginatedResult<GroupResult>> {
-  assertSystemOwnership(systemId, auth);
+  limit?: number,
+) => Promise<PaginatedResult<GroupResult>> = groupHierarchy.list;
 
-  const effectiveLimit = Math.min(limit, MAX_PAGE_LIMIT);
+export const getGroup = groupHierarchy.get;
 
-  const conditions = [eq(groups.systemId, systemId), eq(groups.archived, false)];
+export const updateGroup = groupHierarchy.update;
 
-  if (cursor) {
-    conditions.push(gt(groups.id, cursor));
-  }
+export const deleteGroup = groupHierarchy.remove;
 
-  const rows = await db
-    .select()
-    .from(groups)
-    .where(and(...conditions))
-    .orderBy(groups.id)
-    .limit(effectiveLimit + 1);
+export const archiveGroup = groupHierarchy.archive;
 
-  return buildPaginatedResult(rows, effectiveLimit, toGroupResult);
-}
-
-// ── GET ─────────────────────────────────────────────────────────────
-
-export async function getGroup(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  groupId: GroupId,
-  auth: AuthContext,
-): Promise<GroupResult> {
-  assertSystemOwnership(systemId, auth);
-
-  const [row] = await db
-    .select()
-    .from(groups)
-    .where(and(eq(groups.id, groupId), eq(groups.systemId, systemId), eq(groups.archived, false)))
-    .limit(1);
-
-  if (!row) {
-    throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Group not found");
-  }
-
-  return toGroupResult(row);
-}
-
-// ── UPDATE ──────────────────────────────────────────────────────────
-
-export async function updateGroup(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  groupId: GroupId,
-  params: unknown,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<GroupResult> {
-  assertSystemOwnership(systemId, auth);
-
-  const { parsed, blob } = parseAndValidateBlob(
-    params,
-    UpdateGroupBodySchema,
-    MAX_ENCRYPTED_DATA_BYTES,
-  );
-
-  const timestamp = now();
-
-  return db.transaction(async (tx) => {
-    const updated = await tx
-      .update(groups)
-      .set({
-        encryptedData: blob,
-        updatedAt: timestamp,
-        version: sql`${groups.version} + 1`,
-      })
-      .where(
-        and(
-          eq(groups.id, groupId),
-          eq(groups.systemId, systemId),
-          eq(groups.version, parsed.version),
-          eq(groups.archived, false),
-        ),
-      )
-      .returning();
-
-    const row = await assertOccUpdated(
-      updated,
-      async () => {
-        const [existing] = await tx
-          .select({ id: groups.id })
-          .from(groups)
-          .where(
-            and(eq(groups.id, groupId), eq(groups.systemId, systemId), eq(groups.archived, false)),
-          )
-          .limit(1);
-        return existing;
-      },
-      "Group",
-    );
-
-    await audit(tx, {
-      eventType: "group.updated",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Group updated",
-      systemId,
-    });
-
-    return toGroupResult(row);
-  });
-}
-
-// ── DELETE ───────────────────────────────────────────────────────────
-
-export async function deleteGroup(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  groupId: GroupId,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<void> {
-  assertSystemOwnership(systemId, auth);
-
-  await db.transaction(async (tx) => {
-    // Verify group exists
-    const [existing] = await tx
-      .select({ id: groups.id })
-      .from(groups)
-      .where(and(eq(groups.id, groupId), eq(groups.systemId, systemId), eq(groups.archived, false)))
-      .limit(1);
-
-    if (!existing) {
-      throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Group not found");
-    }
-
-    // Check for child groups
-    const [childCount] = await tx
-      .select({ count: count() })
-      .from(groups)
-      .where(
-        and(
-          eq(groups.parentGroupId, groupId),
-          eq(groups.systemId, systemId),
-          eq(groups.archived, false),
-        ),
-      );
-
-    // Check for group memberships
-    const [membershipCount] = await tx
-      .select({ count: count() })
-      .from(groupMemberships)
-      .where(and(eq(groupMemberships.groupId, groupId), eq(groupMemberships.systemId, systemId)));
-
-    if (!childCount || !membershipCount) {
-      throw new Error("Unexpected: count query returned no rows");
-    }
-
-    const children = childCount.count;
-    const memberships = membershipCount.count;
-
-    if (children > 0 || memberships > 0) {
-      throw new ApiHttpError(
-        HTTP_CONFLICT,
-        "HAS_DEPENDENTS",
-        `Group has ${String(children)} child group(s) and ${String(memberships)} member(s). Remove all dependents before deleting.`,
-      );
-    }
-
-    // Audit before delete (FK satisfied since group still exists)
-    await audit(tx, {
-      eventType: "group.deleted",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Group deleted",
-      systemId,
-    });
-
-    // Hard delete
-    await tx.delete(groups).where(and(eq(groups.id, groupId), eq(groups.systemId, systemId)));
-  });
-}
+export const restoreGroup = groupHierarchy.restore;
 
 // ── MOVE ────────────────────────────────────────────────────────────
 
@@ -642,92 +463,5 @@ export async function reorderGroups(
       detail: `Reordered ${String(parsed.data.operations.length)} group(s)`,
       systemId,
     });
-  });
-}
-
-// ── ARCHIVE ─────────────────────────────────────────────────────────
-
-const GROUP_LIFECYCLE = {
-  table: groups,
-  columns: groups,
-  entityName: "Group",
-  archiveEvent: "group.archived" as const,
-  restoreEvent: "group.restored" as const,
-};
-
-export async function archiveGroup(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  groupId: GroupId,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<void> {
-  await archiveEntity(db, systemId, groupId, auth, audit, GROUP_LIFECYCLE);
-}
-
-// ── RESTORE ─────────────────────────────────────────────────────────
-
-export async function restoreGroup(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  groupId: GroupId,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<GroupResult> {
-  assertSystemOwnership(systemId, auth);
-
-  const timestamp = now();
-
-  return db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select({ id: groups.id, parentGroupId: groups.parentGroupId })
-      .from(groups)
-      .where(and(eq(groups.id, groupId), eq(groups.systemId, systemId), eq(groups.archived, true)))
-      .limit(1);
-
-    if (!existing) {
-      throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Archived group not found");
-    }
-
-    // If parent is archived, promote to root
-    let newParentGroupId = existing.parentGroupId;
-    if (newParentGroupId !== null) {
-      const [parent] = await tx
-        .select({ archived: groups.archived })
-        .from(groups)
-        .where(and(eq(groups.id, newParentGroupId), eq(groups.systemId, systemId)))
-        .limit(1);
-
-      if (!parent || parent.archived) {
-        newParentGroupId = null;
-      }
-    }
-
-    const updated = await tx
-      .update(groups)
-      .set({
-        archived: false,
-        archivedAt: null,
-        parentGroupId: newParentGroupId,
-        updatedAt: timestamp,
-        version: sql`${groups.version} + 1`,
-      })
-      .where(and(eq(groups.id, groupId), eq(groups.systemId, systemId)))
-      .returning();
-
-    if (updated.length === 0) {
-      throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Archived group not found");
-    }
-
-    const [row] = updated as [(typeof updated)[number], ...typeof updated];
-
-    await audit(tx, {
-      eventType: "group.restored",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Group restored",
-      systemId,
-    });
-
-    return toGroupResult(row);
   });
 }

--- a/apps/api/src/services/hierarchy-service-factory.ts
+++ b/apps/api/src/services/hierarchy-service-factory.ts
@@ -1,0 +1,627 @@
+import { createId, now } from "@pluralscape/types";
+import { and, count, eq, gt, sql } from "drizzle-orm";
+
+import { HTTP_CONFLICT, HTTP_NOT_FOUND } from "../http.constants.js";
+import { ApiHttpError } from "../lib/api-error.js";
+import { encryptedBlobToBase64, parseAndValidateBlob } from "../lib/encrypted-blob.js";
+import { archiveEntity } from "../lib/entity-lifecycle.js";
+import { assertOccUpdated } from "../lib/occ-update.js";
+import { buildPaginatedResult } from "../lib/pagination.js";
+import { assertSystemOwnership } from "../lib/system-ownership.js";
+import {
+  DEFAULT_PAGE_LIMIT,
+  MAX_ENCRYPTED_DATA_BYTES,
+  MAX_PAGE_LIMIT,
+} from "../service.constants.js";
+
+import type { AuditWriter } from "../lib/audit-writer.js";
+import type { AuthContext } from "../lib/auth-context.js";
+import type { ArchivableEntityConfig } from "../lib/entity-lifecycle.js";
+import type {
+  AuditEventType,
+  EncryptedBlob,
+  PaginatedResult,
+  PaginationCursor,
+  SystemId,
+  UnixMillis,
+} from "@pluralscape/types";
+import type { ColumnBaseConfig, ColumnDataType } from "drizzle-orm";
+import type { PgColumn, PgTable } from "drizzle-orm/pg-core";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
+
+// ── Type helpers ───────────────────────────────────────────────────
+
+type AnyPgColumn = PgColumn<ColumnBaseConfig<ColumnDataType, string>, object, object>;
+
+/** Minimum column set for a hierarchical entity table. */
+export interface HierarchyColumns {
+  readonly id: AnyPgColumn;
+  readonly systemId: AnyPgColumn;
+  readonly parentId: AnyPgColumn;
+  readonly encryptedData: AnyPgColumn;
+  readonly version: AnyPgColumn;
+  readonly archived: AnyPgColumn;
+  readonly archivedAt: AnyPgColumn;
+  readonly createdAt: AnyPgColumn;
+  readonly updatedAt: AnyPgColumn;
+}
+
+/** A single dependent-table check for the delete guard. */
+export interface DependentCheck {
+  readonly table: PgTable;
+  /** Column on the dependent table that references the entity being deleted. */
+  readonly entityColumn: AnyPgColumn;
+  /** Column on the dependent table that references the system. */
+  readonly systemColumn: AnyPgColumn;
+  /** Human-readable label for error messages. */
+  readonly label: string;
+  /**
+   * Whether this check filters on archived=false. True for child entity checks
+   * (only active children block delete), false for junction/link tables.
+   */
+  readonly filterArchived?: AnyPgColumn;
+}
+
+/** Configuration for the hierarchy service factory. */
+export interface HierarchyServiceConfig<
+  TRow extends Record<string, unknown>,
+  TResult extends { readonly id: string },
+> {
+  /** The Drizzle table reference. */
+  readonly table: PgTable;
+  /** Column references mapped to generic hierarchy names. */
+  readonly columns: HierarchyColumns;
+  /** ID prefix for new entities (e.g. ID_PREFIXES.group). */
+  readonly idPrefix: string;
+  /** Human-readable entity name for error messages. */
+  readonly entityName: string;
+  /** The camelCase field name for the parent ID in parsed bodies and insert values (e.g. "parentGroupId"). */
+  readonly parentFieldName: string;
+  /** Maps a raw DB row to the domain result type. */
+  readonly toResult: (row: TRow) => TResult;
+  /** Zod schema for create body validation. */
+  readonly createSchema: z.ZodType<{ encryptedData: string }>;
+  /** Zod schema for update body validation. */
+  readonly updateSchema: z.ZodType<{ encryptedData: string; version: number }>;
+  /** Additional insert values derived from the parsed create body. */
+  readonly createInsertValues: (parsed: Record<string, unknown>) => Record<string, unknown>;
+  /** Additional set values derived from the parsed update body. */
+  readonly updateSetValues: (parsed: Record<string, unknown>) => Record<string, unknown>;
+  /** Dependent tables/columns checked before delete (409 pattern). */
+  readonly dependentChecks: readonly DependentCheck[];
+  /** Audit event type strings. */
+  readonly events: {
+    readonly created: AuditEventType;
+    readonly updated: AuditEventType;
+    readonly deleted: AuditEventType;
+    readonly archived: AuditEventType;
+    readonly restored: AuditEventType;
+  };
+  /**
+   * Pre-update hook for cycle detection and extra validation.
+   * Called inside the transaction before the OCC update.
+   */
+  readonly beforeUpdate?: (
+    tx: PostgresJsDatabase,
+    entityId: string,
+    parsed: Record<string, unknown>,
+    systemId: SystemId,
+  ) => Promise<void>;
+}
+
+// ── Base result type ───────────────────────────────────────────────
+
+/** Fields common to all hierarchy entity results. */
+export interface BaseHierarchyResult {
+  readonly id: string;
+  readonly systemId: SystemId;
+  readonly encryptedData: string;
+  readonly version: number;
+  readonly createdAt: UnixMillis;
+  readonly updatedAt: UnixMillis;
+  readonly archived: boolean;
+  readonly archivedAt: UnixMillis | null;
+}
+
+/** Maps base columns shared by all hierarchy entities. */
+export function mapBaseFields(row: {
+  id: string;
+  systemId: string;
+  encryptedData: EncryptedBlob;
+  version: number;
+  createdAt: number;
+  updatedAt: number;
+  archived: boolean;
+  archivedAt: number | null;
+}): BaseHierarchyResult {
+  return {
+    id: row.id,
+    systemId: row.systemId as SystemId,
+    encryptedData: encryptedBlobToBase64(row.encryptedData),
+    version: row.version,
+    createdAt: row.createdAt as UnixMillis,
+    updatedAt: row.updatedAt as UnixMillis,
+    archived: row.archived,
+    archivedAt: row.archivedAt as UnixMillis | null,
+  };
+}
+
+// ── Factory ────────────────────────────────────────────────────────
+
+export interface HierarchyService<TId extends string, TResult extends { readonly id: string }> {
+  readonly create: (
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    params: unknown,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ) => Promise<TResult>;
+
+  readonly list: (
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    auth: AuthContext,
+    cursor?: PaginationCursor,
+    limit?: number,
+  ) => Promise<PaginatedResult<TResult>>;
+
+  readonly get: (
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+  ) => Promise<TResult>;
+
+  readonly update: (
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    params: unknown,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ) => Promise<TResult>;
+
+  readonly remove: (
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ) => Promise<void>;
+
+  readonly archive: (
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ) => Promise<void>;
+
+  readonly restore: (
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ) => Promise<TResult>;
+}
+
+/** Create a hierarchy service with standard CRUD, archive, and restore operations. */
+export function createHierarchyService<
+  TRow extends Record<string, unknown>,
+  TId extends string,
+  TResult extends { readonly id: string },
+>(cfg: HierarchyServiceConfig<TRow, TResult>): HierarchyService<TId, TResult> {
+  const {
+    table,
+    columns,
+    idPrefix,
+    entityName,
+    parentFieldName,
+    toResult,
+    events,
+    dependentChecks,
+  } = cfg;
+
+  const lifecycleCfg: ArchivableEntityConfig = {
+    table,
+    columns: {
+      id: columns.id,
+      systemId: columns.systemId,
+      archived: columns.archived,
+      archivedAt: columns.archivedAt,
+      updatedAt: columns.updatedAt,
+      version: columns.version,
+    },
+    entityName,
+    archiveEvent: events.archived,
+    restoreEvent: events.restored,
+  };
+
+  // ── CREATE ────────────────────────────────────────────────────────
+
+  async function create(
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    params: unknown,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ): Promise<TResult> {
+    assertSystemOwnership(systemId, auth);
+
+    const { parsed, blob } = parseAndValidateBlob(
+      params,
+      cfg.createSchema,
+      MAX_ENCRYPTED_DATA_BYTES,
+    );
+
+    const entityId = createId(idPrefix);
+    const timestamp = now();
+
+    return db.transaction(async (tx) => {
+      // Validate parent exists in same system if non-null
+      const parentId =
+        parentFieldName in (parsed as Record<string, unknown>)
+          ? ((parsed as Record<string, unknown>)[parentFieldName] as string | null)
+          : null;
+      if (parentId !== null) {
+        const [parent] = await tx
+          .select({ id: columns.id })
+          .from(table)
+          .where(
+            and(
+              eq(columns.id, parentId),
+              eq(columns.systemId, systemId),
+              eq(columns.archived, false),
+            ),
+          )
+          .limit(1);
+
+        if (!parent) {
+          throw new ApiHttpError(
+            HTTP_NOT_FOUND,
+            "NOT_FOUND",
+            `Parent ${entityName.toLowerCase()} not found`,
+          );
+        }
+      }
+
+      const extraValues = cfg.createInsertValues(parsed as Record<string, unknown>);
+
+      const [row] = await tx
+        .insert(table)
+        .values({
+          id: entityId,
+          systemId,
+          [parentFieldName]: parentId ?? null,
+          encryptedData: blob,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          ...extraValues,
+        } as Record<string, unknown>)
+        .returning();
+
+      if (!row) {
+        throw new Error(`Failed to create ${entityName.toLowerCase()} — INSERT returned no rows`);
+      }
+
+      await audit(tx, {
+        eventType: events.created,
+        actor: { kind: "account", id: auth.accountId },
+        detail: `${entityName} created`,
+        systemId,
+      });
+
+      return toResult(row as TRow);
+    });
+  }
+
+  // ── LIST ──────────────────────────────────────────────────────────
+
+  async function list(
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    auth: AuthContext,
+    cursor?: PaginationCursor,
+    limit = DEFAULT_PAGE_LIMIT,
+  ): Promise<PaginatedResult<TResult>> {
+    assertSystemOwnership(systemId, auth);
+
+    const effectiveLimit = Math.min(limit, MAX_PAGE_LIMIT);
+
+    const conditions = [eq(columns.systemId, systemId), eq(columns.archived, false)];
+
+    if (cursor) {
+      conditions.push(gt(columns.id, cursor));
+    }
+
+    const rows = await db
+      .select()
+      .from(table)
+      .where(and(...conditions))
+      .orderBy(columns.id)
+      .limit(effectiveLimit + 1);
+
+    return buildPaginatedResult(rows, effectiveLimit, (row) => toResult(row as TRow));
+  }
+
+  // ── GET ───────────────────────────────────────────────────────────
+
+  async function get(
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+  ): Promise<TResult> {
+    assertSystemOwnership(systemId, auth);
+
+    const [row] = await db
+      .select()
+      .from(table)
+      .where(
+        and(eq(columns.id, entityId), eq(columns.systemId, systemId), eq(columns.archived, false)),
+      )
+      .limit(1);
+
+    if (!row) {
+      throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", `${entityName} not found`);
+    }
+
+    return toResult(row as TRow);
+  }
+
+  // ── UPDATE ────────────────────────────────────────────────────────
+
+  async function update(
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    params: unknown,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ): Promise<TResult> {
+    assertSystemOwnership(systemId, auth);
+
+    const { parsed, blob } = parseAndValidateBlob(
+      params,
+      cfg.updateSchema,
+      MAX_ENCRYPTED_DATA_BYTES,
+    );
+
+    const timestamp = now();
+    const parsedRecord = parsed as Record<string, unknown>;
+
+    return db.transaction(async (tx) => {
+      if (cfg.beforeUpdate) {
+        await cfg.beforeUpdate(tx, entityId, parsedRecord, systemId);
+      }
+
+      const extraValues = cfg.updateSetValues(parsedRecord);
+
+      const updated = await tx
+        .update(table)
+        .set({
+          encryptedData: blob,
+          updatedAt: timestamp,
+          version: sql`${columns.version} + 1`,
+          ...extraValues,
+        } as Record<string, unknown>)
+        .where(
+          and(
+            eq(columns.id, entityId),
+            eq(columns.systemId, systemId),
+            eq(columns.version, parsedRecord.version as number),
+            eq(columns.archived, false),
+          ),
+        )
+        .returning();
+
+      const row = await assertOccUpdated(
+        updated,
+        async () => {
+          const [existing] = await tx
+            .select({ id: columns.id })
+            .from(table)
+            .where(
+              and(
+                eq(columns.id, entityId),
+                eq(columns.systemId, systemId),
+                eq(columns.archived, false),
+              ),
+            )
+            .limit(1);
+          return existing;
+        },
+        entityName,
+      );
+
+      await audit(tx, {
+        eventType: events.updated,
+        actor: { kind: "account", id: auth.accountId },
+        detail: `${entityName} updated`,
+        systemId,
+      });
+
+      return toResult(row as TRow);
+    });
+  }
+
+  // ── DELETE ────────────────────────────────────────────────────────
+
+  async function remove(
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ): Promise<void> {
+    assertSystemOwnership(systemId, auth);
+
+    await db.transaction(async (tx) => {
+      // Verify entity exists
+      const [existing] = await tx
+        .select({ id: columns.id })
+        .from(table)
+        .where(
+          and(
+            eq(columns.id, entityId),
+            eq(columns.systemId, systemId),
+            eq(columns.archived, false),
+          ),
+        )
+        .limit(1);
+
+      if (!existing) {
+        throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", `${entityName} not found`);
+      }
+
+      // Check dependents
+      await checkDependents(tx, entityId, systemId);
+
+      // Audit before delete (FK satisfied since entity still exists)
+      await audit(tx, {
+        eventType: events.deleted,
+        actor: { kind: "account", id: auth.accountId },
+        detail: `${entityName} deleted`,
+        systemId,
+      });
+
+      // Hard delete
+      await tx.delete(table).where(and(eq(columns.id, entityId), eq(columns.systemId, systemId)));
+    });
+  }
+
+  // ── ARCHIVE ───────────────────────────────────────────────────────
+
+  async function archive(
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ): Promise<void> {
+    await archiveEntity(db, systemId, entityId, auth, audit, lifecycleCfg);
+  }
+
+  // ── RESTORE ───────────────────────────────────────────────────────
+
+  async function restore(
+    db: PostgresJsDatabase,
+    systemId: SystemId,
+    entityId: TId,
+    auth: AuthContext,
+    audit: AuditWriter,
+  ): Promise<TResult> {
+    assertSystemOwnership(systemId, auth);
+
+    const timestamp = now();
+
+    return db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ id: columns.id, parentId: columns.parentId })
+        .from(table)
+        .where(
+          and(eq(columns.id, entityId), eq(columns.systemId, systemId), eq(columns.archived, true)),
+        )
+        .limit(1);
+
+      if (!existing) {
+        throw new ApiHttpError(
+          HTTP_NOT_FOUND,
+          "NOT_FOUND",
+          `Archived ${entityName.toLowerCase()} not found`,
+        );
+      }
+
+      // If parent is archived, promote to root
+      let newParentId = existing.parentId as string | null;
+      if (newParentId !== null) {
+        const [parent] = await tx
+          .select({ archived: columns.archived })
+          .from(table)
+          .where(and(eq(columns.id, newParentId), eq(columns.systemId, systemId)))
+          .limit(1);
+
+        if (!parent || (parent.archived as boolean)) {
+          newParentId = null;
+        }
+      }
+
+      const updated = await tx
+        .update(table)
+        .set({
+          archived: false,
+          archivedAt: null,
+          [parentFieldName]: newParentId,
+          updatedAt: timestamp,
+          version: sql`${columns.version} + 1`,
+        } as Record<string, unknown>)
+        .where(and(eq(columns.id, entityId), eq(columns.systemId, systemId)))
+        .returning();
+
+      if (updated.length === 0) {
+        throw new ApiHttpError(
+          HTTP_NOT_FOUND,
+          "NOT_FOUND",
+          `Archived ${entityName.toLowerCase()} not found`,
+        );
+      }
+
+      const [row] = updated as [(typeof updated)[number], ...typeof updated];
+
+      await audit(tx, {
+        eventType: events.restored,
+        actor: { kind: "account", id: auth.accountId },
+        detail: `${entityName} restored`,
+        systemId,
+      });
+
+      return toResult(row as TRow);
+    });
+  }
+
+  // ── Internal helpers ──────────────────────────────────────────────
+
+  async function checkDependents(
+    tx: PostgresJsDatabase,
+    entityId: string,
+    systemId: SystemId,
+  ): Promise<void> {
+    if (dependentChecks.length === 0) return;
+
+    const counts: { label: string; count: number }[] = [];
+
+    for (const dep of dependentChecks) {
+      const conditions = [eq(dep.entityColumn, entityId), eq(dep.systemColumn, systemId)];
+
+      if (dep.filterArchived) {
+        conditions.push(eq(dep.filterArchived, false));
+      }
+
+      const [result] = await tx
+        .select({ count: count() })
+        .from(dep.table)
+        .where(and(...conditions));
+
+      if (!result) {
+        throw new Error("Unexpected: count query returned no rows");
+      }
+
+      if (result.count > 0) {
+        counts.push({ label: dep.label, count: result.count });
+      }
+    }
+
+    if (counts.length > 0) {
+      const parts = counts.map((c) => `${String(c.count)} ${c.label}`);
+      throw new ApiHttpError(
+        HTTP_CONFLICT,
+        "HAS_DEPENDENTS",
+        `${entityName} has ${parts.join(" and ")}. Remove all dependents before deleting.`,
+      );
+    }
+  }
+
+  return { create, list, get, update, remove, archive, restore };
+}

--- a/apps/api/src/services/subsystem.service.ts
+++ b/apps/api/src/services/subsystem.service.ts
@@ -4,25 +4,16 @@ import {
   subsystemSideSystemLinks,
   subsystems,
 } from "@pluralscape/db/pg";
-import { ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { ID_PREFIXES } from "@pluralscape/types";
 import { CreateSubsystemBodySchema, UpdateSubsystemBodySchema } from "@pluralscape/validation";
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST, HTTP_CONFLICT, HTTP_NOT_FOUND } from "../http.constants.js";
+import { HTTP_BAD_REQUEST } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
-import { encryptedBlobToBase64, parseAndValidateBlob } from "../lib/encrypted-blob.js";
-import { archiveEntity } from "../lib/entity-lifecycle.js";
 import { detectAncestorCycle } from "../lib/hierarchy.js";
-import { assertOccUpdated } from "../lib/occ-update.js";
-import { buildPaginatedResult } from "../lib/pagination.js";
-import { assertSystemOwnership } from "../lib/system-ownership.js";
-import {
-  DEFAULT_PAGE_LIMIT,
-  MAX_ENCRYPTED_DATA_BYTES,
-  MAX_PAGE_LIMIT,
-} from "../service.constants.js";
 
-import type { AuditWriter } from "../lib/audit-writer.js";
+import { createHierarchyService, mapBaseFields } from "./hierarchy-service-factory.js";
+
 import type { AuthContext } from "../lib/auth-context.js";
 import type {
   EncryptedBlob,
@@ -68,171 +59,103 @@ function toSubsystemResult(row: {
   archivedAt: number | null;
 }): SubsystemResult {
   return {
+    ...mapBaseFields(row),
     id: row.id as SubsystemId,
-    systemId: row.systemId as SystemId,
     parentSubsystemId: row.parentSubsystemId as SubsystemId | null,
     architectureType: row.architectureType,
     hasCore: row.hasCore,
     discoveryStatus: row.discoveryStatus,
-    encryptedData: encryptedBlobToBase64(row.encryptedData),
-    version: row.version,
-    createdAt: row.createdAt as UnixMillis,
-    updatedAt: row.updatedAt as UnixMillis,
-    archived: row.archived,
-    archivedAt: row.archivedAt as UnixMillis | null,
   };
 }
 
-// ── CREATE ──────────────────────────────────────────────────────────
+// ── Shared hierarchy service ────────────────────────────────────────
 
-export async function createSubsystem(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  params: unknown,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<SubsystemResult> {
-  assertSystemOwnership(systemId, auth);
+const subsystemHierarchy = createHierarchyService<
+  {
+    id: string;
+    systemId: string;
+    parentSubsystemId: string | null;
+    architectureType: unknown;
+    hasCore: boolean;
+    discoveryStatus: string | null;
+    encryptedData: EncryptedBlob;
+    version: number;
+    createdAt: number;
+    updatedAt: number;
+    archived: boolean;
+    archivedAt: number | null;
+  },
+  SubsystemId,
+  SubsystemResult
+>({
+  table: subsystems,
+  columns: {
+    id: subsystems.id,
+    systemId: subsystems.systemId,
+    parentId: subsystems.parentSubsystemId,
+    encryptedData: subsystems.encryptedData,
+    version: subsystems.version,
+    archived: subsystems.archived,
+    archivedAt: subsystems.archivedAt,
+    createdAt: subsystems.createdAt,
+    updatedAt: subsystems.updatedAt,
+  },
+  idPrefix: ID_PREFIXES.subsystem,
+  entityName: "Subsystem",
+  parentFieldName: "parentSubsystemId",
+  toResult: toSubsystemResult,
+  createSchema: CreateSubsystemBodySchema,
+  updateSchema: UpdateSubsystemBodySchema,
+  createInsertValues: (parsed) => ({
+    architectureType: parsed.architectureType,
+    hasCore: parsed.hasCore,
+    discoveryStatus: parsed.discoveryStatus,
+  }),
+  updateSetValues: (parsed) => ({
+    parentSubsystemId: parsed.parentSubsystemId,
+    architectureType: parsed.architectureType,
+    hasCore: parsed.hasCore,
+    discoveryStatus: parsed.discoveryStatus,
+  }),
+  dependentChecks: [
+    {
+      table: subsystems,
+      entityColumn: subsystems.parentSubsystemId,
+      systemColumn: subsystems.systemId,
+      label: "child subsystem(s)",
+      filterArchived: subsystems.archived,
+    },
+    {
+      table: subsystemMemberships,
+      entityColumn: subsystemMemberships.subsystemId,
+      systemColumn: subsystemMemberships.systemId,
+      label: "membership(s)",
+    },
+    {
+      table: subsystemLayerLinks,
+      entityColumn: subsystemLayerLinks.subsystemId,
+      systemColumn: subsystemLayerLinks.systemId,
+      label: "layer link(s)",
+    },
+    {
+      table: subsystemSideSystemLinks,
+      entityColumn: subsystemSideSystemLinks.subsystemId,
+      systemColumn: subsystemSideSystemLinks.systemId,
+      label: "side system link(s)",
+    },
+  ],
+  events: {
+    created: "subsystem.created",
+    updated: "subsystem.updated",
+    deleted: "subsystem.deleted",
+    archived: "subsystem.archived",
+    restored: "subsystem.restored",
+  },
+  beforeUpdate: async (tx, entityId, parsed, systemId) => {
+    const parentSubsystemId = parsed.parentSubsystemId as string | null;
 
-  const { parsed, blob } = parseAndValidateBlob(
-    params,
-    CreateSubsystemBodySchema,
-    MAX_ENCRYPTED_DATA_BYTES,
-  );
-
-  const subsystemId = createId(ID_PREFIXES.subsystem);
-  const timestamp = now();
-
-  return db.transaction(async (tx) => {
-    if (parsed.parentSubsystemId !== null) {
-      const [parent] = await tx
-        .select({ id: subsystems.id })
-        .from(subsystems)
-        .where(
-          and(
-            eq(subsystems.id, parsed.parentSubsystemId),
-            eq(subsystems.systemId, systemId),
-            eq(subsystems.archived, false),
-          ),
-        )
-        .limit(1);
-
-      if (!parent) {
-        throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Parent subsystem not found");
-      }
-    }
-
-    const [row] = await tx
-      .insert(subsystems)
-      .values({
-        id: subsystemId,
-        systemId,
-        parentSubsystemId: parsed.parentSubsystemId,
-        architectureType: parsed.architectureType,
-        hasCore: parsed.hasCore,
-        discoveryStatus: parsed.discoveryStatus,
-        encryptedData: blob,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      })
-      .returning();
-
-    if (!row) {
-      throw new Error("Failed to create subsystem — INSERT returned no rows");
-    }
-
-    await audit(tx, {
-      eventType: "subsystem.created",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Subsystem created",
-      systemId,
-    });
-
-    return toSubsystemResult(row);
-  });
-}
-
-// ── LIST ────────────────────────────────────────────────────────────
-
-export async function listSubsystems(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  auth: AuthContext,
-  cursor?: PaginationCursor,
-  limit = DEFAULT_PAGE_LIMIT,
-): Promise<PaginatedResult<SubsystemResult>> {
-  assertSystemOwnership(systemId, auth);
-
-  const effectiveLimit = Math.min(limit, MAX_PAGE_LIMIT);
-
-  const conditions = [eq(subsystems.systemId, systemId), eq(subsystems.archived, false)];
-
-  if (cursor) {
-    conditions.push(gt(subsystems.id, cursor));
-  }
-
-  const rows = await db
-    .select()
-    .from(subsystems)
-    .where(and(...conditions))
-    .orderBy(subsystems.id)
-    .limit(effectiveLimit + 1);
-
-  return buildPaginatedResult(rows, effectiveLimit, toSubsystemResult);
-}
-
-// ── GET ─────────────────────────────────────────────────────────────
-
-export async function getSubsystem(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  subsystemId: SubsystemId,
-  auth: AuthContext,
-): Promise<SubsystemResult> {
-  assertSystemOwnership(systemId, auth);
-
-  const [row] = await db
-    .select()
-    .from(subsystems)
-    .where(
-      and(
-        eq(subsystems.id, subsystemId),
-        eq(subsystems.systemId, systemId),
-        eq(subsystems.archived, false),
-      ),
-    )
-    .limit(1);
-
-  if (!row) {
-    throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Subsystem not found");
-  }
-
-  return toSubsystemResult(row);
-}
-
-// ── UPDATE ──────────────────────────────────────────────────────────
-
-export async function updateSubsystem(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  subsystemId: SubsystemId,
-  params: unknown,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<SubsystemResult> {
-  assertSystemOwnership(systemId, auth);
-
-  const { parsed, blob } = parseAndValidateBlob(
-    params,
-    UpdateSubsystemBodySchema,
-    MAX_ENCRYPTED_DATA_BYTES,
-  );
-
-  const timestamp = now();
-
-  return db.transaction(async (tx) => {
     // Reject self-parenting
-    if (parsed.parentSubsystemId === subsystemId) {
+    if (parentSubsystemId === entityId) {
       throw new ApiHttpError(
         HTTP_BAD_REQUEST,
         "VALIDATION_ERROR",
@@ -241,7 +164,7 @@ export async function updateSubsystem(
     }
 
     // If parentSubsystemId is non-null, validate and check for cycles
-    if (parsed.parentSubsystemId !== null) {
+    if (parentSubsystemId !== null) {
       await detectAncestorCycle(
         async (id) => {
           const [row] = await tx
@@ -251,242 +174,32 @@ export async function updateSubsystem(
             .limit(1);
           return row?.parentSubsystemId;
         },
-        parsed.parentSubsystemId,
-        subsystemId,
+        parentSubsystemId,
+        entityId,
         "Subsystem",
       );
     }
+  },
+});
 
-    const updated = await tx
-      .update(subsystems)
-      .set({
-        parentSubsystemId: parsed.parentSubsystemId,
-        architectureType: parsed.architectureType,
-        hasCore: parsed.hasCore,
-        discoveryStatus: parsed.discoveryStatus,
-        encryptedData: blob,
-        updatedAt: timestamp,
-        version: sql`${subsystems.version} + 1`,
-      })
-      .where(
-        and(
-          eq(subsystems.id, subsystemId),
-          eq(subsystems.systemId, systemId),
-          eq(subsystems.version, parsed.version),
-          eq(subsystems.archived, false),
-        ),
-      )
-      .returning();
+// ── Delegated CRUD ──────────────────────────────────────────────────
 
-    const row = await assertOccUpdated(
-      updated,
-      async () => {
-        const [existing] = await tx
-          .select({ id: subsystems.id })
-          .from(subsystems)
-          .where(
-            and(
-              eq(subsystems.id, subsystemId),
-              eq(subsystems.systemId, systemId),
-              eq(subsystems.archived, false),
-            ),
-          )
-          .limit(1);
-        return existing;
-      },
-      "Subsystem",
-    );
+export const createSubsystem = subsystemHierarchy.create;
 
-    await audit(tx, {
-      eventType: "subsystem.updated",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Subsystem updated",
-      systemId,
-    });
-
-    return toSubsystemResult(row);
-  });
-}
-
-// ── DELETE ───────────────────────────────────────────────────────────
-
-export async function deleteSubsystem(
+export const listSubsystems: (
   db: PostgresJsDatabase,
   systemId: SystemId,
-  subsystemId: SubsystemId,
   auth: AuthContext,
-  audit: AuditWriter,
-): Promise<void> {
-  assertSystemOwnership(systemId, auth);
+  cursor?: PaginationCursor,
+  limit?: number,
+) => Promise<PaginatedResult<SubsystemResult>> = subsystemHierarchy.list;
 
-  await db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select({ id: subsystems.id })
-      .from(subsystems)
-      .where(
-        and(
-          eq(subsystems.id, subsystemId),
-          eq(subsystems.systemId, systemId),
-          eq(subsystems.archived, false),
-        ),
-      )
-      .limit(1);
+export const getSubsystem = subsystemHierarchy.get;
 
-    if (!existing) {
-      throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Subsystem not found");
-    }
+export const updateSubsystem = subsystemHierarchy.update;
 
-    // Check all dependents in a single query using subselects
-    const [dependents] = await tx
-      .select({
-        children: sql<number>`(
-          SELECT count(*)
-          FROM ${subsystems}
-          WHERE ${subsystems.parentSubsystemId} = ${subsystemId}
-            AND ${subsystems.systemId} = ${systemId}
-            AND ${subsystems.archived} = false
-        )`.mapWith(Number),
-        memberships: sql<number>`(
-          SELECT count(*)
-          FROM ${subsystemMemberships}
-          WHERE ${subsystemMemberships.subsystemId} = ${subsystemId}
-            AND ${subsystemMemberships.systemId} = ${systemId}
-        )`.mapWith(Number),
-        layerLinks: sql<number>`(
-          SELECT count(*)
-          FROM ${subsystemLayerLinks}
-          WHERE ${subsystemLayerLinks.subsystemId} = ${subsystemId}
-            AND ${subsystemLayerLinks.systemId} = ${systemId}
-        )`.mapWith(Number),
-        sideSystemLinks: sql<number>`(
-          SELECT count(*)
-          FROM ${subsystemSideSystemLinks}
-          WHERE ${subsystemSideSystemLinks.subsystemId} = ${subsystemId}
-            AND ${subsystemSideSystemLinks.systemId} = ${systemId}
-        )`.mapWith(Number),
-      })
-      .from(sql`(SELECT 1) AS _`);
+export const deleteSubsystem = subsystemHierarchy.remove;
 
-    if (!dependents) {
-      throw new Error("Unexpected: dependent count query returned no rows");
-    }
+export const archiveSubsystem = subsystemHierarchy.archive;
 
-    const totalDependents =
-      dependents.children +
-      dependents.memberships +
-      dependents.layerLinks +
-      dependents.sideSystemLinks;
-
-    if (totalDependents > 0) {
-      throw new ApiHttpError(
-        HTTP_CONFLICT,
-        "HAS_DEPENDENTS",
-        `Subsystem has dependents. Remove all child subsystems, memberships, and links before deleting.`,
-      );
-    }
-
-    await audit(tx, {
-      eventType: "subsystem.deleted",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Subsystem deleted",
-      systemId,
-    });
-
-    await tx
-      .delete(subsystems)
-      .where(and(eq(subsystems.id, subsystemId), eq(subsystems.systemId, systemId)));
-  });
-}
-
-// ── ARCHIVE ─────────────────────────────────────────────────────────
-
-const SUBSYSTEM_LIFECYCLE = {
-  table: subsystems,
-  columns: subsystems,
-  entityName: "Subsystem",
-  archiveEvent: "subsystem.archived" as const,
-  restoreEvent: "subsystem.restored" as const,
-};
-
-export async function archiveSubsystem(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  subsystemId: SubsystemId,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<void> {
-  await archiveEntity(db, systemId, subsystemId, auth, audit, SUBSYSTEM_LIFECYCLE);
-}
-
-// ── RESTORE ─────────────────────────────────────────────────────────
-
-export async function restoreSubsystem(
-  db: PostgresJsDatabase,
-  systemId: SystemId,
-  subsystemId: SubsystemId,
-  auth: AuthContext,
-  audit: AuditWriter,
-): Promise<SubsystemResult> {
-  assertSystemOwnership(systemId, auth);
-
-  const timestamp = now();
-
-  return db.transaction(async (tx) => {
-    const [existing] = await tx
-      .select({ id: subsystems.id, parentSubsystemId: subsystems.parentSubsystemId })
-      .from(subsystems)
-      .where(
-        and(
-          eq(subsystems.id, subsystemId),
-          eq(subsystems.systemId, systemId),
-          eq(subsystems.archived, true),
-        ),
-      )
-      .limit(1);
-
-    if (!existing) {
-      throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Archived subsystem not found");
-    }
-
-    // If parent is archived, promote to root
-    let newParentSubsystemId = existing.parentSubsystemId;
-    if (newParentSubsystemId !== null) {
-      const [parent] = await tx
-        .select({ archived: subsystems.archived })
-        .from(subsystems)
-        .where(and(eq(subsystems.id, newParentSubsystemId), eq(subsystems.systemId, systemId)))
-        .limit(1);
-
-      if (!parent || parent.archived) {
-        newParentSubsystemId = null;
-      }
-    }
-
-    const updated = await tx
-      .update(subsystems)
-      .set({
-        archived: false,
-        archivedAt: null,
-        parentSubsystemId: newParentSubsystemId,
-        updatedAt: timestamp,
-        version: sql`${subsystems.version} + 1`,
-      })
-      .where(and(eq(subsystems.id, subsystemId), eq(subsystems.systemId, systemId)))
-      .returning();
-
-    if (updated.length === 0) {
-      throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Archived subsystem not found");
-    }
-
-    const [row] = updated as [(typeof updated)[number], ...typeof updated];
-
-    await audit(tx, {
-      eventType: "subsystem.restored",
-      actor: { kind: "account", id: auth.accountId },
-      detail: "Subsystem restored",
-      systemId,
-    });
-
-    return toSubsystemResult(row);
-  });
-}
+export const restoreSubsystem = subsystemHierarchy.restore;


### PR DESCRIPTION
## Summary

Eliminates structural duplication between `group.service.ts` and `subsystem.service.ts` by extracting a generic `createHierarchyService()` factory that produces typed CRUD, archive, restore, and delete-with-dependent-checking functions from a declarative configuration.

Both services previously implemented near-identical patterns (~730 and ~490 lines respectively) for ownership checks, blob validation, OCC updates, cursor pagination, audit logging, cycle detection, and the 409 dependent-guard pattern. The factory centralizes these into a single implementation that accepts table references, column mappings, validation schemas, and domain-specific hooks.

## Changes

- Adds `hierarchy-service-factory.ts` with `createHierarchyService()` factory producing typed CRUD operations from config
- Rewrites `group.service.ts` as a thin wrapper: factory handles create/list/get/update/delete/archive/restore; group-only operations (move, copy, tree, reorder) remain inline
- Rewrites `subsystem.service.ts` as a thin wrapper: factory handles all operations; subsystem-specific logic (cycle detection on update, extra fields) uses `beforeUpdate` hook and config callbacks
- Updates subsystem delete test mocks to match the new per-table count query pattern (factory uses individual count queries instead of the previous single-subquery approach)
- Service line counts: group 734 -> 467 (-36%), subsystem 493 -> 205 (-58%)

## Test Plan

- [x] All 1469 API tests pass without modification (except 2 subsystem delete tests updated for new query pattern)
- [x] TypeScript strict typecheck passes
- [x] ESLint passes with zero warnings
- [x] All exported function signatures unchanged -- callers (routes, other tests) require no changes

## Review Checklist

- [x] Privacy: new data defaults to maximum restriction (fail-closed)
- [x] Offline: N/A (server-side only)
- [x] Data lifecycle: deletions are intentional, confirmed, and handle cascading references
- [x] Accessibility: N/A (no UI changes)
- [x] Domain terms used correctly (community terminology, not clinical language)

## Deferred Items

- The factory is reusable for other hierarchical entities (layers, side systems, innerworld entities) but those migrations are separate work