### PR TITLE
fix(ci): correct coverage badge color

### DIFF
--- a/.beans/ps-pg06--fix-ci-add-json-summary-reporter-and-bump-dynamic.md
+++ b/.beans/ps-pg06--fix-ci-add-json-summary-reporter-and-bump-dynamic.md
@@ -1,6 +1,6 @@
 ---
 # ps-pg06
-title: 'Fix CI: add json-summary reporter and bump dynamic-badges to v1.8.0'
+title: "Fix CI: add json-summary reporter and bump dynamic-badges to v1.8.0"
 status: completed
 type: bug
 priority: normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,6 @@ jobs:
           valColorRange: ${{ steps.coverage-data.outputs.pct }}
           minColorRange: 50
           maxColorRange: 85
-          invertColorRange: false
 
   migrations:
     name: Migration Freshness


### PR DESCRIPTION
## Summary
- Fix prettier formatting in bean file (quote style)
- Remove `invertColorRange: false` from coverage badge step — GitHub Actions passes all inputs as strings, so `"false"` is non-empty/truthy, causing the action to invert the color scale and show red for high coverage

## Test plan
- [ ] Verify badge turns green after merge to main