### PR TITLE
docs: comprehensive M8 documentation update

### DIFF
--- a/.beans/ps-7j8n--milestone-8-client-app.md
+++ b/.beans/ps-7j8n--milestone-8-client-app.md
@@ -1,13 +1,17 @@
 ---
 # ps-7j8n
 title: "Milestone 8: App Foundation & Data Layer"
-status: in-progress
+status: completed
 type: milestone
 priority: normal
 created_at: 2026-03-08T12:15:46Z
-updated_at: 2026-04-03T01:16:03Z
+updated_at: 2026-04-06T11:22:36Z
 blocked_by:
   - ps-n8uk
 ---
 
 App skeleton, navigation infrastructure, provider tree, and the complete data interaction layer
+
+## Summary of Changes
+
+Milestone 8 complete: app foundation & data layer delivered including app shell & navigation, provider tree & auth flow, local data layer & search, CRDT sync for all entity types, offline-first client, web platform adapter, and comprehensive data hooks across all domains (identity, fronting, communication, social, journaling, structure, utility). Full audit remediation pass completed covering security, performance, code patterns, and documentation.

--- a/.beans/ps-b0qd--m8-docs-update.md
+++ b/.beans/ps-b0qd--m8-docs-update.md
@@ -1,0 +1,24 @@
+---
+# ps-b0qd
+title: M8 docs update
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-06T11:23:30Z
+updated_at: 2026-04-06T12:18:22Z
+---
+
+Update all project documentation to reflect Milestone 8 completion
+
+## Summary of Changes
+
+Comprehensive documentation update for Milestone 8 completion:
+
+- 12 package READMEs (types, crypto, data, db, sync, api-client, email, i18n, queue, rotation-worker, storage, validation)
+- Architecture overview (docs/architecture.md) replacing milestones.md rationale section
+- Mobile developer guide (docs/guides/mobile-developer-guide.md) for contributors and API consumers
+- CHANGELOG.md M8 entry (Added + Fixed sections)
+- milestones.md M8 epics expanded and marked completed
+- README.md updated (status, coverage numbers, E2E counts, ADR count fixed to 32, data package added to repo structure)
+- CONTRIBUTING.md mobile development section added
+- CLAUDE.md verified and updated (local-only, not committed)

--- a/.beans/ps-y621--m8-audit-remediation.md
+++ b/.beans/ps-y621--m8-audit-remediation.md
@@ -1,10 +1,15 @@
 ---
 # ps-y621
 title: M8 audit remediation
-status: in-progress
+status: completed
 type: epic
+priority: normal
 created_at: 2026-04-06T00:52:03Z
-updated_at: 2026-04-06T00:52:03Z
+updated_at: 2026-04-06T11:22:34Z
 ---
 
 Remediate all 80 findings from the M8 comprehensive audit (docs/local-audits/m8-comprehensive-audit.md). Organized by priority tier.
+
+## Summary of Changes
+
+All 31 audit remediation items completed: security hardening (crypto buffers, token zeroing, WsManager disconnect), performance tuning (staleTime, observer overhead, query limits), hook coverage gaps filled across all domains, code pattern normalization (query keys, barrel exports, row-transform splitting), and documentation of known asymmetries.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,28 @@ jobs:
           path: coverage/
           retention-days: 14
 
+      - name: Extract coverage data
+        if: github.ref == 'refs/heads/main'
+        id: coverage-data
+        run: |
+          PCT=$(jq '.total.lines.pct' coverage/coverage-summary.json)
+          echo "pct=$PCT" >> "$GITHUB_OUTPUT"
+          echo "message=${PCT}%" >> "$GITHUB_OUTPUT"
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main'
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: b29472c169f6d431acf2b24a60a33225
+          filename: coverage.json
+          label: coverage
+          message: ${{ steps.coverage-data.outputs.message }}
+          valColorRange: ${{ steps.coverage-data.outputs.pct }}
+          minColorRange: 50
+          maxColorRange: 85
+          invertColorRange: false
+
   migrations:
     name: Migration Freshness
     needs: [lint, typecheck]
@@ -226,10 +248,31 @@ jobs:
       - name: Run E2E tests
         env:
           E2E_DATABASE_URL: postgres://postgres:postgres@localhost:5432/pluralscape_e2e
-        run: pnpm test:e2e
+        run: pnpm test:e2e | tee e2e-output.txt
 
       - name: Run slow E2E tests
         env:
           E2E_DATABASE_URL: postgres://postgres:postgres@localhost:5432/pluralscape_e2e
           E2E_WORKERS: "1"
-        run: pnpm test:e2e:slow
+        run: pnpm test:e2e:slow | tee e2e-slow-output.txt
+
+      - name: Extract E2E test count
+        if: github.ref == 'refs/heads/main'
+        id: e2e-data
+        run: |
+          E2E_COUNT=$(grep -oP '\d+(?= passed)' e2e-output.txt | tail -1)
+          SLOW_COUNT=$(grep -oP '\d+(?= passed)' e2e-slow-output.txt | tail -1)
+          TOTAL=$(( ${E2E_COUNT:-0} + ${SLOW_COUNT:-0} ))
+          echo "count=$TOTAL" >> "$GITHUB_OUTPUT"
+          echo "message=${TOTAL} passed" >> "$GITHUB_OUTPUT"
+
+      - name: Update E2E tests badge
+        if: github.ref == 'refs/heads/main'
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: b29472c169f6d431acf2b24a60a33225
+          filename: e2e-tests.json
+          label: E2E tests
+          message: ${{ steps.e2e-data.outputs.message }}
+          color: brightgreen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), using milestone headers instead of version numbers during pre-production development.
 
+## Milestone 8: App Foundation & Data Layer
+
+### Added
+
+- App shell and navigation — Expo Router layout with `(auth)` and `(app)/(tabs)` route groups, tab bar, stack navigators, deep link configuration, auth-gated routing
+- Provider tree — layered initialization: PlatformProvider, I18nProvider, QueryClientProvider, TRPCProvider, RestClientProvider, AuthProvider, SystemProvider, CryptoProvider, BucketKeyProvider, DataLayerProvider, ConnectionProvider, SyncProvider
+- Auth flow — state machine (unauthenticated/unlocked/locked), TokenStore with platform-aware secure storage, SessionRefreshService with memoized token fetching, BiometricKeyStore
+- Local data layer — SQLite local database with WAL mode, materializer DDL, FriendIndexer, QueryInvalidator bridging sync events to React Query invalidation, full-text search (FTS5) indexes for system and friend data
+- Connection management — ConnectionManager with state machine (disconnected/connecting/connected/backoff/reconnecting), SSE client for real-time notifications, exponential backoff with configurable delays
+- Hook factory pattern — `useOfflineFirstQuery`, `useOfflineFirstInfiniteQuery`, `useDomainMutation` factories with dual-observer architecture (local SQLite + remote tRPC), automatic source branching based on connection state
+- Data package (`packages/data`) — framework-agnostic client data layer: REST query factory, CRDT sync bridge, per-entity row transforms and crypto transforms across all domains
+- Identity data hooks — members, groups/folders, custom fields, custom fronts, system settings, member duplication, archival
+- Fronting data hooks — fronting sessions (with co-fronting), analytics queries, timers, check-in records, fronting comments
+- Communication data hooks — chat channels/messages, board messages, private notes, polls with voting, acknowledgements with mandatory confirmation
+- Social data hooks — privacy buckets, friend network, device tokens, notification configs, external dashboard, friend search with ETag caching
+- Structure and journaling data hooks — inner world (regions, entities, canvas), journal entries/snapshots, structure entities/links/types
+- Utility data hooks — audit log, media upload/download, lifecycle events, API keys, search, account management (deletion, PIN, security)
+- Web platform adapter — platform detection (native vs web), storage drivers (ExpoSqlite for mobile, OPFS SQLite for modern web, IndexedDB fallback), crypto adapters (React Native libsodium vs WASM)
+- PluralKit import — client-side JSON parsing of PluralKit export format
+- i18n integration — locale detection, RTL layout support, nomenclature wiring via i18n provider
+- CRDT sync coverage — all entity types mapped to sync document strategies with materializer registration
+- Mobile developer guide — architecture, hook patterns, platform abstraction, and contributor walkthrough
+- Architecture overview — system topology, package dependencies, data flow, encryption boundaries, security model
+
+### Fixed
+
+- M8 audit remediation (P1 + P2) — hook factory improvements, security fixes (plaintext zeroing on key discard, crypto key handling, error message sanitization), observer overhead documentation, missing hooks for edge-case entities, ConnectionProvider snapshot identity stability, row transform null handling
+
 ## Milestone 7: Data Portability
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,12 @@ switch (status) {
 - **Exhaustive pattern matching** — all `switch` statements on union types must handle every case (use `as never` default)
 - **No magic numbers/strings** — extract to `*.constants.ts` files. Each package/domain has its own (e.g., `crypto.constants.ts`, `middleware.constants.ts`). The ESLint config disables `no-magic-numbers` for this glob. Every constant needs a JSDoc comment and should use numeric underscores for readability (`86_400` not `86400`). When adding a constant, extend the nearest existing `*.constants.ts`; only create a new file when entering a new domain.
 
+### Mobile Development
+
+All interactive UI elements must have accessibility props (`accessibilityLabel`, `accessibilityRole`) with minimum 44x44pt touch targets.
+
+For hook conventions, offline-first patterns, the provider tree architecture, platform abstraction, and a walkthrough of adding new features end-to-end, see the [Mobile Developer Guide](docs/guides/mobile-developer-guide.md).
+
 ### Adding API Endpoints
 
 Every new API feature requires both a REST route and a tRPC procedure. The CI check (`pnpm trpc:parity`) enforces this.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 <p align="center">A community-driven, open-source plurality management platform.</p>
 
+<p align="center">
+  <a href="https://github.com/ThePrismSystem/pluralscape-mono/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ThePrismSystem/b29472c169f6d431acf2b24a60a33225/raw/coverage.json" alt="Coverage"></a>
+  <a href="https://github.com/ThePrismSystem/pluralscape-mono/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ThePrismSystem/b29472c169f6d431acf2b24a60a33225/raw/e2e-tests.json" alt="E2E Tests"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License"></a>
+  <img src="https://img.shields.io/badge/TypeScript-strict-blue?logo=typescript&logoColor=white" alt="TypeScript">
+  <img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun" alt="Bun">
+</p>
+
 Pluralscape helps plural systems (DID, OSDD, and beyond) manage identity tracking, fronting logs, internal communication, and privacy-controlled external sharing across web, iOS, and Android.
 
 ## Status
@@ -26,16 +34,7 @@ pnpm test:coverage     # Tests with coverage report
 pnpm test:e2e          # E2E tests (Playwright)
 ```
 
-### Current Coverage
-
-| Metric     | Coverage |
-| ---------- | -------- |
-| Statements | 93.08%   |
-| Branches   | 86.30%   |
-| Functions  | 91.84%   |
-| Lines      | 93.58%   |
-
-E2E suite: 461 tests across 73 spec files covering auth, CRUD, fronting, sync, webhooks, timers, real-time notifications, chat, boards, notes, polls, acknowledgements, privacy buckets, friends, dashboards, notifications, report export, blobs, custom fields, relationships, innerworld, API keys, check-in records, lifecycle events, notification configs, and tRPC smoke tests. Run `pnpm test:coverage` for up-to-date numbers.
+E2E suite covers auth, CRUD, fronting, sync, webhooks, timers, real-time notifications, chat, boards, notes, polls, acknowledgements, privacy buckets, friends, dashboards, notifications, report export, blobs, custom fields, relationships, innerworld, API keys, check-in records, lifecycle events, notification configs, and tRPC smoke tests. Run `pnpm test:coverage` for up-to-date numbers.
 
 ## Values
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pnpm test:e2e          # E2E tests (Playwright)
 | Functions  | 91.84%   |
 | Lines      | 93.58%   |
 
-E2E suite: 315 tests across 73 spec files covering auth, CRUD, fronting, sync, webhooks, timers, real-time notifications, chat, boards, notes, polls, acknowledgements, privacy buckets, friends, dashboards, notifications, report export, blobs, custom fields, relationships, innerworld, API keys, check-in records, lifecycle events, notification configs, and tRPC smoke tests. Run `pnpm test:coverage` for up-to-date numbers.
+E2E suite: 461 tests across 73 spec files covering auth, CRUD, fronting, sync, webhooks, timers, real-time notifications, chat, boards, notes, polls, acknowledgements, privacy buckets, friends, dashboards, notifications, report export, blobs, custom fields, relationships, innerworld, API keys, check-in records, lifecycle events, notification configs, and tRPC smoke tests. Run `pnpm test:coverage` for up-to-date numbers.
 
 ## Values
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Pluralscape helps plural systems (DID, OSDD, and beyond) manage identity trackin
 
 ## Status
 
-**Active development — Milestones 0-7 complete, Milestone 8 (App Foundation & Data Layer) next.**
+**Active development — Milestones 0-8 complete, Milestone 9 (UI/UX Design) next.**
 
-Milestones 0 (infrastructure), 1 (data layer), 2 (API Core), 3 (Sync and Real-Time), 4 (Fronting Engine), 5 (Communication), 6 (Privacy and Social), and 7 (Data Portability) are complete. The full REST API is documented in a comprehensive [OpenAPI 3.1 specification](docs/openapi/openapi.yaml) ([bundled single-file](docs/openapi.yaml)) covering 304 operations across 31 route domains. The internal tRPC layer provides end-to-end type-safe access to the same service layer for the Expo mobile client (see [tRPC guide](docs/trpc-guide.md) and [ADR 032](docs/adr/032-trpc-parity-enforcement.md)).
+Milestones 0-7 built the full backend: data layer, API, sync, fronting, communication, privacy, and data portability. The REST API covers 304 operations across 31 route domains ([OpenAPI spec](docs/openapi/openapi.yaml)), with a type-safe tRPC layer mirroring the full surface for the Expo mobile client ([ADR 032](docs/adr/032-trpc-parity-enforcement.md)).
 
-Milestone 7 delivered: email notifications (Resend + SMTP adapters with security notification templates), server-side encrypted email storage (ADR 029), webhook enhancements (secret rotation, test/ping endpoint, payload encryption), webhook event dispatch for identity and friend events, API feature completeness (closing audit gaps across account management, friends, API keys, system operations, structure entities, communication, and infrastructure), tRPC parity (35 routers mirroring every REST endpoint with CI-enforced consistency), API consumer guide, multiple audit rounds, and comprehensive E2E test expansion. See the [CHANGELOG](CHANGELOG.md) for details, the [milestone roadmap](docs/planning/milestones.md) for the full plan, and the [feature specification](docs/planning/features.md) for scope.
+Milestone 8 delivered the complete client foundation: Expo app shell with auth-gated routing, a 14-provider initialization tree (platform detection, auth state machine, encryption, sync), offline-first local data layer (SQLite + FTS5 search), 50+ domain data hooks via factory pattern (`useOfflineFirstQuery`/`useOfflineFirstInfiniteQuery`), web platform adapter (OPFS/IndexedDB), CRDT sync coverage for all entity types, and PluralKit import. See the [CHANGELOG](CHANGELOG.md) for details, the [milestone roadmap](docs/planning/milestones.md) for the full plan, the [architecture overview](docs/architecture.md) for system design, and the [mobile developer guide](docs/guides/mobile-developer-guide.md) for client internals.
 
 ## Test Suite
 
@@ -30,12 +30,12 @@ pnpm test:e2e          # E2E tests (Playwright)
 
 | Metric     | Coverage |
 | ---------- | -------- |
-| Statements | 95.54%   |
-| Branches   | 87.37%   |
-| Functions  | 96.22%   |
-| Lines      | 96.06%   |
+| Statements | 93.08%   |
+| Branches   | 86.30%   |
+| Functions  | 91.84%   |
+| Lines      | 93.58%   |
 
-E2E suite: 314 tests across 69 spec files covering auth, CRUD, fronting, sync, webhooks, timers, real-time notifications, chat, boards, notes, polls, acknowledgements, privacy buckets, friends, dashboards, notifications, report export, blobs, custom fields, relationships, innerworld, API keys, check-in records, lifecycle events, notification configs, and tRPC smoke tests. Run `pnpm test:coverage` for up-to-date numbers.
+E2E suite: 315 tests across 73 spec files covering auth, CRUD, fronting, sync, webhooks, timers, real-time notifications, chat, boards, notes, polls, acknowledgements, privacy buckets, friends, dashboards, notifications, report export, blobs, custom fields, relationships, innerworld, API keys, check-in records, lifecycle events, notification configs, and tRPC smoke tests. Run `pnpm test:coverage` for up-to-date numbers.
 
 ## Values
 
@@ -56,6 +56,7 @@ apps/
 packages/
   types/           Shared domain types, Zod validators, branded IDs, API constants
   crypto/          E2E encryption — libsodium (WASM + React Native adapters)
+  data/            Client data layer — query factories, CRDT bridge, row/crypto transforms
   db/              Drizzle ORM schemas — PostgreSQL + SQLite dual-dialect
   sync/            CRDT sync protocol — Automerge
   api-client/      tRPC + TanStack Query client bindings
@@ -79,7 +80,7 @@ ui-design/
 docs/
   openapi/         OpenAPI 3.1 spec (multi-file source, Redocly CLI)
   openapi.yaml     Bundled single-file OpenAPI spec (generated)
-  adr/             Architecture Decision Records (33 accepted)
+  adr/             Architecture Decision Records (32 accepted)
   audits/          Codebase audit reports
   planning/        Specifications, milestones, feature planning
   future-features/ Unscheduled feature design documents
@@ -99,7 +100,7 @@ docs/
 | Media        | S3-compatible (MinIO for self-hosted)           | [ADR 009](docs/adr/009-blob-media-storage.md) |
 | Job Queue    | BullMQ (Valkey) / SQLite (self-hosted fallback) | [ADR 010](docs/adr/010-background-jobs.md)    |
 
-All dependencies verified AGPL-3.0 compatible — see [license audit](docs/audits/001-license-compatibility.md). Architecture decisions documented in [33 ADRs](docs/adr/).
+All dependencies verified AGPL-3.0 compatible — see [license audit](docs/audits/001-license-compatibility.md). Architecture decisions documented in [32 ADRs](docs/adr/).
 
 ## Key Libraries
 
@@ -198,7 +199,7 @@ Domain prefixes: `ps-`, `api-`, `mobile-`, `db-`, `crypto-`, `sync-`, `types-`, 
 
 ## Architecture Decision Records
 
-Major technical decisions are documented as ADRs in [`docs/adr/`](docs/adr/). 33 accepted ADRs cover the full stack from licensing through email provider selection. See the [ADR template](docs/adr/000-template.md) for the format.
+Major technical decisions are documented as ADRs in [`docs/adr/`](docs/adr/). 32 accepted ADRs cover the full stack from licensing through email provider selection. See the [ADR template](docs/adr/000-template.md) for the format.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,6 +223,7 @@ Per-bucket symmetric keys are derived client-side. The server never holds T1 key
 | Encryption boundary | T1/T2/T3 classification; fail-closed on unmapped data         | [adr/018-encryption-at-rest-boundary.md](adr/018-encryption-at-rest-boundary.md) |
 | RLS denormalization | system_id/account_id columns on every table for RLS           | [adr/020-rls-denormalization.md](adr/020-rls-denormalization.md)                 |
 | Email encryption    | Server-side AES-256-GCM; BLAKE2b hash for lookup              | [adr/029-server-side-encrypted-email.md](adr/029-server-side-encrypted-email.md) |
+| Web storage backend | OPFS+wa-sqlite preferred, IndexedDB fallback; auto-detected   | [adr/031-web-storage-backend.md](adr/031-web-storage-backend.md)                 |
 | tRPC parity         | `pnpm trpc:parity` enforces REST+tRPC coverage on every PR    | [adr/032-trpc-parity-enforcement.md](adr/032-trpc-parity-enforcement.md)         |
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,280 @@
+# Pluralscape Architecture Overview
+
+Canonical reference for system topology, package dependencies, data flow, and key design decisions.
+Community terminology is used throughout: "system" (not patient), "member" (not alter), "fronting" (not presenting).
+
+---
+
+## 1. System Topology
+
+### Hosted Deployment
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Expo Client (iOS / Android / Web)                          │
+│  React Native + expo-router                                 │
+│  Local SQLite/SQLCipher  ←── source of truth                │
+└──────────────────────────────┬──────────────────────────────┘
+                               │ HTTPS
+                               │ tRPC (internal) / REST (public)
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Hono API  (Bun runtime)                                    │
+│  tRPC router + REST routes                                  │
+│  Auth middleware  ·  Row-Level Security (PostgreSQL)        │
+└────────────┬──────────────┬──────────────┬──────────────────┘
+             │              │              │
+             ▼              ▼              ▼
+        PostgreSQL        Valkey        S3 / MinIO
+        (primary DB)    (cache/pub-sub) (blob storage)
+```
+
+### Self-Hosted Deployment
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Expo Client                                                │
+│  Local SQLite/SQLCipher                                     │
+└──────────────────────────────┬──────────────────────────────┘
+                               │ HTTPS (local network / Tailscale)
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Hono API  (Bun single binary)                              │
+│  SQLite/SQLCipher + local filesystem                        │
+│  No PostgreSQL, no Valkey, no S3                            │
+│  Minimal tier: personal use                                 │
+│  Full tier: Docker Compose (feature parity with hosted)     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Offline-First Model
+
+```
+Local SQLite  ──── source of truth ────▶  UI / React Query
+     │
+     │  background sync
+     ▼
+Offline queue  ──▶  CRDT merge  ──▶  Encrypted relay  ──▶  Server
+                                       (opaque ciphertext;       │
+                                        server cannot read)      │
+                                                                 ▼
+Receiving client  ◀──  decrypt  ◀──  fan-out  ◀──  persist
+     │
+     ▼
+Materializer  ──▶  React Query invalidation  ──▶  UI re-render
+```
+
+The server persists and relays ciphertext it cannot decrypt. All plaintext lives exclusively on the client.
+
+---
+
+## 2. Package Dependency Graph
+
+Tooling packages (`eslint-config`, `prettier-config`, `tsconfig`, `test-utils`) are omitted — every package depends on them as devDependencies.
+
+```
+                       ┌─────────┐
+                       │  types  │  (leaf — no @pluralscape deps)
+                       └────┬────┘
+            ┌───────────────┼──────────────────────────────┐
+            │               │                              │
+            ▼               ▼                              ▼
+        ┌──────┐     ┌────────────┐                ┌────────────┐
+        │crypto│     │ validation │                │    i18n    │
+        └──┬───┘     └─────┬──────┘                └────────────┘
+           │               │
+      ┌────┴────┐      ┌────┘
+      │         │      │
+      ▼         ▼      ▼
+   ┌────┐     ┌──────────────────┐
+   │ db │     │      sync        │  (types + crypto + validation)
+   └──┬─┘     └──────────────────┘
+      │
+      ▼
+  ┌───────┐
+  │ queue │  (types + db)
+  └───────┘
+
+  ┌──────────────────┐
+  │  rotation-worker │  (types + crypto)
+  └──────────────────┘
+
+  ┌─────────┐
+  │ storage │  (types)
+  └─────────┘
+
+  ┌───────┐
+  │ email │  (no @pluralscape deps)
+  └───────┘
+
+  ┌────────────┐
+  │ api-client │  (depends on @pluralscape/api for router types)
+  └────────────┘
+
+  ┌──────┐
+  │ data │  (api-client + crypto + sync + types)
+  └──────┘
+```
+
+### Classification
+
+| Category    | Packages                                                   |
+| ----------- | ---------------------------------------------------------- |
+| Server-only | `db`, `queue`, `rotation-worker`, `email`                  |
+| Client-only | `api-client`, `data`                                       |
+| Shared      | `types`, `crypto`, `sync`, `validation`, `i18n`, `storage` |
+
+### App Consumers
+
+| App            | Packages consumed                                                          |
+| -------------- | -------------------------------------------------------------------------- |
+| `apps/api`     | `crypto`, `db`, `email`, `queue`, `storage`, `sync`, `types`, `validation` |
+| `apps/mobile`  | `api-client`, `crypto`, `data`, `i18n`, `sync`, `types`                    |
+| `apps/api-e2e` | `api` (for router types), `crypto`, `sync`, `types`                        |
+
+---
+
+## 3. Data Flow
+
+### Request Lifecycle (Online)
+
+```
+Client                          Server
+  │                               │
+  │  1. encrypt payload           │
+  │     (XChaCha20-Poly1305)      │
+  │                               │
+  ├─── tRPC mutation ────────────▶│
+  │                               │  2. auth middleware
+  │                               │     (JWT / session token)
+  │                               │
+  │                               │  3. RLS enforcement
+  │                               │     (PostgreSQL row-level)
+  │                               │
+  │                               │  4. service layer
+  │                               │     (business logic)
+  │                               │
+  │                               │  5. database write
+  │                               │
+  │◀─── response ─────────────────│
+  │                               │
+  │  6. decrypt response          │
+  │     (client holds keys)       │
+```
+
+### Sync Flow
+
+```
+Local mutation
+     │
+     ▼
+Offline queue  ──▶  CRDT merge (conflict resolution)
+                         │
+                         ▼
+                    Client encrypts delta
+                         │
+                         ▼
+                    tRPC mutation  ──▶  Server persists opaque ciphertext
+                                              │
+                                              ▼
+                                         Valkey pub-sub fan-out
+                                              │
+                                              ▼
+                                    Receiving client(s) pull delta
+                                              │
+                                              ▼
+                                    Client decrypts with bucket key
+                                              │
+                                              ▼
+                                    Materializer applies to local SQLite
+                                              │
+                                              ▼
+                                    React Query invalidation → UI
+```
+
+### Encryption Boundaries
+
+| Tier                  | Scope                                                  | Algorithm                                       | Key holder                                       |
+| --------------------- | ------------------------------------------------------ | ----------------------------------------------- | ------------------------------------------------ |
+| T1 — User content     | Member profiles, journal entries, front logs, messages | XChaCha20-Poly1305 (libsodium)                  | Client only; server sees ciphertext              |
+| T2 — Operational data | Email addresses, webhook URLs                          | AES-256-GCM (BLAKE2b hash preserved for lookup) | Server; encrypted at rest, decrypted transiently |
+| T3 — Infrastructure   | Push tokens, session metadata                          | Plaintext (TLS in transit)                      | Server; no application-level encryption          |
+
+Per-bucket symmetric keys are derived client-side. The server never holds T1 key material.
+
+---
+
+## 4. Key Architecture Decisions
+
+| Pattern             | Decision                                                      | ADR                                                                              |
+| ------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| License             | AGPL-3.0 — copyleft to protect community data                 | [adr/001-agpl-3-license.md](adr/001-agpl-3-license.md)                           |
+| Frontend framework  | React Native via Expo — single codebase for iOS, Android, Web | [adr/002-frontend-framework.md](adr/002-frontend-framework.md)                   |
+| API framework       | Hono on Bun — fast, edge-compatible, supports Bun native APIs | [adr/003-api-framework.md](adr/003-api-framework.md)                             |
+| Database            | PostgreSQL (hosted) + SQLite/SQLCipher (client + self-hosted) | [adr/004-database.md](adr/004-database.md)                                       |
+| Offline sync        | CRDT-based encrypted sync; server relays opaque ciphertext    | [adr/005-offline-sync.md](adr/005-offline-sync.md)                               |
+| Encryption          | libsodium — XChaCha20-Poly1305, X25519, Argon2id              | [adr/006-encryption.md](adr/006-encryption.md)                                   |
+| Real-time           | WebSocket + SSE via tRPC subscriptions                        | [adr/007-realtime.md](adr/007-realtime.md)                                       |
+| Runtime             | Bun — faster cold start, native SQLite, built-in test runner  | [adr/008-runtime.md](adr/008-runtime.md)                                         |
+| Blob storage        | S3-compatible (MinIO self-hosted); pre-signed URLs            | [adr/009-blob-media-storage.md](adr/009-blob-media-storage.md)                   |
+| Background jobs     | BullMQ-compatible queue on Valkey                             | [adr/010-background-jobs.md](adr/010-background-jobs.md)                         |
+| Key recovery        | Recovery code derivation via Argon2id, sharded backup         | [adr/011-key-recovery.md](adr/011-key-recovery.md)                               |
+| Self-hosted tiers   | Minimal (single binary) vs Full (Docker Compose)              | [adr/012-self-hosted-tiers.md](adr/012-self-hosted-tiers.md)                     |
+| Encryption boundary | T1/T2/T3 classification; fail-closed on unmapped data         | [adr/018-encryption-at-rest-boundary.md](adr/018-encryption-at-rest-boundary.md) |
+| RLS denormalization | system_id/account_id columns on every table for RLS           | [adr/020-rls-denormalization.md](adr/020-rls-denormalization.md)                 |
+| Email encryption    | Server-side AES-256-GCM; BLAKE2b hash for lookup              | [adr/029-server-side-encrypted-email.md](adr/029-server-side-encrypted-email.md) |
+| tRPC parity         | `pnpm trpc:parity` enforces REST+tRPC coverage on every PR    | [adr/032-trpc-parity-enforcement.md](adr/032-trpc-parity-enforcement.md)         |
+
+---
+
+## 5. Security Model
+
+### Zero-Knowledge Server
+
+The server stores only T1 ciphertext. It cannot read member profiles, journal entries, front logs, or messages. Key material is never transmitted to the server.
+
+Per-bucket symmetric keys are generated client-side and exchanged between devices via encrypted key bundles (X25519 ECDH). Key rotation is lazy: triggered on device removal or compromise, not on every write.
+
+### Fail-Closed Privacy
+
+Privacy bucket membership is evaluated client-side using intersection logic. If bucket data is unavailable, corrupted, or unmapped, access defaults to maximum restriction — the system's data is never accidentally exposed. This principle extends to the API: missing or erroneous privacy context is treated as "deny".
+
+### Trust Boundary
+
+| Layer     | Trusted for                                           | Not trusted for                |
+| --------- | ----------------------------------------------------- | ------------------------------ |
+| Client    | Encryption, local key custody, CRDT authorship        | Server-enforced access control |
+| Server    | Auth, RLS, access control, T2/T3 data confidentiality | T1 data confidentiality        |
+| Transport | TLS in transit                                        | Not applicable                 |
+
+### Deliberate Data Lifecycle
+
+Deleting an entity that has dependents returns HTTP 409 — no silent cascade. Foreign keys use `ON DELETE RESTRICT` for entity relationships. `ON DELETE CASCADE` applies only to `system_id` and `account_id` columns, so an account purge removes all system data atomically.
+
+---
+
+## 6. Development Sequence Rationale
+
+Milestones are ordered to eliminate rework by resolving foundational dependencies first.
+
+**M0 — Infrastructure foundation**: CI/CD, monorepo tooling, shared package scaffolding. No application logic yet; establishes the build and release pipeline.
+
+**M1 — Types, DB, Crypto, Sync design**: Everything depends on the domain model. Encryption tiers constrain how data is stored. The sync protocol must be co-designed with the database schema — retrofitting CRDT sync onto an existing schema guarantees rework. This milestone produces the data layer but no running API.
+
+**M2 — API core**: CRUD operations are the foundation for all subsequent features. Auth gates every endpoint; recovery key generation happens at registration. No API feature can be built before this milestone.
+
+**M3 — Sync and real-time**: With the sync protocol designed in M1, implementation happens early so every subsequent feature is built on top of the sync layer. Multi-device key recovery also lives here. Retrofitting sync onto already-shipped features is the primary risk this avoids.
+
+**M4–M6 — Fronting → Communication → Privacy**: Ordered by dependency. Fronting is the most-used feature and the clearest domain concept. Communication builds on member identity. Privacy governs visibility of everything and integrates the three-tier encryption model — it must come after the data it protects exists.
+
+**M7 — Data portability**: Email notifications, webhook enhancements, and public API surface. Infrastructure that supports external integration is deferred until the core API is stable; it does not drive internal architecture.
+
+**M8 — Client app foundation**: The mobile/web UI consumes the API. Building the client after the API is stable prevents constant frontend rework caused by breaking schema changes. Import/export, PluralKit bridge, and API key management are client-side features bundled here. In practice, M8 epics are developed in parallel with M2–M7 — each API feature ships with its corresponding UI.
+
+**M9–M10 — UI design → buildout**: Visual design system established before the buildout phase; avoids retrofitting accessibility and design tokens.
+
+**M11 — Data interpolation**: Wire screens to tRPC hooks and local SQLite; the full offline-first experience becomes testable end-to-end.
+
+**M12 — Ancillary features**: Vertical slices (timers, custom fields, innerworld, etc.) added after the core loop is proven stable.
+
+**M13–M14 — Self-hosted → polish**: Self-hosted mode requires a complete, stable feature set before the SQLite adapter is meaningful. Polish is the final hardening pass before public launch.

--- a/docs/guides/mobile-developer-guide.md
+++ b/docs/guides/mobile-developer-guide.md
@@ -1,0 +1,354 @@
+# Mobile Developer Guide
+
+This guide covers the Pluralscape mobile app (`apps/mobile/`), built with Expo and React Native. It serves two audiences: contributors working on the mobile codebase, and API consumers or self-hosters who want to understand how the client operates.
+
+For overall system architecture, see [`../architecture.md`](../architecture.md). For the sync protocol, see [`sync-protocol.md`](sync-protocol.md).
+
+---
+
+## Part 1 -- Architecture
+
+### Routing
+
+The app uses [Expo Router](https://expo.dev/router) with file-based routing. Route groups:
+
+- `(auth)/` -- unauthenticated screens: `login`, `register`
+- `(app)/(tabs)/` -- authenticated tabbed screens (main app surface)
+
+`AuthGate` in the root layout redirects to `/(auth)/login` when the auth state is `unauthenticated` and shows a lock screen when `locked`. Authenticated users reach `(app)/(tabs)/`.
+
+### Provider Tree
+
+The root layout (`app/_layout.tsx`) wraps the app in a provider tree. Initialization order (outermost to innermost):
+
+| Provider                | Purpose                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| **PlatformProvider**    | Detects runtime (iOS/Android/web), resolves storage drivers and crypto adapter       |
+| **I18nProvider**        | Locale detection, RTL layout, translation resources                                  |
+| **QueryClientProvider** | React Query cache shared by tRPC and local queries                                   |
+| **TRPCProvider**        | tRPC client with batched HTTP link, SSE subscription link, auth headers              |
+| **RestClientProvider**  | REST API client for endpoints not covered by tRPC (blob uploads, webhooks)           |
+| **AuthProvider**        | Auth state machine (login/logout/lock/unlock), token persistence                     |
+| **AuthBridgeProviders** | Extracts credentials from auth snapshot and distributes them:                        |
+| SystemProvider          | Active `systemId` from auth credentials                                              |
+| CryptoProvider          | `masterKey` (KDF-derived, available only when unlocked)                              |
+| BucketKeyProvider       | Decrypted bucket keys for friend visibility (from key grants, requires `boxKeypair`) |
+| **DataLayerProvider**   | Local SQLite database, event bus, query invalidator                                  |
+| **ConnectionProvider**  | SSE connection state machine, auto-connects on unlock                                |
+| **SyncProvider**        | Sync engine lifecycle: WebSocket manager, key resolver, CRDT bootstrap               |
+| **BootstrapGate**       | Blocks rendering until offline data is ready (or falls back to remote)               |
+| **AuthGate**            | Redirects unauthenticated users to login, shows lock screen when locked              |
+
+### Offline-First Model
+
+Local SQLite is the source of truth once sync has bootstrapped. The dual-observer pattern drives every data hook:
+
+1. Each hook registers two query observers: one local (SQLite), one remote (tRPC).
+2. `useQuerySource()` determines which observer is active based on platform storage backend and sync bootstrap state.
+3. When offline (or before bootstrap), local SQLite queries serve reads. When the sync engine has not yet bootstrapped and no SQLite driver is available, tRPC serves reads directly.
+4. Writes always go through tRPC mutations. The sync engine propagates changes back to local SQLite via CRDT documents.
+
+```
+                          useQuerySource()
+                          /            \
+                     "local"          "remote"
+                        |                |
+              useQuery(SQLite)    trpc.*.useQuery()
+                        |                |
+                  rowTransform      select(decrypt)
+                        |                |
+                        +--- DataQuery --+
+```
+
+When the source is `"local"`, real-time updates flow through the sync engine to the event bus to the `QueryInvalidator`, which invalidates React Query cache entries by table name. When `"remote"`, standard tRPC cache behavior applies.
+
+### Encryption on the Client
+
+All sensitive data is encrypted at rest on the server. The client decrypts on read:
+
+- **MasterKey** -- derived from the user's password via Argon2id. Available from `CryptoProvider` only when auth state is `unlocked`. Used to decrypt entity fields (member names, journal entries, etc.) via a `decrypt` callback in each hook.
+- **Bucket keys** -- per-bucket symmetric keys (AEAD) for friend visibility. `BucketKeyProvider` fetches received key grants, decrypts them with the user's `boxKeypair` (X25519), and caches them. Used to decrypt data shared by friends.
+- **Key zeroing** -- the `AuthStateMachine` fires `onKeyDiscard` when transitioning out of `unlocked`, calling `sodium.memzero()` on the master key. `BucketKeyProvider` zeros all cached keys on unmount.
+
+---
+
+## Part 2 -- Contributing to Mobile
+
+### Hook Factory Pattern
+
+Domain hooks follow a factory pattern defined in `apps/mobile/src/hooks/factories.ts`. Three factories handle the common patterns:
+
+**`useOfflineFirstQuery`** -- single-entity get:
+
+```ts
+// Simplified from factories.ts
+function useOfflineFirstQuery<TRaw, TDecrypted>(config: {
+  queryKey: readonly unknown[]; // React Query cache key
+  table: string; // SQLite table name
+  entityId: string; // Primary key value
+  rowTransform: (row: Record<string, unknown>) => TDecrypted;
+  decrypt?: (raw: TRaw, masterKey: KdfMasterKey) => TDecrypted;
+  useRemote: (args: UseRemoteGetArgs<TRaw, TDecrypted>) => DataQuery<TDecrypted>;
+}): DataQuery<TDecrypted>;
+```
+
+When offline, executes `SELECT * FROM <table> WHERE id = ?` and applies `rowTransform`. When online, delegates to `useRemote` with an optional `select` callback that decrypts using the master key.
+
+**`useOfflineFirstInfiniteQuery`** -- paginated list:
+
+```ts
+// Simplified from factories.ts
+function useOfflineFirstInfiniteQuery<TRaw, TDecrypted>(config: {
+  queryKey: readonly unknown[];
+  table: string;
+  rowTransform: (row: Record<string, unknown>) => TDecrypted;
+  decrypt?: (raw: TRaw, masterKey: KdfMasterKey) => TDecrypted;
+  includeArchived?: boolean;
+  useRemote: (args: UseRemoteListArgs<TRaw, TDecrypted>) => DataListQuery<TDecrypted>;
+}): DataListQuery<TDecrypted>;
+```
+
+Local mode paginates with `LIMIT/OFFSET` over SQLite. Archived entities are excluded by default (`AND archived = 0`). The system ID is auto-appended to the query key for cache isolation.
+
+**`useDomainMutation`** -- mutations with cache invalidation:
+
+```ts
+// Simplified from factories.ts
+function useDomainMutation<TData, TVars>(config: {
+  useMutation: (opts: {
+    onSuccess: (data: TData, vars: TVars) => void;
+  }) => TRPCMutation<TData, TVars>;
+  onInvalidate: (utils: AppUtils, systemId: SystemId, data: TData, vars: TVars) => void;
+}): TRPCMutation<TData, TVars>;
+```
+
+Resolves the active system ID, grabs tRPC utils, and fires `onInvalidate` on mutation success for scoped cache invalidation.
+
+### Writing a New Domain Hook
+
+Use `apps/mobile/src/hooks/use-members.ts` as the reference implementation. Here is the pattern for a single-entity get hook:
+
+```ts
+// From use-members.ts
+export function useMember(
+  memberId: MemberId,
+  opts?: SystemIdOverride,
+): DataQuery<Member | Archived<Member>> {
+  return useOfflineFirstQuery<MemberRaw, Member | Archived<Member>>({
+    queryKey: ["members", memberId], // Convention: [tableName, entityId]
+    table: "members", // SQLite table for local reads
+    entityId: memberId, // Primary key for WHERE clause
+    rowTransform: rowToMember, // SQLite row -> domain type
+    decrypt: decryptMember, // Server DTO -> plaintext domain type
+    systemIdOverride: opts,
+    useRemote: ({ systemId, enabled, select }) =>
+      trpc.member.get.useQuery({ systemId, memberId }, { enabled, select }) as DataQuery<
+        Member | Archived<Member>
+      >,
+  });
+}
+```
+
+And the corresponding list hook:
+
+```ts
+// From use-members.ts
+export function useMembersList(opts?: MemberListOpts): DataListQuery<Member | Archived<Member>> {
+  return useOfflineFirstInfiniteQuery<MemberRaw, Member | Archived<Member>>({
+    queryKey: ["members", "list", opts?.includeArchived ?? false],
+    table: "members",
+    rowTransform: rowToMember,
+    decrypt: decryptMember,
+    includeArchived: opts?.includeArchived,
+    systemIdOverride: opts,
+    useRemote: ({ systemId, enabled, select }) =>
+      trpc.member.list.useInfiniteQuery(
+        { systemId, limit: opts?.limit ?? DEFAULT_LIST_LIMIT /* ... */ },
+        { enabled, getNextPageParam: (lastPage) => lastPage.nextCursor, select },
+      ) as DataListQuery<Member | Archived<Member>>,
+  });
+}
+```
+
+Mutation hooks follow a consistent pattern -- wrap `trpc.*.useMutation` and invalidate related queries:
+
+```ts
+// From use-members.ts
+export function useUpdateMember(): TRPCMutation<
+  RouterOutput["member"]["update"],
+  RouterInput["member"]["update"]
+> {
+  return useDomainMutation({
+    useMutation: (mutOpts) => trpc.member.update.useMutation(mutOpts),
+    onInvalidate: (utils, systemId, _data, variables) => {
+      void utils.member.get.invalidate({ systemId, memberId: variables.memberId });
+      void utils.member.list.invalidate({ systemId });
+    },
+  });
+}
+```
+
+**Key conventions when adding a new domain:**
+
+1. Query keys start with the table name: `["members", ...]`, `["groups", ...]`
+2. Row transforms live in `apps/mobile/src/data/row-transforms/` grouped by domain
+3. Decrypt functions live in `@pluralscape/data/transforms/` (shared with the API)
+4. The `useRemote` callback is a thin wrapper around the tRPC hook -- the factory cannot call tRPC hooks directly because each entity has unique procedure types
+
+### Platform Abstraction
+
+The platform layer (`apps/mobile/src/platform/`) detects the runtime environment and provides appropriate drivers via `PlatformContext`:
+
+**Capabilities** (`PlatformCapabilities`):
+
+| Capability          | Native (iOS/Android)              | Web                                |
+| ------------------- | --------------------------------- | ---------------------------------- |
+| `hasSecureStorage`  | true                              | false                              |
+| `hasBiometric`      | true                              | false                              |
+| `hasBackgroundSync` | true                              | false                              |
+| `hasNativeMemzero`  | true (if native module available) | false                              |
+| `storageBackend`    | `"sqlite"`                        | `"sqlite"` (OPFS) or `"indexeddb"` |
+
+**Storage drivers:**
+
+- **Native**: `expo-sqlite` via `createExpoSqliteDriver()` -- full SQLite with WAL mode
+- **Web with OPFS**: `createOpfsSqliteDriver()` -- SQLite compiled to WASM, backed by Origin Private File System
+- **Web without OPFS**: `IndexedDB` adapters for storage and offline queue (no local SQLite queries -- hooks fall back to remote mode)
+
+**Crypto adapters:**
+
+- **Native**: `ReactNativeSodiumAdapter` from `@pluralscape/crypto/react-native`, with optional native `memzero` for secure key wiping
+- **Web**: `WasmSodiumAdapter` from `@pluralscape/crypto/wasm` -- libsodium compiled to WebAssembly
+
+Platform detection runs once at startup (`detectPlatform()`) and the result is immutable for the session.
+
+### Connection Management
+
+The connection layer (`apps/mobile/src/connection/`) manages two real-time channels:
+
+**SSE Client** (`SseClient`):
+
+- Connects to `/api/v1/notifications/stream` with Bearer auth
+- Uses `@microsoft/fetch-event-source` for cross-platform SSE
+- Tracks `Last-Event-ID` for resume on reconnect
+- Lifecycle callbacks (`onConnected`, `onDisconnected`, `onError`) drive the state machine
+
+**Connection State Machine** (`ConnectionStateMachine`):
+
+States and transitions:
+
+```
+disconnected --CONNECT--> connecting --CONNECTED--> connected
+                              |                         |
+                        CONNECTION_LOST           CONNECTION_LOST
+                              |                         |
+                              v                         v
+                           backoff                 reconnecting
+                              |                         |
+                        BACKOFF_COMPLETE              RETRY
+                              |                         |
+                              v                         v
+                         reconnecting               connecting
+```
+
+- Jittered exponential backoff: base 1s, multiplier 2x, cap 30s, +/-25% jitter
+- `ConnectionManager` orchestrates the SSE client and state machine, auto-reconnecting with saved credentials
+- `ConnectionProvider` auto-connects when auth reaches `unlocked` and disconnects on lock/logout
+- State is exposed via `useSyncExternalStore` for tear-free React integration
+
+**WebSocket Manager** (`WsManager`):
+
+A separate WebSocket channel handles CRDT sync. Created by `SyncProvider`, it follows the same backoff pattern and exposes a `useSyncExternalStore`-compatible interface. The WebSocket adapter is wired to the event bus for `ws:connected` / `ws:disconnected` events.
+
+### Testing
+
+Run mobile unit tests from the monorepo root:
+
+```bash
+pnpm vitest run --project mobile
+```
+
+Tests use Vitest with React Testing Library. The test infrastructure stubs platform-specific modules (Expo, React Native) and provides test helpers for injecting provider context without mounting the full provider tree.
+
+Key test patterns:
+
+- Auth state machine tests verify all state transitions exhaustively
+- Hook tests use the exported context objects (`AuthCtx`, `DataLayerCtx`, `SyncCtx`) to inject stub values
+- Connection and SSE tests verify backoff timing and reconnection behavior
+- Row transform tests cover SQLite row parsing for every domain entity
+
+---
+
+## Part 3 -- Understanding the Client (API Consumers / Self-Hosters)
+
+### API Communication
+
+The mobile app uses **tRPC** (not REST) for all standard API calls. The tRPC client is configured with:
+
+- **httpBatchLink** for queries and mutations -- batches concurrent requests into a single HTTP call
+- **httpSubscriptionLink** for real-time subscriptions via SSE
+- **loggerLink** (dev only) for error logging
+
+The REST client (`RestClientProvider`) exists for operations not covered by tRPC, such as blob uploads.
+
+### Auth Flow
+
+```
+Login screen
+    |
+    v
+POST /auth/login --> sessionToken, salt, accountId, systemId
+    |
+    v
+Argon2id(password, salt) --> masterKey
+    |
+    v
+Derive identity keys (sign + box) from masterKey
+    |
+    v
+AuthStateMachine.dispatch(LOGIN) --> state: "unlocked"
+    |
+    v
+Token persisted to secure storage (native) or memory (web)
+    |
+    v
+Providers initialize: SystemProvider, CryptoProvider, BucketKeyProvider
+    |
+    v
+ConnectionProvider auto-connects SSE
+    |
+    v
+SyncProvider creates engine, connects WebSocket, bootstraps CRDT documents
+    |
+    v
+BootstrapGate unblocks --> AuthGate renders app
+```
+
+### Auth States
+
+| State             | Session token  | Master key  | App behavior                                              |
+| ----------------- | -------------- | ----------- | --------------------------------------------------------- |
+| `unauthenticated` | No             | No          | Redirected to login screen                                |
+| `unlocked`        | Yes            | Yes         | Full app access, sync active, decryption available        |
+| `locked`          | Yes (retained) | No (zeroed) | Lock screen shown, React Query cache cleared, sync paused |
+
+Transitioning from `unlocked` to `locked` zeros the master key via `sodium.memzero()`. The session token is retained so the user can unlock with their password without re-authenticating. Logout clears both the token and key, returning to `unauthenticated`.
+
+### Sync
+
+The sync engine uses Automerge CRDT documents, encrypted and relayed through the server. The server never sees plaintext:
+
+1. **Bootstrap** -- on first connect, the engine downloads all CRDT document headers, then materializes them into local SQLite tables
+2. **Steady state** -- incoming changes arrive via WebSocket, are decrypted with the `DocumentKeyResolver` (which uses the master key and bucket key cache), merged into local Automerge documents, and materialized into SQLite
+3. **Outgoing changes** -- mutations sent via tRPC produce CRDT operations on the server, which are relayed back through the sync channel
+
+If bootstrap fails 3 times, the app falls back to remote-only mode (tRPC queries hit the server directly) and displays a banner warning.
+
+For full sync protocol details, see [`sync-protocol.md`](sync-protocol.md).
+
+### Offline Behavior
+
+- **Reads**: served from local SQLite. The `QueryInvalidator` listens to materialization events from the sync engine and invalidates React Query cache entries, keeping the UI current.
+- **Writes**: mutations go through tRPC. When offline, they are queued locally (via the platform's offline queue adapter) and replayed on reconnect.
+- **Conflict resolution**: Automerge CRDTs handle concurrent edits deterministically. No manual conflict resolution is required.
+- **Degraded mode**: if the platform lacks SQLite support (web without OPFS), the app operates in remote-only mode -- all reads and writes go through tRPC with no local cache beyond React Query's in-memory store.

--- a/docs/planning/milestones.md
+++ b/docs/planning/milestones.md
@@ -266,42 +266,8 @@ These features are tracked but may be deferred past initial launch. Each has a d
 - Custom lifecycle event types — [future feature doc](../future-features/012-custom-lifecycle-events.md)
 - Cosmetic monetization — [future feature doc](../future-features/002-monetization-cosmetics.md)
 
-## Architecture Decision Records
+## Architecture and Decision Records
 
-30 accepted ADRs cover the full stack:
+For system topology, package dependencies, data flow, encryption boundaries, and the development sequence rationale, see the [Architecture Overview](../architecture.md).
 
-- [ADR 001: AGPL-3.0 License](../adr/001-agpl-3-license.md)
-- [ADR 002-008](../adr/) — Foundation decisions (frontend, API, database, sync, encryption, real-time, runtime)
-- [ADR 009: Blob/Media Storage](../adr/009-blob-media-storage.md) — S3-compatible encrypted media, MinIO for self-hosted, local filesystem fallback
-- [ADR 010: Background Job Architecture](../adr/010-background-jobs.md) — BullMQ (Valkey) for hosted, SQLite-backed fallback for self-hosted
-- [ADR 011: Key Lifecycle and Recovery](../adr/011-key-recovery.md) — recovery key, multi-device transfer, password reset semantics
-- [ADR 012: Self-Hosted Deployment Tiers](../adr/012-self-hosted-tiers.md) — minimal (single binary) vs full (Docker Compose), capability matrix
-- [ADR 013: API Authentication with E2E Encryption](../adr/013-api-auth-encryption.md) — hybrid metadata + crypto key model, scoped access, key creation UX
-- [ADR 014: Lazy Key Rotation](../adr/014-lazy-key-rotation.md) — per-bucket lazy rotation with server-side ledger
-- [ADR 015: Push Token Plaintext](../adr/015-push-token-plaintext.md) — push tokens stored in plaintext (server-side only, not user content)
-- [ADR 016: Messages Partitioning](../adr/016-messages-partitioning.md) — hash-based partitioning for the messages table
-- [ADR 017: Audit Log Partitioning](../adr/017-audit-log-partitioning.md) — time-based partitioning with automated retention
-- [ADR 018: Encryption-at-Rest Boundary](../adr/018-encryption-at-rest-boundary.md) — DB-layer encryption boundary for tier-2/tier-3 data
-- [ADR 019: Fronting Sessions Partitioning](../adr/019-fronting-sessions-partitioning.md) — time-based partitioning for active fronting session performance
-- [ADR 020: RLS Denormalization](../adr/020-rls-denormalization.md) — cached system_id/account_id on all tables for RLS policy efficiency
-- [ADR 021: Non-System Account Model](../adr/021-non-system-accounts.md) — viewer accounts, account-level friend connections
-- [ADR 022: System Structure Snapshots](../adr/022-system-snapshots.md) — point-in-time structure captures, manual and scheduled triggers
-- [ADR 023: Zod-Type Alignment](../adr/023-zod-type-alignment.md) — strategy for keeping Zod validation schemas synchronized with TypeScript types
-- [ADR 024: Device Transfer Code Entropy](../adr/024-device-transfer-code-entropy.md) — entropy trade-off for user-typed device transfer codes
-- [ADR 025: Webhook Secret Storage](../adr/025-webhook-secret-storage.md) — T3 plaintext storage for webhook signing secrets
-- [ADR 026: Lifecycle Event Type-Specific Validation](../adr/026-lifecycle-event-type-validation.md) — type-discriminated validation for lifecycle event subtypes
-- [ADR 027: Webhook Secret Rotation](../adr/027-webhook-secret-rotation.md) — procedure for rotating webhook HMAC signing secrets
-- [ADR 028: Opt-in IP Audit Logging](../adr/028-opt-in-ip-audit-logging.md) — IP address and user-agent audit logging is opt-in per account (default off)
-- [ADR 029: Server-Side Encrypted Email](../adr/029-server-side-encrypted-email.md) — AES-256-GCM encryption for server-held email addresses (BLAKE2b hash preserved for lookup)
-- [ADR 030: Email Provider Selection](../adr/030-email-provider-selection.md) — Resend for hosted, Nodemailer/SMTP for self-hosted, stub for dev
-
-## Development Sequence Rationale
-
-1. **Types, DB, Crypto, Sync Design** (M1): Everything depends on the domain model. Encryption tiers affect how data is stored. The sync protocol must be co-designed with the DB schema — retrofitting CRDT sync onto an existing schema guarantees rework.
-2. **API Core** (M2): CRUD operations are the foundation for everything above. Auth gates all other endpoints. Recovery key generation happens at registration.
-3. **Sync and Real-Time** (M3): With sync protocol designed in M1, implementation happens early so every subsequent feature is built on top of the sync layer rather than retrofitted. Multi-device key recovery also lives here.
-4. **Fronting, Communication, Privacy** (M4-M6): Ordered by complexity and dependency. Fronting is the most-used feature. Communication builds on member identity. Privacy governs visibility of everything and integrates the three-tier encryption model.
-5. **Data Portability** (M7): Email notifications, webhook enhancements, and public API audit — infrastructure that supports external integration. Import/export and bridge features moved to M8 since they require the client app.
-6. **Client App** (M8): UI consumes the API. Building it after the API is stable prevents constant frontend rework. Includes import/export, PluralKit bridge, and API key management since these are client-side features. In practice, M8 epics will be developed in parallel with M2-M7 (each API feature gets its corresponding UI). Targets web, iOS, and Android via Expo.
-7. **Self-Hosted** (M9): Two-tier model — minimal single binary for personal use, full Docker Compose for feature parity. Depends on the SQLite adapter and full feature set being stable.
-8. **Polish** (M10): Final hardening pass before public launch.
+32 accepted ADRs are documented in [`docs/adr/`](../adr/).

--- a/docs/planning/milestones.md
+++ b/docs/planning/milestones.md
@@ -137,22 +137,26 @@ Epics:
 - ~~tRPC parity enforcement~~ [COMPLETED] — CI script verifying 1:1 REST ↔ tRPC coverage across routes, input validation, and rate limiting; parity audit and remediation of missing procedures (delete, auth, input validation gaps)
 - ~~API documentation~~ [COMPLETED] — API consumer guide (authentication, encryption lifecycle, REST conventions, tRPC setup, sync protocol, error handling), tRPC consumer guide for mobile developers, OpenAPI expanded to 304 operations across 31 route domains
 
-## Milestone 8: App Foundation & Data Layer
+## Milestone 8: App Foundation & Data Layer [COMPLETED]
 
 Goal: App skeleton, navigation infrastructure, provider tree, and the complete data interaction layer — every React Query hook, auth flow, encryption pipeline, sync client, and offline queue needed to power the client app.
 
 Epics:
 
-- App shell & navigation
-- Provider tree & auth flow
-- Sync & offline client
-- Identity data hooks
-- Fronting data hooks
-- Communication data hooks
-- Social data hooks
-- Structure & journaling data hooks
-- Utility data hooks
-- Web platform data adapter
+- ~~App shell & navigation~~ [COMPLETED] — Expo Router layout with `(auth)` and `(app)/(tabs)` route groups, tab bar, stack navigators, deep link config, auth-gated routing
+- ~~Provider tree & auth flow~~ [COMPLETED] — layered provider initialization (Platform, I18n, QueryClient, tRPC, REST, Auth, System, Crypto, BucketKey, DataLayer, Connection, Sync), auth state machine (unauthenticated/unlocked/locked), TokenStore with platform-aware secure storage, SessionRefreshService, BiometricKeyStore
+- ~~Data package~~ [COMPLETED] — `@pluralscape/data` framework-agnostic client data layer: REST query factory, CRDT sync bridge, per-entity row transforms and crypto transforms across all domains
+- ~~Sync & offline client~~ [COMPLETED] — CRDT sync engine integration, WebSocket client, SSE notification client, offline queue with replay, connection state machine with exponential backoff
+- ~~Local data layer & search~~ [COMPLETED] — SQLite local database (WAL mode), materializer DDL, FriendIndexer, QueryInvalidator bridging sync events to React Query, FTS5 full-text search for system and friend data
+- ~~Identity data hooks~~ [COMPLETED] — members, groups/folders, custom fields, custom fronts, system settings with `useOfflineFirstQuery`/`useOfflineFirstInfiniteQuery` factory pattern
+- ~~Fronting data hooks~~ [COMPLETED] — fronting sessions (co-fronting as parallel timelines), analytics, timers, check-ins, comments
+- ~~Communication data hooks~~ [COMPLETED] — channels/messages, board messages, notes, polls with voting, acknowledgements with mandatory confirmation
+- ~~Social data hooks~~ [COMPLETED] — privacy buckets, friend network, device tokens, notification configs, dashboard, friend search with ETag caching, BucketKeyProvider
+- ~~Structure & journaling data hooks~~ [COMPLETED] — inner world (regions, entities, canvas), journal entries/snapshots, structure entities/links/types
+- ~~Utility data hooks~~ [COMPLETED] — audit log, media upload/download, lifecycle events, API keys, search, account management
+- ~~Web platform data adapter~~ [COMPLETED] — platform detection (native vs web), ExpoSqlite (mobile), OPFS SQLite (modern web), IndexedDB (fallback), crypto adapters (React Native vs WASM)
+- ~~CRDT sync entity coverage~~ [COMPLETED] — all document types mapped to sync strategies with materializer registration tests
+- ~~M8 audit remediation~~ [COMPLETED] — P1 + P2 remediation across hook factories, security (plaintext zeroing, error sanitization), missing hooks, observer overhead documentation, bug fixes
 
 ## Milestone 9: UI/UX Design
 

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,0 +1,152 @@
+# @pluralscape/api-client
+
+Typed API client bindings for the Pluralscape API, covering both REST and tRPC interfaces.
+
+## Overview
+
+This package exposes two client interfaces that serve different consumers. The REST client
+(main entry `@pluralscape/api-client`) wraps the public OpenAPI specification using
+`openapi-fetch`, providing full type safety derived from the generated `api-types.ts` file.
+It is used by E2E tests and any external consumer that communicates with the HTTP API directly.
+
+The tRPC client (sub-entry `@pluralscape/api-client/trpc`) uses `@trpc/react-query` and is
+typed against `AppRouter` from `@pluralscape/api`. This is the primary interface used by the
+Expo mobile app — it provides React Query hooks, end-to-end input/output type inference, and
+automatic request batching.
+
+REST/tRPC parity is enforced in CI (`pnpm trpc:parity`). Every tRPC procedure must have a
+corresponding REST route and vice versa. Both interfaces stay in sync with the server by
+design — neither is a secondary or optional path.
+
+## Key Exports
+
+**Main entry (`@pluralscape/api-client`)**
+
+| Export                    | Description                                                         |
+| ------------------------- | ------------------------------------------------------------------- |
+| `createApiClient(config)` | Creates an `openapi-fetch` client bound to the Pluralscape REST API |
+| `ApiClientConfig`         | Configuration interface (`baseUrl`, `getToken`, `platform`)         |
+| `ApiClient`               | Return type of `createApiClient`                                    |
+| `paths`                   | Generated path/operation types from `docs/openapi.yaml`             |
+| `MaybeOptionalInit`       | Re-exported from `openapi-fetch` for typed request init helpers     |
+
+**tRPC sub-entry (`@pluralscape/api-client/trpc`)**
+
+| Export            | Description                                                                             |
+| ----------------- | --------------------------------------------------------------------------------------- |
+| `trpc`            | `createTRPCReact<AppRouter>()` instance — use to call `.useQuery`, `.useMutation`, etc. |
+| `AppRouter`       | The full tRPC router type from `@pluralscape/api`                                       |
+| `RouterInput`     | Inferred input types for all procedures (`inferRouterInputs<AppRouter>`)                |
+| `RouterOutput`    | Inferred output types for all procedures (`inferRouterOutputs<AppRouter>`)              |
+| `MAX_URL_LENGTH`  | `2083` — URL length threshold at which `httpBatchLink` splits batches                   |
+| `MAX_BATCH_ITEMS` | `10` — maximum operations per batch request                                             |
+
+## Usage
+
+### REST client
+
+```typescript
+import { createApiClient } from "@pluralscape/api-client";
+
+const client = createApiClient({
+  baseUrl: "https://api.pluralscape.app",
+  getToken: () => sessionStorage.getItem("session_token"),
+  platform: "web", // or "mobile" — sets X-Client-Platform header
+});
+
+// Fully typed — path, params, and response all inferred from the OpenAPI spec
+const { data, error } = await client.GET("/api/v1/systems/{systemId}/members", {
+  params: { path: { systemId: "sys_abc123" } },
+});
+```
+
+The `getToken` callback may be synchronous or async and return `string | null`. When
+`null` is returned, the `Authorization` header is omitted entirely.
+
+### tRPC client (mobile app)
+
+Set up the tRPC provider once at the app root:
+
+```typescript
+import { trpc, MAX_URL_LENGTH, MAX_BATCH_ITEMS } from "@pluralscape/api-client/trpc";
+import { httpBatchLink } from "@trpc/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+const trpcClient = trpc.createClient({
+  links: [
+    httpBatchLink({
+      url: `${API_BASE_URL}/trpc`,
+      maxURLLength: MAX_URL_LENGTH,
+      maxItems: MAX_BATCH_ITEMS,
+      headers: () => ({
+        Authorization: `Bearer ${getSessionToken()}`,
+      }),
+    }),
+  ],
+});
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </trpc.Provider>
+  );
+}
+```
+
+Call procedures in components:
+
+```typescript
+import { trpc } from "@pluralscape/api-client/trpc";
+
+function MemberList({ systemId }: { systemId: string }) {
+  const { data } = trpc.member.list.useQuery({ systemId, limit: 20 });
+  // ...
+}
+```
+
+Use `RouterInput` and `RouterOutput` for typed helper functions:
+
+```typescript
+import type { RouterInput, RouterOutput } from "@pluralscape/api-client/trpc";
+
+type MemberListInput = RouterInput["member"]["list"];
+type MemberListOutput = RouterOutput["member"]["list"];
+```
+
+## Dependencies
+
+| Package             | Role                                                     |
+| ------------------- | -------------------------------------------------------- |
+| `openapi-fetch`     | HTTP client with OpenAPI path/param/response type safety |
+| `@trpc/client`      | Core tRPC client (link chain, batch logic)               |
+| `@trpc/react-query` | React Query integration for tRPC procedures              |
+
+Dev dependencies include `openapi-typescript` (type generation) and `@trpc/server` (router
+type inference). `@pluralscape/api` is a dev-only workspace dependency — it is never bundled,
+only used for `AppRouter` type inference at build time.
+
+## Type Generation
+
+REST types are generated from the OpenAPI specification at `docs/openapi.yaml` and written to
+`src/generated/api-types.ts`. Run generation from the monorepo root:
+
+```bash
+pnpm --filter @pluralscape/api-client generate
+```
+
+This executes `scripts/generate-types.ts`, which calls `openapi-typescript` and writes the
+result to `src/generated/api-types.ts`. Commit both the spec and the generated file together.
+The generated file is the source of truth for all REST path and response types.
+
+## Testing
+
+Unit tests only — no integration variant exists for this package.
+
+```bash
+pnpm vitest run --project api-client
+```
+
+Tests cover `createApiClient` construction, `Authorization` header attachment when a token is
+present, and omission of the header when `getToken` returns `null`.

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,0 +1,119 @@
+# @pluralscape/crypto
+
+Client-side encryption layer for Pluralscape — libsodium primitives, key hierarchy, and E2E encryption pipeline.
+
+## Overview
+
+Pluralscape enforces zero-knowledge encryption: the server never sees plaintext user data. This package implements the full client-side cryptographic stack using [libsodium](https://libsodium.org/) (XChaCha20-Poly1305 for symmetric encryption, X25519 for asymmetric, Ed25519 for signing, Argon2id for key derivation). All encryption and decryption happens on the device before any data leaves or arrives from the server.
+
+Data is encrypted at one of three tiers based on its sensitivity and sharing requirements. **T1** (zero-knowledge) encrypts with a sub-key derived from the system master key — only the account owner can decrypt. **T2** (per-bucket) encrypts with a per-Privacy-Bucket symmetric key distributed asymmetrically to authorized friends — enabling selective sharing without the server ever seeing the bucket key. **T3** is a typed passthrough for non-sensitive metadata fields that remain in plaintext. See [ADR 006](../../docs/adr/006-encryption.md) for the full encryption architecture.
+
+The key hierarchy flows from a user password through Argon2id to a 256-bit master key, then to identity keypairs (X25519 + Ed25519, independently derived via BLAKE2B KDF) and per-bucket symmetric keys. Key recovery uses a generated recovery phrase that re-encrypts the master key independently of the password. Device transfer uses a QR-scanned ephemeral key to securely bootstrap a new device without a server round-trip. See [ADR 011](../../docs/adr/011-key-recovery.md) and [ADR 014](../../docs/adr/014-lazy-key-rotation.md) for recovery and rotation details.
+
+## Key Exports
+
+### Main entry (`@pluralscape/crypto`)
+
+**Sodium lifecycle** — `initSodium`, `configureSodium`, `getSodium`, `isReady`
+
+**Key derivation** — `deriveMasterKey`, `generateSalt`, `derivePasswordKey`, `generateMasterKey`, `wrapMasterKey`, `unwrapMasterKey`, `deriveSyncEncryptionKey`
+
+**Symmetric encryption** — `encrypt`, `decrypt`, `encryptJSON`, `decryptJSON`, `encryptStream`, `decryptStream`
+
+**Tier helpers** — `encryptTier1`, `decryptTier1`, `encryptTier1Batch`, `decryptTier1Batch`, `encryptTier2`, `decryptTier2`, `encryptTier2Batch`, `decryptTier2Batch`, `wrapTier3`
+
+**Identity keypairs** — `generateIdentityKeypair`, `encryptPrivateKey`, `decryptPrivateKey`, `serializePublicKey`
+
+**Bucket key management** — `generateBucketKey`, `encryptBucketKey`, `decryptBucketKey`, `rotateBucketKey`, `createBucketKeyCache`
+
+**Key grants** — `createKeyGrant`, `createKeyGrants`, `decryptKeyGrant`
+
+**Recovery and transfer** — `generateRecoveryKey`, `recoverMasterKey`, `isValidRecoveryKeyFormat`, `toRecoveryKeyDisplay`, `serializeRecoveryBackup`, `deserializeRecoveryBackup`, `resetPasswordViaRecoveryKey`, `regenerateRecoveryKey`, `generateTransferCode`, `deriveTransferKey`, `encryptForTransfer`, `decryptFromTransfer`, `encodeQRPayload`, `decodeQRPayload`
+
+**Signing** — `sign`, `verify`, `signThenEncrypt`, `decryptThenVerify`
+
+**Safety numbers** — `computeSafetyNumber`
+
+**Password / PIN** — `hashPassword`, `verifyPassword`, `hashPin`, `verifyPin`
+
+**Key storage** — `createWebKeyStorage`
+
+**Key lifecycle** — `MobileKeyLifecycleManager`, `SECURITY_PRESETS`
+
+**Validation** — `assertAeadKey`, `assertAeadNonce`, `assertBufferLength`, `assertPwhashSalt`, `assertSignature`, `assertSignPublicKey`
+
+**Hex encoding** — `toHex`, `fromHex`
+
+**Blob codec** — `serializeEncryptedBlob`, `deserializeEncryptedBlob`
+
+**Errors** — `DecryptionFailedError`, `KeysLockedError`, `SignatureVerificationError`, `CryptoNotReadyError`, `InvalidInputError`, `BiometricFailedError`, `AlreadyInitializedError`, `InvalidStateTransitionError`, `KeyStorageFailedError`, `UnsupportedOperationError`
+
+### Sub-entry points
+
+| Import path                          | Purpose                                                                           |
+| ------------------------------------ | --------------------------------------------------------------------------------- |
+| `@pluralscape/crypto/blob-pipeline`  | Encrypt/decrypt binary blobs with content validation and upload preparation       |
+| `@pluralscape/crypto/wasm`           | WASM adapter (`WasmSodiumAdapter`) for Bun/Node/Web via `libsodium-wrappers-sumo` |
+| `@pluralscape/crypto/react-native`   | React Native adapter (`ReactNativeSodiumAdapter`) via `react-native-libsodium`    |
+| `@pluralscape/crypto/native-memzero` | `wrapNativeMemzero` — platform native secure memory zeroing                       |
+
+## Usage
+
+Initialize libsodium once before calling any crypto function:
+
+```ts
+import { configureSodium, initSodium } from "@pluralscape/crypto";
+import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
+
+configureSodium(new WasmSodiumAdapter());
+await initSodium();
+```
+
+Derive a master key from a password and encrypt data at T1 (zero-knowledge):
+
+```ts
+import { deriveMasterKey, encryptTier1, decryptTier1, generateSalt } from "@pluralscape/crypto";
+
+const salt = generateSalt();
+const masterKey = await deriveMasterKey({ password: "hunter2", salt });
+
+const blob = encryptTier1({ name: "Maple", role: "host" }, masterKey);
+// blob.tier === 1 — safe to send to server
+
+const plain = decryptTier1(blob, masterKey) as { name: string; role: string };
+```
+
+For Privacy Bucket sharing, generate a bucket key, encrypt data at T2, and distribute the bucket key as a key grant encrypted to each friend's public key:
+
+```ts
+import { generateBucketKey, encryptTier2, createKeyGrant } from "@pluralscape/crypto";
+
+const bucketKey = generateBucketKey();
+const blob = encryptTier2(data, { bucketKey, bucketId: "bucket-uuid" });
+
+const grant = createKeyGrant({ bucketKey, bucketId: "bucket-uuid", recipientPublicKey });
+// Store grant on server — recipient decrypts with their private key
+```
+
+## Dependencies
+
+**Internal**
+
+- `@pluralscape/types` — shared branded types (`BucketId`, `T1EncryptedBlob`, `T2EncryptedBlob`, etc.)
+
+**External**
+
+- `libsodium-wrappers-sumo` — WASM build of libsodium (Bun/Node/Web)
+- `react-native-libsodium` _(optional peer dependency)_ — native libsodium bindings for React Native
+
+## Testing
+
+```bash
+# Unit tests
+pnpm vitest run --project crypto
+
+# Integration tests
+pnpm vitest run --project crypto-integration
+```
+
+Unit tests cover individual cryptographic operations (key derivation, encrypt/decrypt, signing, validation). Integration tests exercise the full key lifecycle, recovery flows, and device transfer protocol against real sodium operations.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -1,0 +1,126 @@
+# @pluralscape/data
+
+Client-side data layer: React Query wiring, REST query factories, CRDT bridge, and per-domain crypto transforms for the Pluralscape mobile app.
+
+## Overview
+
+`@pluralscape/data` is the bridge between the mobile app's UI and the two data sources it reads from: the REST API (via `@pluralscape/api-client`) and the offline-first CRDT sync engine (via `@pluralscape/sync`). It provides a configured React Query client, factory functions that produce type-safe query options objects, and the logic for transparently decrypting API responses using the session master key.
+
+Every entity the app works with — members, fronting sessions, channels, notes, polls, innerworld entities, and more — has a corresponding set of crypto transforms in this package. These transforms handle decrypting ciphertext fields from API responses and encrypting plaintext fields before writes, using the XChaCha20-Poly1305 primitives from `@pluralscape/crypto`. Sensitive fields never leave the client in plaintext.
+
+This package has no runtime dependency on React Native or Expo and does not import any UI primitives. It is consumed by the `apps/mobile` Expo app but is kept framework-agnostic so it can be tested in a plain Node/Vitest environment.
+
+## Key Exports
+
+### Query client
+
+```ts
+import { createAppQueryClient } from "@pluralscape/data";
+```
+
+`createAppQueryClient()` — returns a pre-configured `QueryClient` with opinionated defaults: 30-second stale time, 5-minute GC window, 2 retries on queries, 1 on mutations, and `refetchOnWindowFocus`/`refetchOnReconnect` enabled.
+
+### REST query factory
+
+```ts
+import { createRestQueryFactory } from "@pluralscape/data";
+```
+
+`createRestQueryFactory(deps)` — given an `ApiClient` and a `getMasterKey` accessor, returns a factory whose `queryOptions()` method produces a `{ queryKey, queryFn }` object ready to pass to `useQuery`. The overloaded signature accepts an optional `decrypt` callback; when provided, the raw API response is passed through it together with the live master key before the data is cached.
+
+### CRDT query bridge
+
+```ts
+import { createCrdtQueryBridge } from "@pluralscape/data";
+```
+
+`createCrdtQueryBridge(deps)` — wraps the sync engine's `getDocumentSnapshot` behind a React Query `queryFn`, projecting a typed view from the raw document using a caller-supplied `project` function.
+
+### Crypto transforms (per domain)
+
+All transform modules are re-exported from the root entry and also available as granular sub-path imports (e.g. `@pluralscape/data/transforms/member`).
+
+| Domain        | Transforms                                                                                                             |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| System        | `decryptSystemSettings`, `encryptSystemSettingsUpdate`, `decryptNomenclature`, `encryptNomenclatureUpdate`             |
+| Members       | `decryptMember`, `decryptMemberPage`, `encryptMemberInput`, `encryptMemberUpdate`                                      |
+| Fronting      | `decryptFrontingSession`, `encryptFrontingSessionInput`, `decryptFrontingComment`, `decryptFrontingReport`, ...        |
+| Custom fronts | `decryptCustomFront`, `encryptCustomFrontInput`, `encryptCustomFrontUpdate`                                            |
+| Custom fields | `decryptFieldDefinition`, `decryptFieldValue`, `encryptFieldValueInput`, ...                                           |
+| Communication | `decryptChannel`, `decryptMessage`, `decryptBoardMessage`, `decryptPoll`, `decryptNote`, `decryptAcknowledgement`, ... |
+| Innerworld    | `decryptInner­worldEntity`, `decryptInner­worldRegion`, `decryptInner­worldCanvas`                                     |
+| Relationships | `decryptRelationship`                                                                                                  |
+| Social        | `decryptFriendConnection`, `decryptFriendCode`, `decryptFriendDashboard`, `decryptPrivacyBucket`                       |
+| Notifications | `decryptNotificationConfig`, `decryptDeviceToken`                                                                      |
+| Blobs         | `decodeAndDecryptT1`, `encryptAndEncodeT1`, `encryptInput`, `encryptUpdate`                                            |
+
+## Usage
+
+### Setting up the query client and REST factory
+
+```ts
+import { createAppQueryClient, createRestQueryFactory } from "@pluralscape/data";
+import { createApiClient } from "@pluralscape/api-client";
+
+const queryClient = createAppQueryClient();
+
+const restQuery = createRestQueryFactory({
+  apiClient: createApiClient({ baseUrl: "https://api.example.com" }),
+  getMasterKey: () => sessionStore.masterKey,
+});
+
+// In a React component:
+const memberOpts = restQuery.queryOptions({
+  queryKey: ["member", memberId],
+  path: "/v1/members/{id}",
+  init: { params: { path: { id: memberId } } },
+  decrypt: (raw, masterKey) => decryptMember(raw, masterKey),
+});
+
+const { data: member } = useQuery(memberOpts);
+```
+
+### Reading from the CRDT sync engine
+
+```ts
+import { createCrdtQueryBridge } from "@pluralscape/data";
+
+const bridge = createCrdtQueryBridge({ engine: syncEngine });
+
+const snapshotOpts = bridge.documentQueryOptions({
+  queryKey: ["snapshot", documentId],
+  documentId,
+  project: (doc) => projectSnapshot(doc),
+});
+
+const { data: snapshot } = useQuery(snapshotOpts);
+```
+
+## Dependencies
+
+| Package                   | Role                                                                                                           |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `@pluralscape/api-client` | Generated OpenAPI fetch client — provides typed `GET` (and other methods) used by the REST query factory       |
+| `@pluralscape/crypto`     | `KdfMasterKey` type and low-level decrypt/encrypt primitives used by all transform modules                     |
+| `@pluralscape/sync`       | `SyncDocumentId` type; the CRDT bridge accepts any object implementing `getDocumentSnapshot` from this package |
+| `@pluralscape/types`      | Shared domain types consumed by transforms and the CRDT bridge                                                 |
+| `@tanstack/react-query`   | `QueryClient`, `QueryKey`, and `useQuery` — the caching layer this package configures and integrates with      |
+
+React `>=19.0.0` is a peer dependency (required by React Query v5).
+
+## Testing
+
+Run unit tests from the monorepo root:
+
+```bash
+pnpm vitest run --project data
+```
+
+There is no integration variant — all tests are unit tests that run in a Vitest/Node environment with no network or database I/O.
+
+The test suite covers:
+
+- `createAppQueryClient` — verifies the configured default options (stale time, GC time, retry counts).
+- `createRestQueryFactory` — covers successful decrypted and plain fetches, missing master key, and API error propagation.
+- `createCrdtQueryBridge` — verifies that `documentQueryOptions` projects snapshots correctly and throws when the document is not loaded.
+- Crypto transforms are exercised indirectly through the factory tests; each transform module is individually importable for targeted testing.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,153 @@
+# @pluralscape/db
+
+Drizzle ORM schema, client factory, and query helpers for the Pluralscape database layer.
+
+## Overview
+
+This package defines the complete Pluralscape database schema across two SQL dialects:
+PostgreSQL for hosted deployments and SQLite (via `better-sqlite3-multiple-ciphers`) for
+self-hosted deployments. The schema covers all application domains — members, fronting
+sessions, journals, groups, custom fields, communication, innerworld, blob metadata,
+notifications, key rotation, import/export, audit logging, and more — spanning 40+ tables.
+
+Each dialect has its own Drizzle schema definition under `src/schema/pg/` and
+`src/schema/sqlite/`, exported via the `./pg` and `./sqlite` sub-entry points. The main
+entry point (`@pluralscape/db`) exports the client factory, dialect and deployment
+detection utilities, RLS helpers, shared query helpers, enumeration constants, and view
+types that are dialect-agnostic.
+
+Row-Level Security (RLS) is enforced on the PostgreSQL dialect. Every table is protected
+by tenant-scoped policies keyed on `system_id` and `account_id`. The RLS migration is
+generated from the schema and must be regenerated whenever the schema changes (see
+[Migrations](#migrations)).
+
+## Key Exports
+
+**Client factory** — `createDatabase(config)` and `createDatabaseFromEnv()` return a
+`DatabaseClient` (either `PgDatabaseClient` or `SqliteDatabaseClient`). Both implement
+`Closeable`.
+
+**Dialect and deployment detection** — `getDialect()`, `isPostgreSQL()`, `isSQLite()`,
+`getDialectCapabilities()`, `getDeploymentMode()`. Use these to branch on runtime
+environment.
+
+**RLS utilities** — `setTenantContext()`, `setSystemId()`, `setAccountId()`,
+`accountScope()`, `systemScope()`, `enableRls()`, `applyAllRls()`,
+`generateRlsStatements()`, `RLS_TABLE_POLICIES`. Used by the API to set per-request
+tenant context before executing queries.
+
+**Schema sub-entry points** — `@pluralscape/db/pg` and `@pluralscape/db/sqlite` expose
+the full Drizzle table definitions for each dialect. Import from these when constructing
+Drizzle queries directly.
+
+**Query helpers** — maintenance queries for audit log cleanup (`pgCleanupAuditLog`,
+`sqliteCleanupAuditLog`), orphaned tag cleanup, and device transfer cleanup.
+
+**View types and helpers** — `pgViews`, `sqliteViews`, and mapped row types such as
+`CurrentFronter`, `CurrentFronterWithDuration`, `MemberGroupSummary`,
+`ActiveFriendConnection`, and others.
+
+**Enumeration constants** — domain enums used across the API and schema: `ENTITY_TYPES`,
+`AUDIT_EVENT_TYPES`, `FRONTING_REPORT_FORMATS`, `CHANNEL_TYPES`, `BLOB_PURPOSES`,
+`IMPORT_SOURCES`, `ROTATION_STATES`, and many others.
+
+**Pool and retention constants** — `PG_POOL_MAX_CONNECTIONS`, `PG_POOL_IDLE_TIMEOUT_SECONDS`,
+`PG_POOL_CONNECT_TIMEOUT_SECONDS`, `PG_POOL_MAX_LIFETIME_SECONDS`,
+`AUDIT_LOG_RETENTION_DAYS`.
+
+**Test helpers** — `@pluralscape/db/test-helpers/pg-helpers` provides PGlite-backed
+helpers for integration tests.
+
+## Usage
+
+Creating a client from explicit config:
+
+```ts
+import { createDatabase } from "@pluralscape/db";
+
+const db = createDatabase({
+  dialect: "pg",
+  connectionString: process.env.DATABASE_URL!,
+});
+```
+
+Creating a client from environment variables:
+
+```ts
+import { createDatabaseFromEnv } from "@pluralscape/db";
+
+// Reads DIALECT, DATABASE_URL (pg) or DATABASE_PATH + DATABASE_KEY (sqlite)
+const db = createDatabaseFromEnv();
+```
+
+Importing schema tables for Drizzle queries (PostgreSQL):
+
+```ts
+import { members, frontingSessions } from "@pluralscape/db/pg";
+import { eq } from "drizzle-orm";
+
+const rows = await db.drizzle.select().from(members).where(eq(members.systemId, systemId));
+```
+
+## Dependencies
+
+**Internal**
+
+- `@pluralscape/crypto` — encryption utilities used in SQLCipher key handling
+- `@pluralscape/types` — shared TypeScript types including `Logger`, `BucketContentEntityType`
+
+**External**
+
+- `drizzle-orm` — query builder and schema definition
+- `postgres` — PostgreSQL driver (postgres.js)
+- `better-sqlite3-multiple-ciphers` — SQLite driver with SQLCipher encryption support
+
+**Dev**
+
+- `drizzle-kit` — migration generation CLI
+- `@electric-sql/pglite` — in-process PostgreSQL for integration tests
+- `tsx` — runs TypeScript scripts (migration generation, RLS application)
+
+## Migrations
+
+Migration files live in `migrations/pg/` and `migrations/sqlite/`.
+
+Generate the Drizzle schema migration after schema changes:
+
+```bash
+# PostgreSQL
+pnpm --filter @pluralscape/db db:generate:pg
+
+# SQLite
+pnpm --filter @pluralscape/db db:generate:sqlite
+```
+
+**After any schema change that adds or removes tables, you must also regenerate the RLS
+migration:**
+
+```bash
+pnpm --filter @pluralscape/db exec tsx scripts/generate-rls-migration.ts \
+  > packages/db/migrations/pg/0001_rls_all_tables.sql
+```
+
+The RLS migration must always be `0001_rls_all_tables.sql` (after the `0000` Drizzle
+schema migration). Update the filename reference in
+`src/__tests__/rls-migrations.integration.test.ts` if the migration file changes.
+
+## Testing
+
+Unit tests (no external infrastructure required):
+
+```bash
+pnpm vitest run --project db
+```
+
+Integration tests (requires a running PostgreSQL instance — PGlite is used automatically
+in the test environment):
+
+```bash
+pnpm vitest run --project db-integration
+```
+
+Integration tests cover RLS policy enforcement, schema migrations, CRUD for all entity
+types, audit log cleanup, and client factory behaviour across both dialects.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -1,0 +1,155 @@
+# @pluralscape/email
+
+Platform-agnostic email sending with typed security notification templates.
+
+## Overview
+
+This package provides a common `EmailAdapter` interface that decouples email delivery from the
+rest of the API. All email operations go through `send(params: EmailSendParams)`, which returns
+a `Promise<EmailSendResult>`. Switching providers requires only swapping the adapter — no
+changes to call sites.
+
+Four adapters ship with the package. `ResendEmailAdapter` targets hosted deployments using the
+Resend API. `SmtpEmailAdapter` targets self-hosted deployments via Nodemailer and supports
+optional connection pooling. `StubEmailAdapter` is a no-op suitable as a production fallback
+when no provider is configured. `InMemoryEmailAdapter` (available via the `./testing` entry
+point) captures sent messages in memory for test assertions.
+
+The `./templates` entry point provides five typed security notification templates:
+`recovery-key-regenerated`, `new-device-login`, `password-changed`, `two-factor-changed`, and
+`webhook-failure-digest`. Each template is rendered to `{ subject, html, text }` via
+`renderTemplate`, keeping HTML generation separate from delivery.
+
+Design rationale: ADR 029 (Server-Side Encrypted Email), ADR 030 (Email Provider Selection).
+
+## Key Exports
+
+### Core (`@pluralscape/email`)
+
+| Export                    | Kind      | Purpose                                                                |
+| ------------------------- | --------- | ---------------------------------------------------------------------- |
+| `EmailAdapter`            | interface | Common adapter contract (`providerName`, `send`)                       |
+| `EmailSendParams`         | type      | Input to `send` (`to`, `subject`, `html`, `text`, `from?`, `replyTo?`) |
+| `EmailSendResult`         | type      | Output of `send` (`messageId: string \| null`)                         |
+| `StubEmailAdapter`        | class     | No-op adapter, safe as a production fallback                           |
+| `EmailDeliveryError`      | class     | Provider rejected the message                                          |
+| `EmailConfigurationError` | class     | Adapter is misconfigured (bad API key, SMTP connection failure)        |
+| `EmailRateLimitError`     | class     | Provider rate-limited the request                                      |
+| `InvalidRecipientError`   | class     | Recipient address rejected by the provider                             |
+| `DEFAULT_FROM_ADDRESS`    | const     | Default sender address                                                 |
+| `MAX_RECIPIENTS`          | const     | Maximum recipients per send                                            |
+| `MAX_SUBJECT_LENGTH`      | const     | Maximum subject line length                                            |
+| `validateSendParams`      | function  | Throws on invalid params before hitting the provider                   |
+
+### Resend adapter (`@pluralscape/email/resend`)
+
+| Export                     | Kind      | Purpose                          |
+| -------------------------- | --------- | -------------------------------- |
+| `ResendEmailAdapter`       | class     | Adapter backed by the Resend API |
+| `ResendEmailAdapterConfig` | interface | `{ apiKey, fromAddress? }`       |
+
+Factory methods: `ResendEmailAdapter.create(config)`, `ResendEmailAdapter.fromClient(client, fromAddress?)`.
+
+### SMTP adapter (`@pluralscape/email/smtp`)
+
+| Export             | Kind      | Purpose                                                  |
+| ------------------ | --------- | -------------------------------------------------------- |
+| `SmtpEmailAdapter` | class     | Adapter backed by Nodemailer                             |
+| `SmtpConfig`       | interface | `{ host, port, secure?, auth?, pool?, maxConnections? }` |
+
+Factory methods: `SmtpEmailAdapter.create(config, fromAddress?)`, `SmtpEmailAdapter.fromTransport(transport, fromAddress?)`.
+
+### Templates (`@pluralscape/email/templates`)
+
+| Export                       | Kind      | Purpose                                                                 |
+| ---------------------------- | --------- | ----------------------------------------------------------------------- |
+| `renderTemplate`             | function  | `renderTemplate(name, vars)` → `RenderedEmail`                          |
+| `EmailTemplateMap`           | interface | Maps template name to its variable type                                 |
+| `EmailTemplateName`          | type      | Union of valid template names                                           |
+| `RenderedEmail`              | interface | `{ subject, html, text }`                                               |
+| `RecoveryKeyRegeneratedVars` | interface | `{ timestamp, deviceInfo }`                                             |
+| `NewDeviceLoginVars`         | interface | `{ timestamp, deviceInfo, ipAddress }`                                  |
+| `PasswordChangedVars`        | interface | `{ timestamp }`                                                         |
+| `TwoFactorChangedVars`       | interface | `{ timestamp, action }`                                                 |
+| `WebhookFailureDigestVars`   | interface | `{ webhookUrl, failureCount, lastError, timeRangeStart, timeRangeEnd }` |
+
+### Testing helpers (`@pluralscape/email/testing`)
+
+| Export                    | Kind      | Purpose                                                                        |
+| ------------------------- | --------- | ------------------------------------------------------------------------------ |
+| `InMemoryEmailAdapter`    | class     | Captures sent messages; exposes `.sent`, `.lastSent`, `.sentCount`, `.clear()` |
+| `SentEmail`               | interface | Record type stored in `.sent`                                                  |
+| `runEmailAdapterContract` | function  | Shared contract test suite for custom adapters                                 |
+
+## Usage
+
+```typescript
+import { ResendEmailAdapter } from "@pluralscape/email/resend";
+import { renderTemplate } from "@pluralscape/email/templates";
+
+// 1. Create an adapter
+const adapter = ResendEmailAdapter.create({
+  apiKey: process.env.RESEND_API_KEY!,
+  fromAddress: "notifications@pluralscape.app",
+});
+
+// 2. Render a template
+const email = renderTemplate("new-device-login", {
+  timestamp: new Date().toISOString(),
+  deviceInfo: "Chrome on macOS",
+  ipAddress: "203.0.113.42",
+});
+
+// 3. Send
+const result = await adapter.send({
+  to: "user@example.com",
+  subject: email.subject,
+  html: email.html,
+  text: email.text,
+});
+
+console.log(result.messageId); // provider-assigned ID, or null
+```
+
+For self-hosted deployments, swap in `SmtpEmailAdapter`:
+
+```typescript
+import { SmtpEmailAdapter } from "@pluralscape/email/smtp";
+
+const adapter = SmtpEmailAdapter.create(
+  { host: "mail.example.com", port: 587, secure: false, auth: { user: "u", pass: "p" } },
+  "notifications@example.com",
+);
+```
+
+In tests, use `InMemoryEmailAdapter` and assert on `.sent`:
+
+```typescript
+import { InMemoryEmailAdapter } from "@pluralscape/email/testing";
+
+const adapter = new InMemoryEmailAdapter();
+await adapter.send({ to: "a@b.com", subject: "s", html: "<p>h</p>", text: "h" });
+expect(adapter.sentCount).toBe(1);
+expect(adapter.lastSent?.subject).toBe("s");
+```
+
+## Dependencies
+
+| Package      | Purpose                                       |
+| ------------ | --------------------------------------------- |
+| `resend`     | Resend API SDK (used by `ResendEmailAdapter`) |
+| `nodemailer` | SMTP transport (used by `SmtpEmailAdapter`)   |
+
+## Testing
+
+```bash
+# Unit tests
+pnpm vitest run --project email
+
+# Integration tests
+pnpm vitest run --project email-integration
+```
+
+`runEmailAdapterContract` (from `@pluralscape/email/testing`) is a shared suite that verifies
+any custom adapter implementation satisfies the full `EmailAdapter` contract. Pass it your
+adapter instance in a `describe` block.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,0 +1,178 @@
+# @pluralscape/i18n
+
+Internationalization and community-terminology resolution for the Pluralscape platform.
+
+## Overview
+
+This package wraps [i18next](https://www.i18next.com/) with Pluralscape-specific defaults: namespace
+layout, missing-key handling, and synchronous React initialization via `I18nProvider`. Consumers
+create an instance with `createI18nInstance`, add any additional plugins, and call `.init()` with
+locale resources — the factory keeps the instance uninitialized so each application layer can
+compose plugins in the right order.
+
+A core concern of this package is the **nomenclature system**: plural systems use widely different
+terms for shared concepts (e.g., "headmate", "alter", "part", "insider"). Rather than hardcoding
+any one vocabulary, every community term is represented as a `CanonicalTerm` resolved against the
+system's `NomenclatureSettings` at display time. Consumers call `resolveTerm` and its variants
+(`resolveTermPlural`, `resolveTermLower`, `resolveTermTitle`, `resolveTermUpper`) to get the
+user-preferred word in the right grammatical form.
+
+RTL layout is supported via `getTextDirection` / `isRtl`, which map a locale tag to `"ltr"` or
+`"rtl"`. The four RTL locales currently defined are Arabic (`ar`), Hebrew (`he`), Farsi (`fa`),
+and Urdu (`ur`). Supported locales are declared in `SUPPORTED_LOCALES`; additional locales are
+added there alongside translation resource bundles.
+
+## Key Exports
+
+### Instance creation
+
+| Export                         | Description                                                         |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `createI18nInstance(options?)` | Creates an uninitialized i18next instance with Pluralscape defaults |
+| `CreateI18nOptions`            | `{ missingKeyMode: "warn" \| "throw", logger? }`                    |
+| `createMissingKeyHandler`      | Builds the missing-key callback used internally by the instance     |
+
+### Constants
+
+| Export              | Description                                                                                                                        |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `DEFAULT_LOCALE`    | `"en"`                                                                                                                             |
+| `DEFAULT_NAMESPACE` | `"common"`                                                                                                                         |
+| `NAMESPACES`        | All translation namespaces: `common`, `auth`, `members`, `fronting`, `settings`, `communication`, `groups`, `privacy`, `structure` |
+| `SUPPORTED_LOCALES` | All supported locale tags                                                                                                          |
+| `RTL_LOCALES`       | Locales rendered right-to-left: `ar`, `he`, `fa`, `ur`                                                                             |
+
+### Nomenclature resolvers
+
+All resolvers accept a `CanonicalTerm` and `NomenclatureSettings | null | undefined`.
+When settings are absent or the category is unset, the term's `defaultValue` is used.
+
+| Export                                   | Description                                                                               |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `CANONICAL_TERMS`                        | Map of `SCREAMING_SNAKE` keys to `CanonicalTerm` objects (e.g., `CANONICAL_TERMS.MEMBER`) |
+| `PRESET_PLURAL_RULES`                    | Explicit singular-to-plural map for all built-in term values                              |
+| `resolveTerm(canonical, settings)`       | Display string (user-preferred or default)                                                |
+| `resolveTermPlural(canonical, settings)` | Pluralized form, with heuristic fallback                                                  |
+| `resolveTermLower(canonical, settings)`  | Lowercase form                                                                            |
+| `resolveTermTitle(canonical, settings)`  | Title-case form                                                                           |
+| `resolveTermUpper(canonical, settings)`  | Uppercase form                                                                            |
+| `UseNomenclatureResult`                  | Interface type for the M8 React hook return value                                         |
+
+### Text direction
+
+| Export                     | Description                           |
+| -------------------------- | ------------------------------------- |
+| `isRtl(locale)`            | `true` if the locale is right-to-left |
+| `getTextDirection(locale)` | `"ltr"` or `"rtl"`                    |
+
+### Types
+
+| Export                 | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `I18nConfig`           | Full configuration shape passed to `I18nProvider` |
+| `I18nNamespace`        | Union of valid namespace strings                  |
+| `TranslationResources` | Resource bundle type for `.init()`                |
+
+### React integration (`@pluralscape/i18n/react`)
+
+| Export                  | Description                                                      |
+| ----------------------- | ---------------------------------------------------------------- |
+| `I18nProvider`          | Initializes i18n synchronously and provides it to the React tree |
+| `useTranslation`        | Re-export from `react-i18next`                                   |
+| `Trans`                 | Re-export from `react-i18next`                                   |
+| `UseNomenclatureResult` | Re-export from the core package                                  |
+
+## Usage
+
+### Creating an instance (non-React)
+
+```ts
+import { createI18nInstance, NAMESPACES, DEFAULT_NAMESPACE } from "@pluralscape/i18n";
+
+const i18n = createI18nInstance({ missingKeyMode: "throw" });
+// Add plugins here, then initialize:
+await i18n.init({
+  lng: "en",
+  resources: { en: { common: { greeting: "Hello" } } },
+  defaultNS: DEFAULT_NAMESPACE,
+  ns: [...NAMESPACES],
+  interpolation: { escapeValue: false },
+});
+```
+
+### React provider
+
+```tsx
+import { I18nProvider } from "@pluralscape/i18n/react";
+import type { I18nConfig } from "@pluralscape/i18n";
+
+const config: I18nConfig = {
+  locale: "en",
+  fallbackLocale: "en",
+  missingKeyMode: "warn",
+  logger: console,
+  resources: { en: { common: { greeting: "Hello" } } },
+};
+
+export function App() {
+  return (
+    <I18nProvider config={config}>
+      <Screen />
+    </I18nProvider>
+  );
+}
+```
+
+### Nomenclature resolution
+
+```ts
+import { CANONICAL_TERMS, resolveTerm, resolveTermPlural } from "@pluralscape/i18n";
+
+// settings comes from the system's stored NomenclatureSettings
+const label = resolveTerm(CANONICAL_TERMS.MEMBER, settings); // "Headmate"
+const plural = resolveTermPlural(CANONICAL_TERMS.MEMBER, settings); // "Headmates"
+```
+
+### Text direction
+
+```ts
+import { getTextDirection } from "@pluralscape/i18n";
+
+const dir = getTextDirection("ar"); // "rtl"
+```
+
+### Formatting utilities
+
+```ts
+import {
+  formatDate,
+  formatDateTime,
+  formatTime,
+  formatDuration,
+  formatFrontingDuration,
+  formatNumber,
+  formatCompactNumber,
+  formatPercentage,
+  formatRelativeTime,
+} from "@pluralscape/i18n";
+
+formatDuration(5_400_000); // "1h 30m"
+formatFrontingDuration(startMs, null, now); // ongoing front duration
+formatRelativeTime(timestamp, "en");
+```
+
+## Dependencies
+
+| Package              | Role                                                               |
+| -------------------- | ------------------------------------------------------------------ |
+| `i18next`            | Core i18n engine                                                   |
+| `react-i18next`      | React bindings and `I18nextProvider`                               |
+| `@pluralscape/types` | `CanonicalTerm`, `NomenclatureSettings`, `Locale`, `TextDirection` |
+
+## Testing
+
+Unit tests only (no I/O):
+
+```sh
+pnpm vitest run --project i18n
+```

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -1,0 +1,137 @@
+# @pluralscape/queue
+
+Backend-agnostic job queue with BullMQ and SQLite adapters for reliable async processing.
+
+## Overview
+
+`@pluralscape/queue` provides a shared interface for durable, retryable background jobs across
+Pluralscape's two deployment tiers. The core `JobQueue` and `JobWorker` interfaces define a
+single contract that both adapters implement, keeping application code free of backend-specific
+concerns.
+
+The BullMQ adapter (backed by Valkey) serves the hosted and full self-hosted tiers. It provides
+priority queues, delayed jobs, repeatable schedules, and rate limiting — the same Valkey instance
+already required for real-time pub/sub (see ADR 007). The SQLite adapter runs in-process against
+the existing local database, polling a job table on a configurable interval. It targets the
+minimal self-hosted tier where no external services are available; throughput is lower but all
+retry, backoff, DLQ, and idempotency semantics are identical.
+
+Both adapters enforce idempotency via per-job keys, support exponential backoff with configurable
+retry policies, route exhausted jobs to a dead-letter queue (DLQ), and expose health and metrics
+through the observability layer. Job payloads carry only IDs and encrypted references — never
+plaintext user data. See [ADR 010](../../docs/adr/010-background-jobs.md) for the full decision
+record.
+
+## Key Exports
+
+### Root (`@pluralscape/queue`)
+
+**Interfaces**
+
+- `JobQueue` — enqueue, dequeue, acknowledge, bury, and query jobs
+- `JobWorker` — register handlers and manage the worker lifecycle
+- `JobHandler`, `JobHandlerContext` — per-job-type processing contract
+- `JobEventHooks` — lifecycle callbacks (enqueue, start, complete, fail, bury)
+- `HeartbeatHandle` — token returned by long-running jobs to emit liveness signals
+
+**Base class**
+
+- `BaseJobWorker` — shared worker logic (handler registry, shutdown, heartbeat dispatch)
+
+**Errors**
+
+- `DuplicateHandlerError` — handler registered twice for the same job type
+- `IdempotencyConflictError` — job with this idempotency key already completed or in-flight
+- `InvalidJobTransitionError` — illegal state transition (e.g., completing a buried job)
+- `JobNotFoundError` — job ID not found when acknowledging or burying
+- `NoHandlersRegisteredError` — worker started with no handlers
+- `WorkerAlreadyRunningError` — `start()` called on an already-running worker
+
+**Types**
+
+- `JobEnqueueParams`, `JobFilter`, `IdempotencyCheckResult`
+
+**Constants (exported from root)**
+
+- `DEFAULT_TIMEOUT_MS` (30 000 ms)
+- `DEFAULT_POLL_INTERVAL_MS` (100 ms)
+- `DEFAULT_SHUTDOWN_TIMEOUT_MS` (5 000 ms)
+- `AUDIT_LOG_CLEANUP_CRON` — `"0 3 * * *"` (03:00 UTC)
+- `WEBHOOK_DELIVERY_CLEANUP_CRON` — `"30 3 * * *"` (03:30 UTC)
+
+### Sub-entry points
+
+| Entry point      | Exports                                                                                                                                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/bullmq`        | `BullMQJobQueue`, `BullMQJobWorker`, `createValkeyConnection`, `ValkeyConnectionConfig`, `fromStoredData`, `StoredJobData`                                                                                                                    |
+| `/sqlite`        | `SqliteJobQueue`, `SqliteJobWorker`, `rowToJob`                                                                                                                                                                                               |
+| `/policies`      | `calculateBackoff`, `DEFAULT_RETRY_POLICY`, `DEFAULT_RETRY_POLICIES`, `applyDefaultPolicies`                                                                                                                                                  |
+| `/dlq`           | `DLQManager`, `DLQFilter`                                                                                                                                                                                                                     |
+| `/observability` | `ObservableJobQueue`, `ObservableJobWorker`, `QueueHealthService`, `QueueHealthSummary`, `InMemoryJobMetrics`, `AggregateMetrics`, `JobMetrics`, `JobTypeMetrics`, `StalledJobSweeper`, `StalledSweeperOptions`, `checkAlerts`, `AlertConfig` |
+| `/testing`       | `InMemoryJobQueue`, `InMemoryJobWorker`, `runJobQueueContract`, `runJobWorkerContract`, `makeJobParams`, `testSystemId`, `delay`, `dequeueOrFail`                                                                                             |
+
+## Usage
+
+```ts
+import { BullMQJobQueue, BullMQJobWorker, createValkeyConnection } from "@pluralscape/queue/bullmq";
+import { ObservableJobQueue, ObservableJobWorker } from "@pluralscape/queue/observability";
+import { DEFAULT_RETRY_POLICIES } from "@pluralscape/queue/policies";
+
+const connection = createValkeyConnection({ host: "localhost", port: 6379 });
+
+const queue = new ObservableJobQueue(
+  new BullMQJobQueue({ connection, queueName: "default" }),
+  metrics,
+);
+
+const worker = new ObservableJobWorker(
+  new BullMQJobWorker({ connection, queueName: "default" }),
+  metrics,
+);
+
+worker.register("email.send", async (job, ctx) => {
+  await sendEmail(job.payload.emailId);
+  ctx.heartbeat(); // for long-running jobs
+});
+
+await worker.start();
+
+await queue.enqueue({
+  type: "email.send",
+  payload: { emailId: "abc123" },
+  idempotencyKey: "email-send-abc123",
+  retryPolicy: DEFAULT_RETRY_POLICIES["email.send"],
+});
+```
+
+For the SQLite backend, replace `BullMQJobQueue`/`BullMQJobWorker` with `SqliteJobQueue`/`SqliteJobWorker` from `@pluralscape/queue/sqlite`. The handler registration and lifecycle API is identical.
+
+For tests, use `InMemoryJobQueue` and `InMemoryJobWorker` from `@pluralscape/queue/testing`, or run adapter contract suites against a custom implementation with `runJobQueueContract` and `runJobWorkerContract`.
+
+## Dependencies
+
+| Package              | Role                                                   |
+| -------------------- | ------------------------------------------------------ |
+| `bullmq`             | BullMQ queue and worker (hosted/full self-hosted tier) |
+| `ioredis`            | Valkey/Redis client used by BullMQ                     |
+| `drizzle-orm`        | SQLite job table queries                               |
+| `@pluralscape/db`    | Shared database instance and schema                    |
+| `@pluralscape/types` | Shared domain types                                    |
+
+## Testing
+
+Unit tests (no external services):
+
+```bash
+pnpm vitest run --project queue
+```
+
+Integration tests (requires a running Valkey instance):
+
+```bash
+pnpm vitest run --project queue-integration
+```
+
+Both adapters are covered by the shared contract suites in `/testing`. Integration tests exercise
+the BullMQ adapter against a real Valkey connection, DLQ promotion, stalled-job sweeping, and
+health checks.

--- a/packages/rotation-worker/README.md
+++ b/packages/rotation-worker/README.md
@@ -1,0 +1,120 @@
+# @pluralscape/rotation-worker
+
+Client-side incremental re-encryption worker for privacy bucket key rotation.
+
+## Overview
+
+When a friend is removed from a privacy bucket, Pluralscape immediately revokes their API access and generates a new bucket key. All data previously encrypted under the old key must then be re-encrypted under the new key. This package implements that re-encryption process on the client, following the lazy rotation protocol specified in [ADR 014](../../docs/adr/014-lazy-key-rotation.md).
+
+Re-encryption proceeds in chunks. The worker claims a batch of items from the server-side rotation ledger, fetches each entity blob, decrypts it with the old key, re-encrypts it with the new key, uploads the result, and reports completion. The server never sees key material. Multiple devices owned by the same system can work concurrently — each claims independent chunks, and stale claims are automatically reclaimed after five minutes.
+
+The worker is resumable across sessions. If the device goes offline mid-rotation, progress is preserved in the server ledger. On the next session the worker picks up from where it left off. A 404 response on the rotation resource (rotation deleted or cancelled) causes the worker to stop gracefully. Per-item 404 (entity deleted) and 409 (version conflict from a concurrent newer write) are treated as successful completion of that item.
+
+## Key Exports
+
+### `RotationWorker`
+
+The main class. Instantiate with a `RotationWorkerConfig` and an optional progress callback, then call `start()`. Call `stop()` to abort gracefully at the next chunk boundary.
+
+```ts
+class RotationWorker {
+  constructor(config: RotationWorkerConfig, onProgress?: RotationProgressCallback);
+  get isRunning(): boolean;
+  start(): Promise<void>;
+  stop(): void;
+}
+```
+
+### `decryptWithDualKey`
+
+Selects the correct key based on `keyVersion` and decrypts a blob. Throws `DecryptionFailedError` if the version matches neither key — fails closed rather than guessing.
+
+```ts
+function decryptWithDualKey(
+  payload: EncryptedPayload,
+  keyVersion: number,
+  oldKey: AeadKey,
+  oldKeyVersion: number,
+  newKey: AeadKey,
+  newKeyVersion: number,
+): Uint8Array;
+```
+
+### `processChunk`
+
+Processes a slice of `BucketRotationItem` records: fetches each blob, decrypts with the appropriate key, re-encrypts with the new key, and uploads. Retries each item up to three times with exponential backoff before marking it failed. Respects the abort signal.
+
+```ts
+function processChunk(
+  items: readonly BucketRotationItem[],
+  apiClient: RotationApiClient,
+  oldKey: AeadKey,
+  oldKeyVersion: number,
+  newKey: AeadKey,
+  newKeyVersion: number,
+  signal: AbortSignal,
+): Promise<CompletionItem[]>;
+```
+
+### Types
+
+| Type                        | Description                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------- |
+| `RotationWorkerConfig`      | Worker configuration: bucket ID, rotation ID, old/new keys and versions, chunk size, API client |
+| `RotationApiClient`         | Interface the app must implement to connect the worker to its HTTP layer                        |
+| `RotationProgressCallback`  | `(rotation: BucketKeyRotation) => void` — called after each chunk completes                     |
+| `VersionedEncryptedPayload` | Encrypted blob with its `keyVersion` metadata                                                   |
+| `CompletionItem`            | Per-item result (`completed` or `failed`) reported back to the server                           |
+| `ItemProcessResult`         | Internal per-item result carrying the original `BucketRotationItem`                             |
+
+## Usage
+
+```ts
+import { RotationWorker } from "@pluralscape/rotation-worker";
+import type { RotationApiClient, RotationWorkerConfig } from "@pluralscape/rotation-worker";
+
+// Implement RotationApiClient using your app's HTTP layer
+const apiClient: RotationApiClient = {
+  /* ... */
+};
+
+const config: RotationWorkerConfig = {
+  apiClient,
+  bucketId: "bucket_abc123",
+  rotationId: "rot_xyz789",
+  oldKey: fetchedOldKey,
+  oldKeyVersion: 1,
+  newKey: fetchedNewKey,
+  newKeyVersion: 2,
+  chunkSize: 50, // optional, defaults to KEY_ROTATION.defaultChunkSize
+};
+
+const worker = new RotationWorker(config, (rotation) => {
+  console.log(`Progress: ${rotation.completedItems}/${rotation.totalItems}`);
+});
+
+await worker.start(); // resolves when all items are processed or rotation completes/fails
+```
+
+To stop early (e.g., app backgrounding):
+
+```ts
+worker.stop();
+```
+
+## Dependencies
+
+| Package               | Role                                                                                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@pluralscape/crypto` | `encrypt`, `decrypt`, `AeadKey`, `EncryptedPayload`, `DecryptionFailedError`                                                                   |
+| `@pluralscape/types`  | `BucketId`, `BucketKeyRotation`, `BucketRotationItem`, `ChunkClaimResponse`, `ChunkCompletionResponse`, `EntityType`, `KEY_ROTATION` constants |
+
+## Testing
+
+Unit tests only (no integration variant — the worker is a pure client-side state machine that depends on an injected `RotationApiClient`).
+
+```bash
+pnpm vitest run --project rotation-worker
+```
+
+Tests cover: full rotation loop (single and multi-chunk), early exit when chunk is empty or rotation transitions to `completed`/`failed`, graceful stop via `abort`, 404 on the rotation resource, per-item retry with exponential backoff, per-item 404 and 409 short-circuit, dual-key selection by version, unknown key version rejection, and abort mid-chunk.

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,0 +1,134 @@
+# @pluralscape/storage
+
+Backend-agnostic blob storage adapter interface with S3, filesystem, and in-memory implementations for encrypted media.
+
+## Overview
+
+`@pluralscape/storage` provides a uniform `BlobStorageAdapter` interface that decouples the application from any specific storage backend. Concrete adapters are shipped in sub-entry points (`/s3`, `/filesystem`) so each deployment tier can import only what it needs.
+
+All bytes flowing through the adapter are encrypted before they arrive. The storage layer is zero-knowledge: it stores and retrieves opaque ciphertext and never has access to plaintext media. Per ADR 009, the client encrypts blobs (XChaCha20-Poly1305) before upload, and decrypts them locally after download. The server generates time-limited presigned URLs so clients upload directly to the storage backend, keeping API server bandwidth low.
+
+Quota management and orphan-blob cleanup are provided via the `/quota` sub-entry point. These utilities run server-side and operate on storage-key metadata, not on blob contents.
+
+## Key Exports
+
+### Root entry point (`@pluralscape/storage`)
+
+**Interface and types**
+
+| Export                    | Description                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `BlobStorageAdapter`      | Core adapter interface — all backends implement this                                 |
+| `BlobUploadParams`        | Parameters for `adapter.upload()`                                                    |
+| `PresignedUploadParams`   | Parameters for `adapter.generatePresignedUploadUrl()`                                |
+| `PresignedDownloadParams` | Parameters for `adapter.generatePresignedDownloadUrl()`                              |
+| `PresignedUrlResult`      | Discriminated union: `{ supported: true; url; expiresAt }` or `{ supported: false }` |
+| `StoredBlobMetadata`      | Metadata returned after a successful upload                                          |
+
+**Error classes**
+
+| Export                   | Thrown when                                              |
+| ------------------------ | -------------------------------------------------------- |
+| `BlobNotFoundError`      | `download()` or `getMetadata()` called for a missing key |
+| `BlobAlreadyExistsError` | `upload()` called for a key that already exists          |
+| `BlobTooLargeError`      | Uploaded data exceeds the adapter's size limit           |
+| `QuotaExceededError`     | Upload would exceed a system's storage quota             |
+| `StorageBackendError`    | Unexpected backend error                                 |
+
+**Utilities**
+
+| Export                                 | Description                                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------- |
+| `generateStorageKey(systemId, blobId)` | Builds a `{systemId}/{blobId}` storage key                                  |
+| `parseStorageKey(key)`                 | Splits a key back into `{ systemId, blobId }`, or `null` on malformed input |
+
+### `/s3` — S3-compatible adapter
+
+```ts
+import { S3BlobStorageAdapter } from "@pluralscape/storage/s3";
+import type { S3AdapterConfig } from "@pluralscape/storage/s3";
+```
+
+Works against AWS S3, Cloudflare R2, Backblaze B2, or MinIO. Supports presigned upload and download URLs.
+
+### `/filesystem` — Local filesystem adapter
+
+```ts
+import { FilesystemBlobStorageAdapter } from "@pluralscape/storage/filesystem";
+```
+
+Minimal self-hosted fallback. Stores blobs in a configurable directory. Does not support presigned URLs (`supportsPresignedUrls` is `false`); the API server proxies uploads and downloads directly.
+
+### `/quota` — Quota and cleanup utilities
+
+```ts
+import {
+  BlobQuotaService,
+  createQuotaService,
+  OrphanBlobDetector,
+  BlobCleanupHandler,
+  DEFAULT_QUOTA_BYTES,
+} from "@pluralscape/storage/quota";
+```
+
+`BlobQuotaService` checks and records per-system usage before writes. `OrphanBlobDetector` identifies blobs whose metadata records have been deleted (with a configurable grace period). `BlobCleanupHandler` drives the archival and removal job.
+
+## Usage
+
+### Presigned upload flow (S3 / MinIO)
+
+```ts
+import { S3BlobStorageAdapter } from "@pluralscape/storage/s3";
+import { generateStorageKey, BlobTooLargeError, QuotaExceededError } from "@pluralscape/storage";
+
+const adapter = new S3BlobStorageAdapter({
+  bucket: "pluralscape-media",
+  region: "us-east-1",
+  // endpoint: "http://localhost:9000", // MinIO
+});
+
+const storageKey = generateStorageKey(systemId, blobId);
+
+// Generate a presigned URL for the client to upload directly
+const result = await adapter.generatePresignedUploadUrl({
+  storageKey,
+  mimeType: "image/webp",
+  sizeBytes: encryptedBytes.length,
+  expiresInMs: 5 * 60 * 1_000, // 5 minutes
+});
+
+if (result.supported) {
+  // Client POSTs encrypted bytes directly to result.url — server never sees them
+  console.log("Upload to:", result.url, "— expires at:", result.expiresAt);
+} else {
+  // Filesystem adapter: proxy through the API server instead
+}
+```
+
+### Checking adapter capability at runtime
+
+```ts
+if (!adapter.supportsPresignedUrls) {
+  // Fall back to proxied upload via API
+}
+```
+
+## Dependencies
+
+| Package                         | Purpose                                                         |
+| ------------------------------- | --------------------------------------------------------------- |
+| `@aws-sdk/client-s3`            | S3 API client (upload, download, metadata)                      |
+| `@aws-sdk/s3-request-presigner` | Presigned URL generation                                        |
+| `@pluralscape/types`            | Branded types: `StorageKey`, `SystemId`, `BlobId`, `UnixMillis` |
+
+## Testing
+
+```bash
+# Unit tests
+pnpm vitest run --project storage
+
+# Integration tests (requires S3-compatible backend)
+pnpm vitest run --project storage-integration
+```
+
+Integration tests exercise real I/O against a running storage backend. See `packages/storage/src/__tests__/` for setup requirements.

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -1,0 +1,128 @@
+# @pluralscape/sync
+
+Encrypted offline-first CRDT sync over a zero-knowledge relay using Automerge.
+
+## Overview
+
+`@pluralscape/sync` implements the sync layer for Pluralscape's offline-first architecture. Local SQLite is the source of truth; this package is responsible for merging local changes with remote ones and propagating them through an encrypted relay. The server is a dumb relay — it stores and forwards opaque ciphertext and never reads or merges document contents.
+
+CRDT documents are managed with [Automerge](https://automerge.org/). Each logical entity (system core, fronting sessions, journal, etc.) maps to a dedicated Automerge document. Changes are encrypted client-side using per-document symmetric keys from `@pluralscape/crypto` before submission. The relay stores envelopes; clients decrypt and apply them locally.
+
+Conflict resolution happens entirely on-device: Automerge provides last-writer-wins semantics per field for concurrent edits. Post-merge validation runs after each merge to detect application-level inconsistencies (e.g., overlapping fronting sessions) and surfaces them as `ConflictNotification` events rather than silently discarding data. Documents that exceed size or time thresholds are split or compacted automatically.
+
+## Key Exports
+
+All imports below are from `@pluralscape/sync` unless noted.
+
+**Engine**
+
+- `SyncEngine` / `SyncEngineConfig` — top-level orchestrator; manages sessions, compaction, and the offline queue
+
+**Sessions**
+
+- `EncryptedSyncSession` — single-device sync session over a transport
+- `syncThroughRelay` — convenience function for one-shot relay sync
+
+**Document factories**
+
+- `createDocument`, `createSystemCoreDocument`, `createFrontingDocument`, `createChatDocument`, `createJournalDocument`, `createNoteDocument`, `createPrivacyConfigDocument`, `createBucketDocument`, `fromDoc`
+
+**Encryption**
+
+- `encryptChange` / `decryptChange`, `encryptSnapshot` / `decryptSnapshot`, `verifyEnvelopeSignature`
+
+**Conflict resolution**
+
+- `runAllValidations` — post-merge validation returning `PostMergeValidationResult`
+- `ConflictNotification`, `ConflictResolutionStrategy`, `ConflictPersistenceAdapter`
+
+**Offline queue**
+
+- `replayOfflineQueue` / `ReplayOfflineQueueConfig` / `ReplayResult`
+
+**Document lifecycle**
+
+- `checkCompactionEligibility`, `LazyDocumentSizeTracker`
+- `splitDocument`, `checkTimeSplitEligibility`, `computeNewDocumentId`
+- `checkStorageBudget`, `selectEvictionCandidates`
+
+**Events**
+
+- `createEventBus` — typed event bus (`DataLayerEvent`, `SyncChangesMergedEvent`, `WsSyncMessageEvent`, etc.)
+
+**Sub-entry points**
+
+| Import path                      | Contents                                                                                                                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@pluralscape/sync/adapters`     | `SqliteStorageAdapter`, `WsNetworkAdapter`, `SqliteOfflineQueueAdapter`, `createWsClientAdapter`, `createBunSqliteDriver`, adapter interfaces                 |
+| `@pluralscape/sync/schemas`      | Automerge document schema types (`CrdtSystem`, `CrdtMember`, `CrdtFrontingSession`, `SystemCoreDocument`, `FrontingDocument`, etc.)                           |
+| `@pluralscape/sync/protocol`     | Full protocol message taxonomy (`ClientMessage`, `ServerMessage`, `AuthenticateRequest`, `ManifestResponse`, `DocumentUpdate`, `SYNC_PROTOCOL_VERSION`, etc.) |
+| `@pluralscape/sync/materializer` | Entity registry, base materializer, `diffEntities`, `applyDiff`, `generateAllDdl`, `createMaterializer`, `registerMaterializer`                               |
+
+## Usage
+
+**Bootstrapping the sync engine**
+
+```ts
+import { SyncEngine } from "@pluralscape/sync";
+import {
+  SqliteStorageAdapter,
+  SqliteOfflineQueueAdapter,
+  createBunSqliteDriver,
+  createWsClientAdapter,
+} from "@pluralscape/sync/adapters";
+
+const driver = createBunSqliteDriver(db);
+const storage = new SqliteStorageAdapter(driver);
+const offlineQueue = new SqliteOfflineQueueAdapter(driver);
+const wsAdapter = createWsClientAdapter({ url: "wss://relay.example.com/sync" });
+
+const engine = new SyncEngine({
+  storage,
+  offlineQueue,
+  network: wsAdapter,
+  keyResolver, // DocumentKeyResolver instance
+  eventBus, // EventBus from createEventBus()
+});
+
+await engine.start();
+```
+
+**Encrypting and submitting a change**
+
+```ts
+import { encryptChange, encryptSnapshot } from "@pluralscape/sync";
+
+const envelope = await encryptChange(change, {
+  documentKey,
+  deviceId,
+  systemId,
+});
+
+// envelope is an EncryptedChangeEnvelope — safe to relay to the server
+```
+
+## Dependencies
+
+**Internal**
+
+- `@pluralscape/crypto` — XChaCha20-Poly1305 encryption, Argon2id key derivation
+- `@pluralscape/types` — shared domain types (`SystemId`, `SyncDocumentId`, etc.)
+- `@pluralscape/validation` — input validation schemas
+
+**External**
+
+- [`@automerge/automerge`](https://automerge.org/) ^3 — CRDT library (MIT)
+- `better-sqlite3-multiple-ciphers` — encrypted SQLite (dev/integration only)
+
+## Testing
+
+```bash
+# Unit tests
+pnpm vitest run --project sync
+
+# Integration tests (requires SQLite, hits real storage adapters)
+pnpm vitest run --project sync-integration
+```
+
+Unit tests cover CRDT strategies, encryption round-trips, compaction eligibility, time-split logic, post-merge validation, and the offline queue manager. Integration tests cover the storage adapter, materializer pipeline, and full sync session lifecycle against a real SQLite database.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,132 @@
+# @pluralscape/types
+
+Shared TypeScript domain types and runtime primitives for the Pluralscape monorepo.
+
+## Overview
+
+This package is the single source of truth for every domain type across the Pluralscape system.
+It deliberately contains no business logic and no runtime dependencies beyond the TypeScript
+standard library, keeping the dependency graph clean: every other `@pluralscape/*` package
+imports from here, never the reverse.
+
+The package solves a concrete problem: Pluralscape is E2E encrypted, and the same conceptual
+entity (a member, a fronting session, a journal entry) exists in two forms — a `Server*` variant
+holding ciphertext that the API persists and returns, and a `Client*` variant holding plaintext
+after the mobile app has decrypted it. Without shared types enforced at compile time, it is easy
+to accidentally log, cache, or transmit data in the wrong form. The `encryption.ts` module
+defines both variants for every encrypted entity, and the `ServerSafe<T>` branded wrapper
+(`server-safe.ts`) provides a zero-runtime-overhead type fence that prevents unverified data
+from reaching API responses.
+
+A second key design decision is nominal typing via `Brand<T, B>`. Every entity ID is a distinct
+branded string type (`SystemId`, `MemberId`, `FrontingSessionId`, etc.), preventing cross-entity
+ID mix-ups that structural typing would silently permit. The `ID_PREFIXES` constant maps each
+entity type to its runtime prefix, which `createId()` in `runtime.ts` enforces at creation time.
+See [ADR-006](../../docs/adr/006-encryption.md) for the encryption boundary rationale and
+[ADR-013](../../docs/adr/013-api-auth-encryption.md) for the server/client data boundary.
+
+## Key Exports
+
+### IDs and Branding (`ids.ts`)
+
+- `Brand<T, B>` — phantom-type utility for nominal typing
+- `SystemId`, `MemberId`, `GroupId`, `FrontingSessionId`, `CustomFrontId` — core identity IDs
+- `BucketId`, `KeyGrantId` — privacy bucket IDs
+- `SessionId`, `AccountId`, `AuthKeyId`, `RecoveryKeyId`, `DeviceTransferRequestId` — auth IDs
+- `SyncDocumentId`, `SyncChangeId`, `SyncSnapshotId` — sync document IDs
+- `BlobId`, `JobId`, `WebhookId`, `TimerId`, and 40+ additional branded ID types
+- `HexColor`, `SlugHash`, `ChecksumHex`, `StorageKey` — branded scalar types
+- `ID_PREFIXES` — runtime map of entity type to string prefix (e.g. `"sys_"`, `"mbr_"`)
+- `EntityType` — discriminated union of all entity type strings
+
+### Domain Types by Feature
+
+| Module                 | Types                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `identity.ts`          | `System`, `Member`, `MemberPhoto`, `Tag`, `SaturationLevel`, `CreateMemberBody`, `UpdateMemberBody`                                        |
+| `fronting.ts`          | `ActiveFrontingSession`, `CompletedFrontingSession`, `FrontingSession`, `CustomFront`, `CoFrontState`, `OuttriggerSentiment`               |
+| `privacy.ts`           | `PrivacyBucket`, `BucketVisibilityScope`, `KeyGrant`, `FriendConnection`, `FriendCode`, `BucketAccessCheck`                                |
+| `structure.ts`         | `SystemStructureEntity`, `SystemStructureEntityType`, `Relationship`, `SystemProfile`, `ArchitectureType`                                  |
+| `groups.ts`            | `Group`, `GroupMembership`, `GroupTree`, `GroupMoveOperation`                                                                              |
+| `encryption.ts`        | `Server*` / `Client*` pairs for every encrypted entity, `Encrypted`, `BucketEncrypted`, `ServerSafe`, `DecryptFn`, `EncryptFn`             |
+| `auth.ts`              | `Account`, `AuthKey`, `Session`, `RecoveryKey`, `DeviceTransferRequest`, `LoginCredentials`                                                |
+| `communication.ts`     | `Channel`, `ChatMessage`, `BoardMessage`, `Note`, `Poll`, `PollVote`, `AcknowledgementRequest`                                             |
+| `journal.ts`           | `JournalEntry`, `WikiPage`, `JournalBlock` (paragraph, heading, list, quote, code, image, divider, member/entity link), `FrontingSnapshot` |
+| `lifecycle.ts`         | `LifecycleEvent`, `SplitEvent`, `FusionEvent`, `DiscoveryEvent`, `ArchivalEvent`, and 8 additional event types                             |
+| `custom-fields.ts`     | `FieldDefinition`, `FieldValue`, `FieldType`, `FieldBucketVisibility`                                                                      |
+| `analytics.ts`         | `FrontingAnalytics`, `CoFrontingAnalytics`, `ChartData`, `DateRangeFilter`, `DateRangePreset`                                              |
+| `innerworld.ts`        | `InnerWorldCanvas`, `InnerWorldEntity`, `InnerWorldRegion`                                                                                 |
+| `sync.ts`              | `SyncDocument`, `SyncState`, `SyncIndicator`, `SyncDocumentType`                                                                           |
+| `import-export.ts`     | `ImportJob`, `ExportRequest`, `SPImport*`, `PKImport*`, `AccountPurgeRequest`                                                              |
+| `pk-bridge.ts`         | `PKBridgeConfig`, `PKEntityMapping`, `PKSyncState`, `PKSyncError`                                                                          |
+| `webhooks.ts`          | `WebhookConfig`, `WebhookDelivery`, `WebhookEventPayloadMap`                                                                               |
+| `notifications.ts`     | `DeviceToken`, `NotificationConfig`, `FriendNotificationPreference`                                                                        |
+| `realtime.ts`          | `WebSocketEvent`, `SSEEvent`, `RealtimeSubscription`, `WebSocketConnectionState`                                                           |
+| `settings.ts`          | `SystemSettings`, `AppLockConfig`, `SyncPreferences`, `PrivacyDefaults`                                                                    |
+| `nomenclature.ts`      | `NomenclatureSettings`, `TermCategory`, `TermPreset`                                                                                       |
+| `littles-safe-mode.ts` | `LittlesSafeModeConfig`, `SafeModeUIFlags`, `SafeModeContentItem`                                                                          |
+| `snapshot.ts`          | `SystemSnapshot` and per-entity snapshot subtypes                                                                                          |
+| `key-rotation.ts`      | `BucketKeyRotation`, `BucketRotationItem`, `RotationState`                                                                                 |
+| `audit-log.ts`         | `AuditLogEntry`, `AuditEventType`, `AuditActor`                                                                                            |
+
+### Shared Utilities
+
+- `results.ts` — `Result<T>`, `ApiError`, `ApiErrorResponse`, `ValidationError`
+- `pagination.ts` — `PaginatedResult<T>`, `PaginationCursor`, `OffsetPaginationParams`, `CursorInvalidError`
+- `utility.ts` — `CreateInput<T>`, `UpdateInput<T>`, `DeepReadonly<T>`, `DateRange`, `AuditMetadata`, `Archived<T>`, `EntityReference`
+- `timestamps.ts` — `UnixMillis`, `ISOTimestamp`, `toUnixMillis`, `toUnixMillisOrNull`
+- `api-constants.ts` — `RATE_LIMITS`, `API_ERROR_CODES`, `PAGINATION`, `SESSION_TIMEOUTS`, `BLOB_SIZE_LIMITS`, `KEY_ROTATION`, and related types
+- `server-safe.ts` — `ServerSafe<T>`, `serverSafe()` branding function
+- `checksum.ts` — `toChecksumHex()`
+- `logger.ts` — `Logger` interface (structural, no concrete implementation)
+
+## Usage
+
+Importing domain types across packages:
+
+```typescript
+import type { Member, MemberId, FrontingSession } from "@pluralscape/types";
+import { ID_PREFIXES, createId, now } from "@pluralscape/types";
+
+// IDs are nominally typed — MemberId is not assignable from a plain string
+function getFrontingSession(memberId: MemberId): FrontingSession {
+  /* ... */
+}
+
+// createId enforces the prefix contract at runtime
+const memberId = createId(ID_PREFIXES.member) as MemberId;
+```
+
+Using the server/client encryption boundary:
+
+```typescript
+import type { ServerMember, ClientMember } from "@pluralscape/types";
+import { serverSafe } from "@pluralscape/types";
+
+// API handlers work with ServerMember (ciphertext fields)
+// The mobile app decrypts to ClientMember (plaintext fields)
+function respondWithMember(member: ServerMember) {
+  return serverSafe(member); // brands the value as verified server-safe
+}
+```
+
+## Dependencies
+
+`@pluralscape/types` has no runtime `@pluralscape/*` dependencies. It imports only from the
+TypeScript standard library (`crypto.randomUUID()`) and the built-in `Date` API.
+
+Dev dependencies (`@pluralscape/eslint-config`, `@pluralscape/tsconfig`) are tooling-only and
+not included in consumers' dependency graphs.
+
+## Testing
+
+Unit tests only — no integration variant exists (this package has no I/O boundaries).
+
+```bash
+pnpm vitest run --project types
+```
+
+Tests are co-located in `src/__tests__/` with one file per source module. Coverage focuses on
+runtime utilities (`createId`, `now`, `toISO`, `toUnixMillis`, timestamp conversions, checksum
+encoding), discriminated union type guards, and constants. Pure type exports are validated by the
+TypeScript compiler via `pnpm typecheck` rather than runtime assertions.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -1,0 +1,136 @@
+# @pluralscape/validation
+
+Shared Zod v4 schemas for all API request boundaries across the Pluralscape monorepo.
+
+## Overview
+
+`@pluralscape/validation` provides hand-written Zod schemas for every REST and tRPC request boundary in the API. Both the Hono REST routes (`apps/api/`) and tRPC procedure inputs import from this package, guaranteeing that the two transports enforce identical validation rules at runtime.
+
+TypeScript types remain the source of truth — defined in `@pluralscape/types`, never inferred from schemas. The `packages/validation` schemas are written by hand and verified against those types via contract tests that run `expectTypeOf` (compile-time alignment) and `safeParse` (runtime shape). This approach is documented in [ADR 023](../../docs/adr/023-zod-type-alignment.md).
+
+Scope is intentionally limited to boundary types: API request bodies, job payloads, webhook inputs, and query parameters. Internal domain types that never cross a trust boundary do not have schemas here.
+
+## Key Exports
+
+### Auth and account
+
+- `RegistrationInputSchema`, `LoginCredentialsSchema`
+- `ChangeEmailSchema`, `ChangePasswordSchema`
+- `RegenerateRecoveryKeySchema`, `PasswordResetViaRecoveryKeySchema`
+- `UpdateAccountSettingsSchema`, `DeleteAccountBodySchema`
+
+### System and settings
+
+- `UpdateSystemBodySchema`
+- `SetupProfileStepBodySchema`, `SetupNomenclatureStepBodySchema`, `SetupCompleteBodySchema`
+- `UpdateNomenclatureBodySchema`, `UpdateSystemSettingsBodySchema`
+- `SetPinBodySchema`, `VerifyPinBodySchema`, `RemovePinBodySchema`
+- `BiometricEnrollBodySchema`, `BiometricVerifyBodySchema`
+- `PurgeSystemBodySchema`, `CreateSnapshotBodySchema`, `DuplicateSystemBodySchema`
+
+### Members and groups
+
+- `CreateMemberBodySchema`, `UpdateMemberBodySchema`, `DuplicateMemberBodySchema`, `MemberListQuerySchema`
+- `CreateGroupBodySchema`, `UpdateGroupBodySchema`, `MoveGroupBodySchema`, `ReorderGroupsBodySchema`, `CopyGroupBodySchema`, `AddGroupMemberBodySchema`
+- `CreateCustomFrontBodySchema`, `UpdateCustomFrontBodySchema`
+- `CreateMemberPhotoBodySchema`, `ReorderPhotosBodySchema`
+
+### Fronting
+
+- `CreateFrontingSessionBodySchema`, `UpdateFrontingSessionBodySchema`, `EndFrontingSessionBodySchema`, `FrontingSessionQuerySchema`
+- `CreateFrontingCommentBodySchema`, `UpdateFrontingCommentBodySchema`, `FrontingCommentQuerySchema`
+- `AnalyticsQuerySchema`, `CreateFrontingReportBodySchema`, `UpdateFrontingReportBodySchema`
+
+### Communication
+
+- `CreateChannelBodySchema`, `UpdateChannelBodySchema`, `ChannelQuerySchema`
+- `CreateMessageBodySchema`, `UpdateMessageBodySchema`, `MessageQuerySchema`, `MessageTimestampQuerySchema`
+- `CreateBoardMessageBodySchema`, `UpdateBoardMessageBodySchema`, `ReorderBoardMessagesBodySchema`, `BoardMessageQuerySchema`
+- `CreateNoteBodySchema`, `UpdateNoteBodySchema`, `NoteQuerySchema`
+- `CreatePollBodySchema`, `UpdatePollBodySchema`, `CastVoteBodySchema`, `UpdatePollVoteBodySchema`, `PollQuerySchema`, `PollVoteQuerySchema`
+- `CreateAcknowledgementBodySchema`, `ConfirmAcknowledgementBodySchema`, `AcknowledgementQuerySchema`
+- `CreateTimerConfigBodySchema`, `UpdateTimerConfigBodySchema`, `CreateCheckInRecordBodySchema`, `RespondCheckInRecordBodySchema`
+
+### Privacy and friends
+
+- `CreateBucketBodySchema`, `UpdateBucketBodySchema`, `TagContentBodySchema`, `BucketContentTagQuerySchema`, `SetFieldBucketVisibilityBodySchema`
+- `RedeemFriendCodeBodySchema`, `UpdateFriendVisibilityBodySchema`, `AssignBucketBodySchema`, `FriendConnectionQuerySchema`, `FriendCodeQuerySchema`
+- `FriendExportQuerySchema`, `ListReceivedKeyGrantsQuerySchema`
+
+### Structure and innerworld
+
+- `CreateStructureEntityTypeBodySchema`, `UpdateStructureEntityTypeBodySchema`
+- `CreateStructureEntityBodySchema`, `UpdateStructureEntityBodySchema`
+- `CreateStructureEntityLinkBodySchema`, `UpdateStructureEntityLinkBodySchema`
+- `CreateStructureEntityMemberLinkBodySchema`, `CreateStructureEntityAssociationBodySchema`
+- `CreateRelationshipBodySchema`, `UpdateRelationshipBodySchema`, `RELATIONSHIP_TYPES`
+- `CreateLifecycleEventBodySchema`, `UpdateLifecycleEventBodySchema`, `LIFECYCLE_EVENT_TYPES`, `validateLifecycleMetadata`
+- `CreateRegionBodySchema`, `UpdateRegionBodySchema`, `CreateEntityBodySchema`, `UpdateEntityBodySchema`, `UpdateCanvasBodySchema`
+
+### Infrastructure
+
+- `CreateApiKeyBodySchema`
+- `AuditLogQuerySchema`
+- `InitiateRotationBodySchema`, `ClaimChunkBodySchema`, `CompleteChunkBodySchema`
+- `CreateWebhookConfigBodySchema`, `UpdateWebhookConfigBodySchema`, `RotateWebhookSecretBodySchema`, `WebhookConfigQuerySchema`, `WebhookDeliveryQuerySchema`
+- `RegisterDeviceTokenBodySchema`, `UpdateDeviceTokenBodySchema`, `UpdateNotificationConfigBodySchema`, `UpdateFriendNotificationPreferenceBodySchema`
+- `CreateUploadUrlBodySchema`, `ConfirmUploadBodySchema`
+- `GenerateReportBodySchema`, `BucketExportQuerySchema`
+- `CreateFieldDefinitionBodySchema`, `UpdateFieldDefinitionBodySchema`, `SetFieldValueBodySchema`, `UpdateFieldValueBodySchema`
+
+### Utilities and constants
+
+- `brandedString`, `brandedNumber` — helpers for branded-type schemas, centralising the one warranted `z.custom` call
+- `brandedIdQueryParam` — parse and validate branded ID path/query parameters
+- `booleanQueryParam`, `optionalBooleanQueryParam` — coerce string query params to booleans
+- `IncludeArchivedQuerySchema`, `InnerWorldEntityQuerySchema`, `LifecycleEventQuerySchema`, `RelationshipQuerySchema` and related query schemas
+- `parseTimeToMinutes` — parse human-readable time strings to integer minutes
+- Constants: `AUTH_MIN_PASSWORD_LENGTH`, `MAX_ENCRYPTED_DATA_SIZE`, `MAX_ENCRYPTED_MEMBER_DATA_SIZE`, `MAX_REORDER_OPERATIONS`, `WEBHOOK_EVENT_TYPE_VALUES`, `MAX_ANALYTICS_CUSTOM_RANGE_MS`, `DEVICE_TOKEN_PLATFORM_VALUES`, and more — see `validation.constants.ts`
+
+## Usage
+
+Import schemas directly from the package. Both REST handlers and tRPC procedure inputs use the same schema:
+
+```typescript
+import {
+  CreateMemberBodySchema,
+  CreateFrontingSessionBodySchema,
+  LoginCredentialsSchema,
+} from "@pluralscape/validation";
+
+// tRPC procedure input
+export const createMember = protectedProcedure
+  .input(CreateMemberBodySchema)
+  .mutation(async ({ input, ctx }) => {
+    // input is typed as z.infer<typeof CreateMemberBodySchema>
+  });
+
+// REST handler (Hono)
+app.post("/members", async (c) => {
+  const body = await c.req.json();
+  const parsed = CreateMemberBodySchema.safeParse(body);
+  if (!parsed.success) return c.json({ error: parsed.error }, 400);
+  // parsed.data is fully typed
+});
+
+// Infer request body type
+type LoginCredentials = z.infer<typeof LoginCredentialsSchema>;
+```
+
+## Dependencies
+
+| Package                          | Role                                                                 |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `zod` (`^4.3.6`)                 | Runtime schema parsing and type inference                            |
+| `@pluralscape/types` (workspace) | Canonical TypeScript types; schemas are verified to align with these |
+
+## Testing
+
+Unit tests live in `packages/validation/src/__tests__/`. They use contract tests to verify schema-to-type alignment at both compile time (`expectTypeOf`) and runtime (`safeParse`).
+
+```bash
+# Unit tests
+pnpm vitest run --project validation
+```
+
+There is no integration variant — this package has no I/O boundaries.


### PR DESCRIPTION
## Summary

- 12 package READMEs for all packages in `packages/` (types, crypto, data, db, sync, api-client, email, i18n, queue, rotation-worker, storage, validation)
- Architecture overview (`docs/architecture.md`) covering system topology, package dependency graph, data flow, encryption boundaries, security model, and development sequence rationale — replaces the rationale section in milestones.md
- Mobile developer guide (`docs/guides/mobile-developer-guide.md`) for contributors and API consumers — provider tree, hook factory patterns, platform abstraction, auth flow, sync lifecycle
- CHANGELOG M8 entry with all deliverables
- milestones.md M8 epics expanded and marked completed
- README updated (M8 status, coverage numbers, E2E test count, ADR count fixed to 32, data package added)
- CONTRIBUTING.md mobile development section referencing the mobile developer guide

## Test plan

- [ ] Verify all internal markdown links resolve correctly
- [ ] Spot-check package README accuracy against actual package.json and src/index.ts exports
- [ ] Confirm ADR count is consistently 32 across all docs
- [ ] Confirm M8 is marked completed in milestones.md and CHANGELOG