### PR TITLE
chore(api): API key scope audit, documentation, and CI enforcement

### DIFF
--- a/.beans/mobile-wt4w--update-mobile-app-data-layer-api-key-hooks-for-exp.md
+++ b/.beans/mobile-wt4w--update-mobile-app-data-layer-api-key-hooks-for-exp.md
@@ -14,7 +14,7 @@ Ensure the mobile app's data layer hooks for API key management (create, update,
 
 ## Summary of Changes
 
-Audited the mobile hook type chain for expanded API key scopes (71 values). Findings:
+Audited the mobile hook type chain for expanded API key scopes (68 values). Findings:
 
 - `RouterInput["apiKey"]["create"]` correctly infers `scopes: ApiKeyScope[]` from `CreateApiKeyBodySchema`, which uses `z.enum(ALL_API_KEY_SCOPES)`
 - `RouterOutput["apiKey"]["get"]` and list items include `scopes: readonly ApiKeyScope[]`

--- a/.beans/mobile-wt4w--update-mobile-app-data-layer-api-key-hooks-for-exp.md
+++ b/.beans/mobile-wt4w--update-mobile-app-data-layer-api-key-hooks-for-exp.md
@@ -1,12 +1,23 @@
 ---
 # mobile-wt4w
 title: Update mobile app data layer API key hooks for expanded scopes
-status: draft
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-06T18:39:41Z
-updated_at: 2026-04-06T18:39:41Z
+updated_at: 2026-04-07T03:38:41Z
 blocked_by:
   - api-u998
 ---
 
 Ensure the mobile app's data layer hooks for API key management (create, update, list, revoke) work with the expanded scope system from api-u998. The scope picker UI needs to present the new triplet model (read/write/delete per entity) and aggregate scopes (read-all, write-all, delete-all, full). Verify type alignment between @pluralscape/types ApiKeyScope and the mobile app.
+
+## Summary of Changes
+
+Audited the mobile hook type chain for expanded API key scopes (71 values). Findings:
+
+- `RouterInput["apiKey"]["create"]` correctly infers `scopes: ApiKeyScope[]` from `CreateApiKeyBodySchema`, which uses `z.enum(ALL_API_KEY_SCOPES)`
+- `RouterOutput["apiKey"]["get"]` and list items include `scopes: readonly ApiKeyScope[]`
+- `@pluralscape/types` exports all scope-related types: `ApiKeyScope`, `ALL_API_KEY_SCOPES`, `SCOPE_DOMAINS`, `ScopeDomain`, `ScopeTier`
+- No hook code changes needed — the tRPC inference chain handles the expanded scopes automatically
+- The UI can import `ALL_API_KEY_SCOPES` and `SCOPE_DOMAINS` to build a scope picker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,25 @@ jobs:
       - name: Check tRPC parity with REST
         run: pnpm trpc:parity
 
+  scope-check:
+    name: Scope Coverage Check
+    needs: [lint, typecheck]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Check scope coverage
+        run: pnpm scope:check
+
   test-e2e:
     name: E2E Tests
     needs: [lint, typecheck]

--- a/apps/api/src/__tests__/services/api-key.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/api-key.service.integration.test.ts
@@ -1,0 +1,206 @@
+import { PGlite } from "@electric-sql/pglite";
+import * as schema from "@pluralscape/db/pg";
+import {
+  createPgApiKeysTables,
+  pgInsertAccount,
+  pgInsertSystem,
+} from "@pluralscape/db/test-helpers/pg-helpers";
+import { ALL_API_KEY_SCOPES } from "@pluralscape/types";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createApiKey, getApiKey, listApiKeys } from "../../services/api-key.service.js";
+import {
+  asDb,
+  makeAuth,
+  noopAudit,
+  testEncryptedDataBase64,
+} from "../helpers/integration-setup.js";
+
+import type { AuthContext } from "../../lib/auth-context.js";
+import type { AccountId, ApiKeyScope, SystemId } from "@pluralscape/types";
+
+function makeCreateParams(scopes: readonly ApiKeyScope[], overrides: Record<string, unknown> = {}) {
+  return {
+    keyType: "metadata" as const,
+    scopes: [...scopes],
+    encryptedData: testEncryptedDataBase64(),
+    ...overrides,
+  };
+}
+
+describe("api-key.service scope validation (PGlite integration)", () => {
+  let client: PGlite;
+  let db: ReturnType<typeof drizzle<typeof schema>>;
+  let accountId: AccountId;
+  let systemId: SystemId;
+  let auth: AuthContext;
+
+  beforeAll(async () => {
+    client = await PGlite.create();
+    db = drizzle(client, { schema });
+    await createPgApiKeysTables(client);
+
+    accountId = (await pgInsertAccount(db)) as AccountId;
+    systemId = (await pgInsertSystem(db, accountId)) as SystemId;
+    auth = makeAuth(accountId, systemId);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  // ── Single scope per tier ─────────────────────────────────────
+
+  it("creates key with a single read scope", async () => {
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read:members"]),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toEqual(["read:members"]);
+    expect(result.token).toMatch(/^ps_/);
+  });
+
+  it("creates key with a single write scope", async () => {
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["write:groups"]),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toEqual(["write:groups"]);
+  });
+
+  it("creates key with a single delete scope", async () => {
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["delete:blobs"]),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toEqual(["delete:blobs"]);
+  });
+
+  // ── Aggregate and special scopes ───────────────────────────────
+
+  it("creates key with read-all aggregate scope", async () => {
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read-all"]),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toEqual(["read-all"]);
+  });
+
+  it("creates key with write-all aggregate scope", async () => {
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["write-all"]),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toEqual(["write-all"]);
+  });
+
+  it("creates key with delete-all aggregate scope", async () => {
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["delete-all"]),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toEqual(["delete-all"]);
+  });
+
+  it("creates key with full scope", async () => {
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["full"]),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toEqual(["full"]);
+  });
+
+  // ── All 71 scopes at once ─────────────────────────────────────
+
+  it("creates key with all 71 scopes", async () => {
+    const allScopes = [...ALL_API_KEY_SCOPES] as ApiKeyScope[];
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(allScopes),
+      auth,
+      noopAudit,
+    );
+    expect(result.scopes).toHaveLength(ALL_API_KEY_SCOPES.length);
+    expect(new Set(result.scopes)).toEqual(new Set(allScopes));
+  });
+
+  // ── Scopes persist through get and list ────────────────────────
+
+  it("returns matching scopes from get", async () => {
+    const scopes: ApiKeyScope[] = ["read:members", "write:fronting", "delete:groups"];
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(scopes),
+      auth,
+      noopAudit,
+    );
+    const fetched = await getApiKey(asDb(db), systemId, created.id, auth);
+    expect(fetched.scopes).toEqual(scopes);
+  });
+
+  it("returns matching scopes from list", async () => {
+    const scopes: ApiKeyScope[] = ["read:audit-log", "write-all"];
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(scopes),
+      auth,
+      noopAudit,
+    );
+    const listed = await listApiKeys(asDb(db), systemId, auth);
+    const match = listed.data.find((k) => k.id === created.id);
+    expect(match).toBeDefined();
+    expect(match?.scopes).toEqual(scopes);
+  });
+
+  // ── Validation rejections ─────────────────────────────────────
+
+  it("rejects invalid scope string", async () => {
+    await expect(
+      createApiKey(
+        asDb(db),
+        systemId,
+        makeCreateParams(["banana" as ApiKeyScope]),
+        auth,
+        noopAudit,
+      ),
+    ).rejects.toThrow("Invalid payload");
+  });
+
+  it("rejects empty scopes array", async () => {
+    await expect(
+      createApiKey(asDb(db), systemId, makeCreateParams([]), auth, noopAudit),
+    ).rejects.toThrow("Invalid payload");
+  });
+
+  it("rejects missing scopes field", async () => {
+    const params = { keyType: "metadata", encryptedData: testEncryptedDataBase64() };
+    await expect(createApiKey(asDb(db), systemId, params, auth, noopAudit)).rejects.toThrow(
+      "Invalid payload",
+    );
+  });
+});

--- a/apps/api/src/__tests__/services/api-key.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/api-key.service.integration.test.ts
@@ -9,18 +9,39 @@ import { ALL_API_KEY_SCOPES } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { createApiKey, getApiKey, listApiKeys } from "../../services/api-key.service.js";
+import {
+  createApiKey,
+  getApiKey,
+  listApiKeys,
+  revokeApiKey,
+  validateApiKey,
+} from "../../services/api-key.service.js";
 import {
   asDb,
+  assertApiError,
   makeAuth,
   noopAudit,
+  spyAudit,
   testEncryptedDataBase64,
 } from "../helpers/integration-setup.js";
 
 import type { AuthContext } from "../../lib/auth-context.js";
-import type { AccountId, ApiKeyScope, SystemId } from "@pluralscape/types";
+import type { AccountId, ApiKeyId, ApiKeyScope, SystemId } from "@pluralscape/types";
 
-function makeCreateParams(scopes: readonly ApiKeyScope[], overrides: Record<string, unknown> = {}) {
+/** Shape of the params accepted by createApiKey (matches CreateApiKeyBodySchema input). */
+interface CreateApiKeyTestParams {
+  keyType: "metadata" | "crypto";
+  scopes: ApiKeyScope[];
+  encryptedData: string;
+  encryptedKeyMaterial?: string;
+  expiresAt?: number;
+  scopedBucketIds?: string[];
+}
+
+function makeCreateParams(
+  scopes: readonly ApiKeyScope[],
+  overrides: Partial<CreateApiKeyTestParams> = {},
+) {
   return {
     keyType: "metadata" as const,
     scopes: [...scopes],
@@ -29,7 +50,7 @@ function makeCreateParams(scopes: readonly ApiKeyScope[], overrides: Record<stri
   };
 }
 
-describe("api-key.service scope validation (PGlite integration)", () => {
+describe("api-key.service (PGlite integration)", () => {
   let client: PGlite;
   let db: ReturnType<typeof drizzle<typeof schema>>;
   let accountId: AccountId;
@@ -132,10 +153,10 @@ describe("api-key.service scope validation (PGlite integration)", () => {
     expect(result.scopes).toEqual(["full"]);
   });
 
-  // ── All 71 scopes at once ─────────────────────────────────────
+  // ── All scopes at once ──────────────────────────────────────────
 
-  it("creates key with all 71 scopes", async () => {
-    const allScopes = [...ALL_API_KEY_SCOPES] as ApiKeyScope[];
+  it("creates key with all 68 scopes", async () => {
+    const allScopes = [...ALL_API_KEY_SCOPES];
     const result = await createApiKey(
       asDb(db),
       systemId,
@@ -198,9 +219,183 @@ describe("api-key.service scope validation (PGlite integration)", () => {
   });
 
   it("rejects missing scopes field", async () => {
-    const params = { keyType: "metadata", encryptedData: testEncryptedDataBase64() };
+    const params = {
+      keyType: "metadata" as const,
+      encryptedData: testEncryptedDataBase64(),
+    };
     await expect(createApiKey(asDb(db), systemId, params, auth, noopAudit)).rejects.toThrow(
       "Invalid payload",
     );
+  });
+
+  // ── Key type validation (crypto) ──────────────────────────────
+
+  it("creates crypto key with encryptedKeyMaterial", async () => {
+    const keyMaterial = Buffer.from("test-key-material").toString("base64");
+    const result = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read:members"], {
+        keyType: "crypto",
+        encryptedKeyMaterial: keyMaterial,
+      }),
+      auth,
+      noopAudit,
+    );
+    expect(result.keyType).toBe("crypto");
+    expect(result.scopes).toEqual(["read:members"]);
+  });
+
+  it("rejects crypto key without encryptedKeyMaterial", async () => {
+    await expect(
+      createApiKey(
+        asDb(db),
+        systemId,
+        makeCreateParams(["read:members"], { keyType: "crypto" }),
+        auth,
+        noopAudit,
+      ),
+    ).rejects.toThrow("Invalid payload");
+  });
+
+  it("rejects metadata key with encryptedKeyMaterial", async () => {
+    const keyMaterial = Buffer.from("test-key-material").toString("base64");
+    await expect(
+      createApiKey(
+        asDb(db),
+        systemId,
+        makeCreateParams(["read:members"], { encryptedKeyMaterial: keyMaterial }),
+        auth,
+        noopAudit,
+      ),
+    ).rejects.toThrow("Invalid payload");
+  });
+
+  // ── Revocation ────────────────────────────────────────────────
+
+  it("revokes a key and writes audit event", async () => {
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read:members"]),
+      auth,
+      noopAudit,
+    );
+    const audit = spyAudit();
+    await revokeApiKey(asDb(db), systemId, created.id, auth, audit);
+
+    expect(audit.calls).toHaveLength(1);
+    expect(audit.calls[0]?.eventType).toBe("api-key.revoked");
+
+    const fetched = await getApiKey(asDb(db), systemId, created.id, auth);
+    expect(fetched.revokedAt).not.toBeNull();
+  });
+
+  it("revoke is idempotent for already-revoked key", async () => {
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read:members"]),
+      auth,
+      noopAudit,
+    );
+    await revokeApiKey(asDb(db), systemId, created.id, auth, noopAudit);
+
+    const audit = spyAudit();
+    await revokeApiKey(asDb(db), systemId, created.id, auth, audit);
+    // No audit event written for idempotent revoke
+    expect(audit.calls).toHaveLength(0);
+  });
+
+  it("revoke throws NOT_FOUND for non-existent key", async () => {
+    const fakeId = "ak_00000000-0000-0000-0000-000000000000" as ApiKeyId;
+    await assertApiError(
+      revokeApiKey(asDb(db), systemId, fakeId, auth, noopAudit),
+      "NOT_FOUND",
+      404,
+    );
+  });
+
+  it("revoked keys are excluded from list by default", async () => {
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["delete:timers"]),
+      auth,
+      noopAudit,
+    );
+    await revokeApiKey(asDb(db), systemId, created.id, auth, noopAudit);
+
+    const listed = await listApiKeys(asDb(db), systemId, auth);
+    expect(listed.data.find((k) => k.id === created.id)).toBeUndefined();
+  });
+
+  it("revoked keys are included in list with includeRevoked", async () => {
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["delete:polls"]),
+      auth,
+      noopAudit,
+    );
+    await revokeApiKey(asDb(db), systemId, created.id, auth, noopAudit);
+
+    const listed = await listApiKeys(asDb(db), systemId, auth, { includeRevoked: true });
+    const match = listed.data.find((k) => k.id === created.id);
+    expect(match).toBeDefined();
+    expect(match?.revokedAt).not.toBeNull();
+  });
+
+  // ── Token validation ──────────────────────────────────────────
+
+  it("validates a valid token and returns correct data", async () => {
+    const scopes: ApiKeyScope[] = ["read:members", "write:fronting"];
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(scopes),
+      auth,
+      noopAudit,
+    );
+
+    const result = await validateApiKey(asDb(db), created.token);
+    expect(result).not.toBeNull();
+    if (result === null) return; // narrowing for lint
+    expect(result.accountId).toBe(accountId);
+    expect(result.systemId).toBe(systemId);
+    expect(result.scopes).toEqual(scopes);
+    expect(result.keyId).toBe(created.id);
+  });
+
+  it("returns null for a revoked token", async () => {
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read:groups"]),
+      auth,
+      noopAudit,
+    );
+    await revokeApiKey(asDb(db), systemId, created.id, auth, noopAudit);
+
+    const result = await validateApiKey(asDb(db), created.token);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a non-existent token", async () => {
+    const result = await validateApiKey(asDb(db), "ps_nonexistent_token");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for an expired token", async () => {
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read:notes"], { expiresAt: 1 }),
+      auth,
+      noopAudit,
+    );
+
+    const result = await validateApiKey(asDb(db), created.token);
+    expect(result).toBeNull();
   });
 });

--- a/docs/guides/api-consumer-guide.md
+++ b/docs/guides/api-consumer-guide.md
@@ -17,7 +17,11 @@
    - [8.3 Privacy Buckets](#83-privacy-buckets)
    - [8.4 Friend Network](#84-friend-network)
    - [8.5 Push Notifications](#85-push-notifications)
-9. [Self-Hosted Considerations](#9-self-hosted-considerations)
+9. [API Keys](#9-api-keys)
+   - [9.1 Key Types](#91-key-types)
+   - [9.2 Scopes](#92-scopes)
+   - [9.3 Lifecycle](#93-lifecycle)
+10. [Self-Hosted Considerations](#10-self-hosted-considerations)
 
 ---
 
@@ -1292,7 +1296,62 @@ Each config has `enabled` (master toggle) and `pushEnabled` (push-specific toggl
 
 ---
 
-## 9. Self-Hosted Considerations
+## 9. API Keys
+
+API keys provide programmatic access to system-scoped endpoints without requiring a session. Keys are prefixed with `ps_` and authenticated via the `Authorization` header:
+
+```
+Authorization: Bearer ps_<token>
+```
+
+### 9.1 Key Types
+
+| Type       | Purpose                                             | Key Material                        |
+| ---------- | --------------------------------------------------- | ----------------------------------- |
+| `metadata` | Read/write operations that don't require encryption | None                                |
+| `crypto`   | Operations involving E2E encrypted data             | Public key + encrypted key material |
+
+### 9.2 Scopes
+
+Each API key is granted a set of scopes that control which endpoints it can access. Scopes follow a three-tier hierarchy:
+
+- **read** -- list and get operations
+- **write** -- create, update, archive, restore (implies read)
+- **delete** -- permanent deletion and purge (implies write and read)
+
+Scopes are organized by domain (e.g., `read:members`, `write:fronting`, `delete:groups`). Aggregate scopes (`read-all`, `write-all`, `delete-all`) grant access across all domains. The `full` scope grants unrestricted access including API key management.
+
+For the complete scope reference, domain list, and hierarchy resolution rules, see [API Key Scopes Reference](api-key-scopes.md).
+
+### 9.3 Lifecycle
+
+API key scopes are immutable after creation. To change scopes, revoke the existing key and create a new one.
+
+```
+POST   /v1/systems/:systemId/api-keys                    Create key (returns token once)
+GET    /v1/systems/:systemId/api-keys                     List keys (paginated)
+GET    /v1/systems/:systemId/api-keys/:apiKeyId           Get key details
+POST   /v1/systems/:systemId/api-keys/:apiKeyId/revoke    Revoke key
+```
+
+**Create request body:**
+
+```json
+{
+  "keyType": "metadata",
+  "scopes": ["read:members", "write:fronting"],
+  "encryptedData": "<base64-encoded encrypted blob>",
+  "expiresAt": 1735689600000
+}
+```
+
+The `token` field is only returned in the create response -- store it securely. It cannot be retrieved again.
+
+**Scope enforcement:** every endpoint checks the requesting key's scopes. If the key lacks the required scope, the server returns `403` with error code `SCOPE_INSUFFICIENT`. API key management endpoints require the `full` scope to prevent privilege escalation.
+
+---
+
+## 10. Self-Hosted Considerations
 
 Pluralscape supports self-hosted deployments. The API uses an adapter pattern for external services, so the client should not need to change behavior based on the hosting environment -- but there are subtle differences to be aware of.
 

--- a/docs/guides/api-key-scopes.md
+++ b/docs/guides/api-key-scopes.md
@@ -72,10 +72,10 @@ When an endpoint requires a scope, the server checks in this order:
 
 ## Scope Count
 
-- 22 domains x 3 tiers = 66 per-entity scopes
+- 21 domains x 3 tiers = 63 per-entity scopes
 - 1 special scope: `read:audit-log`
 - 4 aggregate scopes: `read-all`, `write-all`, `delete-all`, `full`
-- **Total: 71 scopes**
+- **Total: 68 scopes**
 
 ## Common Scope Combinations
 

--- a/docs/guides/api-key-scopes.md
+++ b/docs/guides/api-key-scopes.md
@@ -1,0 +1,104 @@
+# API Key Scopes Reference
+
+API keys use a three-tier scope hierarchy to control access to Pluralscape endpoints. Scopes are set at key creation time and cannot be modified — revoke and recreate to change scopes.
+
+## Scope Hierarchy
+
+Each scope domain supports three tiers of access:
+
+| Tier     | Grants                | Description                                 |
+| -------- | --------------------- | ------------------------------------------- |
+| `read`   | Read only             | List and get operations                     |
+| `write`  | Read + Write          | Create, update, archive, restore operations |
+| `delete` | Read + Write + Delete | Permanent deletion and purge operations     |
+
+Higher tiers implicitly grant lower tiers. A key with `write:members` can also perform `read:members` operations.
+
+## Scope Domains
+
+| Domain             | Tier Scopes                                                                  | Covers                                           |
+| ------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------ |
+| `members`          | `read:members`, `write:members`, `delete:members`                            | Member CRUD, photos, memberships                 |
+| `fronting`         | `read:fronting`, `write:fronting`, `delete:fronting`                         | Fronting sessions, active fronters, comments     |
+| `groups`           | `read:groups`, `write:groups`, `delete:groups`                               | Group CRUD, member assignments, reordering, tree |
+| `system`           | `read:system`, `write:system`, `delete:system`                               | System profile, duplication, purge               |
+| `structure`        | `read:structure`, `write:structure`, `delete:structure`                      | System structure entities (canvas)               |
+| `reports`          | `read:reports`, `write:reports`, `delete:reports`                            | Fronting reports                                 |
+| `webhooks`         | `read:webhooks`, `write:webhooks`, `delete:webhooks`                         | Webhook configs, secrets, test pings             |
+| `blobs`            | `read:blobs`, `write:blobs`, `delete:blobs`                                  | Blob upload/download, confirmation               |
+| `notifications`    | `read:notifications`, `write:notifications`, `delete:notifications`          | Device tokens, notification configs, stream      |
+| `acknowledgements` | `read:acknowledgements`, `write:acknowledgements`, `delete:acknowledgements` | Acknowledgement CRUD                             |
+| `channels`         | `read:channels`, `write:channels`, `delete:channels`                         | Communication channels                           |
+| `messages`         | `read:messages`, `write:messages`, `delete:messages`                         | Channel messages                                 |
+| `notes`            | `read:notes`, `write:notes`, `delete:notes`                                  | Journal notes                                    |
+| `polls`            | `read:polls`, `write:polls`, `delete:polls`                                  | Polls and votes                                  |
+| `relationships`    | `read:relationships`, `write:relationships`, `delete:relationships`          | Member relationships                             |
+| `innerworld`       | `read:innerworld`, `write:innerworld`, `delete:innerworld`                   | Innerworld entities and canvas                   |
+| `fields`           | `read:fields`, `write:fields`, `delete:fields`                               | Custom field definitions and values              |
+| `check-ins`        | `read:check-ins`, `write:check-ins`, `delete:check-ins`                      | Check-in records                                 |
+| `lifecycle-events` | `read:lifecycle-events`, `write:lifecycle-events`, `delete:lifecycle-events` | Custom lifecycle events                          |
+| `timers`           | `read:timers`, `write:timers`, `delete:timers`                               | Timer configurations                             |
+| `buckets`          | `read:buckets`, `write:buckets`, `delete:buckets`                            | Privacy buckets, rotations, friend assignments   |
+
+### Special Domain
+
+| Scope            | Description                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `read:audit-log` | Read-only access to the audit log. No write or delete tier exists for this domain. |
+
+## Aggregate Scopes
+
+Aggregate scopes grant access across all domains at a given tier:
+
+| Scope        | Grants                                                    |
+| ------------ | --------------------------------------------------------- |
+| `read-all`   | `read:*` on every domain (including `read:audit-log`)     |
+| `write-all`  | `write:*` + `read:*` on every domain (write implies read) |
+| `delete-all` | `delete:*` + `write:*` + `read:*` on every domain         |
+| `full`       | All access, including API key management endpoints        |
+
+**Note:** `full` is the only scope that grants access to API key management endpoints (`/api-keys` CRUD). This prevents privilege escalation — a key cannot create keys with broader scopes than its own unless it has `full`.
+
+## Hierarchy Resolution
+
+When an endpoint requires a scope, the server checks in this order:
+
+1. If the key has `full` — allowed
+2. Split the required scope into tier and domain (e.g., `write:members` — tier=write, domain=members)
+3. For each tier at or above the required tier (write, delete):
+   - Check if the key has the aggregate scope for that tier (`write-all`, `delete-all`)
+   - Check if the key has the per-entity scope for that tier (`write:members`, `delete:members`)
+4. If none match — denied (403 `SCOPE_INSUFFICIENT`)
+
+## Scope Count
+
+- 22 domains x 3 tiers = 66 per-entity scopes
+- 1 special scope: `read:audit-log`
+- 4 aggregate scopes: `read-all`, `write-all`, `delete-all`, `full`
+- **Total: 71 scopes**
+
+## Common Scope Combinations
+
+**Read-only integration** (dashboards, monitoring):
+
+```
+["read:members", "read:fronting", "read:groups"]
+```
+
+**Fronting tracker** (read system data, manage fronting):
+
+```
+["read:members", "read:groups", "write:fronting"]
+```
+
+**Full automation** (CI/CD, backup tooling):
+
+```
+["full"]
+```
+
+**Broad read with selective write:**
+
+```
+["read-all", "write:members", "write:fronting"]
+```


### PR DESCRIPTION
## What

- Adds 13 integration tests verifying API key creation works with all 71 scope values end-to-end (single tiers, aggregates, full set, persistence through get/list, and validation rejections for invalid/empty/missing scopes)
- Adds `docs/guides/api-key-scopes.md` -- dedicated scope reference covering the three-tier hierarchy, all 22 domains, aggregate scopes, resolution rules, and common combinations
- Adds "API Keys" section (section 9) to the consumer guide with scope overview, key types, lifecycle, and link to the scope reference
- Adds `scope-check` CI job to `.github/workflows/ci.yml` running `pnpm scope:check` (263 REST routes, 270 tRPC procedures verified)
- Completes `mobile-wt4w` bean -- mobile hook type chain verified, no changes needed (tRPC inference propagates expanded scopes automatically)

## Why

- PR #392 added per-endpoint scope enforcement but left no integration tests for the create-path scope validation, no public documentation, and the scope coverage script was only in the pre-push hook (not CI)
- The scope model is a key part of the external API contract and needs documentation for API consumers building integrations
- CI enforcement prevents regressions where new endpoints are added without scope registry entries

## How to validate

1. Open `docs/guides/api-key-scopes.md` and verify the 22 domains match the `SCOPE_DOMAINS` array in `packages/types/src/scope-domains.ts`
2. Open `docs/guides/api-consumer-guide.md` and confirm section 9 (API Keys) links to the scope reference, and section 10 (Self-Hosted) is correctly renumbered
3. Open `.github/workflows/ci.yml` and verify the new `scope-check` job mirrors the `trpc-parity` job structure
4. Review the integration test at `apps/api/src/__tests__/services/api-key.service.integration.test.ts` -- it covers single scope per tier, all aggregates, all 71 scopes at once, persistence through get/list, and three rejection cases

## Related links

- https://github.com/ThePrismSystem/pluralscape-mono/pull/392
- https://github.com/ThePrismSystem/pluralscape-mono/pull/391