### PR TITLE
feat(import-sp): API notes support and encrypted payload alignment

### DIFF
--- a/.beans/db-40md--audit-and-fix-privacy-bucket-encrypted-fields-end.md
+++ b/.beans/db-40md--audit-and-fix-privacy-bucket-encrypted-fields-end.md
@@ -1,0 +1,12 @@
+---
+# db-40md
+title: Audit and fix privacy bucket encrypted fields end-to-end
+status: todo
+type: bug
+priority: critical
+created_at: 2026-04-12T07:51:43Z
+updated_at: 2026-04-12T07:51:43Z
+parent: ps-h2gl
+---
+
+Privacy buckets use encryptedData in the Create/Update API schemas but the @pluralscape/data transforms (narrowPrivacyBucket) don't decrypt — they read name/description directly from the wire type. Either the API is returning decrypted fields alongside the blob (which the transform then ignores), or the transform is wrong. Audit the full pipeline: DB schema → API response → data transform → mobile rendering. Fix so the encrypt/decrypt cycle is consistent with all other entity types.

--- a/.beans/ps-9uqg--simply-plural-import-wizard-ui.md
+++ b/.beans/ps-9uqg--simply-plural-import-wizard-ui.md
@@ -5,7 +5,7 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-04-08T11:56:44Z
-updated_at: 2026-04-08T12:15:27Z
+updated_at: 2026-04-12T06:57:34Z
 parent: ps-vq2h
 blocked_by:
   - ps-nrg4
@@ -37,3 +37,19 @@ Builds the screens, state machine, and UX writing for the import flow. The data 
 ## References
 
 The full wizard flow is documented in [docs/planning/2026-04-08-simply-plural-import.md](../docs/planning/2026-04-08-simply-plural-import.md) — Section "Components" and the "Mobile glue" subsection lay out the data hooks this UI consumes. The integration surface (hooks) is the contract between this bean and ps-nrg4.
+
+## Source Limitation Messaging
+
+The wizard Step 1 (source picker) must clearly communicate what each source imports:
+
+**API import** covers: system profile, members, groups, custom fronts, custom fields, privacy buckets, fronting history, notes (journal entries), polls, channels, and channel categories. This is all essential user data.
+
+**File import** additionally covers: system settings, fronting comments, chat messages, and board messages.
+
+The UI should:
+
+- Show a brief note on the source picker explaining the difference
+- NOT block API import — it covers all essential data
+- Frame file import as "complete" and API import as "most data — notes included"
+- If the user picks API import, do not warn about missing comments/chat/board — these are low-priority social features, not therapeutic data
+- If the user needs a complete import, suggest they export from SP settings and use the file picker

--- a/.beans/ps-wwph--sp-import-api-notes-fetch-comprehensive-e2e-docs.md
+++ b/.beans/ps-wwph--sp-import-api-notes-fetch-comprehensive-e2e-docs.md
@@ -1,0 +1,10 @@
+---
+# ps-wwph
+title: "SP import: API notes fetch + comprehensive E2E + docs"
+status: in-progress
+type: feature
+created_at: 2026-04-12T06:19:18Z
+updated_at: 2026-04-12T06:19:18Z
+---
+
+Enable notes (journal entries) import via SP API using dependent multi-pass fetch, add field-level E2E assertions for every imported entity type, update README with coverage matrix, and update wizard UI bean with source limitation messaging.

--- a/.beans/ps-xfai--fix-sp-import-mapper-payloads-to-match-domain-encr.md
+++ b/.beans/ps-xfai--fix-sp-import-mapper-payloads-to-match-domain-encr.md
@@ -1,0 +1,37 @@
+---
+# ps-xfai
+title: Fix SP import mapper payloads to match domain encrypted field types
+status: completed
+type: bug
+priority: normal
+created_at: 2026-04-12T07:16:20Z
+updated_at: 2026-04-12T08:40:18Z
+---
+
+Import mappers produce ad-hoc payload shapes that don't match the domain EncryptedFields types from @pluralscape/data. This causes decryptMember/decryptNote/etc to throw at runtime when the mobile app tries to read imported data. Each mapper must type its encrypted payload against the corresponding domain type and provide sensible defaults for missing fields.
+
+## Summary of Changes
+
+Derived each `Mapped*` type from two existing contracts: `Create*BodySchema` (validation) and `*EncryptedFields` (data transforms). Every mapper now produces `{ encrypted: EncryptedFields, ...plaintextApiFields }` instead of ad-hoc flat shapes.
+
+### Core changes
+
+- Added `BucketEncryptedFields` to `@pluralscape/data` (was missing)
+- Rewrote all 12 mapper types using `Omit<z.infer<typeof CreateSchema>, "encryptedData"> & { encrypted: EncryptedFields }`
+- Fixed field mappings: `pronouns` → array, `avatarUrl` → `avatarSource` (ImageSource), added `saturationLevel`, `tags`, `emoji`, `backgroundColor`, etc.
+- Removed deprecated wrapper types: `MappedMemberCore`, `MappedMemberOutput`, `MappedPollCore`, `MappedPollOutput`, `MappedJournalParagraphBlock`
+
+### Downstream updates
+
+- E2E persister: encrypts `entity.payload.encrypted` and passes plaintext fields separately
+- Mobile persisters (13 files): updated local `*Payload` interfaces, type guards, and encrypt calls
+- Mobile trpc-persister-api bridge: passes new plaintext fields to tRPC mutations
+- `PersisterProc*` types: updated to include new fields (required, sortOrder, memberId, etc.)
+- Import engine: updated legacy bucket synthesis to use new encrypted shape
+- All mapper unit tests (11 files), integration tests, engine tests, mobile persister tests, and trpc-persister-api tests updated
+
+### Verification
+
+- Full monorepo typecheck: 17/17 packages pass
+- Full monorepo lint: 14/14 packages pass
+- Unit tests: 11,579 passed (833 test files)

--- a/apps/mobile/src/features/import-sp/__tests__/mobile-persister.test.ts
+++ b/apps/mobile/src/features/import-sp/__tests__/mobile-persister.test.ts
@@ -23,10 +23,10 @@ beforeAll(async () => {
 const TEST_MASTER_KEY = makeTestMasterKey();
 
 const PRIVACY_BUCKET_PAYLOAD = {
-  name: "Trusted",
-  description: "visible to trusted friends",
-  color: null,
-  icon: null,
+  encrypted: {
+    name: "Trusted",
+    description: "visible to trusted friends",
+  },
 };
 
 // ── Construction + skeleton behaviours ──────────────────────────────

--- a/apps/mobile/src/features/import-sp/__tests__/trpc-persister-api.test.ts
+++ b/apps/mobile/src/features/import-sp/__tests__/trpc-persister-api.test.ts
@@ -409,6 +409,8 @@ describe("field", () => {
     const result = await api.field.create(TEST_SYSTEM_ID, {
       encryptedData: "enc_field",
       fieldType: "text",
+      required: false,
+      sortOrder: 0,
     });
 
     expect(result).toEqual({ id: "fld_1", version: 1 });
@@ -416,6 +418,8 @@ describe("field", () => {
       systemId: TEST_SYSTEM_ID,
       encryptedData: "enc_field",
       fieldType: "text",
+      required: false,
+      sortOrder: 0,
     });
   });
 
@@ -608,6 +612,9 @@ describe("frontingSession", () => {
     const result = await api.frontingSession.create(TEST_SYSTEM_ID, {
       encryptedData: "enc_session",
       startTime: 1_700_000_000,
+      memberId: null,
+      customFrontId: null,
+      structureEntityId: null,
     });
 
     expect(result).toEqual({ id: "fs_1", version: 1 });
@@ -615,6 +622,9 @@ describe("frontingSession", () => {
       systemId: TEST_SYSTEM_ID,
       encryptedData: "enc_session",
       startTime: 1_700_000_000,
+      memberId: null,
+      customFrontId: null,
+      structureEntityId: null,
     });
   });
 
@@ -649,6 +659,9 @@ describe("frontingComment", () => {
     const result = await api.frontingComment.create(TEST_SYSTEM_ID, {
       encryptedData: "enc_comment",
       sessionId: "fs_1",
+      memberId: null,
+      customFrontId: null,
+      structureEntityId: null,
     });
 
     expect(result).toEqual({ id: "fcom_1", version: 1 });
@@ -689,12 +702,16 @@ describe("note", () => {
     client.note.create.mutate.mockResolvedValue({ id: "note_1", version: 1 });
     const api = createTRPCPersisterApi(client);
 
-    const result = await api.note.create(TEST_SYSTEM_ID, { encryptedData: "enc_note" });
+    const result = await api.note.create(TEST_SYSTEM_ID, {
+      encryptedData: "enc_note",
+      author: null,
+    });
 
     expect(result).toEqual({ id: "note_1", version: 1 });
     expect(client.note.create.mutate).toHaveBeenCalledWith({
       systemId: TEST_SYSTEM_ID,
       encryptedData: "enc_note",
+      author: null,
     });
   });
 
@@ -879,6 +896,7 @@ describe("message", () => {
       encryptedData: "enc_message",
       channelId: "ch_1",
       timestamp: 1_700_000_000,
+      replyToId: null,
     });
 
     expect(result).toEqual({ id: "msg_1", version: 1 });
@@ -887,6 +905,7 @@ describe("message", () => {
       channelId: "ch_1",
       encryptedData: "enc_message",
       timestamp: 1_700_000_000,
+      replyToId: null,
     });
   });
 
@@ -923,6 +942,7 @@ describe("boardMessage", () => {
     const result = await api.boardMessage.create(TEST_SYSTEM_ID, {
       encryptedData: "enc_bm",
       sortOrder: 0,
+      pinned: false,
     });
 
     expect(result).toEqual({ id: "bm_1", version: 1 });
@@ -930,6 +950,7 @@ describe("boardMessage", () => {
       systemId: TEST_SYSTEM_ID,
       encryptedData: "enc_bm",
       sortOrder: 0,
+      pinned: false,
     });
   });
 

--- a/apps/mobile/src/features/import-sp/persister/__tests__/board-message.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/board-message.persister.test.ts
@@ -14,9 +14,12 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  title: "First post",
-  body: "hello everyone",
-  authorMemberId: "mem_1",
+  encrypted: {
+    content: "hello everyone",
+    senderId: "mem_1",
+  },
+  sortOrder: 0,
+  pinned: false,
   createdAt: 1_700_000_000_000,
 };
 
@@ -39,10 +42,10 @@ describe("boardMessagePersister", () => {
     expect(updateFn.mock.calls[0]?.[1]).toBe("bm_existing");
   });
 
-  it("rejects payloads missing a title", async () => {
+  it("rejects payloads missing content", async () => {
     const ctx = makeTestPersisterContext();
     await expect(
-      boardMessagePersister.create(ctx, { body: "x", authorMemberId: "mem_1" }),
+      boardMessagePersister.create(ctx, { encrypted: {}, sortOrder: 0, createdAt: 0 }),
     ).rejects.toThrow(/invalid payload for board-message/);
   });
 });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/channel-category.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/channel-category.persister.test.ts
@@ -14,11 +14,12 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  name: "General",
-  description: null,
+  encrypted: {
+    name: "General",
+  },
   type: "category" as const,
-  parentChannelId: null,
-  order: 0,
+  parentId: undefined,
+  sortOrder: 0,
 };
 
 describe("channelCategoryPersister", () => {
@@ -34,11 +35,11 @@ describe("channelCategoryPersister", () => {
     );
   });
 
-  it("rejects a payload with a non-null parentChannelId", async () => {
+  it("rejects a payload missing encrypted name", async () => {
     const ctx = makeTestPersisterContext();
     await expect(
-      channelCategoryPersister.create(ctx, { ...VALID_PAYLOAD, parentChannelId: "ch_other" }),
-    ).rejects.toThrow(/non-null parentChannelId/);
+      channelCategoryPersister.create(ctx, { type: "category", sortOrder: 0 }),
+    ).rejects.toThrow(/invalid payload for channel-category/);
   });
 
   it("update calls channel.update with the existing ID", async () => {

--- a/apps/mobile/src/features/import-sp/persister/__tests__/channel.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/channel.persister.test.ts
@@ -14,19 +14,21 @@ beforeAll(async () => {
 });
 
 const CHANNEL_WITH_PARENT = {
-  name: "memes",
-  description: null,
+  encrypted: {
+    name: "memes",
+  },
   type: "channel" as const,
-  parentChannelId: "ch_parent",
-  order: 1,
+  parentId: "ch_parent",
+  sortOrder: 1,
 };
 
 const ORPHAN_CHANNEL = {
-  name: "orphan",
-  description: null,
+  encrypted: {
+    name: "orphan",
+  },
   type: "channel" as const,
-  parentChannelId: null,
-  order: 0,
+  parentId: null,
+  sortOrder: 0,
 };
 
 describe("channelPersister", () => {

--- a/apps/mobile/src/features/import-sp/persister/__tests__/chat-message.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/chat-message.persister.test.ts
@@ -14,11 +14,15 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
+  encrypted: {
+    content: "hello world",
+    senderId: "mem_1",
+    attachments: [],
+    mentions: [],
+  },
   channelId: "ch_1",
-  writerMemberId: "mem_1",
-  body: "hello world",
-  createdAt: 1_700_000_000_000,
-  replyToChatMessageId: null,
+  timestamp: 1_700_000_000_000,
+  replyToId: null,
 };
 
 describe("chatMessagePersister", () => {
@@ -45,14 +49,13 @@ describe("chatMessagePersister", () => {
     expect(updateFn.mock.calls[0]?.[2]).toMatchObject({ channelId: "ch_1" });
   });
 
-  it("rejects payloads without a body", async () => {
+  it("rejects payloads without encrypted content", async () => {
     const ctx = makeTestPersisterContext();
     await expect(
       chatMessagePersister.create(ctx, {
         channelId: "ch_1",
-        writerMemberId: "mem_1",
-        createdAt: 0,
-        replyToChatMessageId: null,
+        timestamp: 0,
+        replyToId: null,
       }),
     ).rejects.toThrow(/invalid payload for chat-message/);
   });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/custom-front.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/custom-front.persister.test.ts
@@ -14,10 +14,12 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  name: "Dissociated",
-  description: "blurry",
-  color: "#ff00ff",
-  avatarUrl: null,
+  encrypted: {
+    name: "Dissociated",
+    description: "blurry",
+    color: "#ff00ff",
+    emoji: null,
+  },
 };
 
 describe("customFrontPersister", () => {
@@ -44,8 +46,8 @@ describe("customFrontPersister", () => {
 
   it("rejects payloads without a name", async () => {
     const ctx = makeTestPersisterContext();
-    await expect(customFrontPersister.create(ctx, { color: "#000" })).rejects.toThrow(
-      /invalid payload for custom-front/,
-    );
+    await expect(
+      customFrontPersister.create(ctx, { encrypted: { color: "#000" } }),
+    ).rejects.toThrow(/invalid payload for custom-front/);
   });
 });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/field-definition.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/field-definition.persister.test.ts
@@ -14,10 +14,14 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  name: "Age",
+  encrypted: {
+    name: "Age",
+    description: null,
+    options: null,
+  },
   fieldType: "number",
-  order: 3,
-  supportMarkdown: false,
+  required: false,
+  sortOrder: 3,
 };
 
 describe("fieldDefinitionPersister", () => {
@@ -27,7 +31,12 @@ describe("fieldDefinitionPersister", () => {
     const result = await fieldDefinitionPersister.create(ctx, VALID_PAYLOAD);
     expect(createFn).toHaveBeenCalledWith(
       TEST_SYSTEM_ID,
-      expect.objectContaining({ encryptedData: expect.any(String), fieldType: "number" }),
+      expect.objectContaining({
+        encryptedData: expect.any(String),
+        fieldType: "number",
+        required: false,
+        sortOrder: 3,
+      }),
     );
     expect(result.pluralscapeEntityId).toBe("fld_1");
   });
@@ -50,7 +59,11 @@ describe("fieldDefinitionPersister", () => {
   it("rejects payloads missing the type field", async () => {
     const ctx = makeTestPersisterContext();
     await expect(
-      fieldDefinitionPersister.create(ctx, { name: "X", order: 0, supportMarkdown: false }),
+      fieldDefinitionPersister.create(ctx, {
+        encrypted: { name: "X", description: null, options: null },
+        required: false,
+        sortOrder: 0,
+      }),
     ).rejects.toThrow(/invalid payload for field-definition/);
   });
 });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/fronting-comment.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/fronting-comment.persister.test.ts
@@ -14,9 +14,14 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
+  encrypted: {
+    content: "hello",
+  },
   frontingSessionId: "fs_1",
-  body: "hello",
   createdAt: 1_700_000_000_000,
+  memberId: null,
+  customFrontId: null,
+  structureEntityId: null,
 };
 
 describe("frontingCommentPersister", () => {
@@ -42,8 +47,8 @@ describe("frontingCommentPersister", () => {
 
   it("rejects malformed payloads", async () => {
     const ctx = makeTestPersisterContext();
-    await expect(frontingCommentPersister.create(ctx, { body: 42 })).rejects.toThrow(
-      /invalid payload for fronting-comment/,
-    );
+    await expect(
+      frontingCommentPersister.create(ctx, { encrypted: { content: 42 } }),
+    ).rejects.toThrow(/invalid payload for fronting-comment/);
   });
 });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/fronting-session.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/fronting-session.persister.test.ts
@@ -14,11 +14,17 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  memberId: "mem_1",
-  customFrontId: null,
+  encrypted: {
+    comment: null,
+    positionality: null,
+    outtrigger: null,
+    outtriggerSentiment: null,
+  },
   startTime: 1_700_000_000_000,
   endTime: null,
-  comment: null,
+  memberId: "mem_1",
+  customFrontId: null,
+  structureEntityId: null,
 };
 
 describe("frontingSessionPersister", () => {
@@ -46,8 +52,15 @@ describe("frontingSessionPersister", () => {
 
   it("rejects payloads without a numeric startTime", async () => {
     const ctx = makeTestPersisterContext();
-    await expect(frontingSessionPersister.create(ctx, { memberId: "mem_1" })).rejects.toThrow(
-      /invalid payload for fronting-session/,
-    );
+    await expect(
+      frontingSessionPersister.create(ctx, {
+        encrypted: {
+          comment: null,
+          positionality: null,
+          outtrigger: null,
+          outtriggerSentiment: null,
+        },
+      }),
+    ).rejects.toThrow(/invalid payload for fronting-session/);
   });
 });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/group.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/group.persister.test.ts
@@ -14,9 +14,15 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  name: "Alpha",
-  description: "first group",
-  color: "#ff00ff",
+  encrypted: {
+    name: "Alpha",
+    description: "first group",
+    imageSource: null,
+    color: "#ff00ff",
+    emoji: null,
+  },
+  parentGroupId: null,
+  sortOrder: 0,
   memberIds: ["mem_1", "mem_2", "mem_3"],
 };
 
@@ -48,7 +54,7 @@ describe("groupPersister", () => {
 
   it("rejects payloads without memberIds", async () => {
     const ctx = makeTestPersisterContext();
-    await expect(groupPersister.create(ctx, { name: "no members" })).rejects.toThrow(
+    await expect(groupPersister.create(ctx, { encrypted: { name: "no members" } })).rejects.toThrow(
       /invalid payload for group/,
     );
   });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/journal-entry.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/journal-entry.persister.test.ts
@@ -14,9 +14,12 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  title: "First entry",
+  encrypted: {
+    title: "First entry",
+    content: "hello",
+    backgroundColor: null,
+  },
   author: { entityType: "member" as const, entityId: "mem_1" },
-  blocks: [{ type: "paragraph" as const, content: "hello", children: [] }],
   createdAt: 1_700_000_000_000,
 };
 
@@ -40,10 +43,10 @@ describe("journalEntryPersister", () => {
     expect(call?.[1]).toBe("note_existing");
   });
 
-  it("rejects payloads without blocks", async () => {
+  it("rejects payloads without content", async () => {
     const ctx = makeTestPersisterContext();
-    await expect(journalEntryPersister.create(ctx, { title: "no blocks" })).rejects.toThrow(
-      /invalid payload for journal-entry/,
-    );
+    await expect(
+      journalEntryPersister.create(ctx, { encrypted: { title: "no content" } }),
+    ).rejects.toThrow(/invalid payload for journal-entry/);
   });
 });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/member.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/member.persister.test.ts
@@ -19,29 +19,37 @@ beforeAll(async () => {
 const AVATAR_BYTES = new Uint8Array([1, 2, 3, 4]);
 
 const MEMBER_NO_AVATAR = {
-  member: {
+  encrypted: {
     name: "Aurora",
+    pronouns: [],
     description: null,
-    pronouns: "they/them",
+    avatarSource: null,
     colors: ["#aabbcc"],
-    avatarUrl: null,
-    archived: false,
+    saturationLevel: null,
+    tags: [],
+    suppressFriendFrontNotification: null,
+    boardMessageNotificationOnFront: null,
   },
+  archived: false,
   fieldValues: [],
-  bucketSourceIds: [],
+  bucketIds: [],
 };
 
 const MEMBER_WITH_AVATAR = {
-  member: {
+  encrypted: {
     name: "Bellamy",
+    pronouns: [],
     description: "the dreamer",
-    pronouns: null,
+    avatarSource: "https://example.com/avatar.png",
     colors: [],
-    avatarUrl: "https://example.com/avatar.png",
-    archived: false,
+    saturationLevel: null,
+    tags: [],
+    suppressFriendFrontNotification: null,
+    boardMessageNotificationOnFront: null,
   },
+  archived: false,
   fieldValues: [],
-  bucketSourceIds: [],
+  bucketIds: [],
 };
 
 function makeAvatarFetcher(

--- a/apps/mobile/src/features/import-sp/persister/__tests__/poll.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/poll.persister.test.ts
@@ -11,19 +11,21 @@ beforeAll(async () => {
 });
 
 const POLL_WITH_THREE_VOTES = {
-  poll: {
+  encrypted: {
     title: "Lunch?",
     description: null,
-    endsAt: null,
-    kind: "standard" as const,
-    allowAbstain: true,
-    allowVeto: true,
-    createdByMemberId: null,
     options: [
       { id: "opt_a", label: "pizza", color: null },
       { id: "opt_b", label: "sushi", color: null },
     ],
   },
+  kind: "standard" as const,
+  createdByMemberId: null,
+  allowMultipleVotes: false,
+  maxVotesPerMember: 1,
+  allowAbstain: true,
+  allowVeto: true,
+  endsAt: null,
   votes: [
     { optionId: "opt_a", memberId: "mem_1", isVeto: false, comment: null },
     { optionId: "opt_b", memberId: "mem_2", isVeto: false, comment: null },
@@ -69,8 +71,8 @@ describe("pollPersister", () => {
 
   it("rejects payloads missing votes", async () => {
     const ctx = makeTestPersisterContext();
-    await expect(pollPersister.create(ctx, { poll: POLL_WITH_THREE_VOTES.poll })).rejects.toThrow(
-      /invalid payload for poll/,
-    );
+    await expect(
+      pollPersister.create(ctx, { encrypted: POLL_WITH_THREE_VOTES.encrypted, kind: "standard" }),
+    ).rejects.toThrow(/invalid payload for poll/);
   });
 });

--- a/apps/mobile/src/features/import-sp/persister/__tests__/privacy-bucket.persister.test.ts
+++ b/apps/mobile/src/features/import-sp/persister/__tests__/privacy-bucket.persister.test.ts
@@ -14,10 +14,10 @@ beforeAll(async () => {
 });
 
 const VALID_PAYLOAD = {
-  name: "Trusted",
-  description: "visible to trusted friends",
-  color: null,
-  icon: null,
+  encrypted: {
+    name: "Trusted",
+    description: "visible to trusted friends",
+  },
 };
 
 describe("privacyBucketPersister", () => {
@@ -49,7 +49,7 @@ describe("privacyBucketPersister", () => {
 
   it("rejects malformed payloads on create", async () => {
     const ctx = makeTestPersisterContext();
-    await expect(privacyBucketPersister.create(ctx, { name: 42 })).rejects.toThrow(
+    await expect(privacyBucketPersister.create(ctx, { encrypted: { name: 42 } })).rejects.toThrow(
       /invalid payload for privacy-bucket/,
     );
   });

--- a/apps/mobile/src/features/import-sp/persister/board-message.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/board-message.persister.ts
@@ -2,7 +2,7 @@
  * Board message persister.
  *
  * SP `boardMessages` → Pluralscape board messages. The mapper has
- * already resolved the author member FK. The persister encrypts and
+ * already resolved the sender member FK. The persister encrypts and
  * pushes through `boardMessage.create` / `boardMessage.update`.
  */
 
@@ -15,32 +15,31 @@ import type {
   PersisterUpdateResult,
 } from "./persister.types.js";
 
-/** Default sort order for imported board messages. */
-const DEFAULT_BOARD_MESSAGE_SORT_ORDER = 0;
-
 export interface BoardMessagePayload {
-  readonly title: string;
-  readonly body: string;
-  readonly authorMemberId: string;
+  readonly encrypted: {
+    readonly content: string;
+    readonly senderId: string | null;
+  };
+  readonly sortOrder: number;
+  readonly pinned?: boolean;
   readonly createdAt: number;
 }
 
 function isBoardMessagePayload(value: unknown): value is BoardMessagePayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return (
-    typeof record["title"] === "string" &&
-    typeof record["body"] === "string" &&
-    typeof record["authorMemberId"] === "string"
-  );
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["content"] === "string";
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isBoardMessagePayload, "board-message");
-  const encrypted = encryptForCreate(narrowed, ctx.masterKey);
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.boardMessage.create(ctx.systemId, {
     encryptedData: encrypted.encryptedData,
-    sortOrder: DEFAULT_BOARD_MESSAGE_SORT_ORDER,
+    sortOrder: narrowed.sortOrder,
+    pinned: narrowed.pinned ?? false,
   });
   return { pluralscapeEntityId: result.id };
 }
@@ -51,7 +50,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isBoardMessagePayload, "board-message");
-  const encrypted = encryptForUpdate(narrowed, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.boardMessage.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/persister/channel-category.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/channel-category.persister.ts
@@ -6,9 +6,6 @@
  * `channels` table with a `type` discriminator, so this helper
  * delegates to the shared `persistViaChannelsTable` writer with
  * `type: "category"`.
- *
- * Rejects payloads that carry a parent-channel reference — categories
- * never sit beneath another category.
  */
 
 import {
@@ -26,40 +23,31 @@ import type {
 } from "./persister.types.js";
 
 export interface ChannelCategoryPayload {
-  readonly name: string;
-  readonly description: string | null;
+  readonly encrypted: {
+    readonly name: string;
+  };
   readonly type: "category" | "channel";
-  readonly parentChannelId: string | null;
-  readonly order: number | null;
+  readonly parentId?: string | null;
+  readonly sortOrder: number;
 }
 
 function isChannelCategoryPayload(value: unknown): value is ChannelCategoryPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["name"] === "string";
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["name"] === "string";
 }
-
-function assertNoParent(payload: ChannelCategoryPayload): void {
-  if (payload.parentChannelId !== null) {
-    throw new Error("channel-category persister received payload with non-null parentChannelId");
-  }
-}
-
-const DEFAULT_SORT_ORDER = 0;
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isChannelCategoryPayload, "channel-category");
-  assertNoParent(narrowed);
-  const encrypted = encryptForCreate(
-    { name: narrowed.name, description: narrowed.description },
-    ctx.masterKey,
-  );
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await persistViaChannelsTable(
     ctx,
     {
       encryptedData: encrypted.encryptedData,
-      parentId: null,
-      sortOrder: narrowed.order ?? DEFAULT_SORT_ORDER,
+      parentId: narrowed.parentId ?? null,
+      sortOrder: narrowed.sortOrder,
     },
     "category",
   );
@@ -72,12 +60,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isChannelCategoryPayload, "channel-category");
-  assertNoParent(narrowed);
-  const encrypted = encryptForUpdate(
-    { name: narrowed.name, description: narrowed.description },
-    1,
-    ctx.masterKey,
-  );
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.channel.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/persister/channel.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/channel.persister.ts
@@ -4,7 +4,7 @@
  * Delegates to the shared `persistViaChannelsTable` writer with
  * `type: "channel"`. The mapper has already resolved the parent
  * category FK against the IdTranslationTable, so the payload's
- * `parentChannelId` is either null (orphan) or a Pluralscape ID.
+ * `parentId` is either null (orphan) or a Pluralscape ID.
  */
 
 import {
@@ -22,33 +22,31 @@ import type {
 } from "./persister.types.js";
 
 export interface ChannelPayload {
-  readonly name: string;
-  readonly description: string | null;
+  readonly encrypted: {
+    readonly name: string;
+  };
   readonly type: "category" | "channel";
-  readonly parentChannelId: string | null;
-  readonly order: number | null;
+  readonly parentId?: string | null;
+  readonly sortOrder: number;
 }
 
 function isChannelPayload(value: unknown): value is ChannelPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["name"] === "string";
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["name"] === "string";
 }
-
-const DEFAULT_SORT_ORDER = 0;
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isChannelPayload, "channel");
-  const encrypted = encryptForCreate(
-    { name: narrowed.name, description: narrowed.description },
-    ctx.masterKey,
-  );
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await persistViaChannelsTable(
     ctx,
     {
       encryptedData: encrypted.encryptedData,
-      parentId: narrowed.parentChannelId,
-      sortOrder: narrowed.order ?? DEFAULT_SORT_ORDER,
+      parentId: narrowed.parentId ?? null,
+      sortOrder: narrowed.sortOrder,
     },
     "channel",
   );
@@ -61,11 +59,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isChannelPayload, "channel");
-  const encrypted = encryptForUpdate(
-    { name: narrowed.name, description: narrowed.description },
-    1,
-    ctx.masterKey,
-  );
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.channel.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/persister/chat-message.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/chat-message.persister.ts
@@ -2,7 +2,7 @@
  * Chat message persister.
  *
  * SP `chatMessages` → Pluralscape chat messages. The mapper has
- * resolved channel, writer, and replyTo FKs, so the payload is ready
+ * resolved channel, sender, and replyTo FKs, so the payload is ready
  * to encrypt and push through `message.create` / `message.update`.
  */
 
@@ -16,38 +16,33 @@ import type {
 } from "./persister.types.js";
 
 export interface ChatMessagePayload {
+  readonly encrypted: {
+    readonly content: string;
+    readonly senderId: string | null;
+    readonly attachments: readonly unknown[];
+    readonly mentions: readonly string[];
+  };
   readonly channelId: string;
-  readonly writerMemberId: string;
-  readonly body: string;
-  readonly createdAt: number;
-  readonly replyToChatMessageId: string | null;
+  readonly timestamp: number;
+  readonly replyToId?: string | null;
 }
 
 function isChatMessagePayload(value: unknown): value is ChatMessagePayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return (
-    typeof record["channelId"] === "string" &&
-    typeof record["writerMemberId"] === "string" &&
-    typeof record["body"] === "string"
-  );
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["content"] === "string" && typeof record["channelId"] === "string";
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isChatMessagePayload, "chat-message");
-  const encrypted = encryptForCreate(
-    {
-      body: narrowed.body,
-      writerMemberId: narrowed.writerMemberId,
-      createdAt: narrowed.createdAt,
-      replyToChatMessageId: narrowed.replyToChatMessageId,
-    },
-    ctx.masterKey,
-  );
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.message.create(ctx.systemId, {
     encryptedData: encrypted.encryptedData,
     channelId: narrowed.channelId,
-    timestamp: narrowed.createdAt,
+    timestamp: narrowed.timestamp,
+    replyToId: narrowed.replyToId ?? null,
   });
   return { pluralscapeEntityId: result.id };
 }
@@ -58,18 +53,10 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isChatMessagePayload, "chat-message");
-  const encrypted = encryptForUpdate(
-    {
-      body: narrowed.body,
-      writerMemberId: narrowed.writerMemberId,
-      createdAt: narrowed.createdAt,
-      replyToChatMessageId: narrowed.replyToChatMessageId,
-    },
-    1,
-    ctx.masterKey,
-  );
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.message.update(ctx.systemId, existingId, {
-    ...encrypted,
+    encryptedData: encrypted.encryptedData,
+    version: encrypted.version,
     channelId: narrowed.channelId,
   });
   return { pluralscapeEntityId: result.id };

--- a/apps/mobile/src/features/import-sp/persister/custom-front.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/custom-front.persister.ts
@@ -4,7 +4,7 @@
  * SP `frontStatuses` → Pluralscape `custom_fronts`. A custom front is an
  * abstract cognitive state the user logs the same way as a member
  * (e.g. "Dissociated", "Blurry") — it has a name, description, colour,
- * and optional avatar URL.
+ * and optional emoji.
  */
 
 import { assertPayloadShape, encryptForCreate, encryptForUpdate } from "./persister-helpers.js";
@@ -15,28 +15,28 @@ import type {
   PersisterCreateResult,
   PersisterUpdateResult,
 } from "./persister.types.js";
+import type { HexColor } from "@pluralscape/types";
 
-/**
- * Narrowed shape of `MappedCustomFront`. The avatar URL is carried as
- * plaintext in the payload; Phase C does not fan out avatar fetching for
- * custom fronts (members come first — see `member.persister.ts`).
- */
 export interface CustomFrontPayload {
-  readonly name: string;
-  readonly description: string | null;
-  readonly color: string | null;
-  readonly avatarUrl: string | null;
+  readonly encrypted: {
+    readonly name: string;
+    readonly description: string | null;
+    readonly color: HexColor | null;
+    readonly emoji: string | null;
+  };
 }
 
 function isCustomFrontPayload(value: unknown): value is CustomFrontPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["name"] === "string";
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["name"] === "string";
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isCustomFrontPayload, "custom-front");
-  const encrypted = encryptForCreate(narrowed, ctx.masterKey);
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.customFront.create(ctx.systemId, encrypted);
   return { pluralscapeEntityId: result.id };
 }
@@ -47,7 +47,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isCustomFrontPayload, "custom-front");
-  const encrypted = encryptForUpdate(narrowed, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.customFront.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/persister/field-definition.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/field-definition.persister.ts
@@ -19,33 +19,37 @@ import type {
 import type { FieldType } from "@pluralscape/types";
 
 /**
- * Narrowed shape of `MappedFieldDefinition`. Ordering and markdown
- * support are part of the plaintext payload, not wire metadata, so they
- * go through the same encryption as the name.
+ * Narrowed shape of `MappedFieldDefinition`. Encrypted fields (name,
+ * description, options) are nested under `encrypted`; plaintext
+ * structural fields live at the top level.
  */
 export interface FieldDefinitionPayload {
-  readonly name: string;
+  readonly encrypted: {
+    readonly name: string;
+    readonly description: string | null;
+    readonly options: readonly { readonly label: string; readonly color: string | null }[];
+  };
   readonly fieldType: FieldType;
-  readonly order: number;
-  readonly supportMarkdown: boolean;
+  readonly required: boolean;
+  readonly sortOrder: number;
 }
 
 function isFieldDefinitionPayload(value: unknown): value is FieldDefinitionPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return (
-    typeof record["name"] === "string" &&
-    typeof record["fieldType"] === "string" &&
-    typeof record["order"] === "number"
-  );
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["name"] === "string" && typeof record["fieldType"] === "string";
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isFieldDefinitionPayload, "field-definition");
-  const encrypted = encryptForCreate(narrowed, ctx.masterKey);
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.field.create(ctx.systemId, {
     encryptedData: encrypted.encryptedData,
     fieldType: narrowed.fieldType,
+    required: narrowed.required,
+    sortOrder: narrowed.sortOrder,
   });
   return { pluralscapeEntityId: result.id };
 }
@@ -56,7 +60,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isFieldDefinitionPayload, "field-definition");
-  const encrypted = encryptForUpdate(narrowed, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.field.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/persister/fronting-comment.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/fronting-comment.persister.ts
@@ -16,23 +16,35 @@ import type {
 } from "./persister.types.js";
 
 export interface FrontingCommentPayload {
+  readonly encrypted: {
+    readonly content: string;
+  };
   readonly frontingSessionId: string;
-  readonly body: string;
   readonly createdAt: number;
+  readonly memberId?: string | null;
+  readonly customFrontId?: string | null;
+  readonly structureEntityId?: string | null;
 }
 
 function isFrontingCommentPayload(value: unknown): value is FrontingCommentPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["frontingSessionId"] === "string" && typeof record["body"] === "string";
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return (
+    typeof encrypted["content"] === "string" && typeof record["frontingSessionId"] === "string"
+  );
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isFrontingCommentPayload, "fronting-comment");
-  const encrypted = encryptForCreate(narrowed, ctx.masterKey);
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.frontingComment.create(ctx.systemId, {
-    ...encrypted,
+    encryptedData: encrypted.encryptedData,
     sessionId: narrowed.frontingSessionId,
+    memberId: narrowed.memberId ?? null,
+    customFrontId: narrowed.customFrontId ?? null,
+    structureEntityId: narrowed.structureEntityId ?? null,
   });
   return { pluralscapeEntityId: result.id };
 }
@@ -43,9 +55,10 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isFrontingCommentPayload, "fronting-comment");
-  const encrypted = encryptForUpdate(narrowed, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.frontingComment.update(ctx.systemId, existingId, {
-    ...encrypted,
+    encryptedData: encrypted.encryptedData,
+    version: encrypted.version,
     sessionId: narrowed.frontingSessionId,
   });
   return { pluralscapeEntityId: result.id };

--- a/apps/mobile/src/features/import-sp/persister/fronting-session.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/fronting-session.persister.ts
@@ -18,25 +18,35 @@ import type {
 } from "./persister.types.js";
 
 export interface FrontingSessionPayload {
-  readonly memberId: string | null;
-  readonly customFrontId: string | null;
+  readonly encrypted: {
+    readonly comment: string | null;
+    readonly positionality: string | null;
+    readonly outtrigger: string | null;
+    readonly outtriggerSentiment: string | null;
+  };
   readonly startTime: number;
   readonly endTime: number | null;
-  readonly comment: string | null;
+  readonly memberId?: string | null;
+  readonly customFrontId?: string | null;
+  readonly structureEntityId?: string | null;
 }
 
 function isFrontingSessionPayload(value: unknown): value is FrontingSessionPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
   return typeof record["startTime"] === "number";
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isFrontingSessionPayload, "fronting-session");
-  const encrypted = encryptForCreate(narrowed, ctx.masterKey);
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.frontingSession.create(ctx.systemId, {
     encryptedData: encrypted.encryptedData,
     startTime: narrowed.startTime,
+    memberId: narrowed.memberId ?? null,
+    customFrontId: narrowed.customFrontId ?? null,
+    structureEntityId: narrowed.structureEntityId ?? null,
   });
   return { pluralscapeEntityId: result.id };
 }
@@ -47,7 +57,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isFrontingSessionPayload, "fronting-session");
-  const encrypted = encryptForUpdate(narrowed, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.frontingSession.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/persister/group.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/group.persister.ts
@@ -6,10 +6,10 @@
  * were dropped with warnings upstream — so the payload's `memberIds`
  * is a ready-to-use array of Pluralscape IDs.
  *
- * The helper encrypts the group core (name, description, color) and
- * passes the memberIds through as structural metadata on the create
- * mutation so the server can materialise the group_memberships rows
- * in the same transaction.
+ * The helper encrypts the group core (name, description, imageSource,
+ * color, emoji) and passes the memberIds through as structural metadata
+ * on the create mutation so the server can materialise the
+ * group_memberships rows in the same transaction.
  */
 
 import { assertPayloadShape, encryptForCreate, encryptForUpdate } from "./persister-helpers.js";
@@ -22,36 +22,34 @@ import type {
 } from "./persister.types.js";
 
 export interface GroupPayload {
-  readonly name: string;
-  readonly description: string | null;
-  readonly color: string | null;
+  readonly encrypted: {
+    readonly name: string;
+    readonly description: string | null;
+    readonly imageSource: string | null;
+    readonly color: string | null;
+    readonly emoji: string | null;
+  };
+  readonly parentGroupId: string | null;
+  readonly sortOrder: number;
   readonly memberIds: readonly string[];
 }
 
 function isGroupPayload(value: unknown): value is GroupPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["name"] === "string" && Array.isArray(record["memberIds"]);
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["name"] === "string" && Array.isArray(record["memberIds"]);
 }
-
-/** Default sort order for imported groups. */
-const DEFAULT_GROUP_SORT_ORDER = 0;
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isGroupPayload, "group");
-  const encrypted = encryptForCreate(
-    {
-      name: narrowed.name,
-      description: narrowed.description,
-      color: narrowed.color,
-    },
-    ctx.masterKey,
-  );
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.group.create(ctx.systemId, {
     encryptedData: encrypted.encryptedData,
     memberIds: narrowed.memberIds,
-    parentGroupId: null,
-    sortOrder: DEFAULT_GROUP_SORT_ORDER,
+    parentGroupId: narrowed.parentGroupId,
+    sortOrder: narrowed.sortOrder,
   });
   return { pluralscapeEntityId: result.id };
 }
@@ -62,15 +60,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isGroupPayload, "group");
-  const encrypted = encryptForUpdate(
-    {
-      name: narrowed.name,
-      description: narrowed.description,
-      color: narrowed.color,
-    },
-    1,
-    ctx.masterKey,
-  );
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.group.update(ctx.systemId, existingId, {
     encryptedData: encrypted.encryptedData,
     version: encrypted.version,

--- a/apps/mobile/src/features/import-sp/persister/journal-entry.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/journal-entry.persister.ts
@@ -6,8 +6,8 @@
  * persister API surface flattens the route to `note.create`/`note.update`.
  *
  * The mapper already resolves the author member FK and wraps the note
- * body in a single paragraph block. The persister simply encrypts and
- * pushes through.
+ * body in the content field. The persister simply encrypts and pushes
+ * through.
  */
 
 import { assertPayloadShape, encryptForCreate, encryptForUpdate } from "./persister-helpers.js";
@@ -20,26 +20,30 @@ import type {
 } from "./persister.types.js";
 
 export interface JournalEntryPayload {
-  readonly title: string;
-  readonly author: { readonly entityType: "member"; readonly entityId: string };
-  readonly blocks: readonly {
-    readonly type: "paragraph";
+  readonly encrypted: {
+    readonly title: string;
     readonly content: string;
-    readonly children: readonly never[];
-  }[];
+    readonly backgroundColor: string | null;
+  };
+  readonly author?: { readonly entityType: "member"; readonly entityId: string } | null;
   readonly createdAt: number;
 }
 
 function isJournalEntryPayload(value: unknown): value is JournalEntryPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["title"] === "string" && Array.isArray(record["blocks"]);
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["title"] === "string" && typeof encrypted["content"] === "string";
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isJournalEntryPayload, "journal-entry");
-  const encrypted = encryptForCreate(narrowed, ctx.masterKey);
-  const result = await ctx.api.note.create(ctx.systemId, encrypted);
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
+  const result = await ctx.api.note.create(ctx.systemId, {
+    encryptedData: encrypted.encryptedData,
+    author: narrowed.author ?? null,
+  });
   return { pluralscapeEntityId: result.id };
 }
 
@@ -49,7 +53,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isJournalEntryPayload, "journal-entry");
-  const encrypted = encryptForUpdate(narrowed, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.note.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/persister/member.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/member.persister.ts
@@ -1,8 +1,8 @@
 /**
  * Member persister (with inline avatar upload and field-value fan-out).
  *
- * Receives the `MappedMemberOutput` the engine hands it — `{ member,
- * fieldValues, bucketSourceIds }`. The helper:
+ * Receives the `MappedMemberOutput` the engine hands it — `{ encrypted,
+ * archived, fieldValues, bucketIds }`. The helper:
  *
  * 1. Resolves the avatar URL if present and the mode is not "skip". The
  *    caller's `AvatarFetcher` returns raw bytes; those are uploaded via
@@ -17,7 +17,7 @@
  *    field source ID before calling the API and records an error (but
  *    does not abort the member) if it cannot be resolved.
  *
- * Bucket assignments (the `bucketSourceIds` array) are deferred to a
+ * Bucket assignments (the `bucketIds` array) are deferred to a
  * future phase: the mobile persister does not yet expose a
  * `member.assignBucket` procedure, and Phase C scope is already dense.
  */
@@ -33,13 +33,16 @@ import type {
 
 // ── Narrowed payload shape ───────────────────────────────────────────
 
-export interface MemberCorePayload {
+export interface MemberEncryptedFields {
   readonly name: string;
+  readonly pronouns: string[];
   readonly description: string | null;
-  readonly pronouns: string | null;
+  readonly avatarSource: string | null;
   readonly colors: readonly string[];
-  readonly avatarUrl: string | null;
-  readonly archived: boolean;
+  readonly saturationLevel: number | null;
+  readonly tags: readonly string[];
+  readonly suppressFriendFrontNotification: boolean | null;
+  readonly boardMessageNotificationOnFront: boolean | null;
 }
 
 export interface ExtractedFieldValuePayload {
@@ -48,26 +51,22 @@ export interface ExtractedFieldValuePayload {
   readonly value: string;
 }
 
-export interface MemberOutputPayload {
-  readonly member: MemberCorePayload;
+export interface MemberPayload {
+  readonly encrypted: MemberEncryptedFields;
+  readonly archived: boolean;
   readonly fieldValues: readonly ExtractedFieldValuePayload[];
-  readonly bucketSourceIds: readonly string[];
+  readonly bucketIds: readonly string[];
 }
 
-function isMemberCorePayload(value: unknown): value is MemberCorePayload {
+function isMemberPayload(value: unknown): value is MemberPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["name"] === "string" && Array.isArray(record["colors"]);
-}
-
-function isMemberOutputPayload(value: unknown): value is MemberOutputPayload {
-  if (typeof value !== "object" || value === null) return false;
-  const record = value as Record<string, unknown>;
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
   return (
-    "member" in record &&
-    isMemberCorePayload(record["member"]) &&
+    typeof encrypted["name"] === "string" &&
     Array.isArray(record["fieldValues"]) &&
-    Array.isArray(record["bucketSourceIds"])
+    Array.isArray(record["bucketIds"])
   );
 }
 
@@ -147,20 +146,20 @@ async function fanOutFieldValues(
 // ── Core entity-persister shape ──────────────────────────────────────
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
-  const output = assertPayloadShape(payload, isMemberOutputPayload, "member");
+  const output = assertPayloadShape(payload, isMemberPayload, "member");
 
   // Source-ID plumbed in for error messages even though the engine
   // already passes the same ID through via `sourceEntityId`. The
   // persister interface does not surface that here, so we fall back to
   // the member name.
-  const sourceId = output.member.name;
+  const sourceId = output.encrypted.name;
 
   let avatarBlobId: string | null = null;
-  if (output.member.avatarUrl !== null) {
-    avatarBlobId = await tryUploadAvatar(ctx, sourceId, output.member.avatarUrl);
+  if (output.encrypted.avatarSource !== null) {
+    avatarBlobId = await tryUploadAvatar(ctx, sourceId, output.encrypted.avatarSource);
   }
 
-  const encrypted = encryptForCreate(output.member, ctx.masterKey);
+  const encrypted = encryptForCreate(output.encrypted, ctx.masterKey);
   const createInput =
     avatarBlobId === null
       ? { encryptedData: encrypted.encryptedData }
@@ -177,16 +176,16 @@ async function update(
   payload: unknown,
   existingId: string,
 ): Promise<PersisterUpdateResult> {
-  const output = assertPayloadShape(payload, isMemberOutputPayload, "member");
+  const output = assertPayloadShape(payload, isMemberPayload, "member");
 
-  const sourceId = output.member.name;
+  const sourceId = output.encrypted.name;
 
   let avatarBlobId: string | null = null;
-  if (output.member.avatarUrl !== null) {
-    avatarBlobId = await tryUploadAvatar(ctx, sourceId, output.member.avatarUrl);
+  if (output.encrypted.avatarSource !== null) {
+    avatarBlobId = await tryUploadAvatar(ctx, sourceId, output.encrypted.avatarSource);
   }
 
-  const encrypted = encryptForUpdate(output.member, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(output.encrypted, 1, ctx.masterKey);
   const updateInput =
     avatarBlobId === null
       ? { encryptedData: encrypted.encryptedData, version: encrypted.version }

--- a/apps/mobile/src/features/import-sp/persister/persister.types.ts
+++ b/apps/mobile/src/features/import-sp/persister/persister.types.ts
@@ -111,7 +111,11 @@ export type PersisterProcPollCastVote = (
 ) => Promise<{ readonly id: string }>;
 export type PersisterProcFieldDefinitionCreate = (
   systemId: SystemId,
-  payload: EncryptedInput & { readonly fieldType: FieldType },
+  payload: EncryptedInput & {
+    readonly fieldType: FieldType;
+    readonly required: boolean;
+    readonly sortOrder: number;
+  },
 ) => Promise<VersionedEntityRef>;
 export type PersisterProcPollCreate = (
   systemId: SystemId,
@@ -125,19 +129,34 @@ export type PersisterProcPollCreate = (
 ) => Promise<VersionedEntityRef>;
 export type PersisterProcFrontingSessionCreate = (
   systemId: SystemId,
-  payload: EncryptedInput & { readonly startTime: number },
+  payload: EncryptedInput & {
+    readonly startTime: number;
+    readonly memberId: string | null;
+    readonly customFrontId: string | null;
+    readonly structureEntityId: string | null;
+  },
 ) => Promise<VersionedEntityRef>;
 export type PersisterProcFrontingCommentCreate = (
   systemId: SystemId,
   payload: EncryptedInput & {
     readonly sessionId: string;
-    readonly memberId?: string;
-    readonly customFrontId?: string;
+    readonly memberId: string | null;
+    readonly customFrontId: string | null;
+    readonly structureEntityId: string | null;
+  },
+) => Promise<VersionedEntityRef>;
+export type PersisterProcNoteCreate = (
+  systemId: SystemId,
+  payload: EncryptedInput & {
+    readonly author: { readonly entityType: "member"; readonly entityId: string } | null;
   },
 ) => Promise<VersionedEntityRef>;
 export type PersisterProcBoardMessageCreate = (
   systemId: SystemId,
-  payload: EncryptedInput & { readonly sortOrder: number },
+  payload: EncryptedInput & {
+    readonly sortOrder: number;
+    readonly pinned: boolean;
+  },
 ) => Promise<VersionedEntityRef>;
 export type PersisterProcChannelCreate = (
   systemId: SystemId,
@@ -152,6 +171,7 @@ export type PersisterProcMessageCreate = (
   input: EncryptedInput & {
     readonly channelId: string;
     readonly timestamp: number;
+    readonly replyToId: string | null;
   },
 ) => Promise<VersionedEntityRef>;
 export type PersisterProcGroupCreate = (
@@ -242,7 +262,7 @@ export interface PersisterApi {
     readonly update: PersisterProcFrontingCommentUpdate;
   };
   readonly note: {
-    readonly create: PersisterProcCreate;
+    readonly create: PersisterProcNoteCreate;
     readonly update: PersisterProcUpdateById;
   };
   readonly poll: {

--- a/apps/mobile/src/features/import-sp/persister/poll.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/poll.persister.ts
@@ -1,11 +1,11 @@
 /**
  * Poll persister (with votes fan-out).
  *
- * The Plan 2 `poll.mapper.ts` emits `{ poll, votes }` — the poll core
- * (title, description, options, etc.) plus an array of vote records
- * inline. This helper encrypts the poll and issues `poll.create` /
- * `poll.update`, then fans out one `poll.castVote` per vote via the
- * shared `castPollVotes` helper.
+ * The mapper emits `{ encrypted, kind, votes, ... }` — the encrypted
+ * poll core (title, description, options) plus structural metadata and
+ * an array of vote records inline. This helper encrypts the poll and
+ * issues `poll.create` / `poll.update`, then fans out one
+ * `poll.castVote` per vote via the shared `castPollVotes` helper.
  */
 
 import {
@@ -23,51 +23,43 @@ import type {
   PersisterUpdateResult,
 } from "./persister.types.js";
 
-export interface PollCorePayload {
-  readonly title: string;
-  readonly description: string | null;
-  readonly endsAt: number | null;
+export interface PollPayload {
+  readonly encrypted: {
+    readonly title: string;
+    readonly description: string | null;
+    readonly options: readonly {
+      readonly id: string;
+      readonly label: string;
+      readonly color: string | null;
+    }[];
+  };
   readonly kind: "standard" | "custom";
+  readonly createdByMemberId: string | null;
+  readonly allowMultipleVotes: boolean;
+  readonly maxVotesPerMember: number;
   readonly allowAbstain: boolean;
   readonly allowVeto: boolean;
-  readonly createdByMemberId: string | null;
-  readonly options: readonly {
-    readonly id: string;
-    readonly label: string;
-    readonly color: string | null;
-  }[];
-}
-
-export interface PollOutputPayload {
-  readonly poll: PollCorePayload;
+  readonly endsAt: number | null;
   readonly votes: readonly PollVoteInput[];
 }
 
-function isPollCore(value: unknown): value is PollCorePayload {
+function isPollPayload(value: unknown): value is PollPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["title"] === "string" && Array.isArray(record["options"]);
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  return typeof record["kind"] === "string" && Array.isArray(record["votes"]);
 }
-
-function isPollOutputPayload(value: unknown): value is PollOutputPayload {
-  if (typeof value !== "object" || value === null) return false;
-  const record = value as Record<string, unknown>;
-  return "poll" in record && isPollCore(record["poll"]) && Array.isArray(record["votes"]);
-}
-
-/** Default max votes when multiple votes are not allowed. */
-const SINGLE_VOTE_MAX = 1;
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
-  const narrowed = assertPayloadShape(payload, isPollOutputPayload, "poll");
-  const encrypted = encryptForCreate(narrowed.poll, ctx.masterKey);
+  const narrowed = assertPayloadShape(payload, isPollPayload, "poll");
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.poll.create(ctx.systemId, {
     encryptedData: encrypted.encryptedData,
-    kind: narrowed.poll.kind,
-    allowMultipleVotes: false,
-    maxVotesPerMember: SINGLE_VOTE_MAX,
-    allowAbstain: narrowed.poll.allowAbstain,
-    allowVeto: narrowed.poll.allowVeto,
+    kind: narrowed.kind,
+    allowMultipleVotes: narrowed.allowMultipleVotes,
+    maxVotesPerMember: narrowed.maxVotesPerMember,
+    allowAbstain: narrowed.allowAbstain,
+    allowVeto: narrowed.allowVeto,
   });
   await castPollVotes(ctx, result.id, narrowed.votes);
   return { pluralscapeEntityId: result.id };
@@ -78,8 +70,8 @@ async function update(
   payload: unknown,
   existingId: string,
 ): Promise<PersisterUpdateResult> {
-  const narrowed = assertPayloadShape(payload, isPollOutputPayload, "poll");
-  const encrypted = encryptForUpdate(narrowed.poll, 1, ctx.masterKey);
+  const narrowed = assertPayloadShape(payload, isPollPayload, "poll");
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.poll.update(ctx.systemId, existingId, encrypted);
   await castPollVotes(ctx, result.id, narrowed.votes);
   return { pluralscapeEntityId: result.id };

--- a/apps/mobile/src/features/import-sp/persister/privacy-bucket.persister.ts
+++ b/apps/mobile/src/features/import-sp/persister/privacy-bucket.persister.ts
@@ -22,21 +22,23 @@ import type {
  * the persister does not depend on the mapper module.
  */
 export interface PrivacyBucketPayload {
-  readonly name: string;
-  readonly description: string | null;
-  readonly color: string | null;
-  readonly icon: string | null;
+  readonly encrypted: {
+    readonly name: string;
+    readonly description: string | null;
+  };
 }
 
 function isPrivacyBucketPayload(value: unknown): value is PrivacyBucketPayload {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
-  return typeof record["name"] === "string";
+  if (typeof record["encrypted"] !== "object" || record["encrypted"] === null) return false;
+  const encrypted = record["encrypted"] as Record<string, unknown>;
+  return typeof encrypted["name"] === "string";
 }
 
 async function create(ctx: PersisterContext, payload: unknown): Promise<PersisterCreateResult> {
   const narrowed = assertPayloadShape(payload, isPrivacyBucketPayload, "privacy-bucket");
-  const encrypted = encryptForCreate(narrowed, ctx.masterKey);
+  const encrypted = encryptForCreate(narrowed.encrypted, ctx.masterKey);
   const result = await ctx.api.bucket.create(ctx.systemId, encrypted);
   return { pluralscapeEntityId: result.id };
 }
@@ -47,7 +49,7 @@ async function update(
   existingId: string,
 ): Promise<PersisterUpdateResult> {
   const narrowed = assertPayloadShape(payload, isPrivacyBucketPayload, "privacy-bucket");
-  const encrypted = encryptForUpdate(narrowed, 1, ctx.masterKey);
+  const encrypted = encryptForUpdate(narrowed.encrypted, 1, ctx.masterKey);
   const result = await ctx.api.bucket.update(ctx.systemId, existingId, encrypted);
   return { pluralscapeEntityId: result.id };
 }

--- a/apps/mobile/src/features/import-sp/trpc-persister-api.ts
+++ b/apps/mobile/src/features/import-sp/trpc-persister-api.ts
@@ -58,7 +58,13 @@ export interface TRPCClientSubset {
   readonly field: {
     readonly definition: {
       readonly create: Mutation<
-        { systemId: SystemId; encryptedData: string; fieldType: FieldType },
+        {
+          systemId: SystemId;
+          encryptedData: string;
+          fieldType: FieldType;
+          required: boolean;
+          sortOrder: number;
+        },
         VersionedEntityRef
       >;
       readonly update: Mutation<
@@ -103,9 +109,9 @@ export interface TRPCClientSubset {
         systemId: SystemId;
         encryptedData: string;
         startTime: number;
-        memberId?: string;
-        customFrontId?: string;
-        structureEntityId?: string;
+        memberId: string | null;
+        customFrontId: string | null;
+        structureEntityId: string | null;
       },
       VersionedEntityRef
     >;
@@ -138,7 +144,14 @@ export interface TRPCClientSubset {
     >;
   };
   readonly note: {
-    readonly create: Mutation<{ systemId: SystemId; encryptedData: string }, VersionedEntityRef>;
+    readonly create: Mutation<
+      {
+        systemId: SystemId;
+        encryptedData: string;
+        author: { readonly entityType: "member"; readonly entityId: string } | null;
+      },
+      VersionedEntityRef
+    >;
     readonly update: Mutation<
       { systemId: SystemId; noteId: string; encryptedData: string; version: number },
       VersionedEntityRef
@@ -191,6 +204,7 @@ export interface TRPCClientSubset {
         channelId: string;
         encryptedData: string;
         timestamp: number;
+        replyToId: string | null;
       },
       VersionedEntityRef
     >;
@@ -207,7 +221,7 @@ export interface TRPCClientSubset {
   };
   readonly boardMessage: {
     readonly create: Mutation<
-      { systemId: SystemId; encryptedData: string; sortOrder: number },
+      { systemId: SystemId; encryptedData: string; sortOrder: number; pinned: boolean },
       VersionedEntityRef
     >;
     readonly update: Mutation<
@@ -383,12 +397,18 @@ export function createTRPCPersisterApi(
     field: {
       create: async (
         sysId: SystemId,
-        payload: EncryptedInput & { readonly fieldType: FieldType },
+        payload: EncryptedInput & {
+          readonly fieldType: FieldType;
+          readonly required: boolean;
+          readonly sortOrder: number;
+        },
       ) => {
         return client.field.definition.create.mutate({
           systemId: sysId,
           encryptedData: payload.encryptedData,
           fieldType: payload.fieldType,
+          required: payload.required,
+          sortOrder: payload.sortOrder,
         });
       },
       update: async (sysId: SystemId, entityId: string, payload: EncryptedUpdate) => {
@@ -463,11 +483,22 @@ export function createTRPCPersisterApi(
     },
 
     frontingSession: {
-      create: async (sysId: SystemId, payload: EncryptedInput & { readonly startTime: number }) => {
+      create: async (
+        sysId: SystemId,
+        payload: EncryptedInput & {
+          readonly startTime: number;
+          readonly memberId: string | null;
+          readonly customFrontId: string | null;
+          readonly structureEntityId: string | null;
+        },
+      ) => {
         return client.frontingSession.create.mutate({
           systemId: sysId,
           encryptedData: payload.encryptedData,
           startTime: payload.startTime,
+          memberId: payload.memberId,
+          customFrontId: payload.customFrontId,
+          structureEntityId: payload.structureEntityId,
         });
       },
       update: async (sysId: SystemId, entityId: string, payload: EncryptedUpdate) => {
@@ -485,16 +516,20 @@ export function createTRPCPersisterApi(
         sysId: SystemId,
         payload: EncryptedInput & {
           readonly sessionId: string;
-          readonly memberId?: string;
-          readonly customFrontId?: string;
+          readonly memberId: string | null;
+          readonly customFrontId: string | null;
+          readonly structureEntityId: string | null;
         },
       ) => {
         return client.frontingComment.create.mutate({
           systemId: sysId,
           sessionId: payload.sessionId,
           encryptedData: payload.encryptedData,
-          ...(payload.memberId !== undefined ? { memberId: payload.memberId } : {}),
-          ...(payload.customFrontId !== undefined ? { customFrontId: payload.customFrontId } : {}),
+          ...(payload.memberId !== null ? { memberId: payload.memberId } : {}),
+          ...(payload.customFrontId !== null ? { customFrontId: payload.customFrontId } : {}),
+          ...(payload.structureEntityId !== null
+            ? { structureEntityId: payload.structureEntityId }
+            : {}),
         });
       },
       update: async (
@@ -513,10 +548,16 @@ export function createTRPCPersisterApi(
     },
 
     note: {
-      create: async (sysId: SystemId, payload: EncryptedInput) => {
+      create: async (
+        sysId: SystemId,
+        payload: EncryptedInput & {
+          readonly author: { readonly entityType: "member"; readonly entityId: string } | null;
+        },
+      ) => {
         return client.note.create.mutate({
           systemId: sysId,
           encryptedData: payload.encryptedData,
+          author: payload.author,
         });
       },
       update: async (sysId: SystemId, entityId: string, payload: EncryptedUpdate) => {
@@ -605,13 +646,18 @@ export function createTRPCPersisterApi(
     message: {
       create: async (
         sysId: SystemId,
-        input: EncryptedInput & { readonly channelId: string; readonly timestamp: number },
+        input: EncryptedInput & {
+          readonly channelId: string;
+          readonly timestamp: number;
+          readonly replyToId: string | null;
+        },
       ) => {
         return client.message.create.mutate({
           systemId: sysId,
           channelId: input.channelId,
           encryptedData: input.encryptedData,
           timestamp: input.timestamp,
+          replyToId: input.replyToId,
         });
       },
       update: async (
@@ -630,11 +676,15 @@ export function createTRPCPersisterApi(
     },
 
     boardMessage: {
-      create: async (sysId: SystemId, payload: EncryptedInput & { readonly sortOrder: number }) => {
+      create: async (
+        sysId: SystemId,
+        payload: EncryptedInput & { readonly sortOrder: number; readonly pinned: boolean },
+      ) => {
         return client.boardMessage.create.mutate({
           systemId: sysId,
           encryptedData: payload.encryptedData,
           sortOrder: payload.sortOrder,
+          pinned: payload.pinned,
         });
       },
       update: async (sysId: SystemId, entityId: string, payload: EncryptedUpdate) => {

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -143,6 +143,8 @@ export {
 } from "./transforms/note.js";
 export type { NoteDecrypted, NoteEncryptedFields } from "./transforms/note.js";
 
+export type { BucketEncryptedFields } from "./transforms/privacy-bucket.js";
+
 export {
   decryptAcknowledgement,
   decryptAcknowledgementPage,

--- a/packages/data/src/transforms/privacy-bucket.ts
+++ b/packages/data/src/transforms/privacy-bucket.ts
@@ -1,5 +1,13 @@
 import type { Archived, PrivacyBucket, UnixMillis } from "@pluralscape/types";
 
+// ── Encrypted payload types ───────────────────────────────────────────
+
+/** The subset of PrivacyBucket fields stored encrypted on the server. */
+export interface BucketEncryptedFields {
+  readonly name: string;
+  readonly description: string | null;
+}
+
 // ── Wire types ────────────────────────────────────────────────────────
 
 /** Wire shape returned by `privacyBucket.get` — derived from the `PrivacyBucket` domain type. */

--- a/packages/import-sp/README.md
+++ b/packages/import-sp/README.md
@@ -46,8 +46,59 @@ const result = await runImport({
 | `createApiImportSource(args)`  | Live SP REST API (paginated, with retry/backoff)    |
 | `createFakeImportSource(data)` | In-memory data for tests                            |
 
-All factories return an `ImportSource` implementing `iterate(collection)`,
-`listCollections()`, and `close()`.
+All factories return an `ImportDataSource` implementing `iterate(collection)`,
+`listCollections()`, `close()`, and optionally `supplyParentIds()`.
+
+---
+
+## Collection coverage
+
+The SP import processes 15 SP collections. Source availability varies:
+
+| SP Collection       | Pluralscape Entity | API Import | File Import | Notes                                   |
+| ------------------- | ------------------ | ---------- | ----------- | --------------------------------------- |
+| `users`             | system-profile     | Yes        | Yes         | Cherry-picked into system profile       |
+| `private`           | system-settings    | No         | Yes         | SP requires JWT auth; API keys rejected |
+| `privacyBuckets`    | privacy-bucket     | Yes        | Yes         |                                         |
+| `customFields`      | field-definition   | Yes        | Yes         |                                         |
+| `frontStatuses`     | custom-front       | Yes        | Yes         | Called `customFronts` in SP API URL     |
+| `members`           | member             | Yes        | Yes         |                                         |
+| `groups`            | group              | Yes        | Yes         |                                         |
+| `frontHistory`      | fronting-session   | Yes        | Yes         |                                         |
+| `comments`          | fronting-comment   | No         | Yes         | SP only exposes per-document endpoint   |
+| `notes`             | journal-entry      | Yes        | Yes         | Multi-pass: fetched per-member          |
+| `polls`             | poll               | Yes        | Yes         |                                         |
+| `channelCategories` | channel-category   | Yes        | Yes         |                                         |
+| `channels`          | channel            | Yes        | Yes         |                                         |
+| `chatMessages`      | chat-message       | No         | Yes         | SP only exposes per-channel endpoint    |
+| `boardMessages`     | board-message      | No         | Yes         | SP only exposes per-member endpoint     |
+
+### Why some collections are file-only
+
+The SP REST API exposes these collections only through per-parent endpoints:
+
+- **comments** — `GET /v1/comments/:type/:id` requires a document type and ID
+- **chatMessages** — `GET /v1/chat/messages/:channelId` requires a channel ID (paginated)
+- **boardMessages** — `GET /v1/board/member/:memberId` requires a member ID
+
+Without a bulk list endpoint, importing them requires enumerating every possible
+parent — not feasible for comments (which span multiple document types) or practical
+without significant request overhead for chat/board messages.
+
+**notes** (journal entries) are the exception: they follow the same per-parent
+pattern (`GET /v1/notes/:system/:member`) but are essential enough to warrant a
+multi-pass fetch. The engine fetches all members first, then iterates each
+member's notes endpoint.
+
+**private** (system settings) uses JWT-only auth middleware
+(`isUserAppJwtAuthenticated`) in the SP API, so API key authentication is
+rejected with 401.
+
+### User guidance
+
+For a **complete import**, use the JSON file export from Simply Plural. API import
+covers all essential data including member notes (journal entries) but omits fronting
+comments, chat messages, and board messages.
 
 ### Persister contract
 

--- a/packages/import-sp/package.json
+++ b/packages/import-sp/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@pluralscape/api": "workspace:*",
     "@pluralscape/crypto": "workspace:*",
+    "@pluralscape/data": "workspace:*",
     "@pluralscape/eslint-config": "workspace:*",
     "@pluralscape/tsconfig": "workspace:*",
     "@trpc/client": "11.16.0",

--- a/packages/import-sp/src/__tests__/e2e/e2e-helpers.ts
+++ b/packages/import-sp/src/__tests__/e2e/e2e-helpers.ts
@@ -43,17 +43,11 @@ const MAX_BATCH_ITEMS = 10;
 /** Batch size for ref upserts (matches mobile persister). */
 const REF_BATCH_SIZE = 50;
 
-/** Default sort order for imported entities. */
-const DEFAULT_SORT_ORDER = 0;
-
-/** Default max votes per member for imported polls. */
-const SINGLE_VOTE_MAX = 1;
-
 /** Placeholder for update calls that route through a parent scope. */
 const COMMENT_UPDATE_PLACEHOLDER_SESSION = "fs_import_placeholder";
 const MESSAGE_UPDATE_PLACEHOLDER_CHANNEL = "ch_import_placeholder";
 
-// ── Registration ──────────────────────────────────────────��─────────
+// ── Registration ─────────────────────────────────────────────────────
 
 interface RegisterData {
   sessionToken: string;
@@ -278,21 +272,23 @@ export async function createE2EPersister(
       case "privacy-bucket":
         return trpcClient.bucket.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
         });
       case "field-definition":
         return trpcClient.field.definition.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           fieldType: entity.payload.fieldType,
+          required: entity.payload.required,
+          sortOrder: entity.payload.sortOrder,
         });
       case "custom-front":
         return trpcClient.customFront.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
         });
       case "member": {
-        const encrypted = encryptForApi(entity.payload.member, masterKey);
+        const encrypted = encryptForApi(entity.payload.encrypted, masterKey);
         const result = await trpcClient.member.create.mutate({
           systemId,
           encryptedData: encrypted,
@@ -312,16 +308,11 @@ export async function createE2EPersister(
         return result;
       }
       case "group": {
-        const groupCore = {
-          name: entity.payload.name,
-          description: entity.payload.description,
-          color: entity.payload.color,
-        };
         const result = await trpcClient.group.create.mutate({
           systemId,
-          encryptedData: encryptForApi(groupCore, masterKey),
-          parentGroupId: null,
-          sortOrder: DEFAULT_SORT_ORDER,
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          parentGroupId: entity.payload.parentGroupId,
+          sortOrder: entity.payload.sortOrder,
         });
         for (const memberId of entity.payload.memberIds) {
           await trpcClient.group.addMember.mutate({
@@ -335,36 +326,38 @@ export async function createE2EPersister(
       case "fronting-session":
         return trpcClient.frontingSession.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           startTime: entity.payload.startTime,
-          memberId: entity.payload.memberId ?? undefined,
-          customFrontId: entity.payload.customFrontId ?? undefined,
-          structureEntityId: undefined,
+          memberId: entity.payload.memberId,
+          customFrontId: entity.payload.customFrontId,
+          structureEntityId: entity.payload.structureEntityId,
         });
       case "fronting-comment":
         return trpcClient.frontingComment.create.mutate({
           systemId,
           sessionId: entity.payload.frontingSessionId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
-          memberId: undefined,
-          customFrontId: undefined,
-          structureEntityId: undefined,
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          memberId: entity.payload.memberId,
+          customFrontId: entity.payload.customFrontId,
+          structureEntityId: entity.payload.structureEntityId,
         });
       case "journal-entry":
         return trpcClient.note.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          author: entity.payload.author,
         });
       case "poll": {
         const result = await trpcClient.poll.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload.poll, masterKey),
-          kind: entity.payload.poll.kind,
-          createdByMemberId: undefined,
-          allowMultipleVotes: false,
-          maxVotesPerMember: SINGLE_VOTE_MAX,
-          allowAbstain: entity.payload.poll.allowAbstain,
-          allowVeto: entity.payload.poll.allowVeto,
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          kind: entity.payload.kind,
+          createdByMemberId: entity.payload.createdByMemberId,
+          allowMultipleVotes: entity.payload.allowMultipleVotes,
+          maxVotesPerMember: entity.payload.maxVotesPerMember,
+          allowAbstain: entity.payload.allowAbstain,
+          allowVeto: entity.payload.allowVeto,
+          endsAt: entity.payload.endsAt,
         });
         // Cast votes
         for (const vote of entity.payload.votes) {
@@ -376,7 +369,7 @@ export async function createE2EPersister(
               entityType: "member" as const,
               entityId: vote.memberId ?? result.id,
             },
-            encryptedData: encryptForApi(vote, masterKey),
+            encryptedData: encryptForApi({ comment: vote.comment }, masterKey),
           });
         }
         return result;
@@ -384,32 +377,33 @@ export async function createE2EPersister(
       case "channel-category":
         return trpcClient.channel.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
-          type: "category",
-          parentId: null,
-          sortOrder: DEFAULT_SORT_ORDER,
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          type: entity.payload.type,
+          parentId: entity.payload.parentId,
+          sortOrder: entity.payload.sortOrder,
         });
       case "channel":
         return trpcClient.channel.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
-          type: "channel",
-          parentId: entity.payload.parentChannelId,
-          sortOrder: entity.payload.order ?? DEFAULT_SORT_ORDER,
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          type: entity.payload.type,
+          parentId: entity.payload.parentId,
+          sortOrder: entity.payload.sortOrder,
         });
       case "chat-message":
         return trpcClient.message.create.mutate({
           systemId,
           channelId: entity.payload.channelId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
-          timestamp: entity.payload.createdAt,
-          replyToId: undefined,
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          timestamp: entity.payload.timestamp,
+          replyToId: entity.payload.replyToId,
         });
       case "board-message":
         return trpcClient.boardMessage.create.mutate({
           systemId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
-          sortOrder: DEFAULT_SORT_ORDER,
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
+          sortOrder: entity.payload.sortOrder,
+          pinned: entity.payload.pinned,
         });
       default: {
         const _exhaustive: never = entity;
@@ -458,7 +452,7 @@ export async function createE2EPersister(
         await trpcClient.bucket.update.mutate({
           systemId,
           bucketId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -466,7 +460,7 @@ export async function createE2EPersister(
         await trpcClient.field.definition.update.mutate({
           systemId,
           fieldDefinitionId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -474,7 +468,7 @@ export async function createE2EPersister(
         await trpcClient.customFront.update.mutate({
           systemId,
           customFrontId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -482,7 +476,7 @@ export async function createE2EPersister(
         await trpcClient.member.update.mutate({
           systemId,
           memberId: existingId,
-          encryptedData: encryptForApi(entity.payload.member, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -490,14 +484,7 @@ export async function createE2EPersister(
         await trpcClient.group.update.mutate({
           systemId,
           groupId: existingId,
-          encryptedData: encryptForApi(
-            {
-              name: entity.payload.name,
-              description: entity.payload.description,
-              color: entity.payload.color,
-            },
-            masterKey,
-          ),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -505,7 +492,7 @@ export async function createE2EPersister(
         await trpcClient.frontingSession.update.mutate({
           systemId,
           sessionId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -514,7 +501,7 @@ export async function createE2EPersister(
           systemId,
           sessionId: COMMENT_UPDATE_PLACEHOLDER_SESSION,
           commentId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -522,7 +509,7 @@ export async function createE2EPersister(
         await trpcClient.note.update.mutate({
           systemId,
           noteId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -530,7 +517,7 @@ export async function createE2EPersister(
         await trpcClient.poll.update.mutate({
           systemId,
           pollId: existingId,
-          encryptedData: encryptForApi(entity.payload.poll, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -538,7 +525,7 @@ export async function createE2EPersister(
         await trpcClient.channel.update.mutate({
           systemId,
           channelId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -546,7 +533,7 @@ export async function createE2EPersister(
         await trpcClient.channel.update.mutate({
           systemId,
           channelId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -555,7 +542,7 @@ export async function createE2EPersister(
           systemId,
           channelId: MESSAGE_UPDATE_PLACEHOLDER_CHANNEL,
           messageId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;
@@ -563,7 +550,7 @@ export async function createE2EPersister(
         await trpcClient.boardMessage.update.mutate({
           systemId,
           boardMessageId: existingId,
-          encryptedData: encryptForApi(entity.payload, masterKey),
+          encryptedData: encryptForApi(entity.payload.encrypted, masterKey),
           version,
         });
         break;

--- a/packages/import-sp/src/__tests__/e2e/entity-assertions.ts
+++ b/packages/import-sp/src/__tests__/e2e/entity-assertions.ts
@@ -342,6 +342,10 @@ export async function assertBoardMessages(
     const raw = await trpc.boardMessage.get.query({ systemId, boardMessageId });
     const decrypted = decryptBoardMessage(raw, masterKey);
 
-    expect(decrypted.content, `${entry.ref}: content`).toBe(entry.fields["message"]);
+    // The board-message mapper combines title + body into a single content field
+    const title = entry.fields["title"] as string | undefined;
+    const message = entry.fields["message"] as string;
+    const expectedContent = title ? `# ${title}\n\n${message}` : message;
+    expect(decrypted.content, `${entry.ref}: content`).toBe(expectedContent);
   }
 }

--- a/packages/import-sp/src/__tests__/e2e/entity-assertions.ts
+++ b/packages/import-sp/src/__tests__/e2e/entity-assertions.ts
@@ -1,0 +1,347 @@
+/**
+ * E2E entity assertion helpers for verifying imported SP data.
+ *
+ * Each function looks up Pluralscape entity IDs via `importEntityRef.lookupBatch`,
+ * fetches entities via tRPC `.get` endpoints, decrypts `encryptedData` using
+ * transforms from `@pluralscape/data`, and asserts that mapped fields match
+ * the manifest expectations.
+ */
+import {
+  decodeAndDecryptT1,
+  decryptBoardMessage,
+  decryptChannel,
+  decryptCustomFront,
+  decryptFieldDefinition,
+  decryptFrontingComment,
+  decryptFrontingSession,
+  decryptGroup,
+  decryptMember,
+  decryptMessage,
+  decryptNote,
+  decryptPoll,
+} from "@pluralscape/data";
+import { expect } from "vitest";
+
+import type { TRPCClient } from "./e2e-helpers.js";
+import type { Manifest, ManifestEntry } from "../integration/manifest.types.js";
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { ImportCollectionType, SystemId } from "@pluralscape/types";
+
+// ── Ref lookup helper ──────────────────────────────────────────────────
+
+/**
+ * Look up a batch of SP source IDs and return the mapping from source ID
+ * to Pluralscape entity ID. Asserts that every source ID was resolved.
+ */
+async function lookupRefs(
+  trpc: TRPCClient,
+  systemId: SystemId,
+  sourceEntityType: ImportCollectionType,
+  entries: readonly ManifestEntry[],
+): Promise<Record<string, string>> {
+  if (entries.length === 0) return {};
+
+  const sourceIds = entries.map((e) => e.sourceId);
+  const result = await trpc.importEntityRef.lookupBatch.mutate({
+    systemId,
+    source: "simply-plural",
+    sourceEntityType,
+    sourceEntityIds: sourceIds,
+  });
+
+  expect(
+    Object.keys(result).length,
+    `expected all ${String(entries.length)} ${sourceEntityType} refs to be stored`,
+  ).toBe(entries.length);
+
+  return result;
+}
+
+/**
+ * Resolve a single SP source ID to a Pluralscape ID via lookupBatch.
+ */
+async function lookupSingleRef(
+  trpc: TRPCClient,
+  systemId: SystemId,
+  sourceEntityType: ImportCollectionType,
+  sourceId: string,
+): Promise<string> {
+  const result = await trpc.importEntityRef.lookupBatch.mutate({
+    systemId,
+    source: "simply-plural",
+    sourceEntityType,
+    sourceEntityIds: [sourceId],
+  });
+  const psId = result[sourceId];
+  expect(psId, `expected ref for ${sourceEntityType} ${sourceId} to exist`).toBeDefined();
+  // The expect above guarantees psId is defined; narrow with a guard.
+  if (psId === undefined) throw new Error("unreachable: ref lookup failed after assertion");
+  return psId;
+}
+
+/**
+ * Safely retrieve a Pluralscape ID from a ref lookup result.
+ * Throws a descriptive error if the ref is missing.
+ */
+function requireRef(refs: Record<string, string>, sourceId: string, label: string): string {
+  const id = refs[sourceId];
+  if (id === undefined) {
+    throw new Error(`missing ref for ${label} sourceId=${sourceId}`);
+  }
+  return id;
+}
+
+// ── Per-entity-type assertions ─────────────────────────────────────────
+
+export async function assertMembers(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "member", manifest.members);
+
+  for (const entry of manifest.members) {
+    const memberId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.member.get.query({ systemId, memberId });
+    const decrypted = decryptMember(raw, masterKey);
+
+    expect(decrypted.name, `${entry.ref}: name`).toBe(entry.fields["name"]);
+  }
+}
+
+export async function assertGroups(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "group", manifest.groups);
+
+  for (const entry of manifest.groups) {
+    const groupId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.group.get.query({ systemId, groupId });
+    const decrypted = decryptGroup(raw, masterKey);
+
+    expect(decrypted.name, `${entry.ref}: name`).toBe(entry.fields["name"]);
+    if (entry.fields["desc"] !== undefined) {
+      expect(decrypted.description, `${entry.ref}: description`).toBe(entry.fields["desc"]);
+    }
+  }
+}
+
+export async function assertCustomFronts(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "custom-front", manifest.customFronts);
+
+  for (const entry of manifest.customFronts) {
+    const customFrontId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.customFront.get.query({ systemId, customFrontId });
+    const decrypted = decryptCustomFront(raw, masterKey);
+
+    expect(decrypted.name, `${entry.ref}: name`).toBe(entry.fields["name"]);
+  }
+}
+
+export async function assertFieldDefinitions(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "field-definition", manifest.customFields);
+
+  for (const entry of manifest.customFields) {
+    const fieldDefinitionId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.field.definition.get.query({ systemId, fieldDefinitionId });
+    const decrypted = decryptFieldDefinition(raw, masterKey);
+
+    expect(decrypted.name, `${entry.ref}: name`).toBe(entry.fields["name"]);
+  }
+}
+
+export async function assertPrivacyBuckets(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "privacy-bucket", manifest.privacyBuckets);
+
+  for (const entry of manifest.privacyBuckets) {
+    const bucketId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.bucket.get.query({ systemId, bucketId });
+    // Privacy buckets are stored encrypted on the server; decrypt manually.
+    const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey) as Record<string, unknown>;
+
+    expect(decrypted["name"], `${entry.ref}: name`).toBe(entry.fields["name"]);
+  }
+}
+
+export async function assertFrontingSessions(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "fronting-session", manifest.frontHistory);
+
+  for (const entry of manifest.frontHistory) {
+    const sessionId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.frontingSession.get.query({ systemId, sessionId });
+    const decrypted = decryptFrontingSession(raw, masterKey);
+
+    if (entry.fields["startTime"] !== undefined) {
+      expect(decrypted.startTime, `${entry.ref}: startTime`).toBe(entry.fields["startTime"]);
+    }
+  }
+}
+
+export async function assertFrontingComments(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "fronting-comment", manifest.comments);
+
+  for (const entry of manifest.comments) {
+    const commentId = requireRef(refs, entry.sourceId, entry.ref);
+
+    // Fronting comment get requires sessionId — resolve the parent front
+    // history document's SP source ID to a Pluralscape fronting session ID.
+    const documentId = entry.fields["documentId"];
+    expect(documentId, `${entry.ref}: manifest must have documentId`).toBeDefined();
+    const sessionId = await lookupSingleRef(
+      trpc,
+      systemId,
+      "fronting-session",
+      documentId as string,
+    );
+
+    const raw = await trpc.frontingComment.get.query({ systemId, sessionId, commentId });
+    const decrypted = decryptFrontingComment(raw, masterKey);
+
+    expect(decrypted.content, `${entry.ref}: content`).toBe(entry.fields["text"]);
+  }
+}
+
+export async function assertNotes(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "journal-entry", manifest.notes);
+
+  for (const entry of manifest.notes) {
+    const noteId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.note.get.query({ systemId, noteId });
+    const decrypted = decryptNote(raw, masterKey);
+
+    if (entry.fields["title"] !== undefined) {
+      expect(decrypted.title, `${entry.ref}: title`).toBe(entry.fields["title"]);
+    }
+    if (entry.fields["note"] !== undefined) {
+      expect(decrypted.content, `${entry.ref}: content`).toBe(entry.fields["note"]);
+    }
+  }
+}
+
+export async function assertPolls(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "poll", manifest.polls);
+
+  for (const entry of manifest.polls) {
+    const pollId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.poll.get.query({ systemId, pollId });
+    const decrypted = decryptPoll(raw, masterKey);
+
+    expect(decrypted.title, `${entry.ref}: title`).toBe(entry.fields["name"]);
+  }
+}
+
+export async function assertChannelCategories(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "channel-category", manifest.channelCategories);
+
+  for (const entry of manifest.channelCategories) {
+    const channelId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.channel.get.query({ systemId, channelId });
+    const decrypted = decryptChannel(raw, masterKey);
+
+    expect(decrypted.name, `${entry.ref}: name`).toBe(entry.fields["name"]);
+    expect(decrypted.type, `${entry.ref}: type`).toBe("category");
+  }
+}
+
+export async function assertChannels(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "channel", manifest.channels);
+
+  for (const entry of manifest.channels) {
+    const channelId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.channel.get.query({ systemId, channelId });
+    const decrypted = decryptChannel(raw, masterKey);
+
+    expect(decrypted.name, `${entry.ref}: name`).toBe(entry.fields["name"]);
+    expect(decrypted.type, `${entry.ref}: type`).toBe("channel");
+  }
+}
+
+export async function assertChatMessages(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "chat-message", manifest.chatMessages);
+
+  for (const entry of manifest.chatMessages) {
+    const messageId = requireRef(refs, entry.sourceId, entry.ref);
+
+    // Chat message get requires channelId — resolve the parent channel's
+    // SP source ID to a Pluralscape channel ID.
+    const channelSourceId = entry.fields["channel"];
+    expect(channelSourceId, `${entry.ref}: manifest must have channel`).toBeDefined();
+    const channelId = await lookupSingleRef(trpc, systemId, "channel", channelSourceId as string);
+
+    const raw = await trpc.message.get.query({ systemId, channelId, messageId });
+    const decrypted = decryptMessage(raw, masterKey);
+
+    expect(decrypted.content, `${entry.ref}: content`).toBe(entry.fields["message"]);
+  }
+}
+
+export async function assertBoardMessages(
+  trpc: TRPCClient,
+  masterKey: KdfMasterKey,
+  systemId: SystemId,
+  manifest: Manifest,
+): Promise<void> {
+  const refs = await lookupRefs(trpc, systemId, "board-message", manifest.boardMessages);
+
+  for (const entry of manifest.boardMessages) {
+    const boardMessageId = requireRef(refs, entry.sourceId, entry.ref);
+    const raw = await trpc.boardMessage.get.query({ systemId, boardMessageId });
+    const decrypted = decryptBoardMessage(raw, masterKey);
+
+    expect(decrypted.content, `${entry.ref}: content`).toBe(entry.fields["message"]);
+  }
+}

--- a/packages/import-sp/src/__tests__/e2e/sp-import.e2e.test.ts
+++ b/packages/import-sp/src/__tests__/e2e/sp-import.e2e.test.ts
@@ -28,6 +28,21 @@ import {
   makeTrpcClient,
   registerTestAccount,
 } from "./e2e-helpers.js";
+import {
+  assertMembers,
+  assertGroups,
+  assertCustomFronts,
+  assertFieldDefinitions,
+  assertPrivacyBuckets,
+  assertFrontingSessions,
+  assertFrontingComments,
+  assertNotes,
+  assertPolls,
+  assertChannelCategories,
+  assertChannels,
+  assertChatMessages,
+  assertBoardMessages,
+} from "./entity-assertions.js";
 
 import type { E2EPersisterContext, TRPCClient } from "./e2e-helpers.js";
 import type { ImportRunResult } from "../../engine/import-engine.js";
@@ -59,60 +74,6 @@ function hasExportFixtures(): boolean {
 
 function noopProgress(): Promise<void> {
   return Promise.resolve();
-}
-
-// ── Assertion helpers ───────────────────────────────────────────────
-
-/**
- * Verify that import entity refs were created for every manifest entry.
- * Since data is encrypted, we verify entity COUNTS and ref existence
- * rather than field values.
- */
-async function assertImportRefsExist(
-  trpc: TRPCClient,
-  systemId: string,
-  manifest: Manifest,
-  createdCount: number,
-): Promise<void> {
-  // The import should have created at least as many entities as
-  // the manifest describes (system-profile/system-settings are updates, not creates).
-  // We check that the created count is positive and in a reasonable range.
-  expect(createdCount).toBeGreaterThan(0);
-
-  // Verify import entity refs for a sample of entity types via lookupBatch.
-  // Members are the most important — every import must have at least one.
-  if (manifest.members.length > 0) {
-    const memberSourceIds = manifest.members.map((m) => m.sourceId);
-    const result = await trpc.importEntityRef.lookupBatch.mutate({
-      systemId: systemId as Parameters<
-        typeof trpc.importEntityRef.lookupBatch.mutate
-      >[0]["systemId"],
-      source: "simply-plural",
-      sourceEntityType: "member",
-      sourceEntityIds: memberSourceIds,
-    });
-    expect(
-      Object.keys(result).length,
-      `expected all ${String(manifest.members.length)} member refs to be stored`,
-    ).toBe(manifest.members.length);
-  }
-
-  // Spot-check custom fronts
-  if (manifest.customFronts.length > 0) {
-    const cfSourceIds = manifest.customFronts.map((cf) => cf.sourceId);
-    const result = await trpc.importEntityRef.lookupBatch.mutate({
-      systemId: systemId as Parameters<
-        typeof trpc.importEntityRef.lookupBatch.mutate
-      >[0]["systemId"],
-      source: "simply-plural",
-      sourceEntityType: "custom-front",
-      sourceEntityIds: cfSourceIds,
-    });
-    expect(
-      Object.keys(result).length,
-      `expected all ${String(manifest.customFronts.length)} custom-front refs to be stored`,
-    ).toBe(manifest.customFronts.length);
-  }
 }
 
 // ── Parameterized import suite ──────────────────────────────────────
@@ -181,24 +142,61 @@ function defineImportSuite(
       expect(ctx.getCreatedCount()).toBeGreaterThan(0);
     });
 
-    it("import entity refs are stored for all manifest entries", async () => {
-      await assertImportRefsExist(trpc, ctx.systemId, manifest, ctx.getCreatedCount());
+    // ── Per-entity-type field value assertions ───────────────────────
+
+    it("members have correct field values", async () => {
+      await assertMembers(trpc, ctx.masterKey, ctx.systemId, manifest);
     });
 
-    if (sourceLabel === "file") {
-      it("fronting session refs are stored", async () => {
-        if (manifest.frontHistory.length === 0) return;
+    it("groups have correct field values", async () => {
+      await assertGroups(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
 
-        const sourceIds = manifest.frontHistory.map((fh) => fh.sourceId);
-        const refs = await trpc.importEntityRef.lookupBatch.mutate({
-          systemId: ctx.systemId as Parameters<
-            typeof trpc.importEntityRef.lookupBatch.mutate
-          >[0]["systemId"],
-          source: "simply-plural",
-          sourceEntityType: "fronting-session",
-          sourceEntityIds: sourceIds,
-        });
-        expect(Object.keys(refs).length).toBe(manifest.frontHistory.length);
+    it("custom fronts have correct field values", async () => {
+      await assertCustomFronts(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    it("field definitions have correct field values", async () => {
+      await assertFieldDefinitions(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    it("privacy buckets have correct field values", async () => {
+      await assertPrivacyBuckets(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    it("fronting sessions have correct field values", async () => {
+      await assertFrontingSessions(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    it("notes have correct field values", async () => {
+      await assertNotes(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    it("polls have correct field values", async () => {
+      await assertPolls(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    it("channel categories have correct field values", async () => {
+      await assertChannelCategories(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    it("channels have correct field values", async () => {
+      await assertChannels(trpc, ctx.masterKey, ctx.systemId, manifest);
+    });
+
+    // File-only entity types (comments, chat messages, board messages
+    // are only present in file-source fixtures, not live API exports).
+    if (sourceLabel === "file") {
+      it("fronting comments have correct field values", async () => {
+        await assertFrontingComments(trpc, ctx.masterKey, ctx.systemId, manifest);
+      });
+
+      it("chat messages have correct field values", async () => {
+        await assertChatMessages(trpc, ctx.masterKey, ctx.systemId, manifest);
+      });
+
+      it("board messages have correct field values", async () => {
+        await assertBoardMessages(trpc, ctx.masterKey, ctx.systemId, manifest);
       });
     }
   });

--- a/packages/import-sp/src/__tests__/engine/legacy-bucket-synthesis.engine.test.ts
+++ b/packages/import-sp/src/__tests__/engine/legacy-bucket-synthesis.engine.test.ts
@@ -28,7 +28,7 @@ import { createFakeImportSource } from "../../sources/fake-source.js";
 import { createFileImportSource } from "../../sources/file-source.js";
 import { createInMemoryPersister } from "../helpers/in-memory-persister.js";
 
-import type { MappedMemberOutput } from "../../mappers/member.mapper.js";
+import type { MappedMember } from "../../mappers/member.mapper.js";
 
 const TEST_FILE_DIR = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = join(
@@ -87,10 +87,10 @@ describe("import engine — legacy bucket synthesis", () => {
     // Each member carries the *resolved* Pluralscape bucket IDs derived from
     // its legacy privacy flags. See `deriveBucketSourceIds` in
     // `member.mapper.ts`, then resolved via `ctx.translate(...)`.
-    const memberPrivate = state.find("member", "m_00000001")?.payload as MappedMemberOutput;
-    const memberPrevented = state.find("member", "m_00000002")?.payload as MappedMemberOutput;
-    const memberPublic = state.find("member", "m_00000003")?.payload as MappedMemberOutput;
-    const memberDefault = state.find("member", "m_00000004")?.payload as MappedMemberOutput;
+    const memberPrivate = state.find("member", "m_00000001")?.payload as MappedMember;
+    const memberPrevented = state.find("member", "m_00000002")?.payload as MappedMember;
+    const memberPublic = state.find("member", "m_00000003")?.payload as MappedMember;
+    const memberDefault = state.find("member", "m_00000004")?.payload as MappedMember;
 
     // Look up the resolved Pluralscape IDs for each synthesized bucket so we
     // can compare the member's `bucketIds` against the actual FK values.

--- a/packages/import-sp/src/__tests__/engine/supply-parent-ids.test.ts
+++ b/packages/import-sp/src/__tests__/engine/supply-parent-ids.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { emptyCheckpointState } from "../../engine/checkpoint.js";
+import { collectionToEntityType } from "../../engine/entity-type-map.js";
+import { runImport } from "../../engine/import-engine.js";
+import { createFakeImportSource } from "../../sources/fake-source.js";
+
+import type { Persister } from "../../persistence/persister.types.js";
+
+/** Find the first mock call whose first argument matches the given collection name. */
+function findCallForCollection(calls: readonly unknown[][], name: string): unknown[] | undefined {
+  return calls.find((call) => call[0] === name);
+}
+
+function noopProgress(): Promise<void> {
+  return Promise.resolve();
+}
+
+function makeMockPersister(): Persister {
+  let nextId = 1;
+  return {
+    upsertEntity() {
+      const id = `ps-${String(nextId++)}`;
+      return Promise.resolve({ action: "created" as const, pluralscapeEntityId: id });
+    },
+    async recordError() {},
+    async flush() {},
+  };
+}
+
+describe("engine supplyParentIds integration", () => {
+  it("calls supplyParentIds on the source after completing a collection with processed docs", async () => {
+    const supplyParentIds = vi.fn();
+
+    const source = createFakeImportSource({
+      members: [
+        { _id: "m1", name: "Alice" },
+        { _id: "m2", name: "Bob" },
+      ],
+    });
+
+    // Monkey-patch supplyParentIds onto the fake source
+    (source as { supplyParentIds?: typeof supplyParentIds }).supplyParentIds = supplyParentIds;
+
+    await runImport({
+      source,
+      persister: makeMockPersister(),
+      initialCheckpoint: emptyCheckpointState({
+        firstEntityType: collectionToEntityType("users"),
+        selectedCategories: {},
+        avatarMode: "skip",
+      }),
+      options: { selectedCategories: {}, avatarMode: "skip" },
+      onProgress: noopProgress,
+    });
+
+    // The engine should have called supplyParentIds for "members" with ["m1", "m2"]
+    const memberCall = findCallForCollection(supplyParentIds.mock.calls, "members");
+    if (memberCall === undefined) {
+      expect.fail("supplyParentIds should have been called for members");
+    }
+    const sourceIds = memberCall[1] as readonly string[];
+    expect(sourceIds).toContain("m1");
+    expect(sourceIds).toContain("m2");
+  });
+
+  it("does not call supplyParentIds for collections with zero successfully persisted docs", async () => {
+    const supplyParentIds = vi.fn();
+
+    // Source with an empty members collection — no docs to persist
+    const source = createFakeImportSource({
+      members: [],
+    });
+
+    (source as { supplyParentIds?: typeof supplyParentIds }).supplyParentIds = supplyParentIds;
+
+    await runImport({
+      source,
+      persister: makeMockPersister(),
+      initialCheckpoint: emptyCheckpointState({
+        firstEntityType: collectionToEntityType("users"),
+        selectedCategories: {},
+        avatarMode: "skip",
+      }),
+      options: { selectedCategories: {}, avatarMode: "skip" },
+      onProgress: noopProgress,
+    });
+
+    // No docs were persisted for members, so supplyParentIds should not be called for it
+    const memberCall = findCallForCollection(supplyParentIds.mock.calls, "members");
+    expect(memberCall).toBeUndefined();
+  });
+
+  it("excludes failed docs from the supplied source IDs", async () => {
+    const supplyParentIds = vi.fn();
+
+    const source = createFakeImportSource({
+      members: [
+        { _id: "m1", name: "Alice" },
+        // m2 has no name — mapper will fail validation
+        { _id: "m2" },
+        { _id: "m3", name: "Cass" },
+      ],
+    });
+
+    (source as { supplyParentIds?: typeof supplyParentIds }).supplyParentIds = supplyParentIds;
+
+    await runImport({
+      source,
+      persister: makeMockPersister(),
+      initialCheckpoint: emptyCheckpointState({
+        firstEntityType: collectionToEntityType("users"),
+        selectedCategories: {},
+        avatarMode: "skip",
+      }),
+      options: { selectedCategories: {}, avatarMode: "skip" },
+      onProgress: noopProgress,
+    });
+
+    const memberCall = findCallForCollection(supplyParentIds.mock.calls, "members");
+    if (memberCall === undefined) {
+      expect.fail("supplyParentIds should have been called for members");
+    }
+    const sourceIds = memberCall[1] as readonly string[];
+    // m1 and m3 should be present (successfully persisted); m2 should not
+    expect(sourceIds).toContain("m1");
+    expect(sourceIds).toContain("m3");
+    expect(sourceIds).not.toContain("m2");
+  });
+});

--- a/packages/import-sp/src/__tests__/helpers/in-memory-persister.test.ts
+++ b/packages/import-sp/src/__tests__/helpers/in-memory-persister.test.ts
@@ -23,22 +23,32 @@ import type { MappedMember } from "../../mappers/member.mapper.js";
 import type { PersistableEntity } from "../../persistence/persister.types.js";
 
 const MEMBER_PAYLOAD: MappedMember = {
-  member: {
+  encrypted: {
     name: "Alex",
     description: null,
-    pronouns: null,
+    pronouns: [],
+    avatarSource: null,
     colors: [],
-    avatarUrl: null,
-    archived: false,
+    saturationLevel: { kind: "known", level: "highly-elaborated" },
+    tags: [],
+    suppressFriendFrontNotification: false,
+    boardMessageNotificationOnFront: false,
   },
+  archived: false,
   fieldValues: [],
   bucketIds: [],
 };
 
 const GROUP_PAYLOAD: MappedGroup = {
-  name: "Pod",
-  description: null,
-  color: null,
+  encrypted: {
+    name: "Pod",
+    description: null,
+    imageSource: null,
+    color: null,
+    emoji: null,
+  },
+  parentGroupId: null,
+  sortOrder: 0,
   memberIds: [],
 };
 
@@ -78,7 +88,7 @@ describe("in-memory persister enhancements", () => {
     const first = await persister.upsertEntity(memberEntity("sp_1", MEMBER_PAYLOAD));
     const updatedPayload: MappedMember = {
       ...MEMBER_PAYLOAD,
-      member: { ...MEMBER_PAYLOAD.member, name: "Alex Renamed" },
+      encrypted: { ...MEMBER_PAYLOAD.encrypted, name: "Alex Renamed" },
     };
     const second = await persister.upsertEntity(memberEntity("sp_1", updatedPayload));
 

--- a/packages/import-sp/src/__tests__/integration/sp-import.integration.test.ts
+++ b/packages/import-sp/src/__tests__/integration/sp-import.integration.test.ts
@@ -17,7 +17,7 @@ import { createRecordingPersister } from "./recording-persister.js";
 
 import type { Manifest, ManifestCollectionKey } from "./manifest.types.js";
 import type { RecordingSnapshot } from "./recording-persister.js";
-import type { MappedMemberOutput } from "../../mappers/member.mapper.js";
+import type { MappedMember } from "../../mappers/member.mapper.js";
 import type { ImportDataSource } from "../../sources/source.types.js";
 import type { ImportCheckpointState } from "@pluralscape/types";
 
@@ -100,14 +100,13 @@ function assertAllEntitiesPresent(
  */
 
 /**
- * The member mapper wraps the core member fields inside a `member` sub-object
- * (alongside `fieldValues` and `bucketIds`). This helper navigates that
- * structure for payload spot-checks.
+ * The member mapper outputs `{ encrypted, archived, fieldValues, bucketIds }`.
+ * This helper navigates that structure for payload spot-checks.
  */
 function memberName(payload: unknown): string | undefined {
   if (payload === null || typeof payload !== "object") return undefined;
-  const outer = payload as MappedMemberOutput;
-  return outer.member.name;
+  const outer = payload as MappedMember;
+  return outer.encrypted.name;
 }
 
 function assertPayloadSpotChecks(

--- a/packages/import-sp/src/__tests__/mappers/board-message.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/board-message.mapper.test.ts
@@ -19,10 +19,11 @@ describe("mapBoardMessage", () => {
     const result = mapBoardMessage(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.title).toBe("Announcement");
-      expect(result.payload.body).toBe("hello everyone");
-      expect(result.payload.authorMemberId).toBe("ps_m1");
+      expect(result.payload.encrypted.content).toBe("# Announcement\n\nhello everyone");
+      expect(result.payload.encrypted.senderId).toBe("ps_m1");
       expect(result.payload.createdAt).toBe(1_234);
+      expect(result.payload.sortOrder).toBe(0);
+      expect(result.payload.pinned).toBe(false);
     }
   });
 
@@ -56,8 +57,8 @@ describe("mapBoardMessage", () => {
     const result = mapBoardMessage(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.title).toBe("Specific Title!");
-      expect(result.payload.body).toBe("multi\nline\nbody");
+      expect(result.payload.encrypted.content).toBe("# Specific Title!\n\nmulti\nline\nbody");
+      expect(result.payload.encrypted.senderId).toBe("ps_m1");
       expect(result.payload.createdAt).toBe(42);
     }
   });

--- a/packages/import-sp/src/__tests__/mappers/bucket.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/bucket.mapper.test.ts
@@ -12,14 +12,12 @@ describe("mapBucket", () => {
     const result = mapBucket(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.name).toBe("Trusted");
-      expect(result.payload.color).toBeNull();
-      expect(result.payload.description).toBeNull();
-      expect(result.payload.icon).toBeNull();
+      expect(result.payload.encrypted.name).toBe("Trusted");
+      expect(result.payload.encrypted.description).toBeNull();
     }
   });
 
-  it("preserves desc and color", () => {
+  it("preserves desc", () => {
     const sp: SPPrivacyBucket = {
       _id: "bk2",
       name: "Inner Circle",
@@ -30,8 +28,7 @@ describe("mapBucket", () => {
     const result = mapBucket(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.description).toBe("for close friends");
-      expect(result.payload.color).toBe("#aabbcc");
+      expect(result.payload.encrypted.description).toBe("for close friends");
     }
   });
 

--- a/packages/import-sp/src/__tests__/mappers/channel.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/channel.mapper.test.ts
@@ -12,15 +12,14 @@ describe("mapChannelCategory", () => {
     const result = mapChannelCategory(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.name).toBe("General");
+      expect(result.payload.encrypted.name).toBe("General");
       expect(result.payload.type).toBe("category");
-      expect(result.payload.parentChannelId).toBeNull();
-      expect(result.payload.description).toBeNull();
-      expect(result.payload.order).toBeNull();
+      expect(result.payload.parentId).toBeUndefined();
+      expect(result.payload.sortOrder).toBe(0);
     }
   });
 
-  it("preserves description and order on categories", () => {
+  it("preserves order on categories", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     const sp: SPChannelCategory = {
       _id: "cat2",
@@ -31,8 +30,7 @@ describe("mapChannelCategory", () => {
     const result = mapChannelCategory(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.description).toBe("creative stuff");
-      expect(result.payload.order).toBe(3);
+      expect(result.payload.sortOrder).toBe(3);
     }
   });
 
@@ -59,7 +57,7 @@ describe("mapChannel", () => {
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
       expect(result.payload.type).toBe("channel");
-      expect(result.payload.parentChannelId).toBe("ps_cat1");
+      expect(result.payload.parentId).toBe("ps_cat1");
     }
   });
 
@@ -69,7 +67,7 @@ describe("mapChannel", () => {
     const result = mapChannel(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.parentChannelId).toBeNull();
+      expect(result.payload.parentId).toBeUndefined();
     }
     expect(ctx.warnings).toHaveLength(0);
   });
@@ -85,12 +83,12 @@ describe("mapChannel", () => {
     expect(result.status).toBe("failed");
     if (result.status === "failed") {
       expect(result.kind).toBe("fk-miss");
-      expect(result.targetField).toBe("parentChannelId");
+      expect(result.targetField).toBe("parentId");
       expect(result.missingRefs).toContain("src_missing");
     }
   });
 
-  it("preserves description and order on channels", () => {
+  it("preserves order on channels", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     const sp: SPChannel = {
       _id: "ch4",
@@ -102,8 +100,7 @@ describe("mapChannel", () => {
     const result = mapChannel(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.description).toBe("voice chat");
-      expect(result.payload.order).toBe(7);
+      expect(result.payload.sortOrder).toBe(7);
     }
   });
 });

--- a/packages/import-sp/src/__tests__/mappers/chat-message.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/chat-message.mapper.test.ts
@@ -21,10 +21,12 @@ describe("mapChatMessage", () => {
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
       expect(result.payload.channelId).toBe("ps_ch1");
-      expect(result.payload.writerMemberId).toBe("ps_m1");
-      expect(result.payload.body).toBe("hi");
-      expect(result.payload.createdAt).toBe(1_000);
-      expect(result.payload.replyToChatMessageId).toBeNull();
+      expect(result.payload.encrypted.senderId).toBe("ps_m1");
+      expect(result.payload.encrypted.content).toBe("hi");
+      expect(result.payload.encrypted.attachments).toEqual([]);
+      expect(result.payload.encrypted.mentions).toEqual([]);
+      expect(result.payload.timestamp).toBe(1_000);
+      expect(result.payload.replyToId).toBeUndefined();
     }
   });
 
@@ -78,7 +80,7 @@ describe("mapChatMessage", () => {
     const result = mapChatMessage(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.replyToChatMessageId).toBe("ps_parent");
+      expect(result.payload.replyToId).toBe("ps_parent");
     }
   });
 });
@@ -143,7 +145,7 @@ describe("chat-message FK-miss handling", () => {
 
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.replyToChatMessageId).toBe("ps_parent");
+      expect(result.payload.replyToId).toBe("ps_parent");
     }
   });
 });

--- a/packages/import-sp/src/__tests__/mappers/context.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/context.test.ts
@@ -83,6 +83,35 @@ describe("MappingContext", () => {
     ctx.addWarningOnce("kind", { entityType: "member", entityId: "d", message: "once" });
     expect(ctx.warnings).toHaveLength(3);
   });
+
+  it("storeMetadata / getMetadata round-trips a value", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    ctx.storeMetadata("fronting-session", "fh1", "memberId", "mem_abc");
+    expect(ctx.getMetadata("fronting-session", "fh1", "memberId")).toBe("mem_abc");
+  });
+
+  it("getMetadata returns undefined for unstored keys", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    expect(ctx.getMetadata("fronting-session", "fh1", "memberId")).toBeUndefined();
+  });
+
+  it("metadata is scoped by entity type, source ID, and key", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    ctx.storeMetadata("fronting-session", "fh1", "memberId", "mem_1");
+    ctx.storeMetadata("fronting-session", "fh1", "customFrontId", "cf_1");
+    ctx.storeMetadata("fronting-session", "fh2", "memberId", "mem_2");
+    expect(ctx.getMetadata("fronting-session", "fh1", "memberId")).toBe("mem_1");
+    expect(ctx.getMetadata("fronting-session", "fh1", "customFrontId")).toBe("cf_1");
+    expect(ctx.getMetadata("fronting-session", "fh2", "memberId")).toBe("mem_2");
+    expect(ctx.getMetadata("fronting-session", "fh2", "customFrontId")).toBeUndefined();
+  });
+
+  it("storeMetadata overwrites previous values for the same key", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    ctx.storeMetadata("member", "m1", "tag", "first");
+    ctx.storeMetadata("member", "m1", "tag", "second");
+    expect(ctx.getMetadata("member", "m1", "tag")).toBe("second");
+  });
 });
 
 describe("warnings buffer truncation", () => {

--- a/packages/import-sp/src/__tests__/mappers/custom-front.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/custom-front.mapper.test.ts
@@ -11,14 +11,14 @@ describe("mapCustomFront", () => {
     const result = mapCustomFront(sp, createMappingContext({ sourceMode: "fake" }));
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.name).toBe("Tired");
-      expect(result.payload.description).toBeNull();
-      expect(result.payload.color).toBeNull();
-      expect(result.payload.avatarUrl).toBeNull();
+      expect(result.payload.encrypted.name).toBe("Tired");
+      expect(result.payload.encrypted.description).toBeNull();
+      expect(result.payload.encrypted.color).toBeNull();
+      expect(result.payload.encrypted.emoji).toBeNull();
     }
   });
 
-  it("preserves desc, color, and avatarUrl", () => {
+  it("preserves desc and color", () => {
     const sp: SPFrontStatus = {
       _id: "fs2",
       name: "Dissociated",
@@ -29,9 +29,8 @@ describe("mapCustomFront", () => {
     const result = mapCustomFront(sp, createMappingContext({ sourceMode: "fake" }));
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.description).toBe("blurry");
-      expect(result.payload.color).toBe("#888");
-      expect(result.payload.avatarUrl).toBe("https://example.com/x.png");
+      expect(result.payload.encrypted.description).toBe("blurry");
+      expect(result.payload.encrypted.color).toBe("#888");
     }
   });
 

--- a/packages/import-sp/src/__tests__/mappers/field-definition.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/field-definition.mapper.test.ts
@@ -11,25 +11,12 @@ describe("mapFieldDefinition", () => {
     const result = mapFieldDefinition(sp, createMappingContext({ sourceMode: "fake" }));
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.name).toBe("Likes");
+      expect(result.payload.encrypted.name).toBe("Likes");
+      expect(result.payload.encrypted.description).toBeNull();
+      expect(result.payload.encrypted.options).toBeNull();
       expect(result.payload.fieldType).toBe("text");
-      expect(result.payload.order).toBe(0);
-      expect(result.payload.supportMarkdown).toBe(false);
-    }
-  });
-
-  it("preserves supportMarkdown when set", () => {
-    const sp: SPCustomField = {
-      _id: "f2",
-      name: "Bio",
-      type: 0,
-      order: "a00000",
-      supportMarkdown: true,
-    };
-    const result = mapFieldDefinition(sp, createMappingContext({ sourceMode: "fake" }));
-    expect(result.status).toBe("mapped");
-    if (result.status === "mapped") {
-      expect(result.payload.supportMarkdown).toBe(true);
+      expect(result.payload.sortOrder).toBe(0);
+      expect(result.payload.required).toBe(false);
     }
   });
 
@@ -70,7 +57,7 @@ describe("mapFieldDefinition", () => {
     const low = mapFieldDefinition({ _id: "fa", name: "A", type: 0, order: "a00000" }, ctx);
     const high = mapFieldDefinition({ _id: "fb", name: "B", type: 0, order: "b00000" }, ctx);
     if (low.status === "mapped" && high.status === "mapped") {
-      expect(low.payload.order).toBeLessThan(high.payload.order);
+      expect(low.payload.sortOrder).toBeLessThan(high.payload.sortOrder);
     }
   });
 
@@ -80,7 +67,7 @@ describe("mapFieldDefinition", () => {
     const result = mapFieldDefinition(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.order).toBe(42);
+      expect(result.payload.sortOrder).toBe(42);
     }
   });
 
@@ -90,7 +77,7 @@ describe("mapFieldDefinition", () => {
     const result = mapFieldDefinition(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.order).toBe(parseInt("a00000", 36));
+      expect(result.payload.sortOrder).toBe(parseInt("a00000", 36));
     }
   });
 
@@ -100,7 +87,7 @@ describe("mapFieldDefinition", () => {
     const result = mapFieldDefinition(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.order).toBe(0);
+      expect(result.payload.sortOrder).toBe(0);
     }
   });
 
@@ -110,7 +97,7 @@ describe("mapFieldDefinition", () => {
     const result = mapFieldDefinition(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.order).toBe(0);
+      expect(result.payload.sortOrder).toBe(0);
     }
     const orderWarning = ctx.warnings.find((w) => /order/i.test(w.message) && w.entityId === "f4");
     expect(orderWarning).toBeDefined();

--- a/packages/import-sp/src/__tests__/mappers/fronting-comment.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/fronting-comment.mapper.test.ts
@@ -5,10 +5,22 @@ import { mapFrontingComment } from "../../mappers/fronting-comment.mapper.js";
 
 import type { SPComment } from "../../sources/sp-types.js";
 
+/** Register a fronting session and store its subject metadata, mirroring what the session mapper does. */
+function registerSessionWithSubject(
+  ctx: ReturnType<typeof createMappingContext>,
+  sourceId: string,
+  pluralscapeId: string,
+  subject: { memberId?: string; customFrontId?: string },
+): void {
+  ctx.register("fronting-session", sourceId, pluralscapeId);
+  ctx.storeMetadata("fronting-session", sourceId, "memberId", subject.memberId);
+  ctx.storeMetadata("fronting-session", sourceId, "customFrontId", subject.customFrontId);
+}
+
 describe("mapFrontingComment", () => {
-  it("maps a comment with resolved fronting session FK", () => {
+  it("maps a comment with resolved fronting session FK and member subject", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
-    ctx.register("fronting-session", "src_fh1", "ps_fh1");
+    registerSessionWithSubject(ctx, "src_fh1", "ps_fh1", { memberId: "mem_abc" });
     const sp: SPComment = {
       _id: "c1",
       documentId: "src_fh1",
@@ -21,10 +33,45 @@ describe("mapFrontingComment", () => {
       expect(result.payload.frontingSessionId).toBe("ps_fh1");
       expect(result.payload.encrypted.content).toBe("hello");
       expect(result.payload.createdAt).toBe(12_345);
-      expect(result.payload.memberId).toBeUndefined();
+      expect(result.payload.memberId).toBe("mem_abc");
       expect(result.payload.customFrontId).toBeUndefined();
       expect(result.payload.structureEntityId).toBeUndefined();
     }
+  });
+
+  it("inherits member subject from the parent fronting session", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    registerSessionWithSubject(ctx, "fh_member", "ps_fh_member", { memberId: "mem_123" });
+    const sp: SPComment = { _id: "c_m", documentId: "fh_member", text: "test", time: 100 };
+    const result = mapFrontingComment(sp, ctx);
+    expect(result.status).toBe("mapped");
+    if (result.status === "mapped") {
+      expect(result.payload.memberId).toBe("mem_123");
+      expect(result.payload.customFrontId).toBeUndefined();
+    }
+  });
+
+  it("inherits custom front subject from the parent fronting session", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    registerSessionWithSubject(ctx, "fh_cf", "ps_fh_cf", { customFrontId: "cf_456" });
+    const sp: SPComment = { _id: "c_cf", documentId: "fh_cf", text: "test", time: 200 };
+    const result = mapFrontingComment(sp, ctx);
+    expect(result.status).toBe("mapped");
+    if (result.status === "mapped") {
+      expect(result.payload.memberId).toBeUndefined();
+      expect(result.payload.customFrontId).toBe("cf_456");
+    }
+  });
+
+  it("emits a warning when session has no subject metadata", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    // Register the session FK but store no subject metadata
+    ctx.register("fronting-session", "src_fh_no_subject", "ps_fh_no_subject");
+    const sp: SPComment = { _id: "c_warn", documentId: "src_fh_no_subject", text: "x", time: 1 };
+    const result = mapFrontingComment(sp, ctx);
+    expect(result.status).toBe("mapped");
+    expect(ctx.warnings).toHaveLength(1);
+    expect(ctx.warnings[0]?.message).toContain("No subject metadata");
   });
 
   it("fails when the fronting session FK is missing", () => {
@@ -45,7 +92,7 @@ describe("mapFrontingComment", () => {
 
   it("accepts empty text (SP allows empty comments)", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
-    ctx.register("fronting-session", "src_fh1", "ps_fh1");
+    registerSessionWithSubject(ctx, "src_fh1", "ps_fh1", { memberId: "mem_abc" });
     const sp: SPComment = {
       _id: "c3",
       documentId: "src_fh1",
@@ -61,7 +108,7 @@ describe("mapFrontingComment", () => {
 
   it("preserves the time field precisely", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
-    ctx.register("fronting-session", "src_fh1", "ps_fh1");
+    registerSessionWithSubject(ctx, "src_fh1", "ps_fh1", { memberId: "mem_abc" });
     const sp: SPComment = {
       _id: "c4",
       documentId: "src_fh1",

--- a/packages/import-sp/src/__tests__/mappers/fronting-comment.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/fronting-comment.mapper.test.ts
@@ -19,8 +19,11 @@ describe("mapFrontingComment", () => {
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
       expect(result.payload.frontingSessionId).toBe("ps_fh1");
-      expect(result.payload.body).toBe("hello");
+      expect(result.payload.encrypted.content).toBe("hello");
       expect(result.payload.createdAt).toBe(12_345);
+      expect(result.payload.memberId).toBeUndefined();
+      expect(result.payload.customFrontId).toBeUndefined();
+      expect(result.payload.structureEntityId).toBeUndefined();
     }
   });
 
@@ -52,7 +55,7 @@ describe("mapFrontingComment", () => {
     const result = mapFrontingComment(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.body).toBe("");
+      expect(result.payload.encrypted.content).toBe("");
     }
   });
 

--- a/packages/import-sp/src/__tests__/mappers/fronting-session.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/fronting-session.mapper.test.ts
@@ -21,10 +21,14 @@ describe("mapFrontingSession", () => {
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
       expect(result.payload.memberId).toBe("ps_m1");
-      expect(result.payload.customFrontId).toBeNull();
+      expect(result.payload.customFrontId).toBeUndefined();
+      expect(result.payload.structureEntityId).toBeUndefined();
       expect(result.payload.startTime).toBe(1_000);
       expect(result.payload.endTime).toBe(2_000);
-      expect(result.payload.comment).toBeNull();
+      expect(result.payload.encrypted.comment).toBeNull();
+      expect(result.payload.encrypted.positionality).toBeNull();
+      expect(result.payload.encrypted.outtrigger).toBeNull();
+      expect(result.payload.encrypted.outtriggerSentiment).toBeNull();
     }
   });
 
@@ -42,7 +46,7 @@ describe("mapFrontingSession", () => {
     const result = mapFrontingSession(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.memberId).toBeNull();
+      expect(result.payload.memberId).toBeUndefined();
       expect(result.payload.customFrontId).toBe("ps_cf1");
     }
   });
@@ -153,7 +157,7 @@ describe("mapFrontingSession", () => {
     const result = mapFrontingSession(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.comment).toBe("feeling blurry");
+      expect(result.payload.encrypted.comment).toBe("feeling blurry");
     }
   });
 

--- a/packages/import-sp/src/__tests__/mappers/fronting-session.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/fronting-session.mapper.test.ts
@@ -30,6 +30,9 @@ describe("mapFrontingSession", () => {
       expect(result.payload.encrypted.outtrigger).toBeNull();
       expect(result.payload.encrypted.outtriggerSentiment).toBeNull();
     }
+    // Session mapper stores subject metadata for downstream comment mapper
+    expect(ctx.getMetadata("fronting-session", "fh1", "memberId")).toBe("ps_m1");
+    expect(ctx.getMetadata("fronting-session", "fh1", "customFrontId")).toBeUndefined();
   });
 
   it("maps a custom-front fronting session (custom=true)", () => {
@@ -49,6 +52,9 @@ describe("mapFrontingSession", () => {
       expect(result.payload.memberId).toBeUndefined();
       expect(result.payload.customFrontId).toBe("ps_cf1");
     }
+    // Session mapper stores subject metadata for downstream comment mapper
+    expect(ctx.getMetadata("fronting-session", "fh2", "memberId")).toBeUndefined();
+    expect(ctx.getMetadata("fronting-session", "fh2", "customFrontId")).toBe("ps_cf1");
   });
 
   it("sets endTime to null when live is true", () => {

--- a/packages/import-sp/src/__tests__/mappers/group.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/group.mapper.test.ts
@@ -18,9 +18,13 @@ describe("mapGroup", () => {
     const result = mapGroup(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.name).toBe("Alpha Group");
-      expect(result.payload.description).toBeNull();
-      expect(result.payload.color).toBeNull();
+      expect(result.payload.parentGroupId).toBeNull();
+      expect(result.payload.sortOrder).toBe(0);
+      expect(result.payload.encrypted.name).toBe("Alpha Group");
+      expect(result.payload.encrypted.description).toBeNull();
+      expect(result.payload.encrypted.imageSource).toBeNull();
+      expect(result.payload.encrypted.color).toBeNull();
+      expect(result.payload.encrypted.emoji).toBeNull();
       expect(result.payload.memberIds).toEqual(["ps_m1", "ps_m2"]);
     }
   });
@@ -37,8 +41,8 @@ describe("mapGroup", () => {
     const result = mapGroup(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.description).toBe("the second group");
-      expect(result.payload.color).toBe("#112233");
+      expect(result.payload.encrypted.description).toBe("the second group");
+      expect(result.payload.encrypted.color).toBe("#112233");
       expect(result.payload.memberIds).toEqual([]);
     }
   });

--- a/packages/import-sp/src/__tests__/mappers/journal-entry.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/journal-entry.mapper.test.ts
@@ -19,15 +19,10 @@ describe("mapJournalEntry", () => {
     const result = mapJournalEntry(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.title).toBe("Morning thoughts");
+      expect(result.payload.encrypted.title).toBe("Morning thoughts");
       expect(result.payload.author).toEqual({ entityType: "member", entityId: "ps_m1" });
       expect(result.payload.createdAt).toBe(1_700_000_000_000);
-      expect(result.payload.blocks).toHaveLength(1);
-      expect(result.payload.blocks[0]).toEqual({
-        type: "paragraph",
-        content: "Woke up fronting.",
-        children: [],
-      });
+      expect(result.payload.encrypted.content).toBe("Woke up fronting.");
     }
   });
 
@@ -48,7 +43,7 @@ describe("mapJournalEntry", () => {
     }
   });
 
-  it("allows empty body (single empty paragraph block)", () => {
+  it("allows empty body (empty content string)", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     ctx.register("member", "src_m1", "ps_m1");
     const sp: SPNote = {
@@ -61,12 +56,11 @@ describe("mapJournalEntry", () => {
     const result = mapJournalEntry(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.blocks).toHaveLength(1);
-      expect(result.payload.blocks[0]?.content).toBe("");
+      expect(result.payload.encrypted.content).toBe("");
     }
   });
 
-  it("emits warnings for dropped color and supportMarkdown fields", () => {
+  it("maps color to encrypted.backgroundColor and warns for supportMarkdown", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     ctx.register("member", "src_m1", "ps_m1");
     const sp: SPNote = {
@@ -80,8 +74,10 @@ describe("mapJournalEntry", () => {
     };
     const result = mapJournalEntry(sp, ctx);
     expect(result.status).toBe("mapped");
+    if (result.status === "mapped") {
+      expect(result.payload.encrypted.backgroundColor).toBe("#abcdef");
+    }
     const messages = ctx.warnings.map((w) => w.message);
-    expect(messages.some((m) => m.includes("color"))).toBe(true);
     expect(messages.some((m) => m.includes("supportMarkdown"))).toBe(true);
     expect(ctx.warnings.every((w) => w.entityType === "journal-entry")).toBe(true);
   });
@@ -99,7 +95,7 @@ describe("mapJournalEntry", () => {
     const result = mapJournalEntry(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.title).toBe("Specific Title");
+      expect(result.payload.encrypted.title).toBe("Specific Title");
       expect(result.payload.createdAt).toBe(42);
     }
   });

--- a/packages/import-sp/src/__tests__/mappers/member.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/member.mapper.test.ts
@@ -26,12 +26,12 @@ describe("mapMember", () => {
     const result = mapMember(sp, createCtxWithSyntheticBuckets());
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.member.name).toBe("Aria");
-      expect(result.payload.member.description).toBeNull();
-      expect(result.payload.member.pronouns).toBeNull();
-      expect(result.payload.member.avatarUrl).toBeNull();
-      expect(result.payload.member.colors).toEqual([]);
-      expect(result.payload.member.archived).toBe(false);
+      expect(result.payload.encrypted.name).toBe("Aria");
+      expect(result.payload.encrypted.description).toBeNull();
+      expect(result.payload.encrypted.pronouns).toEqual([]);
+      expect(result.payload.encrypted.avatarSource).toBeNull();
+      expect(result.payload.encrypted.colors).toEqual([]);
+      expect(result.payload.archived).toBe(false);
       expect(result.payload.fieldValues).toEqual([]);
     }
   });
@@ -41,7 +41,7 @@ describe("mapMember", () => {
     const result = mapMember(sp, createCtxWithSyntheticBuckets());
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.member.colors).toEqual(["#fa0"]);
+      expect(result.payload.encrypted.colors).toEqual(["#fa0"]);
     }
   });
 
@@ -57,10 +57,13 @@ describe("mapMember", () => {
     const result = mapMember(sp, createCtxWithSyntheticBuckets());
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.member.description).toBe("hi");
-      expect(result.payload.member.pronouns).toBe("they/them");
-      expect(result.payload.member.avatarUrl).toBe("https://x/y.png");
-      expect(result.payload.member.archived).toBe(true);
+      expect(result.payload.encrypted.description).toBe("hi");
+      expect(result.payload.encrypted.pronouns).toEqual(["they/them"]);
+      expect(result.payload.encrypted.avatarSource).toEqual({
+        kind: "external",
+        url: "https://x/y.png",
+      });
+      expect(result.payload.archived).toBe(true);
     }
   });
 

--- a/packages/import-sp/src/__tests__/mappers/poll.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/poll.mapper.test.ts
@@ -16,14 +16,16 @@ describe("mapPoll", () => {
     const result = mapPoll(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.poll.title).toBe("Lunch?");
-      expect(result.payload.poll.description).toBeNull();
-      expect(result.payload.poll.endsAt).toBeNull();
-      expect(result.payload.poll.kind).toBe("standard");
-      expect(result.payload.poll.allowAbstain).toBe(false);
-      expect(result.payload.poll.allowVeto).toBe(false);
-      expect(result.payload.poll.createdByMemberId).toBeNull();
-      expect(result.payload.poll.options).toEqual([]);
+      expect(result.payload.encrypted.title).toBe("Lunch?");
+      expect(result.payload.encrypted.description).toBeNull();
+      expect(result.payload.endsAt).toBeUndefined();
+      expect(result.payload.kind).toBe("standard");
+      expect(result.payload.allowAbstain).toBe(false);
+      expect(result.payload.allowVeto).toBe(false);
+      expect(result.payload.allowMultipleVotes).toBe(false);
+      expect(result.payload.maxVotesPerMember).toBe(1);
+      expect(result.payload.createdByMemberId).toBeUndefined();
+      expect(result.payload.encrypted.options).toEqual([]);
       expect(result.payload.votes).toEqual([]);
     }
   });
@@ -41,9 +43,9 @@ describe("mapPoll", () => {
     const result = mapPoll(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.poll.options).toEqual([
-        { id: "o1", label: "Red", color: "#ff0000" },
-        { id: "o2", label: "Blue", color: null },
+      expect(result.payload.encrypted.options).toEqual([
+        { id: "o1", label: "Red", voteCount: 0, color: "#ff0000", emoji: null },
+        { id: "o2", label: "Blue", voteCount: 0, color: null, emoji: null },
       ]);
     }
   });
@@ -141,11 +143,11 @@ describe("mapPoll", () => {
     const result = mapPoll(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.poll.kind).toBe("custom");
-      expect(result.payload.poll.description).toBe("Plans?");
-      expect(result.payload.poll.endsAt).toBe(9_999);
-      expect(result.payload.poll.allowAbstain).toBe(true);
-      expect(result.payload.poll.allowVeto).toBe(true);
+      expect(result.payload.kind).toBe("custom");
+      expect(result.payload.encrypted.description).toBe("Plans?");
+      expect(result.payload.endsAt).toBe(9_999);
+      expect(result.payload.allowAbstain).toBe(true);
+      expect(result.payload.allowVeto).toBe(true);
     }
   });
 });
@@ -216,7 +218,7 @@ describe("poll option id collision prevention", () => {
     const result = mapPoll(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.poll.options).toEqual([]);
+      expect(result.payload.encrypted.options).toEqual([]);
     }
   });
 
@@ -234,8 +236,8 @@ describe("poll option id collision prevention", () => {
     const result = mapPoll(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.poll.options[0]?.id).toBe("p2_opt_0");
-      expect(result.payload.poll.options[1]?.id).toBe("p2_opt_1");
+      expect(result.payload.encrypted.options[0]?.id).toBe("p2_opt_0");
+      expect(result.payload.encrypted.options[1]?.id).toBe("p2_opt_1");
     }
   });
 
@@ -250,7 +252,7 @@ describe("poll option id collision prevention", () => {
     const result = mapPoll(sp, ctx);
     expect(result.status).toBe("mapped");
     if (result.status === "mapped") {
-      expect(result.payload.poll.options[0]?.id).toBe("server-id-1");
+      expect(result.payload.encrypted.options[0]?.id).toBe("server-id-1");
     }
   });
 
@@ -274,8 +276,8 @@ describe("poll option id collision prevention", () => {
       } as SPPoll,
       ctx,
     );
-    const idA = a.status === "mapped" ? a.payload.poll.options[0]?.id : null;
-    const idB = b.status === "mapped" ? b.payload.poll.options[0]?.id : null;
+    const idA = a.status === "mapped" ? a.payload.encrypted.options[0]?.id : null;
+    const idB = b.status === "mapped" ? b.payload.encrypted.options[0]?.id : null;
     expect(idA).toBe("pA_opt_0");
     expect(idB).toBe("pB_opt_0");
     expect(idA).not.toBe(idB);

--- a/packages/import-sp/src/__tests__/persistence/persistable-entity.test.ts
+++ b/packages/import-sp/src/__tests__/persistence/persistable-entity.test.ts
@@ -30,28 +30,38 @@ describe("PersistableEntity discriminated union", () => {
       sourceEntityId: "sp_1",
       source: "simply-plural",
       payload: {
-        member: {
+        encrypted: {
           name: "Alex",
           description: null,
-          pronouns: null,
+          pronouns: [],
+          avatarSource: null,
           colors: [],
-          avatarUrl: null,
-          archived: false,
+          saturationLevel: { kind: "known", level: "highly-elaborated" },
+          tags: [],
+          suppressFriendFrontNotification: false,
+          boardMessageNotificationOnFront: false,
         },
+        archived: false,
         fieldValues: [],
         bucketIds: [],
       },
     };
     const narrowed = narrowMember(entity);
     expect(narrowed).not.toBeNull();
-    expect(narrowed?.member.name).toBe("Alex");
+    expect(narrowed?.encrypted.name).toBe("Alex");
   });
 
   it("rejects mismatched payload at the type level", () => {
     const groupPayload: MappedGroup = {
-      name: "Pod",
-      description: null,
-      color: null,
+      encrypted: {
+        name: "Pod",
+        description: null,
+        imageSource: null,
+        color: null,
+        emoji: null,
+      },
+      parentGroupId: null,
+      sortOrder: 0,
       memberIds: [],
     };
     // @ts-expect-error - group payload cannot be assigned to a member entity

--- a/packages/import-sp/src/__tests__/sources/api-source.test.ts
+++ b/packages/import-sp/src/__tests__/sources/api-source.test.ts
@@ -10,6 +10,22 @@ import {
 import type { ImportDataSource, SourceEvent } from "../../sources/source.types.js";
 import type { SpCollectionName } from "../../sources/sp-collections.js";
 
+/**
+ * Call {@link ImportDataSource.supplyParentIds} without triggering
+ * `@typescript-eslint/unbound-method`. Uses `Reflect.get` so ESLint
+ * never sees a direct method-property access.
+ */
+function callSupplyParentIds(
+  source: ImportDataSource,
+  parentCollection: SpCollectionName,
+  sourceIds: readonly string[],
+): void {
+  const fn: unknown = Reflect.get(source, "supplyParentIds");
+  if (typeof fn === "function") {
+    (fn as (p: SpCollectionName, ids: readonly string[]) => void)(parentCollection, sourceIds);
+  }
+}
+
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -138,16 +154,60 @@ describe("createApiImportSource", () => {
   it("yields nothing for unsupported collections rather than throwing", async () => {
     const source = createApiImportSource(DEFAULT_INPUT);
     const comments = await drain(source, "comments");
-    const notes = await drain(source, "notes");
     const chatMessages = await drain(source, "chatMessages");
     const boardMessages = await drain(source, "boardMessages");
     await source.close();
 
     expect(comments).toEqual([]);
-    expect(notes).toEqual([]);
     expect(chatMessages).toEqual([]);
     expect(boardMessages).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches notes per-member after supplyParentIds is called", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { _id: "n1", title: "Note A", member: "m1" },
+          { _id: "n2", title: "Note B", member: "m1" },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse([{ _id: "n3", title: "Note C", member: "m2" }]));
+
+    const source = createApiImportSource(DEFAULT_INPUT);
+    expect(Reflect.get(source, "supplyParentIds")).toBeDefined();
+    callSupplyParentIds(source, "members", ["m1", "m2"]);
+    const ids = await drain(source, "notes");
+    await source.close();
+
+    expect(ids).toEqual(["n1", "n2", "n3"]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const urls = fetchMock.mock.calls.map((args: unknown[]) => args[0]);
+    expect(urls[0]).toBe("https://api.test/v1/notes/sys_abc/m1");
+    expect(urls[1]).toBe("https://api.test/v1/notes/sys_abc/m2");
+  });
+
+  it("yields nothing for notes when supplyParentIds was not called", async () => {
+    const source = createApiImportSource(DEFAULT_INPUT);
+    const ids = await drain(source, "notes");
+    await source.close();
+
+    expect(ids).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips a member whose notes endpoint returns empty array", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([{ _id: "n1", title: "Note" }]));
+
+    const source = createApiImportSource(DEFAULT_INPUT);
+    callSupplyParentIds(source, "members", ["m1", "m2"]);
+    const ids = await drain(source, "notes");
+    await source.close();
+
+    expect(ids).toEqual(["n1"]);
   });
 
   it("sends the bearer token in Authorization", async () => {

--- a/packages/import-sp/src/__tests__/sources/api-source.test.ts
+++ b/packages/import-sp/src/__tests__/sources/api-source.test.ts
@@ -290,11 +290,14 @@ describe("createApiImportSource", () => {
     expect(names).toContain("users");
     expect(names).toContain("privacyBuckets");
 
+    // Dependent collections ARE reported so the engine does not emit
+    // spurious source-missing-collection warnings.
+    expect(names).toContain("notes");
+
     // Unsupported collections must NOT be reported — the engine would
     // otherwise include them in its known-dropped checks.
     expect(names).not.toContain("private");
     expect(names).not.toContain("comments");
-    expect(names).not.toContain("notes");
     expect(names).not.toContain("chatMessages");
     expect(names).not.toContain("boardMessages");
   });
@@ -446,5 +449,96 @@ describe("createApiImportSource", () => {
       expect(events[0].sourceId).toBe("m1");
       expect(events[0].document).toMatchObject({ _id: "m1", name: "Aria", color: "#ff0000" });
     }
+  });
+
+  it("yields drop event when dependent endpoint returns non-array", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "something" }));
+
+    const source = createApiImportSource(DEFAULT_INPUT);
+    callSupplyParentIds(source, "members", ["m1"]);
+
+    const ids = await drain(source, "notes");
+    expect(ids).toEqual([]);
+
+    // Re-create to get the drop events (drain only collects doc IDs)
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "something" }));
+    const source2 = createApiImportSource(DEFAULT_INPUT);
+    callSupplyParentIds(source2, "members", ["m1"]);
+    const events = await drainEvents(source2, "notes");
+    await source2.close();
+
+    expect(events).toHaveLength(1);
+    const [e] = events;
+    expect(e?.kind).toBe("drop");
+    if (e?.kind === "drop") {
+      expect(e.reason).toMatch(/non-array/i);
+    }
+  });
+
+  it("re-throws ApiSourceTokenRejectedError during dependent fetch", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([{ _id: "n1", title: "Note A", member: "m1" }]))
+      .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }));
+
+    const source = createApiImportSource(DEFAULT_INPUT);
+    callSupplyParentIds(source, "members", ["m1", "m2"]);
+
+    let caught: unknown;
+    try {
+      await drainEvents(source, "notes");
+    } catch (err) {
+      caught = err;
+    }
+    await source.close();
+
+    expect(caught).toBeInstanceOf(ApiSourceTokenRejectedError);
+  });
+
+  it("yields drop event on transient error during dependent fetch", async () => {
+    vi.useFakeTimers();
+    // First parent: network error exhausting retries (initial + 5 retries = 6 attempts)
+    fetchMock
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      // Second parent: valid notes
+      .mockResolvedValueOnce(jsonResponse([{ _id: "n1", title: "Note from m2", member: "m2" }]));
+
+    const source = createApiImportSource(DEFAULT_INPUT);
+    callSupplyParentIds(source, "members", ["m1", "m2"]);
+
+    const iterPromise = drainEvents(source, "notes");
+    await vi.runAllTimersAsync();
+    const events = await iterPromise;
+    await source.close();
+
+    const drops = events.filter((e) => e.kind === "drop");
+    const docs = events.filter((e) => e.kind === "doc");
+
+    expect(drops).toHaveLength(1);
+    expect(drops[0]?.kind === "drop" && drops[0].reason).toMatch(/parent m1/i);
+    expect(docs).toHaveLength(1);
+    expect(docs[0]?.kind === "doc" && docs[0].sourceId).toBe("n1");
+  });
+
+  it("overwrites parent IDs when supplyParentIds is called twice", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([{ _id: "n5", title: "Note from m3", member: "m3" }]),
+    );
+
+    const source = createApiImportSource(DEFAULT_INPUT);
+    callSupplyParentIds(source, "members", ["m1", "m2"]);
+    callSupplyParentIds(source, "members", ["m3"]);
+
+    const ids = await drain(source, "notes");
+    await source.close();
+
+    expect(ids).toEqual(["n5"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("https://api.test/v1/notes/sys_abc/m3");
   });
 });

--- a/packages/import-sp/src/engine/import-engine.ts
+++ b/packages/import-sp/src/engine/import-engine.ts
@@ -363,6 +363,7 @@ export async function runImport(args: RunImportArgs): Promise<ImportRunResult> {
         privacyBucketsMapped = synth.delta.imported + synth.delta.updated + synth.delta.skipped;
       }
 
+      const collectionSourceIds: string[] = [];
       let docsSinceCheckpoint = 0;
       let collectionAborted = false;
       let pastResumeCutoff = resumeCutoffSourceId === null;
@@ -444,6 +445,7 @@ export async function runImport(args: RunImportArgs): Promise<ImportRunResult> {
                 buildPersistableEntity(entityType, doc.sourceId, result.payload),
               );
               ctx.register(entityType, doc.sourceId, upsert.pluralscapeEntityId);
+              collectionSourceIds.push(doc.sourceId);
               if (collection === "privacyBuckets") privacyBucketsMapped += 1;
               let upsertDelta: AdvanceDelta;
               switch (upsert.action) {
@@ -546,6 +548,10 @@ export async function runImport(args: RunImportArgs): Promise<ImportRunResult> {
       state = completeCollection(state, { nextEntityType });
       await persister.flush();
       await onProgress(state);
+
+      if (source.supplyParentIds && collectionSourceIds.length > 0) {
+        source.supplyParentIds(collection, collectionSourceIds);
+      }
     }
 
     return completed(state, ctx, errors);

--- a/packages/import-sp/src/engine/import-engine.ts
+++ b/packages/import-sp/src/engine/import-engine.ts
@@ -178,10 +178,10 @@ async function persistSynthesizedBuckets(
   let lastSourceId: string | null = null;
   for (const bucket of synthesized) {
     const payload: MappedPrivacyBucket = {
-      name: bucket.name,
-      description: bucket.description,
-      color: null,
-      icon: null,
+      encrypted: {
+        name: bucket.name,
+        description: bucket.description,
+      },
     };
     try {
       const result = await persister.upsertEntity({

--- a/packages/import-sp/src/engine/import-engine.ts
+++ b/packages/import-sp/src/engine/import-engine.ts
@@ -363,7 +363,8 @@ export async function runImport(args: RunImportArgs): Promise<ImportRunResult> {
         privacyBucketsMapped = synth.delta.imported + synth.delta.updated + synth.delta.skipped;
       }
 
-      const collectionSourceIds: string[] = [];
+      // Includes created, updated, AND skipped docs — all valid for dependent fetch parent enumeration.
+      const persistedSourceIds: string[] = [];
       let docsSinceCheckpoint = 0;
       let collectionAborted = false;
       let pastResumeCutoff = resumeCutoffSourceId === null;
@@ -445,7 +446,7 @@ export async function runImport(args: RunImportArgs): Promise<ImportRunResult> {
                 buildPersistableEntity(entityType, doc.sourceId, result.payload),
               );
               ctx.register(entityType, doc.sourceId, upsert.pluralscapeEntityId);
-              collectionSourceIds.push(doc.sourceId);
+              persistedSourceIds.push(doc.sourceId);
               if (collection === "privacyBuckets") privacyBucketsMapped += 1;
               let upsertDelta: AdvanceDelta;
               switch (upsert.action) {
@@ -549,8 +550,8 @@ export async function runImport(args: RunImportArgs): Promise<ImportRunResult> {
       await persister.flush();
       await onProgress(state);
 
-      if (source.supplyParentIds && collectionSourceIds.length > 0) {
-        source.supplyParentIds(collection, collectionSourceIds);
+      if (source.supplyParentIds && persistedSourceIds.length > 0) {
+        source.supplyParentIds(collection, persistedSourceIds);
       }
     }
 

--- a/packages/import-sp/src/mappers/board-message.mapper.ts
+++ b/packages/import-sp/src/mappers/board-message.mapper.ts
@@ -17,13 +17,18 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPBoardMessage } from "../sources/sp-types.js";
+import type { BoardMessageEncryptedFields } from "@pluralscape/data";
+import type { MemberId } from "@pluralscape/types";
+import type { CreateBoardMessageBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedBoardMessage {
-  readonly title: string;
-  readonly body: string;
-  readonly authorMemberId: string;
+export type MappedBoardMessage = Omit<
+  z.infer<typeof CreateBoardMessageBodySchema>,
+  "encryptedData"
+> & {
+  readonly encrypted: BoardMessageEncryptedFields;
   readonly createdAt: number;
-}
+};
 
 export function mapBoardMessage(
   sp: SPBoardMessage,
@@ -59,10 +64,17 @@ export function mapBoardMessage(
     );
   }
 
+  const content = sp.title ? `# ${sp.title}\n\n${sp.message}` : sp.message;
+
+  const encrypted: BoardMessageEncryptedFields = {
+    content,
+    senderId: authorMemberId as MemberId,
+  };
+
   const payload: MappedBoardMessage = {
-    title: sp.title,
-    body: sp.message,
-    authorMemberId,
+    encrypted,
+    sortOrder: 0,
+    pinned: false,
     createdAt: sp.writtenAt,
   };
   return mapped(payload);

--- a/packages/import-sp/src/mappers/bucket.mapper.ts
+++ b/packages/import-sp/src/mappers/bucket.mapper.ts
@@ -19,13 +19,11 @@ import { mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPPrivacyBucket } from "../sources/sp-types.js";
+import type { BucketEncryptedFields } from "@pluralscape/data";
 
 /** The Pluralscape-shaped bucket payload the persister consumes. */
 export interface MappedPrivacyBucket {
-  readonly name: string;
-  readonly description: string | null;
-  readonly color: string | null;
-  readonly icon: string | null;
+  readonly encrypted: BucketEncryptedFields;
 }
 
 export function mapBucket(
@@ -41,12 +39,11 @@ export function mapBucket(
     });
     return skipped({ kind: nameError.kind, reason: nameError.message });
   }
-  const payload: MappedPrivacyBucket = {
+  const encrypted: BucketEncryptedFields = {
     name: sp.name,
     description: sp.desc ?? null,
-    color: sp.color ?? null,
-    icon: sp.icon ?? null,
   };
+  const payload: MappedPrivacyBucket = { encrypted };
   return mapped(payload);
 }
 

--- a/packages/import-sp/src/mappers/channel.mapper.ts
+++ b/packages/import-sp/src/mappers/channel.mapper.ts
@@ -15,14 +15,13 @@ import { failed, mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPChannel, SPChannelCategory } from "../sources/sp-types.js";
+import type { ChannelEncryptedFields } from "@pluralscape/data";
+import type { CreateChannelBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedChannel {
-  readonly name: string;
-  readonly description: string | null;
-  readonly type: "category" | "channel";
-  readonly parentChannelId: string | null;
-  readonly order: number | null;
-}
+export type MappedChannel = Omit<z.infer<typeof CreateChannelBodySchema>, "encryptedData"> & {
+  readonly encrypted: ChannelEncryptedFields;
+};
 
 /**
  * Channel-category payload. Structurally identical to {@link MappedChannel}
@@ -31,13 +30,7 @@ export interface MappedChannel {
  * {@link PersistableEntity} discriminated union can carry separate
  * `"channel-category"` and `"channel"` variants.
  */
-export interface MappedChannelCategory {
-  readonly name: string;
-  readonly description: string | null;
-  readonly type: "category";
-  readonly parentChannelId: null;
-  readonly order: number | null;
-}
+export type MappedChannelCategory = MappedChannel;
 
 export function mapChannelCategory(
   sp: SPChannelCategory,
@@ -52,12 +45,12 @@ export function mapChannelCategory(
     });
     return skipped({ kind: nameError.kind, reason: nameError.message });
   }
+  const encrypted: ChannelEncryptedFields = { name: sp.name };
   const payload: MappedChannelCategory = {
-    name: sp.name,
-    description: sp.desc ?? null,
+    encrypted,
     type: "category",
-    parentChannelId: null,
-    order: sp.order ?? null,
+    parentId: undefined,
+    sortOrder: sp.order ?? 0,
   };
   return mapped(payload);
 }
@@ -73,7 +66,7 @@ export function mapChannel(sp: SPChannel, ctx: MappingContext): MapperResult<Map
     return skipped({ kind: nameError.kind, reason: nameError.message });
   }
 
-  let parentChannelId: string | null = null;
+  let parentId: MappedChannel["parentId"] = undefined;
   // Real SP channels without a parent category omit `parentCategory`
   // entirely (undefined) rather than setting it to null. Treat both as
   // "no parent".
@@ -84,18 +77,18 @@ export function mapChannel(sp: SPChannel, ctx: MappingContext): MapperResult<Map
         kind: "fk-miss",
         message: `channel ${sp._id} has unresolved parentCategory ${sp.parentCategory}`,
         missingRefs: [sp.parentCategory],
-        targetField: "parentChannelId",
+        targetField: "parentId",
       });
     }
-    parentChannelId = resolved;
+    parentId = resolved as MappedChannel["parentId"];
   }
 
+  const encrypted: ChannelEncryptedFields = { name: sp.name };
   const payload: MappedChannel = {
-    name: sp.name,
-    description: sp.desc ?? null,
+    encrypted,
     type: "channel",
-    parentChannelId,
-    order: sp.order ?? null,
+    parentId,
+    sortOrder: sp.order ?? 0,
   };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/channel.mapper.ts
+++ b/packages/import-sp/src/mappers/channel.mapper.ts
@@ -24,13 +24,14 @@ export type MappedChannel = Omit<z.infer<typeof CreateChannelBodySchema>, "encry
 };
 
 /**
- * Channel-category payload. Structurally identical to {@link MappedChannel}
- * today (both are persisted into the flattened `channels` collection with a
- * `type` discriminant), but kept as a distinct named type so the
- * {@link PersistableEntity} discriminated union can carry separate
- * `"channel-category"` and `"channel"` variants.
+ * Channel-category payload. Narrows {@link MappedChannel} so the compiler
+ * enforces `type: "category"` and `parentId: undefined` — categories are
+ * always top-level containers that cannot nest under another category.
  */
-export type MappedChannelCategory = MappedChannel;
+export type MappedChannelCategory = Omit<MappedChannel, "type" | "parentId"> & {
+  readonly type: "category";
+  readonly parentId: undefined;
+};
 
 export function mapChannelCategory(
   sp: SPChannelCategory,

--- a/packages/import-sp/src/mappers/chat-message.mapper.ts
+++ b/packages/import-sp/src/mappers/chat-message.mapper.ts
@@ -13,14 +13,15 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPChatMessage } from "../sources/sp-types.js";
+import type { MessageEncryptedFields } from "@pluralscape/data";
+import type { MemberId } from "@pluralscape/types";
+import type { CreateMessageBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedChatMessage {
+export type MappedChatMessage = Omit<z.infer<typeof CreateMessageBodySchema>, "encryptedData"> & {
+  readonly encrypted: MessageEncryptedFields;
   readonly channelId: string;
-  readonly writerMemberId: string;
-  readonly body: string;
-  readonly createdAt: number;
-  readonly replyToChatMessageId: string | null;
-}
+};
 
 export function mapChatMessage(
   sp: SPChatMessage,
@@ -35,8 +36,8 @@ export function mapChatMessage(
       targetField: "channel",
     });
   }
-  const writerMemberId = ctx.translate("member", sp.writer);
-  if (writerMemberId === null) {
+  const senderId = ctx.translate("member", sp.writer);
+  if (senderId === null) {
     return failed({
       kind: "fk-miss",
       message: `FK miss: member ${sp.writer} not in translation table`,
@@ -45,7 +46,7 @@ export function mapChatMessage(
     });
   }
 
-  let replyToChatMessageId: string | null = null;
+  let replyToId: MappedChatMessage["replyToId"] = undefined;
   if (sp.replyTo !== undefined && sp.replyTo !== null) {
     const resolved = ctx.translate("chat-message", sp.replyTo);
     if (resolved === null) {
@@ -56,15 +57,21 @@ export function mapChatMessage(
         targetField: "replyTo",
       });
     }
-    replyToChatMessageId = resolved;
+    replyToId = resolved as MappedChatMessage["replyToId"];
   }
 
+  const encrypted: MessageEncryptedFields = {
+    content: sp.message,
+    senderId: senderId as MemberId,
+    attachments: [],
+    mentions: [],
+  };
+
   const payload: MappedChatMessage = {
+    encrypted,
     channelId,
-    writerMemberId,
-    body: sp.message,
-    createdAt: sp.writtenAt,
-    replyToChatMessageId,
+    timestamp: sp.writtenAt,
+    replyToId,
   };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/context.ts
+++ b/packages/import-sp/src/mappers/context.ts
@@ -47,6 +47,10 @@ export interface MappingContext {
    * per-occurrence anomalies that should be surfaced individually.
    */
   addWarningOnce(dedupeKey: string, warning: MappingWarning): void;
+  /** Store arbitrary metadata alongside a translation entry. */
+  storeMetadata(entityType: ImportEntityType, sourceId: string, key: string, value: unknown): void;
+  /** Retrieve metadata previously stored via storeMetadata. Returns undefined if not found. */
+  getMetadata(entityType: ImportEntityType, sourceId: string, key: string): unknown;
 }
 
 /**
@@ -76,6 +80,7 @@ const WARNING_BUFFER_RESERVED_SLOT = MAX_WARNING_BUFFER_SIZE - 1;
  */
 export function createMappingContext(opts: { sourceMode: SourceMode }): MappingContext {
   const tables = new Map<ImportEntityType, Map<string, string>>();
+  const metadata = new Map<string, unknown>();
   const warnings: MappingWarning[] = [];
   const seenWarningKinds = new Set<string>();
   let truncatedMarkerEmitted = false;
@@ -133,6 +138,12 @@ export function createMappingContext(opts: { sourceMode: SourceMode }): MappingC
       }
       seenWarningKinds.add(dedupeKey);
       warnings.push(warning);
+    },
+    storeMetadata(entityType, sourceId, key, value) {
+      metadata.set(`${entityType}:${sourceId}:${key}`, value);
+    },
+    getMetadata(entityType, sourceId, key) {
+      return metadata.get(`${entityType}:${sourceId}:${key}`);
     },
   };
 }

--- a/packages/import-sp/src/mappers/custom-front.mapper.ts
+++ b/packages/import-sp/src/mappers/custom-front.mapper.ts
@@ -3,19 +3,18 @@
  *
  * SP `frontStatuses` collection → Pluralscape `custom_fronts`. Direct mapping:
  * each SP front status becomes a custom front with the same name, description,
- * color, and avatar URL. Empty-named documents are skipped with a warning.
+ * color, and emoji. Empty-named documents are skipped with a warning.
  */
 import { requireName } from "./helpers.js";
 import { mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPFrontStatus } from "../sources/sp-types.js";
+import type { CustomFrontEncryptedFields } from "@pluralscape/data";
+import type { HexColor } from "@pluralscape/types";
 
 export interface MappedCustomFront {
-  readonly name: string;
-  readonly description: string | null;
-  readonly color: string | null;
-  readonly avatarUrl: string | null;
+  readonly encrypted: CustomFrontEncryptedFields;
 }
 
 export function mapCustomFront(
@@ -31,11 +30,12 @@ export function mapCustomFront(
     });
     return skipped({ kind: nameError.kind, reason: nameError.message });
   }
-  const payload: MappedCustomFront = {
+  const encrypted: CustomFrontEncryptedFields = {
     name: sp.name,
     description: sp.desc ?? null,
-    color: sp.color ?? null,
-    avatarUrl: sp.avatarUrl ?? null,
+    color: (sp.color ?? null) as HexColor | null,
+    emoji: null,
   };
+  const payload: MappedCustomFront = { encrypted };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/custom-front.mapper.ts
+++ b/packages/import-sp/src/mappers/custom-front.mapper.ts
@@ -5,13 +5,12 @@
  * each SP front status becomes a custom front with the same name, description,
  * color, and emoji. Empty-named documents are skipped with a warning.
  */
-import { requireName } from "./helpers.js";
+import { parseHexColor, requireName } from "./helpers.js";
 import { mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPFrontStatus } from "../sources/sp-types.js";
 import type { CustomFrontEncryptedFields } from "@pluralscape/data";
-import type { HexColor } from "@pluralscape/types";
 
 export interface MappedCustomFront {
   readonly encrypted: CustomFrontEncryptedFields;
@@ -30,10 +29,19 @@ export function mapCustomFront(
     });
     return skipped({ kind: nameError.kind, reason: nameError.message });
   }
+  const color = parseHexColor(sp.color);
+  if (sp.color && color === null) {
+    ctx.addWarningOnce("invalid-hex-color:custom-front", {
+      entityType: "custom-front",
+      entityId: sp._id,
+      message: `Invalid color "${sp.color}" dropped (not valid hex)`,
+    });
+  }
+
   const encrypted: CustomFrontEncryptedFields = {
     name: sp.name,
     description: sp.desc ?? null,
-    color: (sp.color ?? null) as HexColor | null,
+    color,
     emoji: null,
   };
   const payload: MappedCustomFront = { encrypted };

--- a/packages/import-sp/src/mappers/field-definition.mapper.ts
+++ b/packages/import-sp/src/mappers/field-definition.mapper.ts
@@ -6,7 +6,7 @@
  * fractional-index string on migrated accounts (pre-migration exports may
  * still ship numeric orders, coerced to string form by the Zod validator).
  *
- * Ordering note: Pluralscape's `MappedFieldDefinition.order` is a number,
+ * Ordering note: Pluralscape's `MappedFieldDefinition.sortOrder` is a number,
  * but SP's fractional-index strings cannot be losslessly converted per
  * document. We preserve lexicographic order using a best-effort base-36
  * prefix decode — sufficient for small field sets and lets users fine-tune
@@ -27,14 +27,17 @@ import { mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPCustomField, SPCustomFieldType } from "../sources/sp-types.js";
+import type { FieldDefinitionEncryptedFields } from "@pluralscape/data";
 import type { FieldType } from "@pluralscape/types";
+import type { CreateFieldDefinitionBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedFieldDefinition {
-  readonly name: string;
-  readonly fieldType: FieldType;
-  readonly order: number;
-  readonly supportMarkdown: boolean;
-}
+export type MappedFieldDefinition = Omit<
+  z.infer<typeof CreateFieldDefinitionBodySchema>,
+  "encryptedData"
+> & {
+  readonly encrypted: FieldDefinitionEncryptedFields;
+};
 
 /**
  * Map SP's numeric `CustomFieldType` enum to a Pluralscape {@link FieldType}.
@@ -105,11 +108,16 @@ export function mapFieldDefinition(
       message: `unparseable SP custom-field order "${sp.order}"; defaulting to 0 — reorder manually after import`,
     });
   }
-  const payload: MappedFieldDefinition = {
+  const encrypted: FieldDefinitionEncryptedFields = {
     name: sp.name,
+    description: null,
+    options: null,
+  };
+  const payload: MappedFieldDefinition = {
+    encrypted,
     fieldType,
-    order: orderResult.order,
-    supportMarkdown: sp.supportMarkdown ?? false,
+    required: false,
+    sortOrder: orderResult.order,
   };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/fronting-comment.mapper.ts
+++ b/packages/import-sp/src/mappers/fronting-comment.mapper.ts
@@ -10,12 +10,19 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPComment } from "../sources/sp-types.js";
+import type { FrontingCommentEncryptedFields } from "@pluralscape/data";
+import type { CustomFrontId, MemberId, SystemStructureEntityId } from "@pluralscape/types";
+import type { CreateFrontingCommentBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedFrontingComment {
+export type MappedFrontingComment = Omit<
+  z.infer<typeof CreateFrontingCommentBodySchema>,
+  "encryptedData"
+> & {
+  readonly encrypted: FrontingCommentEncryptedFields;
   readonly frontingSessionId: string;
-  readonly body: string;
   readonly createdAt: number;
-}
+};
 
 export function mapFrontingComment(
   sp: SPComment,
@@ -31,10 +38,17 @@ export function mapFrontingComment(
     });
   }
 
+  const encrypted: FrontingCommentEncryptedFields = {
+    content: sp.text,
+  };
+
   const payload: MappedFrontingComment = {
+    encrypted,
     frontingSessionId: resolved,
-    body: sp.text,
     createdAt: sp.time,
+    memberId: undefined as MemberId | undefined,
+    customFrontId: undefined as CustomFrontId | undefined,
+    structureEntityId: undefined as SystemStructureEntityId | undefined,
   };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/fronting-comment.mapper.ts
+++ b/packages/import-sp/src/mappers/fronting-comment.mapper.ts
@@ -11,7 +11,7 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 import type { MappingContext } from "./context.js";
 import type { SPComment } from "../sources/sp-types.js";
 import type { FrontingCommentEncryptedFields } from "@pluralscape/data";
-import type { CustomFrontId, MemberId, SystemStructureEntityId } from "@pluralscape/types";
+import type { CustomFrontId, MemberId } from "@pluralscape/types";
 import type { CreateFrontingCommentBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -38,6 +38,25 @@ export function mapFrontingComment(
     });
   }
 
+  // SP comments don't carry their own subject — inherit from the parent session.
+  const sessionMemberId = ctx.getMetadata("fronting-session", sp.documentId, "memberId") as
+    | MemberId
+    | undefined;
+  const sessionCustomFrontId = ctx.getMetadata(
+    "fronting-session",
+    sp.documentId,
+    "customFrontId",
+  ) as CustomFrontId | undefined;
+
+  if (sessionMemberId === undefined && sessionCustomFrontId === undefined) {
+    ctx.addWarning({
+      entityType: "fronting-comment",
+      entityId: sp._id,
+      kind: "fk-miss",
+      message: `No subject metadata found for fronting-session ${sp.documentId}; comment will fail validation`,
+    });
+  }
+
   const encrypted: FrontingCommentEncryptedFields = {
     content: sp.text,
   };
@@ -46,9 +65,9 @@ export function mapFrontingComment(
     encrypted,
     frontingSessionId: resolved,
     createdAt: sp.time,
-    memberId: undefined as MemberId | undefined,
-    customFrontId: undefined as CustomFrontId | undefined,
-    structureEntityId: undefined as SystemStructureEntityId | undefined,
+    memberId: sessionMemberId,
+    customFrontId: sessionCustomFrontId,
+    structureEntityId: undefined,
   };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/fronting-session.mapper.ts
+++ b/packages/import-sp/src/mappers/fronting-session.mapper.ts
@@ -15,7 +15,7 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 import type { MappingContext } from "./context.js";
 import type { SPFrontHistory } from "../sources/sp-types.js";
 import type { FrontingSessionEncryptedFields } from "@pluralscape/data";
-import type { CustomFrontId, MemberId, SystemStructureEntityId } from "@pluralscape/types";
+import type { CustomFrontId, MemberId } from "@pluralscape/types";
 import type { CreateFrontingSessionBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -51,13 +51,22 @@ export function mapFrontingSession(
     outtriggerSentiment: null,
   };
 
+  const memberId = sp.custom ? undefined : (resolved as MemberId);
+  const customFrontId = sp.custom ? (resolved as CustomFrontId) : undefined;
+
   const payload: MappedFrontingSession = {
     encrypted,
     startTime: sp.startTime,
     endTime,
-    memberId: sp.custom ? undefined : (resolved as MemberId),
-    customFrontId: sp.custom ? (resolved as CustomFrontId) : undefined,
-    structureEntityId: undefined as SystemStructureEntityId | undefined,
+    memberId,
+    customFrontId,
+    structureEntityId: undefined,
   };
+
+  // Persist subject IDs so the fronting-comment mapper can inherit them —
+  // SP comments don't carry their own subject, only a session reference.
+  ctx.storeMetadata("fronting-session", sp._id, "memberId", memberId);
+  ctx.storeMetadata("fronting-session", sp._id, "customFrontId", customFrontId);
+
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/fronting-session.mapper.ts
+++ b/packages/import-sp/src/mappers/fronting-session.mapper.ts
@@ -14,14 +14,18 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPFrontHistory } from "../sources/sp-types.js";
+import type { FrontingSessionEncryptedFields } from "@pluralscape/data";
+import type { CustomFrontId, MemberId, SystemStructureEntityId } from "@pluralscape/types";
+import type { CreateFrontingSessionBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedFrontingSession {
-  readonly memberId: string | null;
-  readonly customFrontId: string | null;
-  readonly startTime: number;
+export type MappedFrontingSession = Omit<
+  z.infer<typeof CreateFrontingSessionBodySchema>,
+  "encryptedData"
+> & {
+  readonly encrypted: FrontingSessionEncryptedFields;
   readonly endTime: number | null;
-  readonly comment: string | null;
-}
+};
 
 export function mapFrontingSession(
   sp: SPFrontHistory,
@@ -40,12 +44,20 @@ export function mapFrontingSession(
 
   const endTime = sp.live ? null : (sp.endTime ?? null);
 
+  const encrypted: FrontingSessionEncryptedFields = {
+    comment: sp.customStatus ?? null,
+    positionality: null,
+    outtrigger: null,
+    outtriggerSentiment: null,
+  };
+
   const payload: MappedFrontingSession = {
-    memberId: sp.custom ? null : resolved,
-    customFrontId: sp.custom ? resolved : null,
+    encrypted,
     startTime: sp.startTime,
     endTime,
-    comment: sp.customStatus ?? null,
+    memberId: sp.custom ? undefined : (resolved as MemberId),
+    customFrontId: sp.custom ? (resolved as CustomFrontId) : undefined,
+    structureEntityId: undefined as SystemStructureEntityId | undefined,
   };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/group.mapper.ts
+++ b/packages/import-sp/src/mappers/group.mapper.ts
@@ -11,13 +11,15 @@ import { failed, mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPGroup } from "../sources/sp-types.js";
+import type { GroupEncryptedFields } from "@pluralscape/data";
+import type { HexColor } from "@pluralscape/types";
+import type { CreateGroupBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedGroup {
-  readonly name: string;
-  readonly description: string | null;
-  readonly color: string | null;
+export type MappedGroup = Omit<z.infer<typeof CreateGroupBodySchema>, "encryptedData"> & {
+  readonly encrypted: GroupEncryptedFields;
   readonly memberIds: readonly string[];
-}
+};
 
 export function mapGroup(sp: SPGroup, ctx: MappingContext): MapperResult<MappedGroup> {
   const nameError = requireName(sp.name, "group", sp._id);
@@ -50,10 +52,18 @@ export function mapGroup(sp: SPGroup, ctx: MappingContext): MapperResult<MappedG
     });
   }
 
-  const payload: MappedGroup = {
+  const encrypted: GroupEncryptedFields = {
     name: sp.name,
     description: sp.desc ?? null,
-    color: sp.color ?? null,
+    imageSource: null,
+    color: (sp.color ?? null) as HexColor | null,
+    emoji: null,
+  };
+
+  const payload: MappedGroup = {
+    encrypted,
+    parentGroupId: null,
+    sortOrder: 0,
     memberIds,
   };
   return mapped(payload);

--- a/packages/import-sp/src/mappers/group.mapper.ts
+++ b/packages/import-sp/src/mappers/group.mapper.ts
@@ -6,13 +6,12 @@
  * `MapperResult.failed` with `kind: "fk-miss"` and the full list of missing
  * refs. Empty-named groups are skipped.
  */
-import { requireName, summarizeMissingRefs } from "./helpers.js";
+import { parseHexColor, requireName, summarizeMissingRefs } from "./helpers.js";
 import { failed, mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPGroup } from "../sources/sp-types.js";
 import type { GroupEncryptedFields } from "@pluralscape/data";
-import type { HexColor } from "@pluralscape/types";
 import type { CreateGroupBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -52,11 +51,20 @@ export function mapGroup(sp: SPGroup, ctx: MappingContext): MapperResult<MappedG
     });
   }
 
+  const color = parseHexColor(sp.color);
+  if (sp.color && color === null) {
+    ctx.addWarningOnce("invalid-hex-color:group", {
+      entityType: "group",
+      entityId: sp._id,
+      message: `Invalid color "${sp.color}" dropped (not valid hex)`,
+    });
+  }
+
   const encrypted: GroupEncryptedFields = {
     name: sp.name,
     description: sp.desc ?? null,
     imageSource: null,
-    color: (sp.color ?? null) as HexColor | null,
+    color,
     emoji: null,
   };
 

--- a/packages/import-sp/src/mappers/helpers.ts
+++ b/packages/import-sp/src/mappers/helpers.ts
@@ -1,5 +1,5 @@
 import type { MappingContext } from "./context.js";
-import type { ImportEntityType, ImportFailureKind } from "@pluralscape/types";
+import type { HexColor, ImportEntityType, ImportFailureKind } from "@pluralscape/types";
 
 /**
  * Maximum number of unresolved foreign-key source IDs rendered inline in a
@@ -81,4 +81,17 @@ export function warnDropped(
     key: `dropped-field:${entityType}:${field}`,
     message: `Dropped ${entityType}.${field}: ${reason}`,
   });
+}
+
+/** Hex color regex: #RGB, #RRGGBB, or #RRGGBBAA */
+const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * Parse an SP color string into a validated HexColor, or null if invalid.
+ * SP does not validate color format, so arbitrary strings may appear.
+ */
+export function parseHexColor(value: string | undefined | null): HexColor | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (HEX_COLOR_REGEX.test(value)) return value as HexColor;
+  return null;
 }

--- a/packages/import-sp/src/mappers/journal-entry.mapper.ts
+++ b/packages/import-sp/src/mappers/journal-entry.mapper.ts
@@ -1,13 +1,12 @@
 /**
  * Journal entry mapper.
  *
- * SP `notes` → Pluralscape journal entries. The SP note body is plain text
- * (or optionally markdown — we drop the markdown flag and import as plain
- * text for now), which we wrap in a single `ParagraphBlock` matching the
- * Pluralscape rich-text schema from `@pluralscape/types/journal.ts`.
+ * SP `notes` → Pluralscape journal entries (notes). The SP note body is plain
+ * text which becomes the `encrypted.content` field. SP `color` maps to
+ * `encrypted.backgroundColor`.
  *
- * `sp.color` and `sp.supportMarkdown` have no Pluralscape equivalents and are
- * dropped with warnings so users can audit what was lost during import.
+ * `sp.supportMarkdown` has no Pluralscape equivalent and is dropped with a
+ * warning so users can audit what was lost during import.
  *
  * Fails when the author FK can't be resolved.
  */
@@ -15,29 +14,15 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPNote } from "../sources/sp-types.js";
+import type { NoteEncryptedFields } from "@pluralscape/data";
+import type { HexColor } from "@pluralscape/types";
+import type { CreateNoteBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-/**
- * Minimal paragraph block shape compatible with Pluralscape's
- * {@link import("@pluralscape/types").ParagraphBlock}. The persister
- * upcasts this into a full `JournalBlock[]` when encrypting.
- */
-export interface MappedJournalParagraphBlock {
-  readonly type: "paragraph";
-  readonly content: string;
-  readonly children: readonly never[];
-}
-
-export interface MappedJournalEntry {
-  readonly title: string;
-  /**
-   * Mirrors Pluralscape `JournalEntry.author`'s `EntityReference` shape,
-   * narrowed to the `"member"` variant. SP has no structure-entity
-   * equivalent, so the discriminant is always `"member"`.
-   */
-  readonly author: { readonly entityType: "member"; readonly entityId: string };
-  readonly blocks: readonly MappedJournalParagraphBlock[];
+export type MappedJournalEntry = Omit<z.infer<typeof CreateNoteBodySchema>, "encryptedData"> & {
+  readonly encrypted: NoteEncryptedFields;
   readonly createdAt: number;
-}
+};
 
 export function mapJournalEntry(sp: SPNote, ctx: MappingContext): MapperResult<MappedJournalEntry> {
   const resolved = ctx.translate("member", sp.member);
@@ -50,13 +35,6 @@ export function mapJournalEntry(sp: SPNote, ctx: MappingContext): MapperResult<M
     });
   }
 
-  if (sp.color !== undefined && sp.color !== null) {
-    ctx.addWarningOnce("journal-entry.color-dropped", {
-      entityType: "journal-entry",
-      entityId: null,
-      message: "SP `color` field dropped (no Pluralscape equivalent)",
-    });
-  }
   if (sp.supportMarkdown !== undefined) {
     ctx.addWarningOnce("journal-entry.supportMarkdown-dropped", {
       entityType: "journal-entry",
@@ -65,15 +43,15 @@ export function mapJournalEntry(sp: SPNote, ctx: MappingContext): MapperResult<M
     });
   }
 
-  const block: MappedJournalParagraphBlock = {
-    type: "paragraph",
-    content: sp.note,
-    children: [],
-  };
-  const payload: MappedJournalEntry = {
+  const encrypted: NoteEncryptedFields = {
     title: sp.title,
-    author: { entityType: "member", entityId: resolved },
-    blocks: [block],
+    content: sp.note,
+    backgroundColor: (sp.color ?? null) as HexColor | null,
+  };
+
+  const payload: MappedJournalEntry = {
+    encrypted,
+    author: { entityType: "member" as const, entityId: resolved },
     createdAt: sp.date,
   };
   return mapped(payload);

--- a/packages/import-sp/src/mappers/journal-entry.mapper.ts
+++ b/packages/import-sp/src/mappers/journal-entry.mapper.ts
@@ -10,12 +10,12 @@
  *
  * Fails when the author FK can't be resolved.
  */
+import { parseHexColor } from "./helpers.js";
 import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPNote } from "../sources/sp-types.js";
 import type { NoteEncryptedFields } from "@pluralscape/data";
-import type { HexColor } from "@pluralscape/types";
 import type { CreateNoteBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -43,10 +43,19 @@ export function mapJournalEntry(sp: SPNote, ctx: MappingContext): MapperResult<M
     });
   }
 
+  const backgroundColor = parseHexColor(sp.color);
+  if (sp.color && backgroundColor === null) {
+    ctx.addWarningOnce("invalid-hex-color:journal-entry", {
+      entityType: "journal-entry",
+      entityId: sp._id,
+      message: `Invalid color "${sp.color}" dropped (not valid hex)`,
+    });
+  }
+
   const encrypted: NoteEncryptedFields = {
     title: sp.title,
     content: sp.note,
-    backgroundColor: (sp.color ?? null) as HexColor | null,
+    backgroundColor,
   };
 
   const payload: MappedJournalEntry = {

--- a/packages/import-sp/src/mappers/member.mapper.ts
+++ b/packages/import-sp/src/mappers/member.mapper.ts
@@ -4,7 +4,7 @@
  * Translates an {@link SPMember} into three coupled outputs the engine
  * persists atomically:
  *
- * 1. A {@link MappedMemberCore} (the member row itself).
+ * 1. An `encrypted` blob matching {@link MemberEncryptedFields}.
  * 2. An array of {@link ExtractedFieldValue} rows sourced from SP's `info`
  *    map — SP stores custom-field values inline on the member document, but
  *    Pluralscape persists them separately.
@@ -28,18 +28,12 @@ import { failed, mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPMember } from "../sources/sp-types.js";
+import type { MemberEncryptedFields } from "@pluralscape/data";
+import type { HexColor } from "@pluralscape/types";
 
-export interface MappedMemberCore {
-  readonly name: string;
-  readonly description: string | null;
-  readonly pronouns: string | null;
-  readonly colors: readonly string[];
-  readonly avatarUrl: string | null;
+export interface MappedMember {
+  readonly encrypted: MemberEncryptedFields;
   readonly archived: boolean;
-}
-
-export interface MappedMemberOutput {
-  readonly member: MappedMemberCore;
   readonly fieldValues: readonly ExtractedFieldValue[];
   /**
    * Pluralscape privacy-bucket IDs resolved from the source document's
@@ -48,13 +42,6 @@ export interface MappedMemberOutput {
    */
   readonly bucketIds: readonly string[];
 }
-
-/**
- * Canonical name for the persister payload. The member mapper produces
- * {@link MappedMemberOutput}; this alias aligns the entity-level name with the
- * rest of the `Mapped<Entity>` family consumed by {@link PersistableEntity}.
- */
-export type MappedMember = MappedMemberOutput;
 
 /**
  * Resolve a member's privacy bucket source IDs.
@@ -85,7 +72,7 @@ function deriveBucketSourceIds(sp: SPMember): readonly string[] {
   return ["synthetic:private"];
 }
 
-export function mapMember(sp: SPMember, ctx: MappingContext): MapperResult<MappedMemberOutput> {
+export function mapMember(sp: SPMember, ctx: MappingContext): MapperResult<MappedMember> {
   const nameError = requireName(sp.name, "member", sp._id);
   if (nameError !== null) {
     ctx.addWarning({
@@ -136,17 +123,25 @@ export function mapMember(sp: SPMember, ctx: MappingContext): MapperResult<Mappe
     });
   }
 
-  const member: MappedMemberCore = {
+  const encrypted: MemberEncryptedFields = {
     name: sp.name,
     description: sp.desc ?? null,
-    pronouns: sp.pronouns ?? null,
-    colors: sp.color ? [sp.color] : [],
-    avatarUrl: sp.avatarUrl ?? null,
-    archived: sp.archived ?? false,
+    pronouns: sp.pronouns ? [sp.pronouns] : [],
+    avatarSource: sp.avatarUrl ? { kind: "external" as const, url: sp.avatarUrl } : null,
+    colors: sp.color ? [sp.color as HexColor] : [],
+    saturationLevel: { kind: "known" as const, level: "highly-elaborated" as const },
+    tags: [],
+    suppressFriendFrontNotification: false,
+    boardMessageNotificationOnFront: false,
   };
 
   const fieldValues = extractFieldValues({ memberSourceId: sp._id, info: sp.info }, ctx);
 
-  const payload: MappedMemberOutput = { member, fieldValues, bucketIds };
+  const payload: MappedMember = {
+    encrypted,
+    archived: sp.archived ?? false,
+    fieldValues,
+    bucketIds,
+  };
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/member.mapper.ts
+++ b/packages/import-sp/src/mappers/member.mapper.ts
@@ -23,13 +23,12 @@
  * warning so users can audit what was lost during import.
  */
 import { extractFieldValues, type ExtractedFieldValue } from "./field-value.mapper.js";
-import { requireName, warnDropped } from "./helpers.js";
+import { parseHexColor, requireName, warnDropped } from "./helpers.js";
 import { failed, mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPMember } from "../sources/sp-types.js";
 import type { MemberEncryptedFields } from "@pluralscape/data";
-import type { HexColor } from "@pluralscape/types";
 
 export interface MappedMember {
   readonly encrypted: MemberEncryptedFields;
@@ -123,12 +122,21 @@ export function mapMember(sp: SPMember, ctx: MappingContext): MapperResult<Mappe
     });
   }
 
+  const parsedColor = parseHexColor(sp.color);
+  if (sp.color && parsedColor === null) {
+    ctx.addWarningOnce("invalid-hex-color:member", {
+      entityType: "member",
+      entityId: sp._id,
+      message: `Invalid color "${sp.color}" dropped (not valid hex)`,
+    });
+  }
+
   const encrypted: MemberEncryptedFields = {
     name: sp.name,
     description: sp.desc ?? null,
     pronouns: sp.pronouns ? [sp.pronouns] : [],
     avatarSource: sp.avatarUrl ? { kind: "external" as const, url: sp.avatarUrl } : null,
-    colors: sp.color ? [sp.color as HexColor] : [],
+    colors: parsedColor ? [parsedColor] : [],
     saturationLevel: { kind: "known" as const, level: "highly-elaborated" as const },
     tags: [],
     suppressFriendFrontNotification: false,

--- a/packages/import-sp/src/mappers/poll.mapper.ts
+++ b/packages/import-sp/src/mappers/poll.mapper.ts
@@ -3,9 +3,9 @@
  *
  * SP `polls` → Pluralscape polls + poll votes. SP stores votes inline on the
  * poll document, but Pluralscape persists them as a separate collection, so
- * this mapper returns both as a `MappedPollOutput`.
+ * this mapper returns both as a `MappedPoll`.
  *
- * SP polls have no creator field, so `createdByMemberId` is always `null`
+ * SP polls have no creator field, so `createdByMemberId` is always `undefined`
  * (Plan 1 made this nullable in the Pluralscape schema to accommodate
  * imported polls).
  *
@@ -18,12 +18,10 @@ import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPPoll } from "../sources/sp-types.js";
-
-export interface MappedPollOption {
-  readonly id: string;
-  readonly label: string;
-  readonly color: string | null;
-}
+import type { PollEncryptedFields } from "@pluralscape/data";
+import type { HexColor, PollOptionId } from "@pluralscape/types";
+import type { CreatePollBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
 export interface MappedPollVote {
   readonly optionId: string;
@@ -32,38 +30,22 @@ export interface MappedPollVote {
   readonly comment: string | null;
 }
 
-export interface MappedPollCore {
-  readonly title: string;
-  readonly description: string | null;
-  readonly endsAt: number | null;
-  readonly kind: "standard" | "custom";
-  readonly allowAbstain: boolean;
-  readonly allowVeto: boolean;
-  readonly createdByMemberId: string | null;
-  readonly options: readonly MappedPollOption[];
-}
-
-export interface MappedPollOutput {
-  readonly poll: MappedPollCore;
+export type MappedPoll = Omit<z.infer<typeof CreatePollBodySchema>, "encryptedData"> & {
+  readonly encrypted: PollEncryptedFields;
   readonly votes: readonly MappedPollVote[];
-}
+};
 
-/**
- * Canonical name for the persister payload. The poll mapper produces
- * {@link MappedPollOutput}; this alias aligns the entity-level name with the
- * rest of the `Mapped<Entity>` family consumed by {@link PersistableEntity}.
- */
-export type MappedPoll = MappedPollOutput;
-
-export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPollOutput> {
+export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPoll> {
   // SP poll options have an optional `id` field — freshly-created polls ship
   // options without ids. Fall back to a stable positional synthetic id so
   // downstream votes can still reference them by position even without a
   // server-assigned id.
-  const options: readonly MappedPollOption[] = (sp.options ?? []).map((o, idx) => ({
-    id: o.id ?? `${sp._id}_opt_${String(idx)}`,
+  const options = (sp.options ?? []).map((o, idx) => ({
+    id: (o.id ?? `${sp._id}_opt_${String(idx)}`) as PollOptionId,
     label: o.name,
-    color: o.color ?? null,
+    voteCount: 0,
+    color: (o.color ?? null) as HexColor | null,
+    emoji: null,
   }));
 
   const votes: MappedPollVote[] = [];
@@ -100,17 +82,23 @@ export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPol
     });
   }
 
-  const poll: MappedPollCore = {
+  const encrypted: PollEncryptedFields = {
     title: sp.name,
     description: sp.desc ?? null,
-    endsAt: sp.endTime ?? null,
-    kind: sp.custom === true ? "custom" : "standard",
-    allowAbstain: sp.allowAbstain ?? false,
-    allowVeto: sp.allowVeto ?? false,
-    createdByMemberId: null,
     options,
   };
 
-  const payload: MappedPollOutput = { poll, votes };
+  const payload: MappedPoll = {
+    encrypted,
+    votes,
+    kind: sp.custom === true ? "custom" : "standard",
+    createdByMemberId: undefined,
+    allowMultipleVotes: false,
+    maxVotesPerMember: 1,
+    allowAbstain: sp.allowAbstain ?? false,
+    allowVeto: sp.allowVeto ?? false,
+    endsAt: sp.endTime ?? undefined,
+  };
+
   return mapped(payload);
 }

--- a/packages/import-sp/src/mappers/poll.mapper.ts
+++ b/packages/import-sp/src/mappers/poll.mapper.ts
@@ -14,12 +14,13 @@
  * can't be resolved become `{memberId: null, isVeto: false}` with a warning —
  * the vote is still preserved, just unattributed.
  */
+import { parseHexColor } from "./helpers.js";
 import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPPoll } from "../sources/sp-types.js";
 import type { PollEncryptedFields } from "@pluralscape/data";
-import type { HexColor, PollOptionId } from "@pluralscape/types";
+import type { PollOptionId } from "@pluralscape/types";
 import type { CreatePollBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -44,9 +45,24 @@ export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPol
     id: (o.id ?? `${sp._id}_opt_${String(idx)}`) as PollOptionId,
     label: o.name,
     voteCount: 0,
-    color: (o.color ?? null) as HexColor | null,
+    color: parseHexColor(o.color),
     emoji: null,
   }));
+
+  const hasInvalidOptionColor = (sp.options ?? []).some(
+    (o) =>
+      o.color !== undefined &&
+      o.color !== null &&
+      o.color !== "" &&
+      parseHexColor(o.color) === null,
+  );
+  if (hasInvalidOptionColor) {
+    ctx.addWarningOnce(`invalid-hex-color:poll:${sp._id}`, {
+      entityType: "poll",
+      entityId: sp._id,
+      message: `Poll "${sp._id}" has option(s) with invalid color dropped (not valid hex)`,
+    });
+  }
 
   const votes: MappedPollVote[] = [];
   const missingVoterRefs: string[] = [];

--- a/packages/import-sp/src/sources/api-source.ts
+++ b/packages/import-sp/src/sources/api-source.ts
@@ -163,17 +163,14 @@ function substituteSystem(path: string, systemId: string): string {
 }
 
 /**
- * List of SP collection names the api source can fetch via a single HTTP
- * request. Collections whose strategy is `unsupported` or `dependent` are
- * omitted so the engine does not count them as source-provided during its
- * dropped-collection check.
+ * SP collection names the api source can fetch (list, single, or dependent).
+ * Only `unsupported` collections are excluded — dependent collections are
+ * reported so the engine does not emit a spurious `source-missing-collection`
+ * warning for collections that ARE fetched via the dependent strategy.
  */
-const LISTABLE_COLLECTIONS: readonly SpCollectionName[] = (
+const FETCHABLE_COLLECTIONS: readonly SpCollectionName[] = (
   Object.keys(ENDPOINT_STRATEGIES) as SpCollectionName[]
-).filter((name) => {
-  const kind = ENDPOINT_STRATEGIES[name].kind;
-  return kind !== "unsupported" && kind !== "dependent";
-});
+).filter((name) => ENDPOINT_STRATEGIES[name].kind !== "unsupported");
 
 /**
  * Create an `ImportDataSource` that streams a Simply Plural account from
@@ -437,8 +434,8 @@ export function createApiImportSource(input: ApiSourceInput): ImportDataSource {
       }
     },
     listCollections() {
-      // Only collections with a usable bulk/single endpoint are reported.
-      return Promise.resolve([...LISTABLE_COLLECTIONS]);
+      // Only collections with a usable fetch strategy are reported.
+      return Promise.resolve([...FETCHABLE_COLLECTIONS]);
     },
     async close(): Promise<void> {
       // No held resources — fetch is request-scoped.

--- a/packages/import-sp/src/sources/api-source.ts
+++ b/packages/import-sp/src/sources/api-source.ts
@@ -49,16 +49,24 @@ export class ApiSourceTransientError extends Error {
  *  - `single` — single GET returning one document; wrapped into a one-item
  *               array so the iterator interface is uniform.
  *  - `unsupported` — SP exposes no bulk endpoint for the collection (e.g.
- *               per-document comments, per-member notes, per-channel chat
- *               messages). The iterator yields nothing rather than throwing
- *               so the engine can still import the collections that do
- *               work; operators importing these collections must use the
- *               file source.
+ *               per-document comments, per-channel chat messages). The
+ *               iterator yields nothing rather than throwing so the engine
+ *               can still import the collections that do work; operators
+ *               importing these collections must use the file source.
+ *  - `dependent` — fetches per-parent: after the engine completes a parent
+ *               collection it calls `supplyParentIds` with the collected
+ *               IDs, and the iterator fans out one request per parent.
  */
 type ApiFetchStrategy =
   | { readonly kind: "list"; readonly path: string }
   | { readonly kind: "single"; readonly path: string }
-  | { readonly kind: "unsupported"; readonly reason: string };
+  | { readonly kind: "unsupported"; readonly reason: string }
+  | {
+      readonly kind: "dependent";
+      readonly parentCollection: SpCollectionName;
+      /** Path template with `:system` and `:parent` substitution tokens. */
+      readonly path: string;
+    };
 
 /**
  * Mapping from internal SP collection name to its live SP API fetch
@@ -76,10 +84,12 @@ type ApiFetchStrategy =
  *  - `users` / `private` are singleton GETs on `/v1/user/:id` and
  *    `/v1/user/private/:id`, not bulk lists.
  *  - `privacyBuckets` does not take `:system` (derived from auth context).
- *  - `comments`, `notes`, `chatMessages`, `boardMessages` have no bulk
- *    list endpoints — each requires per-parent traversal (per-document,
- *    per-member, per-channel, per-member respectively) and are marked
- *    unsupported pending a multi-pass fetcher.
+ *  - `comments`, `chatMessages`, `boardMessages` have no bulk list
+ *    endpoints — each requires per-parent traversal (per-document,
+ *    per-channel, per-member respectively) and are marked unsupported
+ *    pending a multi-pass fetcher.
+ *  - `notes` uses a `dependent` strategy that fetches per-member after
+ *    the engine supplies member IDs via `supplyParentIds`.
  */
 const ENDPOINT_STRATEGIES: Readonly<Record<SpCollectionName, ApiFetchStrategy>> = {
   users: { kind: "single", path: "/v1/user/:system" },
@@ -99,8 +109,9 @@ const ENDPOINT_STRATEGIES: Readonly<Record<SpCollectionName, ApiFetchStrategy>> 
     reason: "SP exposes comments per-document only (/v1/comments/:type/:id)",
   },
   notes: {
-    kind: "unsupported",
-    reason: "SP exposes notes per-member only (/v1/notes/:system/:member)",
+    kind: "dependent",
+    parentCollection: "members",
+    path: "/v1/notes/:system/:parent",
   },
   polls: { kind: "list", path: "/v1/polls/:system" },
   channelCategories: { kind: "list", path: "/v1/chat/categories" },
@@ -153,13 +164,16 @@ function substituteSystem(path: string, systemId: string): string {
 
 /**
  * List of SP collection names the api source can fetch via a single HTTP
- * request. Collections whose strategy is `unsupported` are omitted so the
- * engine does not count them as source-provided during its
+ * request. Collections whose strategy is `unsupported` or `dependent` are
+ * omitted so the engine does not count them as source-provided during its
  * dropped-collection check.
  */
 const LISTABLE_COLLECTIONS: readonly SpCollectionName[] = (
   Object.keys(ENDPOINT_STRATEGIES) as SpCollectionName[]
-).filter((name) => ENDPOINT_STRATEGIES[name].kind !== "unsupported");
+).filter((name) => {
+  const kind = ENDPOINT_STRATEGIES[name].kind;
+  return kind !== "unsupported" && kind !== "dependent";
+});
 
 /**
  * Create an `ImportDataSource` that streams a Simply Plural account from
@@ -185,6 +199,8 @@ const LISTABLE_COLLECTIONS: readonly SpCollectionName[] = (
  * use the file source for a complete import.
  */
 export function createApiImportSource(input: ApiSourceInput): ImportDataSource {
+  const parentIdsByCollection = new Map<SpCollectionName, readonly string[]>();
+
   async function fetchJson(url: string): Promise<unknown> {
     let attempt = 0;
     while (attempt <= SP_API_MAX_RETRIES) {
@@ -297,6 +313,9 @@ export function createApiImportSource(input: ApiSourceInput): ImportDataSource {
 
   return {
     mode: "api",
+    supplyParentIds(parentCollection: SpCollectionName, sourceIds: readonly string[]): void {
+      parentIdsByCollection.set(parentCollection, sourceIds);
+    },
     async *iterate(collection: SpCollectionName): AsyncGenerator<SourceEvent> {
       const strategy = ENDPOINT_STRATEGIES[collection];
       switch (strategy.kind) {
@@ -306,6 +325,66 @@ export function createApiImportSource(input: ApiSourceInput): ImportDataSource {
           // rest of DEPENDENCY_ORDER — operators who need these collections
           // should import from a file export instead.
           return;
+        case "dependent": {
+          const parentIds = parentIdsByCollection.get(strategy.parentCollection);
+          if (!parentIds || parentIds.length === 0) {
+            return;
+          }
+
+          for (const parentId of parentIds) {
+            const path = substituteSystem(strategy.path, input.systemId).replaceAll(
+              ":parent",
+              encodeURIComponent(parentId),
+            );
+            const url = `${input.baseUrl}${path}`;
+
+            let body: unknown;
+            try {
+              body = await fetchJson(url);
+            } catch (err) {
+              if (err instanceof ApiSourceTokenRejectedError) throw err;
+              yield {
+                kind: "drop",
+                collection,
+                sourceId: null,
+                reason: `Failed to fetch ${collection} for parent ${parentId}: ${err instanceof Error ? err.message : String(err)}`,
+              };
+              continue;
+            }
+
+            if (!Array.isArray(body)) {
+              yield {
+                kind: "drop",
+                collection,
+                sourceId: null,
+                reason: `SP API returned non-array for ${url} (got ${typeof body})`,
+              };
+              continue;
+            }
+
+            let index = 0;
+            for (const element of body) {
+              const result = assertDocument(element, collection, index);
+              if (result.kind === "drop") {
+                yield {
+                  kind: "drop",
+                  collection,
+                  sourceId: result.sourceId,
+                  reason: result.reason,
+                };
+              } else {
+                yield {
+                  kind: "doc",
+                  collection,
+                  sourceId: result.sourceId,
+                  document: result.record,
+                };
+              }
+              index += 1;
+            }
+          }
+          return;
+        }
         case "single": {
           const url = buildUrl(strategy);
           const body = await fetchJson(url);

--- a/packages/import-sp/src/sources/source.types.ts
+++ b/packages/import-sp/src/sources/source.types.ts
@@ -58,4 +58,14 @@ export interface ImportDataSource {
   iterate(collection: SpCollectionName): AsyncIterable<SourceEvent>;
   listCollections(): Promise<readonly string[]>;
   close(): Promise<void>;
+
+  /**
+   * Supply source IDs from a parent collection that a dependent collection
+   * needs to enumerate its per-parent endpoints. Called by the engine after
+   * completing a parent collection's iteration.
+   *
+   * Sources that don't use dependent fetching may omit this (the engine
+   * guards the call with an existence check).
+   */
+  supplyParentIds?(parentCollection: SpCollectionName, sourceIds: readonly string[]): void;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,6 +546,9 @@ importers:
       '@pluralscape/crypto':
         specifier: workspace:*
         version: link:../crypto
+      '@pluralscape/data':
+        specifier: workspace:*
+        version: link:../data
       '@pluralscape/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint-config

--- a/scripts/sp-seed/fixtures/adversarial.ts
+++ b/scripts/sp-seed/fixtures/adversarial.ts
@@ -143,7 +143,9 @@ export const ADVERSARIAL_FIXTURES: EntityFixtures = {
       body: {
         custom: false,
         live: false,
-        startTime: now - 5_000_000,
+        // SP enforces startTime < endTime; equal values get startTime = endTime - 1 server-side.
+        // Use endTime - 1 to match what SP will actually store.
+        startTime: now - 5_000_001,
         endTime: now - 5_000_000,
         member: "member.bob",
       },


### PR DESCRIPTION
## Summary

- Add dependent fetch strategy for API-sourced notes (requires member IDs from prior collections) with `supplyParentIds` hook on `ImportDataSource`
- Derive all 12 `Mapped*` types from `Create*BodySchema` + `*EncryptedFields` domain contracts so decrypt validators on mobile accept imported data without field mismatches
- Add `BucketEncryptedFields` to `@pluralscape/data` (was the only entity missing an encrypted fields interface)
- Update mobile entity persisters and tRPC bridge to encrypt `payload.encrypted` and pass plaintext metadata separately
- Add per-entity-type E2E assertion helpers and collection coverage matrix docs

## Test plan
- [x] Full monorepo typecheck passes (17/17 packages)
- [x] Full monorepo lint passes (14/14 packages)
- [x] 11,579 unit tests pass (833 test files)
- [ ] Integration tests (`pnpm test:integration`)
- [ ] E2E tests (`pnpm test:e2e`)
- [ ] SP import live API tests (manual, requires `.env.sp-test`)