### PR TITLE
fix(api): security audit remediation

### DIFF
--- a/.beans/api-u998--per-endpoint-api-key-scope-enforcement.md
+++ b/.beans/api-u998--per-endpoint-api-key-scope-enforcement.md
@@ -1,0 +1,12 @@
+---
+# api-u998
+title: Per-endpoint API key scope enforcement
+status: draft
+type: feature
+created_at: 2026-04-06T14:28:06Z
+updated_at: 2026-04-06T14:28:06Z
+---
+
+Add scope checking to all system-scoped endpoints. Each endpoint should validate that the API key's scopes include the required scope for that operation (e.g., read:members for GET /members). The AuthContext.apiKeyScopes field is already populated by the auth middleware (added in security audit remediation). This task adds requireScope() checks to route handlers and tRPC procedures.
+
+Scopes to enforce: read:members, write:members, read:fronting, write:fronting, read:groups, write:groups, read:system, write:system, read:webhooks, write:webhooks, read:audit-log, read:blobs, write:blobs, read:notifications, write:notifications, full.

--- a/.beans/ps-5qw5--security-audit-remediation.md
+++ b/.beans/ps-5qw5--security-audit-remediation.md
@@ -1,0 +1,24 @@
+---
+# ps-5qw5
+title: Security audit remediation
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-06T14:02:50Z
+updated_at: 2026-04-06T14:43:15Z
+---
+
+Implement 5 confirmed findings from the STRIDE+OWASP security audit.\n\n- [x] Task 1: Enforce SMTP TLS in production\n- [x] Task 2: Tighten CSP to default-src 'none'\n- [x] Task 3: API key authentication middleware\n- [x] Task 4: Recovery key per-account rate limiting\n- [x] Tasks 5-6: Resource quotas (hierarchy factory + groups)\n- [x] Tasks 7-9: Resource quotas (members, custom fronts, channels)\n- [x] Task 10: Update existing limits (buckets, photos)\n- [x] Task 11: Create M11 follow-up bean\n- [x] Task 12: Full verification
+
+## Summary of Changes
+
+Implemented 5 security audit remediation items:
+
+1. **SMTP TLS enforcement** — runtime guard refuses to start with plaintext SMTP in production
+2. **CSP tightened** — default-src 'none' with base-uri and form-action 'none'
+3. **API key auth middleware** — ps\_ prefixed tokens, dual-path auth, scoped AuthContext
+4. **Recovery key per-account rate limit** — 3/hour keyed by email hash
+5. **Resource quotas** — members (5000), groups (200), custom fronts (200), channels (50), buckets (50), photos (5/member + 500/system)
+
+Also created follow-up bean api-u998 for per-endpoint API key scope enforcement (M11).
+Corrected 2 false positives in audit report (webhook DNS rebinding, session revocation audit).

--- a/apps/api/src/__tests__/helpers/integration-setup.ts
+++ b/apps/api/src/__tests__/helpers/integration-setup.ts
@@ -59,6 +59,7 @@ export function testEncryptedDataBase64(): string {
 /** Build a minimal AuthContext for integration tests. */
 export function makeAuth(accountId: AccountId, systemId: SystemId): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId,
     systemId,
     sessionId: `sess_${crypto.randomUUID()}` as SessionId,

--- a/apps/api/src/__tests__/helpers/mock-db.ts
+++ b/apps/api/src/__tests__/helpers/mock-db.ts
@@ -67,11 +67,18 @@ export function mockDb(overrides?: Partial<MockChain>): {
     }
   }
 
-  // Wire up fluent chaining: each method returns the chain
+  // Wire up fluent chaining: each method returns the chain.
+  // `where` returns a thenable chain so `await tx.select().from().where()`
+  // resolves to an empty array (for quota count queries) while still supporting
+  // further chaining like `.for("update")` or `.limit(1)`.
+  const thenableChain = Object.assign(Object.create(chain), {
+    then: (resolve: (v: unknown[]) => void) => Promise.resolve([]).then(resolve),
+  });
+
   chain.select.mockReturnValue(chain);
   chain.from.mockReturnValue(chain);
   chain.leftJoin.mockReturnValue(chain);
-  chain.where.mockReturnValue(chain);
+  chain.where.mockReturnValue(thenableChain);
   chain.orderBy.mockReturnValue(chain);
   chain.limit.mockResolvedValue([]);
   chain.insert.mockReturnValue(chain);
@@ -80,7 +87,7 @@ export function mockDb(overrides?: Partial<MockChain>): {
   chain.update.mockReturnValue(chain);
   chain.set.mockReturnValue(chain);
   chain.delete.mockReturnValue(chain);
-  chain.for.mockReturnValue(chain);
+  chain.for.mockReturnValue(thenableChain);
   chain.onConflictDoNothing.mockReturnValue(chain);
   chain.groupBy.mockResolvedValue([]);
   // execute is used by RLS context helpers (setTenantContext, setAccountId)

--- a/apps/api/src/__tests__/helpers/shared-mocks.ts
+++ b/apps/api/src/__tests__/helpers/shared-mocks.ts
@@ -2,27 +2,29 @@
  * Shared mock data used by both REST route tests and tRPC router tests.
  * Single source of truth for test auth contexts and IDs.
  */
-import type { AuthContext } from "../../lib/auth-context.js";
-import type { SystemId } from "@pluralscape/types";
+import type { SessionAuthContext } from "../../lib/auth-context.js";
+import type { AccountId, SessionId, SystemId } from "@pluralscape/types";
 
 /** System ID used across all tests. */
 export const MOCK_SYSTEM_ID = "sys_550e8400-e29b-41d4-a716-446655440000" as SystemId;
 
 /** Shared auth context for system-scoped tests. */
-export const MOCK_AUTH: AuthContext = {
-  accountId: "acct_test001" as AuthContext["accountId"],
+export const MOCK_AUTH: SessionAuthContext = {
+  authMethod: "session" as const,
+  accountId: "acct_test001" as AccountId,
   systemId: MOCK_SYSTEM_ID,
-  sessionId: "sess_test001" as AuthContext["sessionId"],
+  sessionId: "sess_test001" as SessionId,
   accountType: "system",
   ownedSystemIds: new Set([MOCK_SYSTEM_ID]),
   auditLogIpTracking: false,
 };
 
 /** Auth context for account-level routes with no active system. */
-export const MOCK_ACCOUNT_ONLY_AUTH: AuthContext = {
-  accountId: "acct_test001" as AuthContext["accountId"],
+export const MOCK_ACCOUNT_ONLY_AUTH: SessionAuthContext = {
+  authMethod: "session" as const,
+  accountId: "acct_test001" as AccountId,
   systemId: null,
-  sessionId: "sess_test001" as AuthContext["sessionId"],
+  sessionId: "sess_test001" as SessionId,
   accountType: "system",
   ownedSystemIds: new Set<SystemId>(),
   auditLogIpTracking: false,

--- a/apps/api/src/__tests__/helpers/test-auth.ts
+++ b/apps/api/src/__tests__/helpers/test-auth.ts
@@ -4,7 +4,7 @@
  * Centralizes default values so adding fields to AuthContext does not
  * require updating every test file individually.
  */
-import type { AuthContext } from "../../lib/auth-context.js";
+import type { SessionAuthContext } from "../../lib/auth-context.js";
 import type { AccountId, SessionId, SystemId } from "@pluralscape/types";
 
 /** Default system ID used across service unit tests. */
@@ -18,15 +18,16 @@ interface TestAuthOverrides {
   readonly accountId?: string;
   readonly systemId?: string;
   readonly sessionId?: string;
-  readonly accountType?: AuthContext["accountType"];
+  readonly accountType?: SessionAuthContext["accountType"];
   readonly ownedSystemIds?: ReadonlySet<SystemId>;
   readonly auditLogIpTracking?: boolean;
 }
 
-/** Create a test AuthContext with sensible defaults. Override any field via the options. */
-export function makeTestAuth(overrides?: TestAuthOverrides): AuthContext {
+/** Create a test SessionAuthContext with sensible defaults. Override any field via the options. */
+export function makeTestAuth(overrides?: TestAuthOverrides): SessionAuthContext {
   const systemId = (overrides?.systemId ?? DEFAULT_SYSTEM_ID) as SystemId;
   return {
+    authMethod: "session" as const,
     accountId: (overrides?.accountId ?? "acct_test") as AccountId,
     systemId,
     sessionId: (overrides?.sessionId ?? "sess_test") as SessionId,

--- a/apps/api/src/__tests__/lib/audit-writer.test.ts
+++ b/apps/api/src/__tests__/lib/audit-writer.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AuthContext } from "../../lib/auth-context.js";
-import type { AccountId, SystemId } from "@pluralscape/types";
+import type { AuthContext, SessionAuthContext } from "../../lib/auth-context.js";
+import type { AccountId, SessionId, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Context } from "hono";
 
@@ -55,16 +55,17 @@ function mockParams(callIndex: number): Record<string, unknown> {
   return writeAuditLogSpy.mock.calls[callIndex]?.[1] as Record<string, unknown>;
 }
 
-function createAuth(overrides?: Partial<AuthContext>): AuthContext {
+function createAuth(overrides?: Partial<SessionAuthContext>): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId: "acc_test-account" as AuthContext["accountId"],
     systemId: "sys_test-system" as AuthContext["systemId"],
-    sessionId: "ses_test-session" as AuthContext["sessionId"],
+    sessionId: "ses_test-session" as SessionId,
     accountType: "system" as AuthContext["accountType"],
     ownedSystemIds: new Set(["sys_test-system" as AuthContext["systemId"] & string]),
     auditLogIpTracking: false,
     ...overrides,
-  };
+  } satisfies SessionAuthContext;
 }
 
 describe("createAuditWriter", () => {

--- a/apps/api/src/__tests__/lib/friend-access.test.ts
+++ b/apps/api/src/__tests__/lib/friend-access.test.ts
@@ -25,6 +25,7 @@ const BUCKET_B = "bkt_bbb" as BucketId;
 
 function makeAuth(accountId: AccountId = ACCOUNT_ID): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId,
     systemId: null,
     sessionId: "sess_test" as SessionId,

--- a/apps/api/src/__tests__/middleware-composition.test.ts
+++ b/apps/api/src/__tests__/middleware-composition.test.ts
@@ -31,7 +31,7 @@ describe("middleware composition", () => {
     const res = await testApp.request("/health");
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
     expect(res.headers.get("x-frame-options")).toBe("DENY");
-    expect(res.headers.get("content-security-policy")).toContain("default-src 'self'");
+    expect(res.headers.get("content-security-policy")).toContain("default-src 'none'");
   });
 
   it("sets X-Request-Id header on all responses", async () => {

--- a/apps/api/src/__tests__/middleware/auth.test.ts
+++ b/apps/api/src/__tests__/middleware/auth.test.ts
@@ -7,11 +7,13 @@ import { requestIdMiddleware } from "../../middleware/request-id.js";
 
 import type { AuthContext, AuthEnv } from "../../lib/auth-context.js";
 import type { ValidateSessionResult } from "../../lib/session-auth.js";
+import type { ValidateApiKeyResult } from "../../services/api-key.service.js";
 import type { ApiErrorResponse } from "@pluralscape/types";
 
 // ── Mocks ────────────────────────────────────────────────────────────
 
 const mockValidateSession = vi.fn<() => Promise<ValidateSessionResult>>();
+const mockValidateApiKey = vi.fn<() => Promise<ValidateApiKeyResult | null>>();
 const mockGetDb = vi.fn();
 const mockDbUpdate = vi.fn().mockReturnValue({
   set: vi.fn().mockReturnValue({
@@ -41,12 +43,17 @@ vi.mock("../../lib/session-auth.js", () => ({
   validateSession: (): Promise<ValidateSessionResult> => mockValidateSession(),
 }));
 
+vi.mock("../../services/api-key.service.js", () => ({
+  validateApiKey: (): Promise<ValidateApiKeyResult | null> => mockValidateApiKey(),
+}));
+
 vi.mock("../../lib/db.js", () => ({
   getDb: (): unknown => mockGetDb(),
 }));
 
 vi.mock("@pluralscape/db/pg", () => ({
   sessions: { id: "sessions.id" },
+  apiKeys: { id: "apiKeys.id" },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -78,6 +85,9 @@ function createApp(): Hono<AuthEnv> {
 
 /** A valid 64-char lowercase hex token for tests. */
 const VALID_TOKEN = "a0".repeat(32);
+
+/** A valid API key token: ps_ prefix + 64 lowercase hex chars. */
+const VALID_API_KEY_TOKEN = `ps_${"b1".repeat(32)}`;
 
 interface MockSessionData {
   id: string;
@@ -120,12 +130,26 @@ function makeValidResult(
   };
 }
 
+function makeValidApiKeyResult(
+  overrides: Partial<ValidateApiKeyResult> = {},
+): ValidateApiKeyResult {
+  return {
+    accountId: "acct_apikey" as ValidateApiKeyResult["accountId"],
+    systemId: "sys_apikey" as ValidateApiKeyResult["systemId"],
+    scopes: ["read:members", "read:fronting"],
+    auditLogIpTracking: false,
+    keyId: "ak_00000000-0000-0000-0000-000000000001" as ValidateApiKeyResult["keyId"],
+    ...overrides,
+  };
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("authMiddleware", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     mockValidateSession.mockReset();
+    mockValidateApiKey.mockReset();
     mockGetDb.mockReset();
     mockNow.mockReset();
     mockDbUpdate.mockClear();
@@ -356,5 +380,163 @@ describe("authMiddleware", () => {
 
     expect(res.status).toBe(200);
     expect(mockValidateSession).toHaveBeenCalled();
+  });
+
+  // ── API key authentication ──────────────────────────────────────────
+
+  describe("API key authentication", () => {
+    it("returns 200 with apiKeyScopes in auth context for valid API key", async () => {
+      const apiKeyResult = makeValidApiKeyResult();
+      const mockDb = { update: mockDbUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      mockValidateApiKey.mockResolvedValue(apiKeyResult);
+      mockNow.mockReturnValue(2_000_000);
+
+      const app = createApp();
+      const res = await app.request("/protected", {
+        headers: { Authorization: `Bearer ${VALID_API_KEY_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { auth: AuthContext };
+      expect(body.auth).toEqual(
+        expect.objectContaining({
+          accountId: "acct_apikey",
+          systemId: "sys_apikey",
+          accountType: "system",
+          apiKeyScopes: ["read:members", "read:fronting"],
+        }),
+      );
+    });
+
+    it("returns 401 for revoked API key", async () => {
+      const mockDb = { update: mockDbUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      mockValidateApiKey.mockResolvedValue(null);
+
+      const app = createApp();
+      const res = await app.request("/protected", {
+        headers: { Authorization: `Bearer ${VALID_API_KEY_TOKEN}` },
+      });
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as ApiErrorResponse;
+      expect(body.error.code).toBe("UNAUTHENTICATED");
+      expect(body.error.message).toBe("Invalid or revoked API key");
+    });
+
+    it("returns 401 for expired API key", async () => {
+      const mockDb = { update: mockDbUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      // validateApiKey returns null for expired keys
+      mockValidateApiKey.mockResolvedValue(null);
+
+      const app = createApp();
+      const res = await app.request("/protected", {
+        headers: { Authorization: `Bearer ${VALID_API_KEY_TOKEN}` },
+      });
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as ApiErrorResponse;
+      expect(body.error.code).toBe("UNAUTHENTICATED");
+      expect(body.error.message).toBe("Invalid or revoked API key");
+    });
+
+    it("returns 401 for invalid API key (bad hash)", async () => {
+      const mockDb = { update: mockDbUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      // validateApiKey returns null when no matching hash found
+      mockValidateApiKey.mockResolvedValue(null);
+
+      const invalidApiKey = `ps_${"ff".repeat(32)}`;
+      const app = createApp();
+      const res = await app.request("/protected", {
+        headers: { Authorization: `Bearer ${invalidApiKey}` },
+      });
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as ApiErrorResponse;
+      expect(body.error.code).toBe("UNAUTHENTICATED");
+      expect(body.error.message).toBe("Invalid or revoked API key");
+    });
+
+    it("ownedSystemIds contains only the key's systemId", async () => {
+      const apiKeyResult = makeValidApiKeyResult({
+        systemId: "sys_only" as ValidateApiKeyResult["systemId"],
+      });
+      const mockDb = { update: mockDbUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      mockValidateApiKey.mockResolvedValue(apiKeyResult);
+      mockNow.mockReturnValue(2_000_000);
+
+      const app = createApp();
+      const res = await app.request("/protected", {
+        headers: { Authorization: `Bearer ${VALID_API_KEY_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { auth: Record<string, unknown> };
+      // Sets are serialized as empty objects in JSON; verify systemId matches
+      expect(body.auth.systemId).toBe("sys_only");
+      expect(body.auth.accountType).toBe("system");
+    });
+
+    it("fires lastUsedAt update for valid API key", async () => {
+      const apiKeyResult = makeValidApiKeyResult();
+      const mockDb = { update: mockDbUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      mockValidateApiKey.mockResolvedValue(apiKeyResult);
+      mockNow.mockReturnValue(3_000_000);
+
+      const app = createApp();
+      const res = await app.request("/protected", {
+        headers: { Authorization: `Bearer ${VALID_API_KEY_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockDbUpdate).toHaveBeenCalled();
+    });
+
+    it("does not crash when lastUsedAt update fails for API key", async () => {
+      const apiKeyResult = makeValidApiKeyResult();
+      const failingUpdate = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockRejectedValue(new Error("DB write error")),
+        }),
+      });
+      const mockDb = { update: failingUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      mockValidateApiKey.mockResolvedValue(apiKeyResult);
+      mockNow.mockReturnValue(3_000_000);
+
+      const app = createApp();
+      const res = await app.request("/protected", {
+        headers: { Authorization: `Bearer ${VALID_API_KEY_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        "Failed to update API key lastUsedAt",
+        expect.objectContaining({ err: expect.any(Error) }),
+      );
+    });
+
+    it("does not call validateSession for API key tokens", async () => {
+      const apiKeyResult = makeValidApiKeyResult();
+      const mockDb = { update: mockDbUpdate };
+      mockGetDb.mockResolvedValue(mockDb);
+      mockValidateApiKey.mockResolvedValue(apiKeyResult);
+      mockNow.mockReturnValue(2_000_000);
+
+      const app = createApp();
+      await app.request("/protected", {
+        headers: { Authorization: `Bearer ${VALID_API_KEY_TOKEN}` },
+      });
+
+      expect(mockValidateSession).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/__tests__/middleware/auth.test.ts
+++ b/apps/api/src/__tests__/middleware/auth.test.ts
@@ -5,7 +5,7 @@ import { authMiddleware } from "../../middleware/auth.js";
 import { errorHandler } from "../../middleware/error-handler.js";
 import { requestIdMiddleware } from "../../middleware/request-id.js";
 
-import type { AuthContext, AuthEnv } from "../../lib/auth-context.js";
+import type { AuthContext, AuthEnv, SessionAuthContext } from "../../lib/auth-context.js";
 import type { ValidateSessionResult } from "../../lib/session-auth.js";
 import type { ValidateApiKeyResult } from "../../services/api-key.service.js";
 import type { ApiErrorResponse } from "@pluralscape/types";
@@ -102,7 +102,7 @@ interface MockSessionData {
 
 function makeValidResult(
   sessionOverrides: Partial<MockSessionData> = {},
-  authOverrides: Partial<AuthContext> = {},
+  authOverrides: Partial<SessionAuthContext> = {},
 ): ValidateSessionResult {
   const session: MockSessionData = {
     id: "sess_00000000-0000-0000-0000-000000000001",
@@ -118,9 +118,10 @@ function makeValidResult(
   return {
     ok: true,
     auth: {
+      authMethod: "session" as const,
       accountId: "acct_xyz" as AuthContext["accountId"],
       systemId: "sys_001" as AuthContext["systemId"],
-      sessionId: "sess_00000000-0000-0000-0000-000000000001" as AuthContext["sessionId"],
+      sessionId: "sess_00000000-0000-0000-0000-000000000001" as SessionAuthContext["sessionId"],
       accountType: "system",
       ownedSystemIds: new Set(["sys_001" as AuthContext["systemId"] & string]),
       auditLogIpTracking: false,
@@ -277,6 +278,7 @@ describe("authMiddleware", () => {
     const body = (await res.json()) as { auth: AuthContext };
     expect(body.auth).toEqual(
       expect.objectContaining({
+        authMethod: "session",
         accountId: "acct_xyz",
         systemId: "sys_001",
         sessionId: "sess_00000000-0000-0000-0000-000000000001",
@@ -401,12 +403,15 @@ describe("authMiddleware", () => {
       const body = (await res.json()) as { auth: AuthContext };
       expect(body.auth).toEqual(
         expect.objectContaining({
+          authMethod: "apiKey",
           accountId: "acct_apikey",
           systemId: "sys_apikey",
           accountType: "system",
           apiKeyScopes: ["read:members", "read:fronting"],
+          keyId: "ak_00000000-0000-0000-0000-000000000001",
         }),
       );
+      expect(body.auth).not.toHaveProperty("sessionId");
     });
 
     it("returns 401 for revoked API key", async () => {

--- a/apps/api/src/__tests__/middleware/idempotency.test.ts
+++ b/apps/api/src/__tests__/middleware/idempotency.test.ts
@@ -46,6 +46,7 @@ describe("idempotency middleware", () => {
     app.use("*", requestIdMiddleware());
     app.use("*", (c, next) => {
       c.set("auth", {
+        authMethod: "session" as const,
         accountId: "acct-1" as never,
         systemId: null,
         sessionId: "sess-1" as never,
@@ -117,6 +118,7 @@ describe("idempotency middleware", () => {
     errApp.use("*", requestIdMiddleware());
     errApp.use("*", (c, next) => {
       c.set("auth", {
+        authMethod: "session" as const,
         accountId: "acct-1" as never,
         systemId: null,
         sessionId: "sess-1" as never,
@@ -246,6 +248,7 @@ describe("idempotency middleware", () => {
     app.use("*", requestIdMiddleware());
     app.use("*", (c, next) => {
       c.set("auth", {
+        authMethod: "session" as const,
         accountId: "acct-auth-test" as never,
         systemId: null,
         sessionId: "sess-auth" as never,

--- a/apps/api/src/__tests__/middleware/secure-headers.test.ts
+++ b/apps/api/src/__tests__/middleware/secure-headers.test.ts
@@ -33,7 +33,9 @@ describe("createSecureHeaders", () => {
     expect(res.status).toBe(200);
     const csp = res.headers.get("Content-Security-Policy");
     expect(csp).toBeDefined();
-    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'none'");
     expect(csp).toContain("frame-ancestors 'none'");
   });
 

--- a/apps/api/src/__tests__/middleware/smtp-tls-guard.test.ts
+++ b/apps/api/src/__tests__/middleware/smtp-tls-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Validates the SMTP TLS guard logic extracted from index.ts.
+ * The guard throws at startup when SMTP is used in production without TLS.
+ */
+
+/** Inline guard function matching the one added to index.ts. */
+function assertSmtpSecure(provider: string, secure: boolean, nodeEnv: string): void {
+  if (nodeEnv === "production" && provider === "smtp" && !secure) {
+    throw new Error(
+      "SMTP_SECURE must be enabled (SMTP_SECURE=1) when using SMTP in production. " +
+        "Refusing to start with plaintext email transport.",
+    );
+  }
+}
+
+describe("SMTP TLS production guard", () => {
+  it("throws when SMTP provider is used in production without TLS", () => {
+    expect(() => { assertSmtpSecure("smtp", false, "production"); }).toThrow(
+      "SMTP_SECURE must be enabled",
+    );
+  });
+
+  it("does not throw when SMTP provider is used in production with TLS", () => {
+    expect(() => { assertSmtpSecure("smtp", true, "production"); }).not.toThrow();
+  });
+
+  it("does not throw when SMTP provider is used in development without TLS", () => {
+    expect(() => { assertSmtpSecure("smtp", false, "development"); }).not.toThrow();
+  });
+
+  it("does not throw for non-SMTP providers regardless of secure flag", () => {
+    expect(() => { assertSmtpSecure("resend", false, "production"); }).not.toThrow();
+    expect(() => { assertSmtpSecure("stub", false, "production"); }).not.toThrow();
+  });
+});

--- a/apps/api/src/__tests__/middleware/smtp-tls-guard.test.ts
+++ b/apps/api/src/__tests__/middleware/smtp-tls-guard.test.ts
@@ -17,21 +17,29 @@ function assertSmtpSecure(provider: string, secure: boolean, nodeEnv: string): v
 
 describe("SMTP TLS production guard", () => {
   it("throws when SMTP provider is used in production without TLS", () => {
-    expect(() => { assertSmtpSecure("smtp", false, "production"); }).toThrow(
-      "SMTP_SECURE must be enabled",
-    );
+    expect(() => {
+      assertSmtpSecure("smtp", false, "production");
+    }).toThrow("SMTP_SECURE must be enabled");
   });
 
   it("does not throw when SMTP provider is used in production with TLS", () => {
-    expect(() => { assertSmtpSecure("smtp", true, "production"); }).not.toThrow();
+    expect(() => {
+      assertSmtpSecure("smtp", true, "production");
+    }).not.toThrow();
   });
 
   it("does not throw when SMTP provider is used in development without TLS", () => {
-    expect(() => { assertSmtpSecure("smtp", false, "development"); }).not.toThrow();
+    expect(() => {
+      assertSmtpSecure("smtp", false, "development");
+    }).not.toThrow();
   });
 
   it("does not throw for non-SMTP providers regardless of secure flag", () => {
-    expect(() => { assertSmtpSecure("resend", false, "production"); }).not.toThrow();
-    expect(() => { assertSmtpSecure("stub", false, "production"); }).not.toThrow();
+    expect(() => {
+      assertSmtpSecure("resend", false, "production");
+    }).not.toThrow();
+    expect(() => {
+      assertSmtpSecure("stub", false, "production");
+    }).not.toThrow();
   });
 });

--- a/apps/api/src/__tests__/middleware/smtp-tls-guard.test.ts
+++ b/apps/api/src/__tests__/middleware/smtp-tls-guard.test.ts
@@ -1,19 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-/**
- * Validates the SMTP TLS guard logic extracted from index.ts.
- * The guard throws at startup when SMTP is used in production without TLS.
- */
-
-/** Inline guard function matching the one added to index.ts. */
-function assertSmtpSecure(provider: string, secure: boolean, nodeEnv: string): void {
-  if (nodeEnv === "production" && provider === "smtp" && !secure) {
-    throw new Error(
-      "SMTP_SECURE must be enabled (SMTP_SECURE=1) when using SMTP in production. " +
-        "Refusing to start with plaintext email transport.",
-    );
-  }
-}
+import { assertSmtpSecure } from "../../lib/smtp-tls-guard.js";
 
 describe("SMTP TLS production guard", () => {
   it("throws when SMTP provider is used in production without TLS", () => {

--- a/apps/api/src/__tests__/routes/auth/password-reset.test.ts
+++ b/apps/api/src/__tests__/routes/auth/password-reset.test.ts
@@ -33,7 +33,14 @@ vi.mock("../../../services/recovery-key.service.js", () => ({
 
 vi.mock("../../../lib/db.js", () => mockDbFactory());
 
-vi.mock("../../../middleware/rate-limit.js", () => mockRateLimitFactory());
+vi.mock("../../../lib/email-hash.js", () => ({
+  hashEmail: vi.fn().mockReturnValue("hashed-email"),
+}));
+
+vi.mock("../../../middleware/rate-limit.js", () => ({
+  ...mockRateLimitFactory(),
+  checkRateLimit: vi.fn().mockResolvedValue({ allowed: true, retryAfterMs: 0 }),
+}));
 
 // ── Imports after mocks ──────────────────────────────────────────
 
@@ -43,6 +50,7 @@ const {
   DecryptionFailedError,
   InvalidInputError,
 } = await import("../../../services/recovery-key.service.js");
+const { checkRateLimit } = await import("../../../middleware/rate-limit.js");
 const { passwordResetRoute } = await import("../../../routes/auth/password-reset.js");
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -170,6 +178,18 @@ describe("POST /password-reset/recovery-key", () => {
     expect(res.status).toBe(401);
     const body = (await res.json()) as ApiErrorResponse;
     expect(body.error.code).toBe("UNAUTHENTICATED");
+  });
+
+  it("returns 429 when per-account recovery rate limit is exceeded", async () => {
+    vi.mocked(checkRateLimit).mockResolvedValueOnce({ allowed: false, retryAfterMs: 3_000 });
+
+    const app = createApp();
+    const res = await postJSON(app, VALID_BODY);
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(body.error.message).toBe("Too many recovery attempts for this account");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/auth/password-reset.test.ts
+++ b/apps/api/src/__tests__/routes/auth/password-reset.test.ts
@@ -198,7 +198,7 @@ describe("POST /password-reset/recovery-key", () => {
 
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiErrorResponse;
-    expect(body.error.code).toBe("INVALID_INPUT");
+    expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
   it("re-throws unexpected errors as 500", async () => {

--- a/apps/api/src/__tests__/routes/auth/password-reset.test.ts
+++ b/apps/api/src/__tests__/routes/auth/password-reset.test.ts
@@ -192,6 +192,15 @@ describe("POST /password-reset/recovery-key", () => {
     expect(body.error.message).toBe("Too many recovery attempts for this account");
   });
 
+  it("returns 400 when email is missing from recovery request", async () => {
+    const app = createApp();
+    const res = await postJSON(app, { recoveryKey: "a".repeat(52) });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("INVALID_INPUT");
+  });
+
   it("re-throws unexpected errors as 500", async () => {
     vi.mocked(resetPasswordWithRecoveryKey).mockRejectedValueOnce(new Error("DB timeout"));
     vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/apps/api/src/__tests__/routes/auth/sessions.test.ts
+++ b/apps/api/src/__tests__/routes/auth/sessions.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../../middleware/auth.js", () => ({
       () =>
         async (c: { set: (key: string, value: unknown) => void }, next: () => Promise<void>) => {
           c.set("auth", {
+            authMethod: "session",
             accountId: "acct_test",
             sessionId: MOCK_CURRENT_SESSION_ID,
             systemId: null,

--- a/apps/api/src/__tests__/routes/members/photos/create.test.ts
+++ b/apps/api/src/__tests__/routes/members/photos/create.test.ts
@@ -128,7 +128,7 @@ describe("POST /systems/:systemId/members/:memberId/photos", () => {
   it("returns 409 when quota exceeded", async () => {
     const { ApiHttpError } = await import("../../../../lib/api-error.js");
     vi.mocked(createMemberPhoto).mockRejectedValueOnce(
-      new ApiHttpError(409, "QUOTA_EXCEEDED", "Maximum of 50 photos per member"),
+      new ApiHttpError(409, "QUOTA_EXCEEDED", "Maximum of 5 photos per member"),
     );
 
     const app = createApp();

--- a/apps/api/src/__tests__/secure-headers.test.ts
+++ b/apps/api/src/__tests__/secure-headers.test.ts
@@ -37,7 +37,7 @@ describe("secureHeaders middleware", () => {
     const app = createApp();
     const res = await app.request("/test");
     const csp = res.headers.get("content-security-policy");
-    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("default-src 'none'");
   });
 
   it("sets Content-Security-Policy with frame-ancestors none", async () => {

--- a/apps/api/src/__tests__/services/api-key-validate.test.ts
+++ b/apps/api/src/__tests__/services/api-key-validate.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AccountId, ApiKeyId, ApiKeyScope, SystemId } from "@pluralscape/types";
+
+// ── Mock db chain ───────────────────────────────────────────────────
+
+const mockChain = {
+  select: vi.fn(),
+  from: vi.fn(),
+  innerJoin: vi.fn(),
+  where: vi.fn(),
+  limit: vi.fn(),
+};
+
+function wireChain(): void {
+  for (const fn of Object.values(mockChain)) {
+    fn.mockReset();
+  }
+  mockChain.select.mockReturnValue(mockChain);
+  mockChain.from.mockReturnValue(mockChain);
+  mockChain.innerJoin.mockReturnValue(mockChain);
+  mockChain.where.mockReturnValue(mockChain);
+  mockChain.limit.mockResolvedValue([]);
+}
+
+// ── Mocks ───────────────────────────────────────────────────────────
+
+let mockNow = 1000;
+
+vi.mock("@pluralscape/db/pg", () => ({
+  apiKeys: {
+    id: "id",
+    accountId: "accountId",
+    systemId: "systemId",
+    scopes: "scopes",
+    tokenHash: "tokenHash",
+    revokedAt: "revokedAt",
+    expiresAt: "expiresAt",
+  },
+  accounts: {
+    id: "id",
+    auditLogIpTracking: "auditLogIpTracking",
+  },
+}));
+
+vi.mock("@pluralscape/types", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@pluralscape/types")>();
+  return {
+    ...actual,
+    now: vi.fn(() => mockNow),
+  };
+});
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    eq: vi.fn((a: unknown, b: unknown) => [a, b]),
+  };
+});
+
+// ── Import under test ───────────────────────────────────────────────
+
+const { validateApiKey } = await import("../../services/api-key.service.js");
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const TOKEN = "ps_key_abc123";
+const ACCOUNT_ID = "acct_test-account" as AccountId;
+const SYSTEM_ID = "sys_test-system" as SystemId;
+const KEY_ID = "ak_test-key" as ApiKeyId;
+const SCOPES: ApiKeyScope[] = ["read:members"];
+
+function makeValidRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: KEY_ID,
+    accountId: ACCOUNT_ID,
+    systemId: SYSTEM_ID,
+    scopes: SCOPES,
+    revokedAt: null,
+    expiresAt: null,
+    auditLogIpTracking: false,
+    ...overrides,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("validateApiKey", () => {
+  beforeEach(() => {
+    wireChain();
+    mockNow = 1000;
+  });
+
+  it("returns result for valid, non-revoked, non-expired key", async () => {
+    mockChain.limit.mockResolvedValueOnce([makeValidRow()]);
+
+    const result = await validateApiKey(mockChain as never, TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(result?.accountId).toBe(ACCOUNT_ID);
+    expect(result?.systemId).toBe(SYSTEM_ID);
+    expect(result?.scopes).toEqual(SCOPES);
+    expect(result?.keyId).toBe(KEY_ID);
+  });
+
+  it("returns null when no row matches the token hash", async () => {
+    // limit defaults to [] — no rows
+    const result = await validateApiKey(mockChain as never, TOKEN);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when key is revoked", async () => {
+    mockChain.limit.mockResolvedValueOnce([makeValidRow({ revokedAt: 500 })]);
+
+    const result = await validateApiKey(mockChain as never, TOKEN);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when key is expired", async () => {
+    mockNow = 2000;
+    mockChain.limit.mockResolvedValueOnce([makeValidRow({ expiresAt: 1500 })]);
+
+    const result = await validateApiKey(mockChain as never, TOKEN);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns result when key has future expiry", async () => {
+    mockNow = 1000;
+    mockChain.limit.mockResolvedValueOnce([makeValidRow({ expiresAt: 5000 })]);
+
+    const result = await validateApiKey(mockChain as never, TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(result?.keyId).toBe(KEY_ID);
+  });
+
+  it("returns result when expiresAt is null (no expiry)", async () => {
+    mockChain.limit.mockResolvedValueOnce([makeValidRow({ expiresAt: null })]);
+
+    const result = await validateApiKey(mockChain as never, TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(result?.keyId).toBe(KEY_ID);
+  });
+
+  it("includes auditLogIpTracking from joined account", async () => {
+    mockChain.limit.mockResolvedValueOnce([makeValidRow({ auditLogIpTracking: true })]);
+
+    const result = await validateApiKey(mockChain as never, TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(result?.auditLogIpTracking).toBe(true);
+  });
+
+  it("hashes token with SHA-256 for lookup", async () => {
+    mockChain.limit.mockResolvedValueOnce([makeValidRow()]);
+
+    await validateApiKey(mockChain as never, TOKEN);
+
+    // Verify innerJoin and where were called (proving the query chain ran)
+    expect(mockChain.innerJoin).toHaveBeenCalled();
+    expect(mockChain.where).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/__tests__/services/biometric.service.test.ts
+++ b/apps/api/src/__tests__/services/biometric.service.test.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockDb } from "../helpers/mock-db.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AuthContext } from "../../lib/auth-context.js";
-import type { BiometricTokenId } from "@pluralscape/types";
+import type { AuthContext, SessionAuthContext } from "../../lib/auth-context.js";
+import type { BiometricTokenId, SessionId } from "@pluralscape/types";
 
 // ── Mocks ────────────────────────────────────────────────────────
 
@@ -53,16 +53,17 @@ const { enrollBiometric, verifyBiometric } = await import("../../services/biomet
 
 // ── Fixtures ─────────────────────────────────────────────────────
 
-function createAuth(overrides?: Partial<AuthContext>): AuthContext {
+function createAuth(overrides?: Partial<SessionAuthContext>): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId: "acct_abc" as AuthContext["accountId"],
     systemId: "sys_xyz" as AuthContext["systemId"],
-    sessionId: "sess_001" as AuthContext["sessionId"],
+    sessionId: "sess_001" as SessionId,
     accountType: "system",
     ownedSystemIds: new Set(["sys_xyz" as AuthContext["systemId"] & string]),
     auditLogIpTracking: false,
     ...overrides,
-  };
+  } satisfies SessionAuthContext;
 }
 
 const VALID_ENROLL_BODY = { token: "my-biometric-token" };

--- a/apps/api/src/__tests__/services/bucket.service.test.ts
+++ b/apps/api/src/__tests__/services/bucket.service.test.ts
@@ -249,7 +249,7 @@ describe("bucket service", () => {
     });
 
     it("throws QUOTA_EXCEEDED when at max buckets", async () => {
-      thenableQueue.push([], [{ count: 100 }]);
+      thenableQueue.push([], [{ count: 50 }]);
 
       await expect(
         createBucket({} as never, SYSTEM_ID, validPayload, AUTH, mockAudit),

--- a/apps/api/src/__tests__/services/channel.service.test.ts
+++ b/apps/api/src/__tests__/services/channel.service.test.ts
@@ -57,6 +57,9 @@ vi.mock("@pluralscape/db/pg", () => ({
     channelId: "channel_id",
     archived: "archived",
   },
+  systems: {
+    id: "id",
+  },
 }));
 
 vi.mock("@pluralscape/types", async (importOriginal) => {

--- a/apps/api/src/__tests__/services/channel.service.test.ts
+++ b/apps/api/src/__tests__/services/channel.service.test.ts
@@ -229,6 +229,17 @@ describe("channel service", () => {
         expect.objectContaining({ status: 404, code: "NOT_FOUND" }),
       );
     });
+
+    it("throws QUOTA_EXCEEDED when channel count is at maximum", async () => {
+      const { db, chain } = mockDb();
+      chain.where
+        .mockReturnValueOnce(chain) // quota FOR UPDATE lock -> chains to .for()
+        .mockResolvedValueOnce([{ count: 50 }]); // quota count -> at limit
+
+      await expect(createChannel(db, SYSTEM_ID, validPayload, AUTH, mockAudit)).rejects.toThrow(
+        expect.objectContaining({ status: 429, code: "QUOTA_EXCEEDED" }),
+      );
+    });
   });
 
   // ── listChannels ───────────────────────────────────────────────

--- a/apps/api/src/__tests__/services/friend-code.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/friend-code.service.integration.test.ts
@@ -46,6 +46,7 @@ describe("friend-code.service (PGlite integration)", () => {
 
   function makeAccountAuth(accountId: AccountId, systemId: SystemId): AuthContext {
     return {
+      authMethod: "session" as const,
       accountId,
       systemId,
       sessionId: `sess_${crypto.randomUUID()}` as never,

--- a/apps/api/src/__tests__/services/friend-dashboard.service.test.ts
+++ b/apps/api/src/__tests__/services/friend-dashboard.service.test.ts
@@ -104,6 +104,7 @@ const STUB_ENCRYPTED_DATA = "enc_stub";
 
 function makeAuth(): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId: ACCOUNT_ID,
     systemId: null,
     sessionId: "sess_test" as SessionId,

--- a/apps/api/src/__tests__/services/group.service.test.ts
+++ b/apps/api/src/__tests__/services/group.service.test.ts
@@ -185,6 +185,23 @@ describe("createGroup", () => {
       ),
     ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
   });
+
+  it("throws QUOTA_EXCEEDED when group count is at maximum", async () => {
+    const { db, chain } = mockDb();
+    chain.where
+      .mockReturnValueOnce(chain) // quota FOR UPDATE lock -> chains to .for()
+      .mockResolvedValueOnce([{ count: 200 }]); // quota count -> at limit
+
+    await expect(
+      createGroup(
+        db,
+        SYSTEM_ID,
+        { encryptedData: VALID_BLOB_BASE64, parentGroupId: null, sortOrder: 0 },
+        AUTH,
+        mockAudit,
+      ),
+    ).rejects.toThrow(expect.objectContaining({ status: 429, code: "QUOTA_EXCEEDED" }));
+  });
 });
 
 describe("listGroups", () => {

--- a/apps/api/src/__tests__/services/key-rotation.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/key-rotation.service.integration.test.ts
@@ -312,7 +312,7 @@ describe("key-rotation.service (PGlite integration)", () => {
       expect(claim.rotationState).toBe(ROTATION_STATES.migrating);
       for (const item of claim.data) {
         expect(item.status).toBe(ROTATION_ITEM_STATUSES.claimed);
-        expect(item.claimedBy).toBe(auth.sessionId);
+        expect(item.claimedBy).toBe(auth.authMethod === "session" ? auth.sessionId : null);
       }
     });
 

--- a/apps/api/src/__tests__/services/member-photo.service.test.ts
+++ b/apps/api/src/__tests__/services/member-photo.service.test.ts
@@ -90,6 +90,7 @@ describe("createMemberPhoto", () => {
     chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
     chain.where
       .mockReturnValueOnce(chain) // assertMemberActive → chains to .limit()
+      .mockReturnValueOnce(chain) // FOR UPDATE lock → chains to .for()
       .mockResolvedValueOnce([{ count: 0 }]) // per-member count query
       .mockResolvedValueOnce([{ count: 0 }]) // system-wide count query
       .mockResolvedValueOnce([{ maxSort: null }]); // max sort query (first photo)
@@ -119,6 +120,7 @@ describe("createMemberPhoto", () => {
     chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
     chain.where
       .mockReturnValueOnce(chain) // assertMemberActive → chains to .limit()
+      .mockReturnValueOnce(chain) // FOR UPDATE lock → chains to .for()
       .mockResolvedValueOnce([{ count: 0 }]) // per-member count query
       .mockResolvedValueOnce([{ count: 0 }]); // system-wide count query
     // No max sort query when sortOrder is explicit
@@ -142,7 +144,8 @@ describe("createMemberPhoto", () => {
     chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
     chain.where
       .mockReturnValueOnce(chain) // assertMemberActive → chains to .limit()
-      .mockResolvedValueOnce([{ count: 5 }]); // count at quota
+      .mockReturnValueOnce(chain) // FOR UPDATE lock → chains to .for()
+      .mockResolvedValueOnce([{ count: 5 }]); // per-member count at quota
 
     await expect(
       createMemberPhoto(

--- a/apps/api/src/__tests__/services/member-photo.service.test.ts
+++ b/apps/api/src/__tests__/services/member-photo.service.test.ts
@@ -90,7 +90,8 @@ describe("createMemberPhoto", () => {
     chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
     chain.where
       .mockReturnValueOnce(chain) // assertMemberActive → chains to .limit()
-      .mockResolvedValueOnce([{ count: 0 }]) // count query
+      .mockResolvedValueOnce([{ count: 0 }]) // per-member count query
+      .mockResolvedValueOnce([{ count: 0 }]) // system-wide count query
       .mockResolvedValueOnce([{ maxSort: null }]); // max sort query (first photo)
     chain.returning.mockResolvedValueOnce([makePhotoRow()]);
 
@@ -118,7 +119,8 @@ describe("createMemberPhoto", () => {
     chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
     chain.where
       .mockReturnValueOnce(chain) // assertMemberActive → chains to .limit()
-      .mockResolvedValueOnce([{ count: 0 }]); // count query
+      .mockResolvedValueOnce([{ count: 0 }]) // per-member count query
+      .mockResolvedValueOnce([{ count: 0 }]); // system-wide count query
     // No max sort query when sortOrder is explicit
     chain.returning.mockResolvedValueOnce([makePhotoRow({ sortOrder: 5 })]);
 
@@ -140,7 +142,7 @@ describe("createMemberPhoto", () => {
     chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
     chain.where
       .mockReturnValueOnce(chain) // assertMemberActive → chains to .limit()
-      .mockResolvedValueOnce([{ count: 50 }]); // count at quota
+      .mockResolvedValueOnce([{ count: 5 }]); // count at quota
 
     await expect(
       createMemberPhoto(

--- a/apps/api/src/__tests__/services/member.service.test.ts
+++ b/apps/api/src/__tests__/services/member.service.test.ts
@@ -156,6 +156,17 @@ describe("createMember", () => {
       createMember(db, SYSTEM_ID, { encryptedData: VALID_BLOB_BASE64 }, AUTH, mockAudit),
     ).rejects.toThrow(expect.objectContaining({ status: 404, code: "NOT_FOUND" }));
   });
+
+  it("throws QUOTA_EXCEEDED when member count is at maximum", async () => {
+    const { db, chain } = mockDb();
+    chain.where
+      .mockReturnValueOnce(chain) // quota FOR UPDATE lock -> chains to .for()
+      .mockResolvedValueOnce([{ count: 5000 }]); // quota count -> at limit
+
+    await expect(
+      createMember(db, SYSTEM_ID, { encryptedData: VALID_BLOB_BASE64 }, AUTH, mockAudit),
+    ).rejects.toThrow(expect.objectContaining({ status: 429, code: "QUOTA_EXCEEDED" }));
+  });
 });
 
 describe("listMembers", () => {

--- a/apps/api/src/__tests__/services/member.service.test.ts
+++ b/apps/api/src/__tests__/services/member.service.test.ts
@@ -412,6 +412,8 @@ describe("duplicateMember", () => {
     chain.returning.mockResolvedValueOnce([newRow]);
     // Photos select in tx: tx.select().from(memberPhotos).where() — terminal (no .limit())
     chain.where
+      .mockReturnValueOnce(chain) // quota FOR UPDATE lock → chains to .for()
+      .mockResolvedValueOnce([]) // quota count → resolves to empty (under quota)
       .mockReturnValueOnce(chain) // source member → chains to .limit()
       .mockResolvedValueOnce([
         {
@@ -448,6 +450,8 @@ describe("duplicateMember", () => {
     chain.returning.mockResolvedValueOnce([newRow]);
     // Field values select in tx: tx.select().from(fieldValues).where() — terminal
     chain.where
+      .mockReturnValueOnce(chain) // quota FOR UPDATE lock → chains to .for()
+      .mockResolvedValueOnce([]) // quota count → resolves to empty (under quota)
       .mockReturnValueOnce(chain) // source member → chains to .limit()
       .mockResolvedValueOnce([
         {
@@ -484,6 +488,8 @@ describe("duplicateMember", () => {
     chain.returning.mockResolvedValueOnce([newRow]);
     // Group memberships select in tx: tx.select().from(groupMemberships).where() — terminal
     chain.where
+      .mockReturnValueOnce(chain) // quota FOR UPDATE lock → chains to .for()
+      .mockResolvedValueOnce([]) // quota count → resolves to empty (under quota)
       .mockReturnValueOnce(chain) // source member → chains to .limit()
       .mockResolvedValueOnce([
         {

--- a/apps/api/src/__tests__/services/webhook-delivery.service.test.ts
+++ b/apps/api/src/__tests__/services/webhook-delivery.service.test.ts
@@ -57,6 +57,7 @@ const {
 
 function makeAuth(accountId: string, systemId: string) {
   return {
+    authMethod: "session" as const,
     accountId: accountId as AccountId,
     systemId: systemId as SystemId,
     sessionId: "sess_test" as SessionId,

--- a/apps/api/src/__tests__/snapshot.test.ts
+++ b/apps/api/src/__tests__/snapshot.test.ts
@@ -6,7 +6,7 @@ import { mockDb } from "./helpers/mock-db.js";
 import { mockOwnershipFailure } from "./helpers/mock-ownership.js";
 
 import type { AuditWriter } from "../lib/audit-writer.js";
-import type { AuthContext } from "../lib/auth-context.js";
+import type { AuthContext, SessionAuthContext } from "../lib/auth-context.js";
 import type {
   AccountId,
   EncryptedBlob,
@@ -80,8 +80,9 @@ const FAKE_BLOB: EncryptedBlob = {
   bucketId: null,
 };
 
-function stubAuth(overrides?: Partial<AuthContext>): AuthContext {
+function stubAuth(overrides?: Partial<SessionAuthContext>): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId: ACCOUNT_ID,
     systemId: SYSTEM_ID,
     sessionId: "ses_00000000-0000-0000-0000-000000000001" as SessionId,
@@ -89,7 +90,7 @@ function stubAuth(overrides?: Partial<AuthContext>): AuthContext {
     ownedSystemIds: new Set([SYSTEM_ID]),
     auditLogIpTracking: false,
     ...overrides,
-  };
+  } satisfies SessionAuthContext;
 }
 
 function stubAudit(): AuditWriter {

--- a/apps/api/src/__tests__/system-duplicate.test.ts
+++ b/apps/api/src/__tests__/system-duplicate.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockDb } from "./helpers/mock-db.js";
 
 import type { AuditWriter } from "../lib/audit-writer.js";
-import type { AuthContext } from "../lib/auth-context.js";
+import type { AuthContext, SessionAuthContext } from "../lib/auth-context.js";
 import type { AccountId, EncryptedBlob, SessionId, SystemId } from "@pluralscape/types";
 
 // ── Mocks ───────────────────────────────────────────────────────────
@@ -39,8 +39,9 @@ const FAKE_BLOB: EncryptedBlob = {
   bucketId: null,
 };
 
-function stubAuth(overrides?: Partial<AuthContext>): AuthContext {
+function stubAuth(overrides?: Partial<SessionAuthContext>): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId: ACCOUNT_ID,
     systemId: SYSTEM_ID,
     sessionId: "ses_00000000-0000-0000-0000-000000000001" as SessionId,
@@ -48,7 +49,7 @@ function stubAuth(overrides?: Partial<AuthContext>): AuthContext {
     ownedSystemIds: new Set([SYSTEM_ID]),
     auditLogIpTracking: false,
     ...overrides,
-  };
+  } satisfies SessionAuthContext;
 }
 
 function stubAudit(): AuditWriter {

--- a/apps/api/src/__tests__/system-purge.test.ts
+++ b/apps/api/src/__tests__/system-purge.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockDb } from "./helpers/mock-db.js";
 
 import type { AuditWriter } from "../lib/audit-writer.js";
-import type { AuthContext } from "../lib/auth-context.js";
+import type { AuthContext, SessionAuthContext } from "../lib/auth-context.js";
 import type { AccountId, SessionId, SystemId } from "@pluralscape/types";
 
 // ── Mocks ───────────────────────────────────────────────────────────
@@ -35,8 +35,9 @@ const { purgeSystem } = await import("../services/system-purge.service.js");
 const SYSTEM_ID = "sys_00000000-0000-0000-0000-000000000001" as SystemId;
 const ACCOUNT_ID = "acc_00000000-0000-0000-0000-000000000001" as AccountId;
 
-function stubAuth(overrides?: Partial<AuthContext>): AuthContext {
+function stubAuth(overrides?: Partial<SessionAuthContext>): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId: ACCOUNT_ID,
     systemId: SYSTEM_ID,
     sessionId: "ses_00000000-0000-0000-0000-000000000001" as SessionId,
@@ -44,7 +45,7 @@ function stubAuth(overrides?: Partial<AuthContext>): AuthContext {
     ownedSystemIds: new Set([SYSTEM_ID]),
     auditLogIpTracking: false,
     ...overrides,
-  };
+  } satisfies SessionAuthContext;
 }
 
 function stubAudit(): AuditWriter {

--- a/apps/api/src/__tests__/trpc/context.test.ts
+++ b/apps/api/src/__tests__/trpc/context.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { AuthContext } from "../../lib/auth-context.js";
-import type { SystemId } from "@pluralscape/types";
+import type { AuthContext, SessionAuthContext } from "../../lib/auth-context.js";
+import type { AccountId, SessionId, SystemId } from "@pluralscape/types";
 
 vi.mock("../../lib/db.js", () => ({
   getDb: vi.fn().mockResolvedValue({ __mock: "db" }),
@@ -18,10 +18,11 @@ vi.mock("../../lib/request-meta.js", () => ({
 const { createAuditWriter } = await import("../../lib/audit-writer.js");
 const { createTRPCContext } = await import("../../trpc/context.js");
 
-const MOCK_AUTH: AuthContext = {
-  accountId: "acct_ctx001" as AuthContext["accountId"],
+const MOCK_AUTH: SessionAuthContext = {
+  authMethod: "session" as const,
+  accountId: "acct_ctx001" as AccountId,
   systemId: "sys_550e8400-e29b-41d4-a716-446655440000" as SystemId,
-  sessionId: "sess_ctx001" as AuthContext["sessionId"],
+  sessionId: "sess_ctx001" as SessionId,
   accountType: "system",
   ownedSystemIds: new Set(["sys_550e8400-e29b-41d4-a716-446655440000" as SystemId]),
   auditLogIpTracking: false,

--- a/apps/api/src/__tests__/trpc/route-handler.test.ts
+++ b/apps/api/src/__tests__/trpc/route-handler.test.ts
@@ -41,6 +41,7 @@ const { validateSession } = await import("../../lib/session-auth.js");
 const { trpcRoute } = await import("../../routes/trpc.js");
 
 const MOCK_AUTH: AuthContext = {
+  authMethod: "session" as const,
   accountId: "acct_550e8400-e29b-41d4-a716-446655440000" as AccountId,
   systemId: "sys_550e8400-e29b-41d4-a716-446655440000" as SystemId,
   sessionId: "sess_550e8400-e29b-41d4-a716-446655440000" as SessionId,

--- a/apps/api/src/__tests__/ws/auth-handler.test.ts
+++ b/apps/api/src/__tests__/ws/auth-handler.test.ts
@@ -46,6 +46,7 @@ type AuthContextWithSystem = AuthContext & { readonly systemId: SystemId };
 function validAuth(): AuthContextWithSystem {
   const systemId = crypto.randomUUID() as SystemId;
   return {
+    authMethod: "session" as const,
     accountId: crypto.randomUUID() as AccountId,
     systemId,
     sessionId: crypto.randomUUID() as SessionId,

--- a/apps/api/src/__tests__/ws/bounded-subscribe.test.ts
+++ b/apps/api/src/__tests__/ws/bounded-subscribe.test.ts
@@ -43,6 +43,7 @@ function mockWs(): { close: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi
 
 function mockAuth(accountId = crypto.randomUUID() as AccountId): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId,
     systemId: crypto.randomUUID() as SystemId,
     sessionId: crypto.randomUUID() as SessionId,

--- a/apps/api/src/__tests__/ws/broadcast-sync.test.ts
+++ b/apps/api/src/__tests__/ws/broadcast-sync.test.ts
@@ -20,6 +20,7 @@ interface MockPubSub {
 
 function mockAuth(accountId = "acct_test" as AccountId) {
   return {
+    authMethod: "session" as const,
     accountId,
     systemId: "sys_test" as SystemId,
     sessionId: "sess_test" as SessionId,

--- a/apps/api/src/__tests__/ws/broadcast.test.ts
+++ b/apps/api/src/__tests__/ws/broadcast.test.ts
@@ -25,6 +25,7 @@ function mockLog(): AppLogger {
 
 function mockAuth(accountId = "acct_test" as AccountId) {
   return {
+    authMethod: "session" as const,
     accountId,
     systemId: "sys_test" as SystemId,
     sessionId: "sess_test" as SessionId,

--- a/apps/api/src/__tests__/ws/connection-manager.test.ts
+++ b/apps/api/src/__tests__/ws/connection-manager.test.ts
@@ -14,6 +14,7 @@ type AuthContextWithSystem = AuthContext & { readonly systemId: SystemId };
 function mockAuth(accountId = crypto.randomUUID() as AccountId): AuthContextWithSystem {
   const systemId = crypto.randomUUID() as SystemId;
   return {
+    authMethod: "session" as const,
     accountId,
     systemId,
     sessionId: crypto.randomUUID() as SessionId,

--- a/apps/api/src/__tests__/ws/graceful-shutdown.test.ts
+++ b/apps/api/src/__tests__/ws/graceful-shutdown.test.ts
@@ -22,6 +22,7 @@ function mockWs(): { close: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi
 function mockAuth(accountId = crypto.randomUUID() as AccountId): AuthContext {
   const systemId = crypto.randomUUID() as SystemId;
   return {
+    authMethod: "session" as const,
     accountId,
     systemId,
     sessionId: crypto.randomUUID() as SessionId,

--- a/apps/api/src/__tests__/ws/handlers.test.ts
+++ b/apps/api/src/__tests__/ws/handlers.test.ts
@@ -68,6 +68,7 @@ function mockWs(): { close: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi
 
 function mockAuth(accountId = crypto.randomUUID() as AccountId): AuthContext {
   return {
+    authMethod: "session" as const,
     accountId,
     systemId: crypto.randomUUID() as SystemId,
     sessionId: crypto.randomUUID() as SessionId,

--- a/apps/api/src/__tests__/ws/message-router.test.ts
+++ b/apps/api/src/__tests__/ws/message-router.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../lib/session-auth.js", () => ({
   validateSession: vi.fn().mockResolvedValue({
     ok: true,
     auth: {
+      authMethod: "session" as const,
       accountId: "acct_test" as AccountId,
       systemId: "sys_test" as SystemId,
       sessionId: "sess_test" as SessionId,
@@ -687,6 +688,7 @@ describe("message-router", () => {
       brokenManager.authenticate(
         "conn-broken",
         {
+          authMethod: "session" as const,
           accountId: "acct_test" as AccountId,
           systemId: "sys_test" as SystemId,
           sessionId: "sess_test" as SessionId,
@@ -708,6 +710,7 @@ describe("message-router", () => {
       brokenManager.authenticate(
         "conn-sub",
         {
+          authMethod: "session" as const,
           accountId: "acct_test" as AccountId,
           systemId: "sys_test" as SystemId,
           sessionId: "sess_test" as SessionId,
@@ -896,6 +899,7 @@ describe("message-router", () => {
       manager.authenticate(
         "conn-sub",
         {
+          authMethod: "session" as const,
           accountId: "acct_test" as AccountId,
           systemId: "sys_sub" as SystemId,
           sessionId: "sess_sub" as SessionId,
@@ -1099,6 +1103,7 @@ describe("message-router", () => {
       brokenManager.authenticate(
         "conn-broken-mfst",
         {
+          authMethod: "session" as const,
           accountId: "acct_test" as AccountId,
           systemId: "sys_test" as SystemId,
           sessionId: "sess_test" as SessionId,
@@ -1140,6 +1145,7 @@ describe("message-router", () => {
       brokenManager.authenticate(
         "conn-broken-sub",
         {
+          authMethod: "session" as const,
           accountId: "acct_test" as AccountId,
           systemId: "sys_test" as SystemId,
           sessionId: "sess_test" as SessionId,
@@ -1181,6 +1187,7 @@ describe("message-router", () => {
       brokenManager.authenticate(
         "conn-broken-snap",
         {
+          authMethod: "session" as const,
           accountId: "acct_test" as AccountId,
           systemId: "sys_test" as SystemId,
           sessionId: "sess_test" as SessionId,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -169,6 +169,14 @@ async function start(): Promise<void> {
     initEmailAdapter(ResendEmailAdapter.create({ apiKey, fromAddress: env.EMAIL_FROM }));
     logger.info("Email adapter initialized", { provider: "resend" });
   } else if (emailProvider === "smtp") {
+    // Refuse to start with plaintext SMTP in production
+    if (env.NODE_ENV === "production" && !env.SMTP_SECURE) {
+      throw new Error(
+        "SMTP_SECURE must be enabled (SMTP_SECURE=1) when using SMTP in production. " +
+          "Refusing to start with plaintext email transport.",
+      );
+    }
+
     const { SmtpEmailAdapter } = await import("@pluralscape/email/smtp");
     const host = env.SMTP_HOST;
     const port = env.SMTP_PORT;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { initEmailAdapter } from "./lib/email.js";
 import { logger } from "./lib/logger.js";
 import { setNotificationPubSub } from "./lib/notification-pubsub.js";
 import { sanitizeS3Error } from "./lib/s3-log-sanitizer.js";
+import { assertSmtpSecure } from "./lib/smtp-tls-guard.js";
 import { initStorageAdapter } from "./lib/storage.js";
 import { accessLogMiddleware } from "./middleware/access-log.js";
 import { createCorsMiddleware } from "./middleware/cors.js";
@@ -169,13 +170,7 @@ async function start(): Promise<void> {
     initEmailAdapter(ResendEmailAdapter.create({ apiKey, fromAddress: env.EMAIL_FROM }));
     logger.info("Email adapter initialized", { provider: "resend" });
   } else if (emailProvider === "smtp") {
-    // Refuse to start with plaintext SMTP in production
-    if (env.NODE_ENV === "production" && !env.SMTP_SECURE) {
-      throw new Error(
-        "SMTP_SECURE must be enabled (SMTP_SECURE=1) when using SMTP in production. " +
-          "Refusing to start with plaintext email transport.",
-      );
-    }
+    assertSmtpSecure(emailProvider, env.SMTP_SECURE, env.NODE_ENV);
 
     const { SmtpEmailAdapter } = await import("@pluralscape/email/smtp");
     const host = env.SMTP_HOST;

--- a/apps/api/src/lib/auth-context.ts
+++ b/apps/api/src/lib/auth-context.ts
@@ -1,19 +1,58 @@
 import type { AppLogger } from "./logger.js";
-import type { AccountId, AccountType, ApiKeyScope, SessionId, SystemId } from "@pluralscape/types";
+import type {
+  AccountId,
+  AccountType,
+  ApiKeyId,
+  ApiKeyScope,
+  SessionId,
+  SystemId,
+} from "@pluralscape/types";
 
-/** Authenticated request context attached to Hono context by auth middleware. */
-export interface AuthContext {
+/** Fields shared by all authentication methods. */
+interface BaseAuthContext {
   readonly accountId: AccountId;
   /** Null for viewer accounts that are not associated with a system. */
   readonly systemId: SystemId | null;
-  readonly sessionId: SessionId;
   readonly accountType: AccountType;
   /** Non-archived system IDs owned by this account, populated at auth time. */
   readonly ownedSystemIds: ReadonlySet<SystemId>;
   /** When true, IP address and user-agent are persisted in audit log entries (ADR 028). */
   readonly auditLogIpTracking: boolean;
-  /** Present when authenticated via API key. Contains the scopes granted to the key. */
-  readonly apiKeyScopes?: readonly ApiKeyScope[];
+}
+
+/** Auth context for session-based authentication. */
+export interface SessionAuthContext extends BaseAuthContext {
+  readonly authMethod: "session";
+  readonly sessionId: SessionId;
+}
+
+/** Auth context for API key authentication. */
+export interface ApiKeyAuthContext extends BaseAuthContext {
+  readonly authMethod: "apiKey";
+  readonly keyId: ApiKeyId;
+  readonly apiKeyScopes: readonly ApiKeyScope[];
+}
+
+/** Authenticated request context attached to Hono context by auth middleware. */
+export type AuthContext = SessionAuthContext | ApiKeyAuthContext;
+
+/**
+ * Narrow to session auth, throwing if authenticated via API key.
+ * Use at callsites that require a real session (logout, revocation, device transfer, biometric).
+ */
+export function requireSession(auth: AuthContext): SessionAuthContext {
+  if (auth.authMethod !== "session") {
+    throw new Error("This operation requires session authentication");
+  }
+  return auth;
+}
+
+/**
+ * Extract session ID if authenticated via session, null otherwise.
+ * Use for optional audit tracking where API key auth is acceptable.
+ */
+export function getSessionIdOrNull(auth: AuthContext): SessionId | null {
+  return auth.authMethod === "session" ? auth.sessionId : null;
 }
 
 /** Hono environment type augmentation for authenticated routes. */

--- a/apps/api/src/lib/auth-context.ts
+++ b/apps/api/src/lib/auth-context.ts
@@ -1,5 +1,5 @@
 import type { AppLogger } from "./logger.js";
-import type { AccountId, AccountType, SessionId, SystemId } from "@pluralscape/types";
+import type { AccountId, AccountType, ApiKeyScope, SessionId, SystemId } from "@pluralscape/types";
 
 /** Authenticated request context attached to Hono context by auth middleware. */
 export interface AuthContext {
@@ -12,6 +12,8 @@ export interface AuthContext {
   readonly ownedSystemIds: ReadonlySet<SystemId>;
   /** When true, IP address and user-agent are persisted in audit log entries (ADR 028). */
   readonly auditLogIpTracking: boolean;
+  /** Present when authenticated via API key. Contains the scopes granted to the key. */
+  readonly apiKeyScopes?: readonly ApiKeyScope[];
 }
 
 /** Hono environment type augmentation for authenticated routes. */

--- a/apps/api/src/lib/session-auth.ts
+++ b/apps/api/src/lib/session-auth.ts
@@ -78,6 +78,7 @@ export async function validateSession(
   return {
     ok: true,
     auth: {
+      authMethod: "session" as const,
       accountId,
       systemId: firstSystemId ?? null,
       sessionId: row.session.id as SessionId,

--- a/apps/api/src/lib/smtp-tls-guard.ts
+++ b/apps/api/src/lib/smtp-tls-guard.ts
@@ -1,0 +1,12 @@
+/**
+ * Runtime guard that refuses to start with plaintext SMTP in production.
+ * Called during email adapter initialization.
+ */
+export function assertSmtpSecure(provider: string, secure: boolean, nodeEnv: string): void {
+  if (nodeEnv === "production" && provider === "smtp" && !secure) {
+    throw new Error(
+      "SMTP_SECURE must be enabled (SMTP_SECURE=1) when using SMTP in production. " +
+        "Refusing to start with plaintext email transport.",
+    );
+  }
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-import { sessions } from "@pluralscape/db/pg";
+import { apiKeys, sessions } from "@pluralscape/db/pg";
 import { LAST_ACTIVE_THROTTLE_MS, now } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 
@@ -7,18 +7,20 @@ import { ApiHttpError } from "../lib/api-error.js";
 import { getDb } from "../lib/db.js";
 import { getContextLogger } from "../lib/logger.js";
 import { validateSession } from "../lib/session-auth.js";
+import { validateApiKey } from "../services/api-key.service.js";
 
-import { SESSION_TOKEN_PATTERN } from "./middleware.constants.js";
+import { API_KEY_TOKEN_PATTERN, SESSION_TOKEN_PATTERN } from "./middleware.constants.js";
 
 import type { AuthEnv } from "../lib/auth-context.js";
+import type { SessionId, SystemId } from "@pluralscape/types";
 import type { MiddlewareHandler } from "hono";
 
 /**
- * Authentication middleware that validates session tokens.
+ * Authentication middleware that validates session tokens and API keys.
  *
- * Extracts Bearer token from Authorization header, validates the session,
- * and sets the auth context on the Hono context. Also throttles lastActive
- * updates to avoid write amplification.
+ * Extracts Bearer token from Authorization header, detects token type by format
+ * (ps_ prefix = API key, 64-char hex = session), validates accordingly,
+ * and sets the auth context on the Hono context.
  */
 export function authMiddleware(): MiddlewareHandler<AuthEnv> {
   return async (c, next) => {
@@ -34,14 +36,48 @@ export function authMiddleware(): MiddlewareHandler<AuthEnv> {
     }
 
     const token = match[1];
+    const db = await getDb();
 
+    // ── API key path ──────────────────────────────────────────────
+    if (API_KEY_TOKEN_PATTERN.test(token)) {
+      const result = await validateApiKey(db, token);
+      if (!result) {
+        throw new ApiHttpError(HTTP_UNAUTHORIZED, "UNAUTHENTICATED", "Invalid or revoked API key");
+      }
+
+      // Fire-and-forget lastUsedAt update
+      const currentTime = now();
+      void db
+        .update(apiKeys)
+        .set({ lastUsedAt: currentTime })
+        .where(eq(apiKeys.id, result.keyId))
+        .then(() => {})
+        .catch((err: unknown) => {
+          log.error(
+            "Failed to update API key lastUsedAt",
+            err instanceof Error ? { err } : { error: String(err) },
+          );
+        });
+
+      c.set("auth", {
+        accountId: result.accountId,
+        systemId: result.systemId,
+        sessionId: result.keyId as string as SessionId,
+        accountType: "system" as const,
+        ownedSystemIds: new Set<SystemId>([result.systemId]),
+        auditLogIpTracking: result.auditLogIpTracking,
+        apiKeyScopes: result.scopes,
+      });
+
+      return next();
+    }
+
+    // ── Session token path ────────────────────────────────────────
     if (!SESSION_TOKEN_PATTERN.test(token)) {
       throw new ApiHttpError(HTTP_UNAUTHORIZED, "UNAUTHENTICATED", "Invalid or revoked session");
     }
 
-    const db = await getDb();
     const result = await validateSession(db, token);
-
     if (!result.ok) {
       throw new ApiHttpError(HTTP_UNAUTHORIZED, "UNAUTHENTICATED", "Authentication required");
     }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -12,7 +12,7 @@ import { validateApiKey } from "../services/api-key.service.js";
 import { API_KEY_TOKEN_PATTERN, SESSION_TOKEN_PATTERN } from "./middleware.constants.js";
 
 import type { AuthEnv } from "../lib/auth-context.js";
-import type { SessionId, SystemId } from "@pluralscape/types";
+import type { SystemId } from "@pluralscape/types";
 import type { MiddlewareHandler } from "hono";
 
 /**
@@ -51,7 +51,6 @@ export function authMiddleware(): MiddlewareHandler<AuthEnv> {
         .update(apiKeys)
         .set({ lastUsedAt: currentTime })
         .where(eq(apiKeys.id, result.keyId))
-        .then(() => {})
         .catch((err: unknown) => {
           log.error(
             "Failed to update API key lastUsedAt",
@@ -60,12 +59,13 @@ export function authMiddleware(): MiddlewareHandler<AuthEnv> {
         });
 
       c.set("auth", {
+        authMethod: "apiKey" as const,
         accountId: result.accountId,
         systemId: result.systemId,
-        sessionId: result.keyId as string as SessionId,
         accountType: "system" as const,
         ownedSystemIds: new Set<SystemId>([result.systemId]),
         auditLogIpTracking: result.auditLogIpTracking,
+        keyId: result.keyId,
         apiKeyScopes: result.scopes,
       });
 
@@ -93,7 +93,6 @@ export function authMiddleware(): MiddlewareHandler<AuthEnv> {
         .update(sessions)
         .set({ lastActive: currentTime })
         .where(eq(sessions.id, result.session.id))
-        .then(() => {})
         .catch((err: unknown) => {
           log.error(
             "Failed to update session lastActive",

--- a/apps/api/src/middleware/middleware.constants.ts
+++ b/apps/api/src/middleware/middleware.constants.ts
@@ -16,6 +16,9 @@ export const MAX_RATE_LIMIT_ENTRIES = 10_000;
 /** Regex pattern for valid hex-encoded session tokens (32 bytes = 64 lowercase hex chars). */
 export const SESSION_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
 
+/** Regex pattern for API key tokens: "ps_" prefix + 64 lowercase hex chars. */
+export const API_KEY_TOKEN_PATTERN = /^ps_[0-9a-f]{64}$/;
+
 // ── Body limit ──────────────────────────────────────────────────────
 
 /** Maximum request body size in bytes (256 KiB). */

--- a/apps/api/src/middleware/secure-headers.ts
+++ b/apps/api/src/middleware/secure-headers.ts
@@ -17,7 +17,9 @@ export function createSecureHeaders(): MiddlewareHandler {
 
   return honoSecureHeaders({
     contentSecurityPolicy: {
-      defaultSrc: ["'self'"],
+      defaultSrc: ["'none'"],
+      baseUri: ["'none'"],
+      formAction: ["'none'"],
       frameAncestors: ["'none'"],
     },
     xFrameOptions: "DENY",

--- a/apps/api/src/routes/account/device-transfer.ts
+++ b/apps/api/src/routes/account/device-transfer.ts
@@ -13,6 +13,7 @@ import {
 } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
+import { requireSession } from "../../lib/auth-context.js";
 import { getDb } from "../../lib/db.js";
 import { parseJsonBody } from "../../lib/parse-json-body.js";
 import { envelope } from "../../lib/response.js";
@@ -60,6 +61,7 @@ deviceTransferRoute.use(
 // POST / — Initiate a device transfer
 deviceTransferRoute.post("/", async (c) => {
   const auth = c.get("auth");
+  const session = requireSession(auth);
   const db = await getDb();
   const body = await parseJsonBody(c);
   const audit = createAuditWriter(c, auth);
@@ -78,7 +80,7 @@ deviceTransferRoute.post("/", async (c) => {
     const result = await initiateTransfer(
       db,
       auth.accountId,
-      auth.sessionId,
+      session.sessionId,
       parseResult.data,
       audit,
     );
@@ -105,12 +107,13 @@ deviceTransferRoute.use(
 // POST /:id/approve — Approve a pending device transfer (source device only)
 deviceTransferRoute.post("/:id/approve", async (c) => {
   const auth = c.get("auth");
+  const session = requireSession(auth);
   const db = await getDb();
   const audit = createAuditWriter(c, auth);
   const transferId = c.req.param("id");
 
   try {
-    await approveTransfer(db, transferId, auth.accountId, auth.sessionId, audit);
+    await approveTransfer(db, transferId, auth.accountId, session.sessionId, audit);
     return c.body(null, HTTP_NO_CONTENT);
   } catch (error: unknown) {
     if (error instanceof TransferNotFoundError) {
@@ -137,6 +140,7 @@ deviceTransferRoute.use(
 // POST /:id/complete — Complete a device transfer
 deviceTransferRoute.post("/:id/complete", async (c) => {
   const auth = c.get("auth");
+  const session = requireSession(auth);
   const db = await getDb();
   const body = await parseJsonBody(c);
   const audit = createAuditWriter(c, auth);
@@ -157,7 +161,7 @@ deviceTransferRoute.post("/:id/complete", async (c) => {
       db,
       transferId,
       auth.accountId,
-      auth.sessionId,
+      session.sessionId,
       parseResult.data.code,
       audit,
     );

--- a/apps/api/src/routes/auth/password-reset.ts
+++ b/apps/api/src/routes/auth/password-reset.ts
@@ -35,7 +35,7 @@ passwordResetRoute.post("/recovery-key", async (c) => {
       ? (body as { email: unknown }).email
       : undefined;
   if (typeof email !== "string") {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "INVALID_INPUT", "Email is required");
+    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Email is required");
   }
 
   // Per-account rate limiting on recovery attempts (keyed by email hash)

--- a/apps/api/src/routes/auth/password-reset.ts
+++ b/apps/api/src/routes/auth/password-reset.ts
@@ -1,7 +1,11 @@
 import { RATE_LIMITS } from "@pluralscape/types";
 import { Hono } from "hono";
 
-import { HTTP_TOO_MANY_REQUESTS, HTTP_UNAUTHORIZED } from "../../http.constants.js";
+import {
+  HTTP_BAD_REQUEST,
+  HTTP_TOO_MANY_REQUESTS,
+  HTTP_UNAUTHORIZED,
+} from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
@@ -25,22 +29,25 @@ passwordResetRoute.use("*", createCategoryRateLimiter("authHeavy"));
 passwordResetRoute.post("/recovery-key", async (c) => {
   const body = await parseJsonBody(c);
 
-  // Per-account rate limiting on recovery attempts (keyed by email hash)
+  // Validate email presence — required for both the service call and rate limiting
   const email =
     typeof body === "object" && body !== null && "email" in body
-      ? (body as Record<string, unknown>).email
+      ? (body as { email: unknown }).email
       : undefined;
-  if (typeof email === "string") {
-    const emailHash = hashEmail(email);
-    const { limit, windowMs } = RATE_LIMITS.recoveryAttempt;
-    const rateCheck = await checkRateLimit(`recovery:${emailHash}`, limit, windowMs);
-    if (!rateCheck.allowed) {
-      throw new ApiHttpError(
-        HTTP_TOO_MANY_REQUESTS,
-        "RATE_LIMITED",
-        "Too many recovery attempts for this account",
-      );
-    }
+  if (typeof email !== "string") {
+    throw new ApiHttpError(HTTP_BAD_REQUEST, "INVALID_INPUT", "Email is required");
+  }
+
+  // Per-account rate limiting on recovery attempts (keyed by email hash)
+  const emailHash = hashEmail(email);
+  const { limit, windowMs } = RATE_LIMITS.recoveryAttempt;
+  const rateCheck = await checkRateLimit(`recovery:${emailHash}`, limit, windowMs);
+  if (!rateCheck.allowed) {
+    throw new ApiHttpError(
+      HTTP_TOO_MANY_REQUESTS,
+      "RATE_LIMITED",
+      "Too many recovery attempts for this account",
+    );
   }
 
   const platform = extractPlatform(c);

--- a/apps/api/src/routes/auth/password-reset.ts
+++ b/apps/api/src/routes/auth/password-reset.ts
@@ -1,14 +1,16 @@
+import { RATE_LIMITS } from "@pluralscape/types";
 import { Hono } from "hono";
 
-import { HTTP_UNAUTHORIZED } from "../../http.constants.js";
+import { HTTP_TOO_MANY_REQUESTS, HTTP_UNAUTHORIZED } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
+import { hashEmail } from "../../lib/email-hash.js";
 import { getContextLogger } from "../../lib/logger.js";
 import { parseJsonBody } from "../../lib/parse-json-body.js";
 import { extractPlatform } from "../../lib/request-meta.js";
 import { envelope } from "../../lib/response.js";
-import { createCategoryRateLimiter } from "../../middleware/rate-limit.js";
+import { checkRateLimit, createCategoryRateLimiter } from "../../middleware/rate-limit.js";
 import {
   DecryptionFailedError,
   InvalidInputError,
@@ -22,6 +24,24 @@ passwordResetRoute.use("*", createCategoryRateLimiter("authHeavy"));
 
 passwordResetRoute.post("/recovery-key", async (c) => {
   const body = await parseJsonBody(c);
+
+  // Per-account rate limiting on recovery attempts (keyed by email hash)
+  const email =
+    typeof body === "object" && body !== null && "email" in body
+      ? (body as Record<string, unknown>).email
+      : undefined;
+  if (typeof email === "string") {
+    const emailHash = hashEmail(email);
+    const { limit, windowMs } = RATE_LIMITS.recoveryAttempt;
+    const rateCheck = await checkRateLimit(`recovery:${emailHash}`, limit, windowMs);
+    if (!rateCheck.allowed) {
+      throw new ApiHttpError(
+        HTTP_TOO_MANY_REQUESTS,
+        "RATE_LIMITED",
+        "Too many recovery attempts for this account",
+      );
+    }
+  }
 
   const platform = extractPlatform(c);
   const audit = createAuditWriter(c);

--- a/apps/api/src/routes/auth/sessions.ts
+++ b/apps/api/src/routes/auth/sessions.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { HTTP_BAD_REQUEST, HTTP_NO_CONTENT, HTTP_NOT_FOUND } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
+import { requireSession } from "../../lib/auth-context.js";
 import { getDb } from "../../lib/db.js";
 import { parseIdParam } from "../../lib/id-param.js";
 import { parseCursor, parsePaginationLimit } from "../../lib/pagination.js";
@@ -42,11 +43,12 @@ sessionsRoute.get("/sessions", async (c) => {
 // DELETE /auth/sessions/:id — revoke a specific session
 sessionsRoute.delete("/sessions/:id", async (c) => {
   const auth = c.get("auth");
+  const session = requireSession(auth);
   const db = await getDb();
   const targetId = parseIdParam(c.req.param("id"), "sess_");
 
   // Cannot revoke current session via this endpoint — use POST /auth/logout
-  if (targetId === auth.sessionId) {
+  if (targetId === session.sessionId) {
     throw new ApiHttpError(
       HTTP_BAD_REQUEST,
       "VALIDATION_ERROR",
@@ -67,19 +69,21 @@ sessionsRoute.delete("/sessions/:id", async (c) => {
 // POST /auth/logout — revoke the current session
 sessionsRoute.post("/logout", async (c) => {
   const auth = c.get("auth");
+  const session = requireSession(auth);
   const db = await getDb();
   const audit = createAuditWriter(c, auth);
 
-  await logoutCurrentSession(db, auth.sessionId, auth.accountId, audit);
+  await logoutCurrentSession(db, session.sessionId, auth.accountId, audit);
   return c.body(null, HTTP_NO_CONTENT);
 });
 
 // POST /auth/sessions/revoke-all — revoke all sessions except current
 sessionsRoute.post("/sessions/revoke-all", async (c) => {
   const auth = c.get("auth");
+  const session = requireSession(auth);
   const db = await getDb();
   const audit = createAuditWriter(c, auth);
 
-  const count = await revokeAllSessions(db, auth.accountId, auth.sessionId, audit);
+  const count = await revokeAllSessions(db, auth.accountId, session.sessionId, audit);
   return c.json(envelope({ revokedCount: count }));
 });

--- a/apps/api/src/services/api-key.service.ts
+++ b/apps/api/src/services/api-key.service.ts
@@ -1,7 +1,14 @@
 import { createHash, randomBytes } from "node:crypto";
 
-import { apiKeys } from "@pluralscape/db/pg";
-import { ID_PREFIXES, createId, now, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
+import { accounts, apiKeys } from "@pluralscape/db/pg";
+import {
+  API_KEY_TOKEN_PREFIX,
+  ID_PREFIXES,
+  createId,
+  now,
+  toUnixMillis,
+  toUnixMillisOrNull,
+} from "@pluralscape/types";
 import { CreateApiKeyBodySchema } from "@pluralscape/validation";
 import { and, desc, eq, isNull, lt } from "drizzle-orm";
 
@@ -17,6 +24,7 @@ import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../service.constants.js";
 import type { AuditWriter } from "../lib/audit-writer.js";
 import type { AuthContext } from "../lib/auth-context.js";
 import type {
+  AccountId,
   ApiKeyId,
   ApiKeyScope,
   PaginatedResult,
@@ -98,7 +106,8 @@ function toApiKeyResult(row: {
 
 /** Generate a cryptographically random API key token and its SHA-256 hash. */
 function generateTokenPair(): { token: string; tokenHash: string } {
-  const token = randomBytes(API_KEY_TOKEN_BYTES).toString("hex");
+  const raw = randomBytes(API_KEY_TOKEN_BYTES).toString("hex");
+  const token = `${API_KEY_TOKEN_PREFIX}${raw}`;
   const tokenHash = createHash("sha256").update(token).digest("hex");
   return { token, tokenHash };
 }
@@ -269,4 +278,54 @@ export async function revokeApiKey(
       systemId,
     });
   });
+}
+
+// ── VALIDATE ──────────────────────────────────────────────────────────
+
+/** Result of API key validation — returned to auth middleware. */
+export interface ValidateApiKeyResult {
+  readonly accountId: AccountId;
+  readonly systemId: SystemId;
+  readonly scopes: readonly ApiKeyScope[];
+  readonly auditLogIpTracking: boolean;
+  readonly keyId: ApiKeyId;
+}
+
+/**
+ * Validate an API key token and return the associated account and system.
+ * Returns null if the key is invalid, revoked, or expired.
+ */
+export async function validateApiKey(
+  db: PostgresJsDatabase,
+  token: string,
+): Promise<ValidateApiKeyResult | null> {
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+  const currentTime = now();
+
+  const [row] = await db
+    .select({
+      id: apiKeys.id,
+      accountId: apiKeys.accountId,
+      systemId: apiKeys.systemId,
+      scopes: apiKeys.scopes,
+      revokedAt: apiKeys.revokedAt,
+      expiresAt: apiKeys.expiresAt,
+      auditLogIpTracking: accounts.auditLogIpTracking,
+    })
+    .from(apiKeys)
+    .innerJoin(accounts, eq(accounts.id, apiKeys.accountId))
+    .where(eq(apiKeys.tokenHash, tokenHash))
+    .limit(1);
+
+  if (!row) return null;
+  if (row.revokedAt !== null) return null;
+  if (row.expiresAt !== null && currentTime > row.expiresAt) return null;
+
+  return {
+    accountId: row.accountId as AccountId,
+    systemId: row.systemId as SystemId,
+    scopes: row.scopes,
+    auditLogIpTracking: row.auditLogIpTracking,
+    keyId: row.id as ApiKeyId,
+  };
 }

--- a/apps/api/src/services/biometric.service.ts
+++ b/apps/api/src/services/biometric.service.ts
@@ -6,6 +6,7 @@ import { and, eq, isNull } from "drizzle-orm";
 
 import { HTTP_BAD_REQUEST, HTTP_FORBIDDEN, HTTP_UNAUTHORIZED } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
+import { requireSession } from "../lib/auth-context.js";
 import { toHex } from "../lib/hex.js";
 import { withTenantTransaction } from "../lib/rls-context.js";
 import { tenantCtx } from "../lib/tenant-context.js";
@@ -36,6 +37,7 @@ export async function enrollBiometric(
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<{ id: BiometricTokenId }> {
+  const session = requireSession(auth);
   const parsed = BiometricEnrollBodySchema.safeParse(params);
   if (!parsed.success) {
     throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid enroll payload");
@@ -73,7 +75,7 @@ export async function enrollBiometric(
 
     await tx.insert(biometricTokens).values({
       id,
-      sessionId: auth.sessionId,
+      sessionId: session.sessionId,
       tokenHash,
       createdAt: timestamp,
     });
@@ -97,6 +99,7 @@ export async function verifyBiometric(
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<{ verified: true }> {
+  const session = requireSession(auth);
   const parsed = BiometricVerifyBodySchema.safeParse(params);
   if (!parsed.success) {
     throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid verify payload");
@@ -119,7 +122,7 @@ export async function verifyBiometric(
       .set({ usedAt: now() })
       .where(
         and(
-          eq(biometricTokens.sessionId, auth.sessionId),
+          eq(biometricTokens.sessionId, session.sessionId),
           eq(biometricTokens.tokenHash, tokenHash),
           isNull(biometricTokens.usedAt),
         ),

--- a/apps/api/src/services/bucket.constants.ts
+++ b/apps/api/src/services/bucket.constants.ts
@@ -1,2 +1,2 @@
 /** Maximum number of non-archived privacy buckets per system. */
-export const MAX_BUCKETS_PER_SYSTEM = 100;
+export const MAX_BUCKETS_PER_SYSTEM = 50;

--- a/apps/api/src/services/channel.service.ts
+++ b/apps/api/src/services/channel.service.ts
@@ -1,9 +1,9 @@
-import { channels, messages } from "@pluralscape/db/pg";
+import { channels, messages, systems } from "@pluralscape/db/pg";
 import { ID_PREFIXES, createId, now, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
 import { CreateChannelBodySchema, UpdateChannelBodySchema } from "@pluralscape/validation";
 import { and, count, eq, gt, sql } from "drizzle-orm";
 
-import { HTTP_CONFLICT, HTTP_NOT_FOUND } from "../http.constants.js";
+import { HTTP_CONFLICT, HTTP_NOT_FOUND, HTTP_TOO_MANY_REQUESTS } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
 import { encryptedBlobToBase64, parseAndValidateBlob } from "../lib/encrypted-blob.js";
 import { archiveEntity, restoreEntity } from "../lib/entity-lifecycle.js";
@@ -19,6 +19,9 @@ import {
 } from "../service.constants.js";
 
 import { dispatchWebhookEvent } from "./webhook-dispatcher.js";
+
+/** Maximum non-archived channels per system (includes categories). */
+const MAX_CHANNELS_PER_SYSTEM = 50;
 
 import type { AuditWriter } from "../lib/audit-writer.js";
 import type { AuthContext } from "../lib/auth-context.js";
@@ -106,6 +109,22 @@ export async function createChannel(
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
+    // Enforce per-system channel quota
+    await tx.select({ id: systems.id }).from(systems).where(eq(systems.id, systemId)).for("update");
+
+    const [existing] = await tx
+      .select({ count: count() })
+      .from(channels)
+      .where(and(eq(channels.systemId, systemId), eq(channels.archived, false)));
+
+    if ((existing?.count ?? 0) >= MAX_CHANNELS_PER_SYSTEM) {
+      throw new ApiHttpError(
+        HTTP_TOO_MANY_REQUESTS,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_CHANNELS_PER_SYSTEM)} channels per system`,
+      );
+    }
+
     // If parentId provided, validate it exists, belongs to system, and is a category
     if (parsed.parentId) {
       const [parent] = await tx

--- a/apps/api/src/services/custom-front.service.ts
+++ b/apps/api/src/services/custom-front.service.ts
@@ -1,9 +1,9 @@
-import { customFronts, frontingSessions } from "@pluralscape/db/pg";
+import { customFronts, frontingSessions, systems } from "@pluralscape/db/pg";
 import { ID_PREFIXES, createId, now, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
 import { CreateCustomFrontBodySchema, UpdateCustomFrontBodySchema } from "@pluralscape/validation";
 import { and, count, eq, gt, sql } from "drizzle-orm";
 
-import { HTTP_CONFLICT, HTTP_NOT_FOUND } from "../http.constants.js";
+import { HTTP_CONFLICT, HTTP_NOT_FOUND, HTTP_TOO_MANY_REQUESTS } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
 import { encryptedBlobToBase64, parseAndValidateBlob } from "../lib/encrypted-blob.js";
 import { archiveEntity, restoreEntity } from "../lib/entity-lifecycle.js";
@@ -19,6 +19,9 @@ import {
 } from "../service.constants.js";
 
 import { dispatchWebhookEvent } from "./webhook-dispatcher.js";
+
+/** Maximum non-archived custom fronts per system. */
+const MAX_CUSTOM_FRONTS_PER_SYSTEM = 200;
 
 import type { AuditWriter } from "../lib/audit-writer.js";
 import type { AuthContext } from "../lib/auth-context.js";
@@ -89,6 +92,22 @@ export async function createCustomFront(
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
+    // Enforce per-system custom front quota
+    await tx.select({ id: systems.id }).from(systems).where(eq(systems.id, systemId)).for("update");
+
+    const [existing] = await tx
+      .select({ count: count() })
+      .from(customFronts)
+      .where(and(eq(customFronts.systemId, systemId), eq(customFronts.archived, false)));
+
+    if ((existing?.count ?? 0) >= MAX_CUSTOM_FRONTS_PER_SYSTEM) {
+      throw new ApiHttpError(
+        HTTP_TOO_MANY_REQUESTS,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_CUSTOM_FRONTS_PER_SYSTEM)} custom fronts per system`,
+      );
+    }
+
     const [row] = await tx
       .insert(customFronts)
       .values({

--- a/apps/api/src/services/group.service.ts
+++ b/apps/api/src/services/group.service.ts
@@ -69,6 +69,9 @@ function toGroupResult(row: {
   };
 }
 
+/** Maximum non-archived groups per system. */
+const MAX_GROUPS_PER_SYSTEM = 200;
+
 // ── Shared hierarchy service ────────────────────────────────────────
 
 const groupHierarchy = createHierarchyService<
@@ -101,6 +104,7 @@ const groupHierarchy = createHierarchyService<
   },
   idPrefix: ID_PREFIXES.group,
   entityName: "Group",
+  maxPerSystem: MAX_GROUPS_PER_SYSTEM,
   parentFieldName: "parentGroupId",
   toResult: toGroupResult,
   createSchema: CreateGroupBodySchema,

--- a/apps/api/src/services/hierarchy-service-factory.ts
+++ b/apps/api/src/services/hierarchy-service-factory.ts
@@ -1,7 +1,8 @@
+import { systems } from "@pluralscape/db/pg";
 import { createId, now } from "@pluralscape/types";
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, count, eq, gt, sql } from "drizzle-orm";
 
-import { HTTP_NOT_FOUND } from "../http.constants.js";
+import { HTTP_NOT_FOUND, HTTP_TOO_MANY_REQUESTS } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
 import { parseAndValidateBlob } from "../lib/encrypted-blob.js";
 import { archiveEntity } from "../lib/entity-lifecycle.js";
@@ -81,6 +82,28 @@ export function createHierarchyService<
     const timestamp = now();
 
     return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
+      // Enforce per-system quota if configured
+      if (cfg.maxPerSystem !== undefined) {
+        await tx
+          .select({ id: systems.id })
+          .from(systems)
+          .where(eq(systems.id, systemId))
+          .for("update");
+
+        const [existing] = await tx
+          .select({ count: count() })
+          .from(table)
+          .where(and(eq(columns.systemId, systemId), eq(columns.archived, false)));
+
+        if ((existing?.count ?? 0) >= cfg.maxPerSystem) {
+          throw new ApiHttpError(
+            HTTP_TOO_MANY_REQUESTS,
+            "QUOTA_EXCEEDED",
+            `Maximum of ${String(cfg.maxPerSystem)} ${entityName.toLowerCase()}s per system`,
+          );
+        }
+      }
+
       // Validate parent exists in same system if non-null
       const parsedRecord = parsed as Record<string, unknown>;
       const rawParentId = parentFieldName in parsedRecord ? parsedRecord[parentFieldName] : null;

--- a/apps/api/src/services/hierarchy-service-factory.ts
+++ b/apps/api/src/services/hierarchy-service-factory.ts
@@ -406,6 +406,22 @@ export function createHierarchyService<
         );
       }
 
+      // Enforce per-system quota on restore if configured
+      if (cfg.maxPerSystem !== undefined) {
+        const [activeCount] = await tx
+          .select({ count: count() })
+          .from(table)
+          .where(and(eq(columns.systemId, systemId), eq(columns.archived, false)));
+
+        if ((activeCount?.count ?? 0) >= cfg.maxPerSystem) {
+          throw new ApiHttpError(
+            HTTP_TOO_MANY_REQUESTS,
+            "QUOTA_EXCEEDED",
+            `Maximum of ${String(cfg.maxPerSystem)} ${entityName.toLowerCase()}s per system`,
+          );
+        }
+      }
+
       // If parent is archived, promote to root
       let newParentId = typeof existing.parentId === "string" ? existing.parentId : null;
       if (newParentId !== null) {

--- a/apps/api/src/services/hierarchy-service-types.ts
+++ b/apps/api/src/services/hierarchy-service-types.ts
@@ -60,6 +60,8 @@ export interface HierarchyServiceConfig<
   readonly idPrefix: string;
   /** Human-readable entity name for error messages. */
   readonly entityName: string;
+  /** Maximum non-archived entities per system. When set, create() enforces this quota. */
+  readonly maxPerSystem?: number;
   /** The camelCase field name for the parent ID in parsed bodies and insert values (e.g. "parentGroupId"). */
   readonly parentFieldName: string;
   /** Maps a raw DB row to the domain result type. */

--- a/apps/api/src/services/key-rotation.service.ts
+++ b/apps/api/src/services/key-rotation.service.ts
@@ -297,7 +297,7 @@ export async function claimRotationChunk(
       .update(bucketRotationItems)
       .set({
         status: ROTATION_ITEM_STATUSES.claimed,
-        claimedBy: auth.sessionId,
+        claimedBy: auth.authMethod === "session" ? auth.sessionId : auth.keyId,
         claimedAt: timestamp,
       })
       .where(

--- a/apps/api/src/services/member-photo.service.ts
+++ b/apps/api/src/services/member-photo.service.ts
@@ -1,5 +1,5 @@
 import { deserializeEncryptedBlob, InvalidInputError } from "@pluralscape/crypto";
-import { memberPhotos } from "@pluralscape/db/pg";
+import { memberPhotos, systems } from "@pluralscape/db/pg";
 import { ID_PREFIXES, createId, now, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
 import { CreateMemberPhotoBodySchema, ReorderPhotosBodySchema } from "@pluralscape/validation";
 import { and, count, eq, gt, max, or } from "drizzle-orm";
@@ -132,6 +132,9 @@ export async function createMemberPhoto(
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
+    // Lock system row to serialize concurrent quota checks
+    await tx.select({ id: systems.id }).from(systems).where(eq(systems.id, systemId)).for("update");
+
     // Check quota inside transaction to prevent TOCTOU races
     const [countResult] = await tx
       .select({ count: count() })
@@ -477,6 +480,40 @@ export async function restoreMemberPhoto(
 
     if (!existing) {
       throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Photo not found");
+    }
+
+    // Enforce per-member photo quota on restore
+    const [memberCount] = await tx
+      .select({ count: count() })
+      .from(memberPhotos)
+      .where(
+        and(
+          eq(memberPhotos.memberId, memberId),
+          eq(memberPhotos.systemId, systemId),
+          eq(memberPhotos.archived, false),
+        ),
+      );
+
+    if ((memberCount?.count ?? 0) >= MAX_PHOTOS_PER_MEMBER) {
+      throw new ApiHttpError(
+        HTTP_CONFLICT,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_PHOTOS_PER_MEMBER)} photos per member`,
+      );
+    }
+
+    // Enforce system-wide photo quota on restore
+    const [systemCount] = await tx
+      .select({ count: count() })
+      .from(memberPhotos)
+      .where(and(eq(memberPhotos.systemId, systemId), eq(memberPhotos.archived, false)));
+
+    if ((systemCount?.count ?? 0) >= MAX_PHOTOS_PER_SYSTEM) {
+      throw new ApiHttpError(
+        HTTP_CONFLICT,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_PHOTOS_PER_SYSTEM)} photos per system`,
+      );
     }
 
     const timestamp = now();

--- a/apps/api/src/services/member-photo.service.ts
+++ b/apps/api/src/services/member-photo.service.ts
@@ -28,7 +28,10 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Constants ───────────────────────────────────────────────────────
 
-const MAX_PHOTOS_PER_MEMBER = 50;
+const MAX_PHOTOS_PER_MEMBER = 5;
+
+/** Maximum non-archived photos across all members in a system. */
+const MAX_PHOTOS_PER_SYSTEM = 500;
 const MAX_ENCRYPTED_PHOTO_DATA_BYTES = 131_072;
 
 /** Default page size for photo list. */
@@ -146,6 +149,20 @@ export async function createMemberPhoto(
         HTTP_CONFLICT,
         "QUOTA_EXCEEDED",
         `Maximum of ${String(MAX_PHOTOS_PER_MEMBER)} photos per member`,
+      );
+    }
+
+    // System-wide photo quota
+    const [systemCount] = await tx
+      .select({ count: count() })
+      .from(memberPhotos)
+      .where(and(eq(memberPhotos.systemId, systemId), eq(memberPhotos.archived, false)));
+
+    if ((systemCount?.count ?? 0) >= MAX_PHOTOS_PER_SYSTEM) {
+      throw new ApiHttpError(
+        HTTP_CONFLICT,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_PHOTOS_PER_SYSTEM)} photos per system`,
       );
     }
 

--- a/apps/api/src/services/member.service.ts
+++ b/apps/api/src/services/member.service.ts
@@ -11,6 +11,7 @@ import {
   polls,
   relationships,
   systemStructureEntityMemberLinks,
+  systems,
 } from "@pluralscape/db/pg";
 import { ID_PREFIXES, createId, now, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
 import {
@@ -20,7 +21,12 @@ import {
 } from "@pluralscape/validation";
 import { and, count, eq, gt, inArray, or, sql } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST, HTTP_CONFLICT, HTTP_NOT_FOUND } from "../http.constants.js";
+import {
+  HTTP_BAD_REQUEST,
+  HTTP_CONFLICT,
+  HTTP_NOT_FOUND,
+  HTTP_TOO_MANY_REQUESTS,
+} from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
 import { encryptedBlobToBase64, validateEncryptedBlob } from "../lib/encrypted-blob.js";
 import { assertOccUpdated } from "../lib/occ-update.js";
@@ -35,6 +41,9 @@ import {
 } from "../routes/members/members.constants.js";
 
 import { dispatchWebhookEvent } from "./webhook-dispatcher.js";
+
+/** Maximum non-archived members per system. */
+const MAX_MEMBERS_PER_SYSTEM = 5_000;
 
 import type { AuditWriter } from "../lib/audit-writer.js";
 import type { AuthContext } from "../lib/auth-context.js";
@@ -106,6 +115,22 @@ export async function createMember(
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
+    // Enforce per-system member quota
+    await tx.select({ id: systems.id }).from(systems).where(eq(systems.id, systemId)).for("update");
+
+    const [existing] = await tx
+      .select({ count: count() })
+      .from(members)
+      .where(and(eq(members.systemId, systemId), eq(members.archived, false)));
+
+    if ((existing?.count ?? 0) >= MAX_MEMBERS_PER_SYSTEM) {
+      throw new ApiHttpError(
+        HTTP_TOO_MANY_REQUESTS,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_MEMBERS_PER_SYSTEM)} members per system`,
+      );
+    }
+
     const [row] = await tx
       .insert(members)
       .values({

--- a/apps/api/src/services/member.service.ts
+++ b/apps/api/src/services/member.service.ts
@@ -330,6 +330,22 @@ export async function duplicateMember(
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
+    // Enforce per-system member quota
+    await tx.select({ id: systems.id }).from(systems).where(eq(systems.id, systemId)).for("update");
+
+    const [existingCount] = await tx
+      .select({ count: count() })
+      .from(members)
+      .where(and(eq(members.systemId, systemId), eq(members.archived, false)));
+
+    if ((existingCount?.count ?? 0) >= MAX_MEMBERS_PER_SYSTEM) {
+      throw new ApiHttpError(
+        HTTP_TOO_MANY_REQUESTS,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_MEMBERS_PER_SYSTEM)} members per system`,
+      );
+    }
+
     // Verify source member inside transaction to prevent TOCTOU
     const [source] = await tx
       .select()
@@ -535,6 +551,20 @@ export async function restoreMember(
 
     if (!existing) {
       throw new ApiHttpError(HTTP_NOT_FOUND, "NOT_FOUND", "Member not found");
+    }
+
+    // Enforce per-system member quota on restore
+    const [activeCount] = await tx
+      .select({ count: count() })
+      .from(members)
+      .where(and(eq(members.systemId, systemId), eq(members.archived, false)));
+
+    if ((activeCount?.count ?? 0) >= MAX_MEMBERS_PER_SYSTEM) {
+      throw new ApiHttpError(
+        HTTP_TOO_MANY_REQUESTS,
+        "QUOTA_EXCEEDED",
+        `Maximum of ${String(MAX_MEMBERS_PER_SYSTEM)} members per system`,
+      );
     }
 
     const timestamp = now();

--- a/apps/api/src/trpc/routers/account.ts
+++ b/apps/api/src/trpc/routers/account.ts
@@ -22,6 +22,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import { z } from "zod/v4";
 
+import { requireSession } from "../../lib/auth-context.js";
 import {
   MAX_TRANSFER_CODE_ATTEMPTS,
   TRANSFER_INITIATION_LIMIT,
@@ -284,9 +285,10 @@ export const accountRouter = router({
     .use(initiateTransferLimiter)
     .input(initiateTransferInput)
     .mutation(async ({ ctx, input }) => {
+      const session = requireSession(ctx.auth);
       const audit = ctx.createAudit(ctx.auth);
       try {
-        return await initiateTransfer(ctx.db, ctx.auth.accountId, ctx.auth.sessionId, input, audit);
+        return await initiateTransfer(ctx.db, ctx.auth.accountId, session.sessionId, input, audit);
       } catch (err) {
         if (err instanceof TransferValidationError) {
           throw new TRPCError({ code: "BAD_REQUEST", message: err.message, cause: err });
@@ -304,13 +306,14 @@ export const accountRouter = router({
     .use(approveTransferLimiter)
     .input(z.object({ transferId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
+      const session = requireSession(ctx.auth);
       const audit = ctx.createAudit(ctx.auth);
       try {
         await approveTransfer(
           ctx.db,
           input.transferId,
           ctx.auth.accountId,
-          ctx.auth.sessionId,
+          session.sessionId,
           audit,
         );
         return { success: true as const };
@@ -334,13 +337,14 @@ export const accountRouter = router({
     .use(completeTransferLimiter)
     .input(completeTransferInput)
     .mutation(async ({ ctx, input }) => {
+      const session = requireSession(ctx.auth);
       const audit = ctx.createAudit(ctx.auth);
       try {
         return await completeTransfer(
           ctx.db,
           input.transferId,
           ctx.auth.accountId,
-          ctx.auth.sessionId,
+          session.sessionId,
           input.code,
           audit,
         );

--- a/apps/api/src/trpc/routers/auth.ts
+++ b/apps/api/src/trpc/routers/auth.ts
@@ -2,6 +2,7 @@ import { brandedIdQueryParam } from "@pluralscape/validation";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod/v4";
 
+import { requireSession } from "../../lib/auth-context.js";
 import { logger } from "../../lib/logger.js";
 import {
   LoginThrottledError,
@@ -139,8 +140,9 @@ export const authRouter = router({
 
   /** Logout the current session. Requires authentication. */
   logout: protectedProcedure.use(authLightLimiter).mutation(async ({ ctx }) => {
+    const session = requireSession(ctx.auth);
     const audit = ctx.createAudit(ctx.auth);
-    await logoutCurrentSession(ctx.db, ctx.auth.sessionId, ctx.auth.accountId, audit);
+    await logoutCurrentSession(ctx.db, session.sessionId, ctx.auth.accountId, audit);
     return { success: true as const };
   }),
 
@@ -166,7 +168,8 @@ export const authRouter = router({
       .use(authLightLimiter)
       .input(z.object({ sessionId: brandedIdQueryParam("sess_") }))
       .mutation(async ({ input, ctx }) => {
-        if (input.sessionId === ctx.auth.sessionId) {
+        const session = requireSession(ctx.auth);
+        if (input.sessionId === session.sessionId) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "Use logout to revoke the current session",
@@ -183,8 +186,9 @@ export const authRouter = router({
         return { revoked: true as const };
       }),
     revokeAll: protectedProcedure.use(authLightLimiter).mutation(async ({ ctx }) => {
+      const session = requireSession(ctx.auth);
       const audit = ctx.createAudit(ctx.auth);
-      const count = await revokeAllSessions(ctx.db, ctx.auth.accountId, ctx.auth.sessionId, audit);
+      const count = await revokeAllSessions(ctx.db, ctx.auth.accountId, session.sessionId, audit);
       return { revokedCount: count };
     }),
   }),

--- a/packages/types/src/api-constants.ts
+++ b/packages/types/src/api-constants.ts
@@ -69,6 +69,7 @@ const RATE_LIMIT_FRIEND_CODE = 10;
 const RATE_LIMIT_FRIEND_CODE_REDEEM = 5;
 const RATE_LIMIT_PUBLIC_API = 60;
 const RATE_LIMIT_SSE_STREAM = 5;
+const RATE_LIMIT_RECOVERY_ATTEMPT = 3;
 
 export const RATE_LIMITS = {
   global: { limit: RATE_LIMIT_GLOBAL, windowMs: MS_PER_MINUTE },
@@ -88,6 +89,7 @@ export const RATE_LIMITS = {
   friendCodeRedeem: { limit: RATE_LIMIT_FRIEND_CODE_REDEEM, windowMs: MS_PER_MINUTE },
   publicApi: { limit: RATE_LIMIT_PUBLIC_API, windowMs: MS_PER_MINUTE },
   sseStream: { limit: RATE_LIMIT_SSE_STREAM, windowMs: MS_PER_MINUTE },
+  recoveryAttempt: { limit: RATE_LIMIT_RECOVERY_ATTEMPT, windowMs: MS_PER_HOUR },
 } as const satisfies Record<string, RateLimitConfig>;
 
 export type RateLimitCategory = keyof typeof RATE_LIMITS;

--- a/packages/types/src/api-keys.ts
+++ b/packages/types/src/api-keys.ts
@@ -5,6 +5,9 @@ import type { AuditMetadata } from "./utility.js";
 /** A branded API key token — prevents accidental logging. */
 export type ApiKeyToken = Brand<string, "ApiKeyToken">;
 
+/** Prefix for API key tokens to distinguish them from session tokens. */
+export const API_KEY_TOKEN_PREFIX = "ps_";
+
 /** Scopes an API key can be granted. */
 export type ApiKeyScope =
   | "read:members"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -397,6 +397,7 @@ export type {
   ApiKey,
   ApiKeyWithSecret,
 } from "./api-keys.js";
+export { API_KEY_TOKEN_PREFIX } from "./api-keys.js";
 
 // ── Jobs ──────────────────────────────────────────────────────
 export type {

--- a/security/260406-0808-stride-owasp-full-audit/attack-surface-map.md
+++ b/security/260406-0808-stride-owasp-full-audit/attack-surface-map.md
@@ -1,0 +1,160 @@
+# Attack Surface Map — Pluralscape Full Audit
+
+**Date:** 2026-04-06 08:08
+
+## Entry Points
+
+### Public (Unauthenticated)
+
+| Method    | Path                      | Risk Profile                                            |
+| --------- | ------------------------- | ------------------------------------------------------- |
+| POST      | `/v1/auth/register`       | Account creation, rate limited (authHeavy)              |
+| POST      | `/v1/auth/login`          | Credential verification, anti-enumeration, rate limited |
+| POST      | `/v1/auth/biometric`      | Biometric auth flow                                     |
+| GET       | `/v1/auth/biometric`      | Biometric challenge retrieval                           |
+| POST      | `/v1/auth/password-reset` | Password reset via recovery key                         |
+| POST      | `/v1/auth/recovery-key`   | Recovery key operations                                 |
+| GET       | `/v1/healthcheck`         | Health endpoint                                         |
+| WebSocket | `/v1/sync`                | Sync relay (auth in first message)                      |
+
+### Authenticated (Session Required)
+
+| Method         | Path                       | Risk Profile                                                                  |
+| -------------- | -------------------------- | ----------------------------------------------------------------------------- |
+| GET/DELETE     | `/v1/auth/sessions`        | Session management                                                            |
+| GET/PUT/DELETE | `/v1/account/*`            | Account operations                                                            |
+| GET/POST       | `/v1/systems/`             | System CRUD                                                                   |
+| ALL            | `/v1/systems/:systemId/*`  | System-scoped resources (members, groups, fields, relationships, blobs, etc.) |
+| GET            | `/v1/notifications/stream` | SSE notification stream                                                       |
+
+### tRPC Procedures (~40+ routers)
+
+| Type          | Category  | Examples                                                                                      |
+| ------------- | --------- | --------------------------------------------------------------------------------------------- |
+| Public        | Auth      | `auth.register`, `auth.login`, `auth.resetPasswordWithRecoveryKey`                            |
+| Protected     | Account   | `account.get`, `account.update`, `account.delete`                                             |
+| Protected     | System    | `system.create`, `system.list`, `system.get`, `system.update`                                 |
+| Protected     | Domain    | member, group, channel, poll, journal, fronting, webhook, blob, notification, analytics, etc. |
+| System-scoped | Resources | All operations requiring systemId ownership validation                                        |
+
+## Data Flows
+
+### Authentication Flow
+
+```
+Client → POST /v1/auth/login (email, password)
+  → Server: lookup emailHash (BLAKE2b)
+  → Server: verify password (Argon2id)
+  → Server: create session (random 32-byte token)
+  → Server: store SHA-256(token) in sessions table
+  → Client: receives plaintext token
+  → Client: stores in SecureStore (mobile) / memory (web)
+  → Subsequent requests: Authorization: Bearer <token>
+```
+
+### Sync Flow
+
+```
+Client → WebSocket /v1/sync
+  → First message: AuthenticateRequest (session token)
+  → Server: validates session, binds account
+  → Client → SubmitChange/SubmitSnapshot (encrypted + signed)
+  → Server: stores opaque envelope (no decryption)
+  → Server → broadcasts to other connected clients
+  → Client: decrypts locally, applies CRDT merge
+```
+
+### Blob Upload Flow
+
+```
+Client → tRPC blob.createUploadUrl (metadata)
+  → Server: generates S3 presigned PUT URL (1h expiry)
+  → Client: encrypts blob locally (XChaCha20-Poly1305)
+  → Client → PUT to S3 presigned URL (encrypted bytes)
+  → Client → tRPC blob.confirmUpload (checksum)
+  → Server: verifies S3 object exists, stores metadata
+```
+
+### Key Rotation Flow
+
+```
+Account owner → initiate rotation for bucket
+  → Server: creates rotation record (initiated state)
+  → Client worker: claims items in chunks
+  → Client: decrypt with old key → re-encrypt with new key
+  → Client → submit re-encrypted item
+  → Server: tracks progress (completedItems / totalItems)
+  → All items done → rotation state = completed
+```
+
+### Device Transfer Flow
+
+```
+Source device → create transfer request (encrypted master key material)
+  → Server: stores encrypted transfer payload
+  → Target device → poll for transfer request
+  → Target device: decrypt with shared secret
+  → Target device: now has master key, can derive all sub-keys
+```
+
+## Abuse Paths
+
+### Path 1: Session Token Theft → Account Takeover
+
+```
+Attacker steals session token (XSS, network sniff, device access)
+  → Has full account access until token expires/revoked
+  → Can access all owned systems, sync data, manage sessions
+  Mitigations: TLS required, idle timeout, session listing/revocation
+  Gap: No session binding to IP/device fingerprint
+```
+
+### Path 2: Recovery Key Compromise → Account Takeover
+
+```
+Attacker obtains recovery key (physical access, social engineering)
+  → Can reset password without email verification
+  → Full account takeover
+  Mitigations: 52-char high-entropy key, user-managed backup
+  Gap: No secondary verification for recovery key usage
+```
+
+### Path 3: Presigned URL Leakage → Blob Access
+
+```
+S3 presigned download URLs leaked (logs, referrer headers, shared links)
+  → Attacker can download encrypted blobs
+  → Cannot decrypt without master key (E2E encrypted)
+  Mitigations: Time-limited URLs (24h), E2E encryption
+  Gap: 24h window is generous; referrer leakage possible
+```
+
+### Path 4: WebSocket Auth Race
+
+```
+Connect to WebSocket before sending auth message
+  → Window where unauthenticated connection exists
+  → If server processes messages before auth completes...
+  Mitigations: Auth required as first message, connection closed on failure
+  Gap: Need to verify no messages processed before auth completes
+```
+
+### Path 5: Rate Limit Bypass via Distributed Attack
+
+```
+In-memory rate limiter (single-instance mode)
+  → Different instances have separate counters
+  → Distributed attack across IPs bypasses per-IP limits
+  Mitigations: Valkey-backed limiter for production
+  Gap: Self-hosted single-instance still uses in-memory (by design)
+```
+
+### Path 6: Email Hash Rainbow Table
+
+```
+BLAKE2b email hashes are deterministic with pepper
+  → If EMAIL_HASH_PEPPER leaks, rainbow table possible
+  → Per-account salt mitigates but pepper is shared
+  Mitigations: 32-byte pepper, per-account salt, encrypted email column
+  Gap: Pepper compromise + DB access = email recovery
+```

--- a/security/260406-0808-stride-owasp-full-audit/dependency-audit.md
+++ b/security/260406-0808-stride-owasp-full-audit/dependency-audit.md
@@ -1,0 +1,56 @@
+# Dependency Audit — Pluralscape Full Audit
+
+**Date:** 2026-04-06
+**Tool:** `pnpm audit --audit-level=moderate`
+
+## Results
+
+```
+No known vulnerabilities found
+```
+
+**0 vulnerabilities detected across all severity levels.**
+
+## Security Overrides (pnpm)
+
+The following dependency overrides are configured in the root `package.json` to ensure patched versions are used throughout the monorepo:
+
+| Package           | Minimum Version | Reason                             |
+| ----------------- | --------------- | ---------------------------------- |
+| `fast-xml-parser` | >=5.5.7         | CVE patches for XML parsing        |
+| `node-forge`      | >=1.4.0         | CVE patches for crypto operations  |
+| `handlebars`      | >=4.7.9         | CVE patches for template injection |
+| `flatted`         | >=3.4.2         | CVE patches for circular JSON      |
+| `yaml`            | >=2.8.3         | CVE patches for YAML parsing       |
+| `brace-expansion` | >=5.0.5         | ReDoS fix                          |
+| `picomatch`       | >=4.0.4         | ReDoS fix                          |
+| `esbuild`         | >=0.25.0        | Security patches                   |
+
+## GitHub Actions Pinning
+
+All CI/CD actions are pinned to commit SHAs (not floating version tags):
+
+| Action                             | SHA            | Version |
+| ---------------------------------- | -------------- | ------- |
+| `actions/checkout`                 | `de0fac2e...`  | v6      |
+| `pnpm/action-setup`                | `fc06bc125...` | v5      |
+| `actions/setup-node`               | `53b83947...`  | v6      |
+| `actions/upload-artifact`          | `bbbca2dd...`  | v7      |
+| `schneegans/dynamic-badges-action` | `e9a478b1...`  | v1.7.0  |
+| `oven-sh/setup-bun`                | `0c5077e5...`  | v2      |
+
+## Docker Image Pinning
+
+| Image             | Digest               |
+| ----------------- | -------------------- |
+| `postgres:18`     | `sha256:a9abf427...` |
+| `valkey/valkey:9` | `sha256:3b55fbaa...` |
+
+## Lock File
+
+- `pnpm-lock.yaml` is committed and CI uses `--frozen-lockfile`
+- No pre/post install scripts besides `husky` (legitimate git hook manager)
+
+## Assessment
+
+**Supply chain security is strong.** Dependencies are actively maintained, overrides address known CVEs, CI/CD actions are SHA-pinned, and Docker images use digest pinning.

--- a/security/260406-0808-stride-owasp-full-audit/findings.md
+++ b/security/260406-0808-stride-owasp-full-audit/findings.md
@@ -1,0 +1,214 @@
+# Findings — Pluralscape Full Audit
+
+**Date:** 2026-04-06
+**Total Findings:** 7 (0 Critical, 1 High, 2 Medium, 2 Low, 2 Info)
+
+---
+
+## [HIGH] Finding 1: SMTP Plaintext Email in Production {#finding-1} — FIXED
+
+- **OWASP:** A05 — Security Misconfiguration
+- **STRIDE:** Information Disclosure
+- **Location:** `apps/api/src/env.ts:74-77`
+- **Confidence:** Confirmed
+
+**Description:** `SMTP_SECURE` defaults to `"0"` (plaintext) and has no production enforcement. Unlike `EMAIL_HASH_PEPPER` and `EMAIL_ENCRYPTION_KEY` which use Zod `.refine()` to require values in production, SMTP security is entirely opt-in. If a self-hosted deployment uses SMTP without explicitly setting `SMTP_SECURE=1`, password reset emails, security notifications, and new-device alerts are sent over plaintext SMTP.
+
+**Attack Scenario:**
+
+1. Self-hosted Pluralscape instance configured with SMTP but `SMTP_SECURE` left at default
+2. Attacker on same network segment performs passive traffic capture
+3. Password reset email captured in plaintext, containing recovery key or reset link
+4. Attacker uses captured credentials for account takeover
+
+**Code Evidence:**
+
+```typescript
+// apps/api/src/env.ts:74-77
+SMTP_SECURE: z
+  .enum(["0", "1"])
+  .default("0")
+  .transform((v) => v === "1"),
+```
+
+Compare with enforced secrets (same file):
+
+```typescript
+// EMAIL_HASH_PEPPER and EMAIL_ENCRYPTION_KEY have .refine() for production
+```
+
+**Mitigation:**
+
+```typescript
+SMTP_SECURE: z
+  .enum(["0", "1"])
+  .default("0")
+  .transform((v) => v === "1"),
+// Add after createEnv():
+// .refine((env) => !isProduction || env.EMAIL_PROVIDER !== "smtp" || env.SMTP_SECURE, {
+//   message: "SMTP_SECURE must be '1' in production when using SMTP provider",
+// })
+```
+
+**References:** CWE-319 (Cleartext Transmission of Sensitive Information)
+
+---
+
+## [MEDIUM] Finding 2: Incomplete Content Security Policy {#finding-2} — FIXED
+
+- **OWASP:** A05 — Security Misconfiguration
+- **STRIDE:** Information Disclosure
+- **Location:** `apps/api/src/middleware/secure-headers.ts:15-34`
+- **Confidence:** Confirmed
+
+**Description:** The Content-Security-Policy header only sets `default-src 'self'` and `frame-ancestors 'none'`. While this is a reasonable baseline for a pure API server, the CSP lacks `form-action`, `upgrade-insecure-requests`, and `base-uri` directives that would further harden the policy.
+
+**Code Evidence:**
+
+```typescript
+// apps/api/src/middleware/secure-headers.ts
+"Content-Security-Policy": "default-src 'self'; frame-ancestors 'none'"
+```
+
+**Mitigation:**
+
+```typescript
+"Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'none'; upgrade-insecure-requests"
+```
+
+Note: Since this is a pure API (no HTML responses), `default-src 'none'` is more appropriate than `'self'`.
+
+**References:** CWE-1021 (Improper Restriction of Rendered UI Layers)
+
+---
+
+## [MEDIUM] Finding 3: Webhook DNS Rebinding TOCTOU {#finding-3} — FALSE POSITIVE
+
+- **OWASP:** A10 — Server-Side Request Forgery
+- **STRIDE:** Tampering
+- **Location:** `apps/api/src/jobs/webhook-deliver.ts`, `apps/api/src/lib/ip-validation.ts:312-341`
+- **Confidence:** Likely
+
+**Description:** Webhook URL validation resolves DNS and checks the resolved IP against blocked ranges (loopback, private, link-local, CGNAT, metadata) at webhook creation time. However, the actual HTTP delivery in the webhook worker does NOT use IP pinning — it resolves DNS independently. A sophisticated attacker could configure DNS to return a safe IP during validation, then rebind to an internal IP before delivery.
+
+**Attack Scenario:**
+
+1. Attacker registers webhook with URL pointing to their controlled domain
+2. During validation, DNS resolves to attacker's public IP (passes validation)
+3. Attacker updates DNS to resolve to `169.254.169.254` (cloud metadata) or `10.0.0.1` (internal)
+4. Webhook delivery resolves DNS again, hitting the internal service
+5. Attacker receives internal service response via webhook payload
+
+**Code Evidence:**
+
+- Validation: `apps/api/src/lib/ip-validation.ts:312-341` — resolves DNS, blocks private IPs
+- Delivery: `apps/api/src/jobs/webhook-deliver.ts` — standard `fetch()` without IP pinning
+- IP pinning utility EXISTS: `buildIpPinnedFetchArgs` in `ip-validation.ts` but is not used in delivery
+
+**Mitigation:** Use `buildIpPinnedFetchArgs` in the webhook delivery worker to pin the resolved IP at delivery time:
+
+```typescript
+const { url, init } = await buildIpPinnedFetchArgs(webhookUrl);
+const response = await fetch(url, { ...init, method: "POST", body, headers });
+```
+
+**References:** CWE-918 (Server-Side Request Forgery), CWE-350 (Reliance on Reverse DNS)
+
+---
+
+## [MEDIUM] Finding 4: API Key Authentication Not Implemented {#finding-4} — FIXED
+
+- **OWASP:** A01 — Broken Access Control
+- **STRIDE:** Elevation of Privilege
+- **Location:** `apps/api/src/middleware/auth.ts`
+- **Confidence:** Confirmed
+
+**Description:** The `apiKeys` database table exists with full CRUD operations (creation, listing, revocation, scope management) via `api-key.service.ts`, including `ApiKeyScope` types. However, the auth middleware only handles Bearer session tokens. There is no middleware to authenticate requests using API keys or enforce their scopes.
+
+This means API keys can be created and managed but serve no actual authentication purpose — they cannot be used to access any endpoint. If any documentation or client code expects API key authentication, it silently fails to authenticate.
+
+**Code Evidence:**
+
+```typescript
+// apps/api/src/middleware/auth.ts — only handles Bearer session tokens
+const match = authorization?.match(/^Bearer\s+(.+)$/i);
+// No API key format handling (e.g., "ApiKey sk_..." or "X-API-Key" header)
+```
+
+**Impact:** Low immediate risk (no auth bypass since keys simply don't work), but represents incomplete feature with potential for future confusion. If a user creates an API key expecting it to grant access, they'll get 401 on every request.
+
+**Mitigation:** Either implement API key authentication middleware or remove the API key management endpoints to avoid confusion.
+
+**References:** CWE-306 (Missing Authentication for Critical Function)
+
+---
+
+## [LOW] Finding 5: Coarse-Grained Recovery Key Rate Limiting {#finding-5} — FIXED
+
+- **OWASP:** A07 — Identification and Authentication Failures
+- **STRIDE:** Spoofing
+- **Location:** `apps/api/src/services/recovery-key.service.ts:196`
+- **Confidence:** Likely
+
+**Description:** Recovery key password reset uses the global `authHeavy` rate limiter (shared with login). There is no per-account throttle on recovery key attempts. While the recovery key itself has high entropy (52 characters), a distributed attacker could attempt recovery key resets across many accounts without triggering per-account limits.
+
+**Mitigation:** Add per-account rate limiting on recovery key attempts (e.g., 3 attempts per hour per account, independent of login rate limit).
+
+**References:** CWE-307 (Improper Restriction of Excessive Authentication Attempts)
+
+---
+
+## [LOW] Finding 6: No Resource Quotas for Core Entities {#finding-6} — FIXED
+
+- **OWASP:** A04 — Insecure Design
+- **STRIDE:** Denial of Service
+- **Location:** `apps/api/src/services/`
+- **Confidence:** Confirmed
+
+**Description:** Several core entity types have no per-system creation limits:
+
+- Members (no limit found)
+- Groups (no limit found)
+- Custom fronts (no limit found)
+- Journal entries (no limit found)
+- Wiki pages (no limit found)
+
+Other entities do have quotas: webhooks (25), field definitions (200), friend codes (10), buckets (100), photos (50), sessions (50).
+
+**Impact:** A malicious or compromised account could create millions of entities, consuming database and sync storage.
+
+**Mitigation:** Add per-system quotas for members, groups, custom fronts, and other unbounded entity types.
+
+**References:** CWE-770 (Allocation of Resources Without Limits)
+
+---
+
+## [INFO] Finding 7: Missing Session Revocation Audit Event {#finding-7} — FALSE POSITIVE
+
+- **OWASP:** A09 — Security Logging and Monitoring Failures
+- **STRIDE:** Repudiation
+- **Location:** `packages/types/src/audit-log.ts`
+- **Confidence:** Possible
+
+**Description:** The audit log event types include `auth.login`, `auth.logout`, `auth.password-changed`, `auth.recovery-key-used`, but no explicit `auth.session-revoked` event for when a user manually revokes a specific session. Session revocation is only indirectly covered by the password-change flow (which revokes all sessions).
+
+**Mitigation:** Add `auth.session-revoked` event type to the audit log schema.
+
+**References:** CWE-778 (Insufficient Logging)
+
+---
+
+## [INFO] Finding 8: Session lastActive TOCTOU {#finding-8}
+
+- **OWASP:** A07 — Identification and Authentication Failures
+- **STRIDE:** Tampering
+- **Location:** `apps/api/src/middleware/auth.ts:56`
+- **Confidence:** Possible
+
+**Description:** The `lastActive` timestamp update on session validation is fire-and-forget (async, non-blocking). Between validation and the update completing, concurrent requests could see a stale `lastActive` value, potentially allowing a session that should have timed out to remain valid for one additional request.
+
+**Impact:** Minimal — no authorization bypass, only a potential one-request grace period on idle timeout. The 5-minute throttle on updates makes the window extremely narrow.
+
+**Mitigation:** No action required. The design trade-off (performance vs precision) is acceptable for idle timeout enforcement.
+
+**References:** CWE-367 (Time-of-check Time-of-use Race Condition)

--- a/security/260406-0808-stride-owasp-full-audit/overview.md
+++ b/security/260406-0808-stride-owasp-full-audit/overview.md
@@ -1,0 +1,63 @@
+# Security Audit — STRIDE + OWASP Full Audit
+
+**Date:** 2026-04-06 08:08
+**Scope:** Full monorepo — apps/api, apps/mobile, packages/crypto, packages/db, packages/sync, packages/storage, packages/queue, packages/email, packages/rotation-worker, packages/validation
+**Focus:** Comprehensive
+**Iterations:** 24 vectors tested
+**Auditor:** Autonomous security sweep (autoresearch-security)
+
+## Summary
+
+- **Total Findings:** 7
+  - Critical: 0 | High: 1 | Medium: 3 | Low: 2 | Info: 2
+- **STRIDE Coverage:** 6/6 categories tested
+- **OWASP Coverage:** 10/10 categories tested
+- **Confirmed:** 4 | Likely: 1 | Possible: 2
+- **Metric Score:** 87/100 (coverage 80 + findings 7)
+
+## Overall Assessment
+
+Pluralscape has a **strong security posture** for a pre-production application. The architecture demonstrates security-first design with defense-in-depth: E2E encryption (XChaCha20-Poly1305), comprehensive RLS policies, per-category rate limiting, Argon2id password hashing, anti-enumeration timing, and SHA-pinned CI/CD.
+
+No critical vulnerabilities were found. The highest-severity finding (SMTP plaintext) is a configuration hardening issue, not an exploitable code flaw. The codebase's zero-knowledge encryption model means that even server-side compromises have limited impact on user data confidentiality.
+
+## Top Findings
+
+1. **[HIGH] [SMTP Plaintext Email](./findings.md#finding-1)** — `SMTP_SECURE` defaults to false, not enforced in production. Password reset and security notification emails could be sent over plaintext SMTP.
+
+2. **[MEDIUM] [Incomplete CSP](./findings.md#finding-2)** — Content-Security-Policy only sets `default-src 'self'`. For a pure API server, `default-src 'none'` with explicit directives would be more restrictive.
+
+3. **[MEDIUM] [Webhook DNS Rebinding](./findings.md#finding-3)** — IP pinning utility exists but isn't used in webhook delivery, leaving a DNS rebinding TOCTOU window for SSRF.
+
+4. **[MEDIUM] [API Key Auth Gap](./findings.md#finding-4)** — API key CRUD exists but no authentication middleware consumes them. Feature is incomplete.
+
+## STRIDE Coverage
+
+| Category               | Tested | Findings                       |
+| ---------------------- | ------ | ------------------------------ |
+| Spoofing               | ✓      | 1 (Low — recovery rate limit)  |
+| Tampering              | ✓      | 1 (Medium — DNS rebinding)     |
+| Repudiation            | ✓      | 1 (Info — missing audit event) |
+| Information Disclosure | ✓      | 2 (High — SMTP, Medium — CSP)  |
+| Denial of Service      | ✓      | 1 (Low — no entity quotas)     |
+| Elevation of Privilege | ✓      | 1 (Medium — API key auth)      |
+
+## Files in This Report
+
+- [Threat Model](./threat-model.md) — STRIDE analysis, assets, trust boundaries
+- [Attack Surface Map](./attack-surface-map.md) — entry points, data flows, abuse paths
+- [Findings](./findings.md) — all findings ranked by severity
+- [OWASP Coverage](./owasp-coverage.md) — per-category test results
+- [Dependency Audit](./dependency-audit.md) — known CVEs in dependencies
+- [Recommendations](./recommendations.md) — prioritized mitigations with code snippets
+- [Iteration Log](./security-audit-results.tsv) — raw data from every vector tested
+
+## Key Strengths
+
+- **Zero-knowledge encryption**: Client encrypts all sensitive data before sending; server stores opaque blobs. Master key hierarchy with KDF-derived sub-keys.
+- **RLS everywhere**: All 90+ tables have row-level security policies with fail-closed NULLIF() guards.
+- **Rate limiting on all layers**: HTTP, tRPC, WebSocket mutations/reads, SSE streams — all with per-category limits.
+- **Anti-enumeration**: Constant-time dummy hash verification on invalid accounts.
+- **Supply chain security**: Zero CVEs, SHA-pinned CI actions, digest-pinned Docker images, frozen lockfile.
+- **Idempotency**: Registration, blob upload, and other critical operations are idempotent with deduplication.
+- **Memory safety**: Sensitive key material cleared with memzero() after use.

--- a/security/260406-0808-stride-owasp-full-audit/owasp-coverage.md
+++ b/security/260406-0808-stride-owasp-full-audit/owasp-coverage.md
@@ -1,0 +1,106 @@
+# OWASP Top 10 Coverage — Pluralscape Full Audit
+
+**Date:** 2026-04-06
+
+## Coverage Matrix
+
+| ID  | Category                       | Tested | Findings             | Status                   |
+| --- | ------------------------------ | ------ | -------------------- | ------------------------ |
+| A01 | Broken Access Control          | ✓      | 1 (Medium)           | ⚠️ API key auth gap      |
+| A02 | Cryptographic Failures         | ✓      | 0                    | ✅ Clean                 |
+| A03 | Injection                      | ✓      | 0                    | ✅ Clean                 |
+| A04 | Insecure Design                | ✓      | 1 (Low)              | ⚠️ Missing entity quotas |
+| A05 | Security Misconfiguration      | ✓      | 2 (1 High, 1 Medium) | ⚠️ SMTP + CSP            |
+| A06 | Vulnerable Components          | ✓      | 0                    | ✅ Clean                 |
+| A07 | Auth & Identification Failures | ✓      | 1 (Low)              | ⚠️ Recovery rate limit   |
+| A08 | Software & Data Integrity      | ✓      | 0                    | ✅ Clean                 |
+| A09 | Logging & Monitoring Failures  | ✓      | 1 (Info)             | ⚠️ Missing audit event   |
+| A10 | Server-Side Request Forgery    | ✓      | 1 (Medium)           | ⚠️ DNS rebinding         |
+
+**Coverage: 10/10 categories tested**
+
+## Per-Category Detail
+
+### A01 — Broken Access Control
+
+- [x] IDOR on all parameterized routes — **PASS**: `ownedSystemIds` check via `assertSystemOwnership()`
+- [x] Missing authorization middleware — **PASS**: All system-scoped endpoints use `systemProcedure`
+- [x] Horizontal privilege escalation — **PASS**: RLS policies enforce account/system isolation
+- [x] Vertical privilege escalation — **N/A**: No admin endpoints exist
+- [x] Directory traversal — **PASS**: No file system operations with user input
+- [x] CORS misconfiguration — **PASS**: Wildcard matching validates dot-prefix, bare `*` rejected
+- [x] Function-level access control — **FINDING**: API key scope enforcement not implemented
+
+### A02 — Cryptographic Failures
+
+- [x] Sensitive data in plaintext — **PASS**: Two-tier encryption model, email encrypted
+- [x] Weak hashing — **PASS**: No MD5/SHA1, uses BLAKE2b + Argon2id
+- [x] Hardcoded secrets — **PASS**: All secrets in env vars, .env gitignored
+- [x] Missing encryption at rest — **PASS**: SQLCipher (mobile), XChaCha20 (server)
+- [x] Weak RNG — **PASS**: All crypto uses libsodium.randombytes_buf()
+- [x] Nonce reuse — **PASS**: Fresh 24-byte nonce per encryption, XChaCha20 192-bit nonce space
+
+### A03 — Injection
+
+- [x] SQL injection — **PASS**: Drizzle ORM parameterized queries, no raw SQL with user input
+- [x] Command injection — **PASS**: No child_process with user input
+- [x] XSS — **N/A**: Pure API, no HTML rendering
+- [x] Template injection — **PASS**: No dynamic template rendering
+- [x] Path injection — **PASS**: No fs operations with user input
+- [x] Header injection — **PASS**: No user input in response headers
+- [x] Log injection — **PASS**: Pino structured logging, no string interpolation
+
+### A04 — Insecure Design
+
+- [x] Missing rate limiting — **PASS**: Per-category rate limiting on all endpoints
+- [x] No account lockout — **PASS**: 10-attempt throttle per 15-min window
+- [x] Predictable identifiers — **PASS**: Branded UUIDs with prefix validation
+- [x] Race conditions — **PASS**: Idempotency, OCC, FOR UPDATE locks
+- [x] CSRF — **PASS**: Bearer token auth, no cookie-based paths
+- [x] Resource limits — **FINDING**: No quotas for members, groups, custom fronts
+
+### A05 — Security Misconfiguration
+
+- [x] Debug mode — **PASS**: Stack traces masked in production
+- [x] Default credentials — **N/A**: No default admin accounts
+- [x] Verbose errors — **PASS**: Generic error messages in production
+- [x] Security headers — **FINDING**: CSP incomplete (default-src only)
+- [x] SMTP security — **FINDING**: SMTP_SECURE not enforced in production
+- [x] Stack traces in errors — **PASS**: Production error handler sanitizes
+
+### A06 — Vulnerable and Outdated Components
+
+- [x] Known CVEs — **PASS**: `pnpm audit` reports 0 vulnerabilities
+- [x] Outdated frameworks — **PASS**: Active maintenance, recent versions
+- [x] Security overrides — **PASS**: pnpm overrides patch known CVE-affected packages
+- [x] Prototype pollution — **PASS**: No vulnerable patterns detected
+
+### A07 — Identification and Authentication Failures
+
+- [x] Weak password policies — **PASS**: Argon2id with OWASP Sensitive parameters
+- [x] Session fixation — **PASS**: New session on every login
+- [x] JWT vulnerabilities — **N/A**: No JWT, uses opaque session tokens
+- [x] Insecure password reset — **PASS**: Recovery keys are single-use, high entropy
+- [x] Session invalidation — **PASS**: Revocation flag, idle timeout, absolute expiry
+- [x] Recovery key rate limiting — **FINDING**: Uses global rate limit, not per-account
+
+### A08 — Software and Data Integrity
+
+- [x] CI/CD pipeline integrity — **PASS**: All actions SHA-pinned, minimal permissions
+- [x] Unsigned dependencies — **PASS**: pnpm-lock.yaml committed, frozen lockfile in CI
+- [x] Insecure deserialization — **PASS**: All JSON.parse guarded with Zod validation
+- [x] Webhook signing — **PASS**: HMAC-SHA256 with timestamp, optional encryption
+
+### A09 — Security Logging and Monitoring
+
+- [x] Audit logs for security events — **PASS**: Comprehensive event types
+- [x] Failed auth logging — **PASS**: Login failures logged
+- [x] Sensitive data in logs — **PASS**: No PII/secrets in log output
+- [x] Session revocation logging — **FINDING**: No explicit session-revoked event
+
+### A10 — Server-Side Request Forgery
+
+- [x] Unvalidated URLs — **PASS**: Webhook URLs validated against IP blocklist
+- [x] DNS rebinding — **FINDING**: IP pinning available but not used in delivery
+- [x] Missing allowlist — **PASS**: Private/loopback/metadata IPs blocked
+- [x] Proxy/redirect validation — **PASS**: No open redirect endpoints

--- a/security/260406-0808-stride-owasp-full-audit/recommendations.md
+++ b/security/260406-0808-stride-owasp-full-audit/recommendations.md
@@ -1,0 +1,143 @@
+# Recommendations — Pluralscape Full Audit
+
+**Date:** 2026-04-06
+**Priority order:** Fix Critical/High first, then Medium, then Low.
+
+---
+
+## Priority 1 — High (Fix This Sprint)
+
+### 1. Enforce SMTP TLS in Production
+
+**Finding:** [SMTP Plaintext Email](./findings.md#finding-1)
+**Effort:** 10 minutes
+**File:** `apps/api/src/env.ts:74-77`
+
+Add a production refinement to the env schema that requires `SMTP_SECURE=1` when using the SMTP provider in production:
+
+```typescript
+// In the createEnv() runtimeEnvStrict or via .superRefine():
+.superRefine((env, ctx) => {
+  if (isProduction && env.EMAIL_PROVIDER === "smtp" && !env.SMTP_SECURE) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "SMTP_SECURE must be '1' in production when using SMTP provider",
+      path: ["SMTP_SECURE"],
+    });
+  }
+})
+```
+
+Alternative: Default `SMTP_SECURE` to `"1"` in production and `"0"` in development.
+
+---
+
+## Priority 2 — Medium (Fix Next Sprint)
+
+### 2. Tighten Content Security Policy
+
+**Finding:** [Incomplete CSP](./findings.md#finding-2)
+**Effort:** 5 minutes
+**File:** `apps/api/src/middleware/secure-headers.ts`
+
+Since this is a pure API server (no HTML responses), use the most restrictive CSP:
+
+```typescript
+"Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'none'; upgrade-insecure-requests"
+```
+
+### 3. Enable IP Pinning in Webhook Delivery
+
+**Finding:** [Webhook DNS Rebinding](./findings.md#finding-3)
+**Effort:** 30 minutes
+**File:** `apps/api/src/jobs/webhook-deliver.ts`
+
+The IP pinning utility already exists (`buildIpPinnedFetchArgs` in `apps/api/src/lib/ip-validation.ts`). Use it in the webhook delivery worker:
+
+```typescript
+// In webhook delivery worker, replace direct fetch with:
+const { url: pinnedUrl, init: pinnedInit } = await buildIpPinnedFetchArgs(webhookUrl);
+const response = await fetch(pinnedUrl, {
+  ...pinnedInit,
+  method: "POST",
+  body: signedPayload,
+  headers: webhookHeaders,
+});
+```
+
+This resolves DNS at delivery time and validates the resolved IP against the same blocklist used at creation time, closing the rebinding window.
+
+### 4. Implement API Key Authentication (or Remove Endpoints)
+
+**Finding:** [API Key Auth Gap](./findings.md#finding-4)
+**Effort:** 2-4 hours (implement) or 30 minutes (remove)
+
+**Option A — Implement:** Add API key auth middleware that:
+
+1. Checks for `X-API-Key` header or `ApiKey` prefix in Authorization
+2. Hashes the key and looks up in `apiKeys` table
+3. Validates: not revoked, not expired, account matches
+4. Enforces scope restrictions on the matched procedure
+
+**Option B — Remove:** If API keys are not yet needed, remove the CRUD endpoints and database table to reduce attack surface. Re-add when the feature is actually needed.
+
+---
+
+## Priority 3 — Low (Plan for Future Sprint)
+
+### 5. Add Per-Account Recovery Key Rate Limiting
+
+**Finding:** [Coarse Recovery Rate Limit](./findings.md#finding-5)
+**Effort:** 1 hour
+
+Add a dedicated rate limiter for recovery key attempts, separate from the login rate limiter:
+
+```typescript
+const recoveryRateLimiter = createCategoryRateLimiter("recovery", {
+  windowMs: 3600_000, // 1 hour
+  max: 3, // 3 attempts per account per hour
+  keyExtractor: accountKeyExtractor,
+});
+```
+
+### 6. Add Resource Quotas for Core Entities
+
+**Finding:** [Missing Entity Quotas](./findings.md#finding-6)
+**Effort:** 2-3 hours
+
+Add per-system limits for entities that currently have no caps:
+
+| Entity          | Suggested Limit   |
+| --------------- | ----------------- |
+| Members         | 500 per system    |
+| Groups          | 200 per system    |
+| Custom fronts   | 100 per system    |
+| Journal entries | 10,000 per system |
+| Wiki pages      | 1,000 per system  |
+| Channels        | 200 per system    |
+
+Implement as count check in service layer before insert (consistent with existing patterns for webhooks, field definitions, etc.).
+
+### 7. Add Session Revocation Audit Event
+
+**Finding:** [Missing Audit Event](./findings.md#finding-7)
+**Effort:** 15 minutes
+
+Add `auth.session-revoked` to the audit event types and emit it when a user manually revokes a specific session via the session management endpoint.
+
+---
+
+## No Action Required
+
+The following areas were audited and found to be secure:
+
+- **Cryptography:** XChaCha20-Poly1305, Argon2id (OWASP Sensitive), BLAKE2b KDF, Ed25519 signing — all correctly implemented with proper nonce generation and memory safety
+- **SQL Injection:** Drizzle ORM parameterized queries throughout
+- **Access Control:** RLS policies on all tables, `ownedSystemIds` pre-populated from DB
+- **Session Management:** SHA-256 hashed tokens, idle + absolute timeout, revocation
+- **WebSocket Security:** Auth timeout, pre-auth message rejection, connection caps
+- **Rate Limiting:** Per-category across HTTP, tRPC, WebSocket, and SSE
+- **Dependencies:** Zero known CVEs, SHA-pinned CI actions, digest-pinned Docker images
+- **Input Validation:** Zod on all tRPC inputs, branded ID types
+- **CORS:** Proper wildcard validation, bare `*` rejected
+- **Error Handling:** Generic errors in production, no stack traces or DB details leaked

--- a/security/260406-0808-stride-owasp-full-audit/threat-model.md
+++ b/security/260406-0808-stride-owasp-full-audit/threat-model.md
@@ -1,0 +1,108 @@
+# Threat Model — Pluralscape Full Audit
+
+**Date:** 2026-04-06 08:08
+**Methodology:** STRIDE + OWASP Top 10
+
+## Asset Inventory
+
+| Asset                                       | Type           | Sensitivity | Location                          |
+| ------------------------------------------- | -------------- | ----------- | --------------------------------- |
+| Account credentials (passwordHash, kdfSalt) | Data store     | Critical    | `accounts` table (Postgres)       |
+| Master encryption keys (encryptedMasterKey) | Data store     | Critical    | `accounts` table                  |
+| Auth keys (Ed25519 private keys)            | Data store     | Critical    | `authKeys` table                  |
+| Session tokens (tokenHash)                  | Data store     | Critical    | `sessions` table                  |
+| Recovery keys (encrypted)                   | Data store     | Critical    | `recoveryKeys` table              |
+| API keys (keyHash + encrypted data)         | Data store     | High        | `apiKeys` table                   |
+| Email (encryptedEmail + emailHash)          | Data store     | High        | `accounts` table                  |
+| Member/headmate data (E2E encrypted)        | Data store     | High        | Various system-scoped tables      |
+| Audit log (IP, user-agent)                  | Data store     | Medium      | `auditLog` table (partitioned)    |
+| Blob storage (avatars, attachments)         | Data store     | Medium      | S3-compatible storage             |
+| CRDT sync envelopes (encrypted)             | Data flow      | High        | Sync relay (Postgres + in-memory) |
+| Device transfer material                    | Data flow      | Critical    | `deviceTransferRequests` table    |
+| Webhook payloads (encrypted)                | Data flow      | Medium      | External delivery                 |
+| Valkey/Redis cache (rate limit, pub/sub)    | Infrastructure | Medium      | Valkey instance                   |
+| Session cookies/tokens (client-side)        | Client         | High        | Mobile secure store / browser     |
+
+## Trust Boundaries
+
+```
+Trust Boundaries:
+  ├── Mobile App ←→ API Server (TLS, Bearer token auth)
+  │     └── Expo SecureStore holds session token + master key
+  ├── Browser Client ←→ API Server (TLS, Bearer token auth)
+  ├── API Server ←→ PostgreSQL (RLS-enforced, GUC variables)
+  │     └── app.current_account_id + app.current_system_id
+  ├── API Server ←→ Valkey (rate limiting, pub/sub, idempotency)
+  ├── API Server ←→ S3 (presigned URLs, server-signed)
+  ├── API Server ←→ Email Provider (SMTP/Resend API)
+  ├── WebSocket ←→ Sync Relay (session auth in first message)
+  ├── SSE ←→ Notification Stream (session auth via Bearer)
+  ├── Public routes ←→ Authenticated routes (protectedProcedure)
+  ├── Account-scoped ←→ System-scoped (ownedSystemIds set)
+  ├── Self-hosted ←→ Hosted deployment mode
+  └── Client-side crypto ←→ Server-side storage (zero-knowledge)
+```
+
+## STRIDE Analysis
+
+### Spoofing (S)
+
+| Threat                  | Target           | Risk   | Existing Mitigations                                       |
+| ----------------------- | ---------------- | ------ | ---------------------------------------------------------- |
+| Session token theft     | Auth system      | High   | SHA-256 hashed storage, TLS required, idle timeout (7-30d) |
+| JWT/token forgery       | Auth system      | Low    | No JWT used — opaque session tokens with DB lookup         |
+| WebSocket auth bypass   | Sync relay       | Medium | Auth in first message, connection closed on failure        |
+| API key impersonation   | API keys         | Medium | Hash-indexed lookup, scope restrictions                    |
+| Password brute force    | Login            | Medium | Argon2id (4 iterations, 64 MiB), rate limiting (authHeavy) |
+| Anti-enumeration bypass | Login/register   | Low    | Dummy hash timing on invalid accounts (~500ms)             |
+| Recovery key guessing   | Account recovery | Low    | 52-char recovery key (high entropy)                        |
+
+### Tampering (T)
+
+| Threat                     | Target   | Risk | Existing Mitigations                                                |
+| -------------------------- | -------- | ---- | ------------------------------------------------------------------- |
+| SQL injection              | Database | Low  | Drizzle ORM parameterized queries, branded ID types                 |
+| CRDT envelope manipulation | Sync     | Low  | Ed25519 signed, XChaCha20-Poly1305 AEAD, AAD includes docId+version |
+| Blob content tampering     | Storage  | Low  | AEAD encryption with checksum in S3 metadata                        |
+| Request body manipulation  | API      | Low  | Zod validation on all tRPC inputs, 256 KiB body limit               |
+| Prototype pollution        | API      | Low  | Hono framework, no manual JSON.parse on untrusted input             |
+
+### Repudiation (R)
+
+| Threat                      | Target       | Risk   | Existing Mitigations                                       |
+| --------------------------- | ------------ | ------ | ---------------------------------------------------------- |
+| Denied admin actions        | Audit system | Low    | Audit log with event types, actor JSON, IP opt-in          |
+| Session manipulation denial | Auth         | Low    | Session table tracks creation, lastActive, platform        |
+| Missing security event logs | Monitoring   | Medium | Audit log exists but completeness of logged events unclear |
+
+### Information Disclosure (I)
+
+| Threat                   | Target          | Risk   | Existing Mitigations                                       |
+| ------------------------ | --------------- | ------ | ---------------------------------------------------------- |
+| Email address leakage    | Account privacy | Low    | BLAKE2b hashed + XChaCha20 encrypted at rest               |
+| Error message exposure   | API responses   | Low    | Safe error serialization, no stack traces in prod          |
+| PII in logs              | Logging         | Medium | Pino structured logging, but need to verify no PII leakage |
+| S3 presigned URL leakage | Blob storage    | Medium | Time-limited URLs (1h upload, 24h download)                |
+| CRDT metadata exposure   | Sync relay      | Low    | Envelopes encrypted end-to-end                             |
+| Timing side channels     | Auth            | Low    | Anti-enumeration with constant-time dummy hash             |
+
+### Denial of Service (D)
+
+| Threat                          | Target           | Risk    | Existing Mitigations                                    |
+| ------------------------------- | ---------------- | ------- | ------------------------------------------------------- |
+| API request flooding            | All endpoints    | Low     | Per-category rate limiting (IP-keyed), 429 responses    |
+| WebSocket connection exhaustion | Sync             | Low     | 10 per account, 500 global unauth, 50 per-IP unauth     |
+| SSE stream exhaustion           | Notifications    | Low     | 2 streams per account                                   |
+| Slowloris attacks               | HTTP server      | Low     | Body limit, connection timeouts                         |
+| Regex DoS                       | Input validation | Unknown | Need to audit Zod schemas for catastrophic backtracking |
+| Large blob upload               | Storage          | Medium  | S3 presigned URLs bypass API, need size validation      |
+
+### Elevation of Privilege (E)
+
+| Threat                             | Target           | Risk   | Existing Mitigations                                   |
+| ---------------------------------- | ---------------- | ------ | ------------------------------------------------------ |
+| IDOR (accessing other user's data) | All resources    | Low    | RLS policies, ownedSystemIds set, 404 on unauthorized  |
+| Horizontal escalation              | Cross-account    | Low    | Account-scoped RLS + application layer checks          |
+| Vertical escalation                | Admin access     | N/A    | No admin endpoints exist                               |
+| API key scope bypass               | API keys         | Medium | Scopes enforced, but need to verify check completeness |
+| System ownership bypass            | System resources | Low    | Pre-populated ownedSystemIds set from DB at auth time  |


### PR DESCRIPTION
## Summary

Implements 5 confirmed findings from the STRIDE+OWASP full security audit (`security/260406-0808-stride-owasp-full-audit/`). Two original findings were false positives (webhook DNS rebinding already mitigated; session revocation already audited via `auth.logout`).

- **SMTP TLS enforcement** — runtime guard refuses to start with plaintext SMTP in production
- **CSP tightened** — `default-src 'none'` with `base-uri` and `form-action 'none'` for pure API server
- **API key auth middleware** — `ps_` prefixed tokens, dual-path auth in existing middleware, scoped `AuthContext` with `apiKeyScopes` field (per-endpoint enforcement deferred to M11 bean `api-u998`)
- **Recovery key per-account rate limit** — 3 attempts/hour keyed by email hash, stacked on existing IP-based `authHeavy` limiter
- **Resource quotas** — members (5,000/system), groups (200), custom fronts (200), channels (50), buckets (100→50), photos (50→5/member + new 500/system)

## Test plan

- [x] 10,284 unit tests pass
- [x] 2,384 integration tests pass
- [x] Typecheck clean (16/16 packages)
- [x] Lint clean (zero warnings)
- [x] Format clean