### PR TITLE
fix(data): add encrypt/decrypt cycle for privacy bucket transforms

### DIFF
--- a/.beans/db-40md--audit-and-fix-privacy-bucket-encrypted-fields-end.md
+++ b/.beans/db-40md--audit-and-fix-privacy-bucket-encrypted-fields-end.md
@@ -1,12 +1,25 @@
 ---
 # db-40md
 title: Audit and fix privacy bucket encrypted fields end-to-end
-status: todo
+status: completed
 type: bug
 priority: critical
 created_at: 2026-04-12T07:51:43Z
-updated_at: 2026-04-12T07:51:43Z
+updated_at: 2026-04-12T10:25:35Z
 parent: ps-h2gl
 ---
 
 Privacy buckets use encryptedData in the Create/Update API schemas but the @pluralscape/data transforms (narrowPrivacyBucket) don't decrypt — they read name/description directly from the wire type. Either the API is returning decrypted fields alongside the blob (which the transform then ignores), or the transform is wrong. Audit the full pipeline: DB schema → API response → data transform → mobile rendering. Fix so the encrypt/decrypt cycle is consistent with all other entity types.
+
+## Summary of Changes
+
+Rewrote `@pluralscape/data` privacy bucket transforms to follow the same encrypt/decrypt pattern as all other entity types (custom-front, member, group, etc.):
+
+- **Wire type**: `PrivacyBucketRaw` now omits plaintext `name`/`description` and carries `encryptedData` instead
+- **Assertion guard**: `assertBucketEncryptedFields` validates the decrypted blob shape
+- **Decrypt**: `decryptPrivacyBucket` / `decryptPrivacyBucketPage` replace orphaned `narrowPrivacyBucket` / `narrowPrivacyBucketPage`
+- **Encrypt**: `encryptBucketInput` / `encryptBucketUpdate` added for write path
+- **Barrel exports**: Updated `packages/data/src/index.ts` with all new functions and types
+- **Tests**: Full rewrite with real encryption round-trips, assertion guard coverage, and page decryption tests
+
+No consumers needed changes — the old `narrow*` functions were orphaned (exported but never imported).

--- a/.beans/ps-0w7l--sp-import-audit-findings.md
+++ b/.beans/ps-0w7l--sp-import-audit-findings.md
@@ -1,10 +1,11 @@
 ---
 # ps-0w7l
 title: SP Import Audit Findings
-status: todo
+status: completed
 type: epic
+priority: normal
 created_at: 2026-04-10T21:05:12Z
-updated_at: 2026-04-10T21:05:12Z
+updated_at: 2026-04-12T10:09:41Z
 parent: ps-h2gl
 ---
 

--- a/.beans/ps-nrg4--simply-plural-import.md
+++ b/.beans/ps-nrg4--simply-plural-import.md
@@ -1,11 +1,11 @@
 ---
 # ps-nrg4
 title: Simply Plural import
-status: in-progress
+status: completed
 type: epic
 priority: normal
 created_at: 2026-03-31T23:13:07Z
-updated_at: 2026-04-08T22:12:46Z
+updated_at: 2026-04-12T10:09:41Z
 parent: ps-h2gl
 ---
 

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -143,7 +143,17 @@ export {
 } from "./transforms/note.js";
 export type { NoteDecrypted, NoteEncryptedFields } from "./transforms/note.js";
 
-export type { BucketEncryptedFields } from "./transforms/privacy-bucket.js";
+export {
+  decryptPrivacyBucket,
+  decryptPrivacyBucketPage,
+  encryptBucketInput,
+  encryptBucketUpdate,
+} from "./transforms/privacy-bucket.js";
+export type {
+  BucketEncryptedFields,
+  PrivacyBucketRaw,
+  PrivacyBucketPage,
+} from "./transforms/privacy-bucket.js";
 
 export {
   decryptAcknowledgement,

--- a/packages/data/src/transforms/__tests__/privacy-bucket.test.ts
+++ b/packages/data/src/transforms/__tests__/privacy-bucket.test.ts
@@ -43,8 +43,8 @@ function makeServerBucket(
     version: 1,
     createdAt: toUnixMillis(1_700_000_000_000),
     updatedAt: toUnixMillis(1_700_001_000_000),
-    archived: false as boolean,
-    archivedAt: null as UnixMillis | null,
+    archived: false,
+    archivedAt: null,
     ...overrides,
   };
 }
@@ -140,6 +140,16 @@ describe("encryptBucketInput", () => {
     expect(bucket.name).toBe(fields.name);
     expect(bucket.description).toBe(fields.description);
   });
+
+  it("round-trips null description", () => {
+    const fields: BucketEncryptedFields = { name: "Secret", description: null };
+    const { encryptedData } = encryptBucketInput(fields, masterKey);
+    const raw = { ...makeServerBucket(), encryptedData };
+    const bucket = decryptPrivacyBucket(raw, masterKey);
+
+    expect(bucket.name).toBe("Secret");
+    expect(bucket.description).toBeNull();
+  });
 });
 
 describe("encryptBucketUpdate", () => {
@@ -160,6 +170,16 @@ describe("encryptBucketUpdate", () => {
     expect(bucket.name).toBe(fields.name);
     expect(bucket.description).toBe(fields.description);
   });
+
+  it("round-trips null description", () => {
+    const fields: BucketEncryptedFields = { name: "Hidden", description: null };
+    const { encryptedData } = encryptBucketUpdate(fields, 3, masterKey);
+    const raw = { ...makeServerBucket(), encryptedData, version: 3 };
+    const bucket = decryptPrivacyBucket(raw, masterKey);
+
+    expect(bucket.name).toBe("Hidden");
+    expect(bucket.description).toBeNull();
+  });
 });
 
 describe("assertBucketEncryptedFields", () => {
@@ -178,6 +198,16 @@ describe("assertBucketEncryptedFields", () => {
     };
     expect(() => decryptPrivacyBucket(raw, masterKey)).toThrow(
       "missing required string field: name",
+    );
+  });
+
+  it("throws when description key is missing", () => {
+    const raw = {
+      ...makeServerBucket(),
+      encryptedData: makeBase64Blob({ name: "Test" }, masterKey),
+    };
+    expect(() => decryptPrivacyBucket(raw, masterKey)).toThrow(
+      "missing required field: description",
     );
   });
 

--- a/packages/data/src/transforms/__tests__/privacy-bucket.test.ts
+++ b/packages/data/src/transforms/__tests__/privacy-bucket.test.ts
@@ -1,72 +1,193 @@
-import { describe, expect, it } from "vitest";
+import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
+import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
+import { toUnixMillis } from "@pluralscape/types";
+import { beforeAll, describe, expect, it } from "vitest";
 
-import { narrowPrivacyBucket, narrowPrivacyBucketPage } from "../privacy-bucket.js";
+import { encryptAndEncodeT1 } from "../decode-blob.js";
+import {
+  decryptPrivacyBucket,
+  decryptPrivacyBucketPage,
+  encryptBucketInput,
+  encryptBucketUpdate,
+} from "../privacy-bucket.js";
 
-import type { PrivacyBucketRaw } from "../privacy-bucket.js";
+import { makeBase64Blob } from "./helpers.js";
+
+import type { BucketEncryptedFields, PrivacyBucketRaw } from "../privacy-bucket.js";
+import type { KdfMasterKey } from "@pluralscape/crypto";
 import type { BucketId, SystemId, UnixMillis } from "@pluralscape/types";
 
-const NOW = 1_700_000_000_000 as UnixMillis;
-const LATER = 1_700_002_000_000 as UnixMillis;
+let masterKey: KdfMasterKey;
 
-function makeRaw(overrides?: Partial<PrivacyBucketRaw>): PrivacyBucketRaw {
+beforeAll(async () => {
+  configureSodium(new WasmSodiumAdapter());
+  await initSodium();
+  masterKey = generateMasterKey();
+});
+
+function makeEncryptedFields(): BucketEncryptedFields {
+  return {
+    name: "Friends",
+    description: "Visible to close friends",
+  };
+}
+
+function makeServerBucket(
+  fields: BucketEncryptedFields = makeEncryptedFields(),
+  overrides?: Partial<{ archived: boolean; archivedAt: UnixMillis | null }>,
+): PrivacyBucketRaw {
   return {
     id: "bkt_test0001" as BucketId,
     systemId: "sys_test001" as SystemId,
-    name: "Friends",
-    description: "Visible to close friends",
+    encryptedData: encryptAndEncodeT1(fields, masterKey),
     version: 1,
-    createdAt: NOW,
-    updatedAt: NOW,
-    archived: false,
-    archivedAt: null,
+    createdAt: toUnixMillis(1_700_000_000_000),
+    updatedAt: toUnixMillis(1_700_001_000_000),
+    archived: false as boolean,
+    archivedAt: null as UnixMillis | null,
     ...overrides,
   };
 }
 
-describe("narrowPrivacyBucket", () => {
-  it("returns live entity with archived: false", () => {
-    const result = narrowPrivacyBucket(makeRaw());
-    expect(result.archived).toBe(false);
+describe("decryptPrivacyBucket", () => {
+  it("decrypts encryptedData and merges passthrough fields", () => {
+    const raw = makeServerBucket();
+    const result = decryptPrivacyBucket(raw, masterKey);
+
     expect(result.id).toBe("bkt_test0001");
     expect(result.systemId).toBe("sys_test001");
+    expect(result.version).toBe(1);
+    expect(result.createdAt).toBe(1_700_000_000_000);
+    expect(result.updatedAt).toBe(1_700_001_000_000);
+    expect(result.archived).toBe(false);
+
     expect(result.name).toBe("Friends");
     expect(result.description).toBe("Visible to close friends");
-    expect(result.version).toBe(1);
-    expect(result.createdAt).toBe(NOW);
-    expect(result.updatedAt).toBe(NOW);
-  });
-
-  it("returns archived entity with archivedAt", () => {
-    const result = narrowPrivacyBucket(makeRaw({ archived: true, archivedAt: LATER }));
-    expect(result.archived).toBe(true);
-    if (result.archived) {
-      expect(result.archivedAt).toBe(LATER);
-    }
-  });
-
-  it("throws when archived=true but archivedAt is null", () => {
-    expect(() => narrowPrivacyBucket(makeRaw({ archived: true, archivedAt: null }))).toThrow(
-      "missing archivedAt",
-    );
   });
 
   it("handles null description", () => {
-    const result = narrowPrivacyBucket(makeRaw({ description: null }));
+    const fields: BucketEncryptedFields = { name: "Private", description: null };
+    const raw = makeServerBucket(fields);
+    const result = decryptPrivacyBucket(raw, masterKey);
     expect(result.description).toBeNull();
+  });
+
+  it("throws when encryptedData is corrupted", () => {
+    const raw = { ...makeServerBucket(), encryptedData: "not-valid-base64!!!" };
+    expect(() => decryptPrivacyBucket(raw, masterKey)).toThrow();
+  });
+
+  it("returns archived variant when raw.archived is true", () => {
+    const archivedAt = toUnixMillis(1_700_002_000_000);
+    const raw = makeServerBucket(makeEncryptedFields(), { archived: true, archivedAt });
+    const result = decryptPrivacyBucket(raw, masterKey);
+
+    expect(result.archived).toBe(true);
+    if (result.archived) {
+      expect(result.archivedAt).toBe(archivedAt);
+    }
+    expect(result.name).toBe("Friends");
+  });
+
+  it("throws when archived=true but archivedAt is null", () => {
+    const raw = makeServerBucket(makeEncryptedFields(), { archived: true, archivedAt: null });
+    expect(() => decryptPrivacyBucket(raw, masterKey)).toThrow("missing archivedAt");
   });
 });
 
-describe("narrowPrivacyBucketPage", () => {
-  it("narrows all items and preserves cursor", () => {
-    const page = { data: [makeRaw(), makeRaw()], nextCursor: "cursor_abc" };
-    const result = narrowPrivacyBucketPage(page);
+describe("decryptPrivacyBucketPage", () => {
+  it("decrypts all items and preserves cursor", () => {
+    const data = [makeServerBucket(), makeServerBucket()];
+    const page = { data, nextCursor: "cursor_abc" };
+    const result = decryptPrivacyBucketPage(page, masterKey);
+
     expect(result.data).toHaveLength(2);
     expect(result.nextCursor).toBe("cursor_abc");
+    result.data.forEach((b) => {
+      expect(b.name).toBe("Friends");
+    });
   });
 
-  it("handles empty page", () => {
-    const result = narrowPrivacyBucketPage({ data: [], nextCursor: null });
-    expect(result.data).toHaveLength(0);
+  it("handles null cursor", () => {
+    const page = { data: [makeServerBucket()], nextCursor: null };
+    const result = decryptPrivacyBucketPage(page, masterKey);
     expect(result.nextCursor).toBeNull();
+  });
+
+  it("handles empty data array", () => {
+    const page = { data: [] as PrivacyBucketRaw[], nextCursor: null };
+    const result = decryptPrivacyBucketPage(page, masterKey);
+    expect(result.data).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+  });
+});
+
+describe("encryptBucketInput", () => {
+  it("encrypts fields to a base64 encryptedData string", () => {
+    const fields = makeEncryptedFields();
+    const result = encryptBucketInput(fields, masterKey);
+
+    expect(typeof result.encryptedData).toBe("string");
+    expect(result.encryptedData.length).toBeGreaterThan(0);
+  });
+
+  it("round-trips: encrypt then decrypt returns original fields", () => {
+    const fields = makeEncryptedFields();
+    const { encryptedData } = encryptBucketInput(fields, masterKey);
+    const raw = { ...makeServerBucket(), encryptedData };
+    const bucket = decryptPrivacyBucket(raw, masterKey);
+
+    expect(bucket.name).toBe(fields.name);
+    expect(bucket.description).toBe(fields.description);
+  });
+});
+
+describe("encryptBucketUpdate", () => {
+  it("includes version in the output", () => {
+    const fields = makeEncryptedFields();
+    const result = encryptBucketUpdate(fields, 7, masterKey);
+
+    expect(typeof result.encryptedData).toBe("string");
+    expect(result.version).toBe(7);
+  });
+
+  it("round-trips through decryptPrivacyBucket", () => {
+    const fields = makeEncryptedFields();
+    const { encryptedData } = encryptBucketUpdate(fields, 2, masterKey);
+    const raw = { ...makeServerBucket(), encryptedData, version: 2 };
+    const bucket = decryptPrivacyBucket(raw, masterKey);
+
+    expect(bucket.name).toBe(fields.name);
+    expect(bucket.description).toBe(fields.description);
+  });
+});
+
+describe("assertBucketEncryptedFields", () => {
+  it("throws when decrypted blob is not an object", () => {
+    const raw = {
+      ...makeServerBucket(),
+      encryptedData: makeBase64Blob("not-an-object", masterKey),
+    };
+    expect(() => decryptPrivacyBucket(raw, masterKey)).toThrow("not an object");
+  });
+
+  it("throws when blob is missing name field", () => {
+    const raw = {
+      ...makeServerBucket(),
+      encryptedData: makeBase64Blob({ description: null }, masterKey),
+    };
+    expect(() => decryptPrivacyBucket(raw, masterKey)).toThrow(
+      "missing required string field: name",
+    );
+  });
+
+  it("throws when description is invalid type", () => {
+    const raw = {
+      ...makeServerBucket(),
+      encryptedData: makeBase64Blob({ name: "Test", description: 42 }, masterKey),
+    };
+    expect(() => decryptPrivacyBucket(raw, masterKey)).toThrow(
+      "description must be string or null",
+    );
   });
 });

--- a/packages/data/src/transforms/acknowledgement.ts
+++ b/packages/data/src/transforms/acknowledgement.ts
@@ -45,6 +45,15 @@ export interface AcknowledgementDecrypted {
   readonly updatedAt: UnixMillis;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertAcknowledgementFieldsSubset =
+  AcknowledgementEncryptedFields extends Pick<
+    AcknowledgementDecrypted,
+    keyof AcknowledgementEncryptedFields
+  >
+    ? true
+    : never;
+
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape returned by `acknowledgement.get` — derived from `AcknowledgementDecrypted`. */

--- a/packages/data/src/transforms/board-message.ts
+++ b/packages/data/src/transforms/board-message.ts
@@ -35,6 +35,12 @@ export interface BoardMessageEncryptedFields {
   readonly senderId: MemberId;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertBoardMessageFieldsSubset =
+  BoardMessageEncryptedFields extends Pick<BoardMessage, keyof BoardMessageEncryptedFields>
+    ? true
+    : never;
+
 // ── Validators ────────────────────────────────────────────────────────
 
 function assertBoardMessageEncryptedFields(

--- a/packages/data/src/transforms/channel.ts
+++ b/packages/data/src/transforms/channel.ts
@@ -34,6 +34,10 @@ export interface ChannelEncryptedFields {
   readonly name: string;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertChannelFieldsSubset =
+  ChannelEncryptedFields extends Pick<Channel, keyof ChannelEncryptedFields> ? true : never;
+
 // ── Validators ────────────────────────────────────────────────────────
 
 function assertChannelEncryptedFields(raw: unknown): asserts raw is ChannelEncryptedFields {

--- a/packages/data/src/transforms/custom-field.ts
+++ b/packages/data/src/transforms/custom-field.ts
@@ -45,6 +45,15 @@ export interface FieldDefinitionDecrypted {
   readonly updatedAt: UnixMillis;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertFieldDefinitionFieldsSubset =
+  FieldDefinitionEncryptedFields extends Pick<
+    FieldDefinitionDecrypted,
+    keyof FieldDefinitionEncryptedFields
+  >
+    ? true
+    : never;
+
 /**
  * A fully decrypted field value, combining wire metadata with the decrypted value union.
  * `fieldType` and `value` are decrypted from the encrypted blob.

--- a/packages/data/src/transforms/custom-front.ts
+++ b/packages/data/src/transforms/custom-front.ts
@@ -32,6 +32,12 @@ export interface CustomFrontEncryptedFields {
   readonly emoji: string | null;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertCustomFrontFieldsSubset =
+  CustomFrontEncryptedFields extends Pick<CustomFront, keyof CustomFrontEncryptedFields>
+    ? true
+    : never;
+
 // ── Validators ────────────────────────────────────────────────────────
 
 function assertCustomFrontEncryptedFields(raw: unknown): asserts raw is CustomFrontEncryptedFields {

--- a/packages/data/src/transforms/fronting-comment.ts
+++ b/packages/data/src/transforms/fronting-comment.ts
@@ -31,6 +31,12 @@ export interface FrontingCommentEncryptedFields {
   readonly content: string;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertFrontingCommentFieldsSubset =
+  FrontingCommentEncryptedFields extends Pick<FrontingComment, keyof FrontingCommentEncryptedFields>
+    ? true
+    : never;
+
 // ── Validators ────────────────────────────────────────────────────────
 
 function assertFrontingCommentEncryptedFields(

--- a/packages/data/src/transforms/fronting-report.ts
+++ b/packages/data/src/transforms/fronting-report.ts
@@ -15,6 +15,12 @@ export interface FrontingReportEncryptedFields {
   readonly chartData: readonly ChartData[];
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertFrontingReportFieldsSubset =
+  FrontingReportEncryptedFields extends Pick<FrontingReport, keyof FrontingReportEncryptedFields>
+    ? true
+    : never;
+
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape for a fronting report — adds wire-only fields absent from the domain type. */

--- a/packages/data/src/transforms/fronting-session.ts
+++ b/packages/data/src/transforms/fronting-session.ts
@@ -18,6 +18,12 @@ export interface FrontingSessionEncryptedFields {
   readonly outtriggerSentiment: OuttriggerSentiment | null;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertFrontingSessionFieldsSubset =
+  FrontingSessionEncryptedFields extends Pick<FrontingSession, keyof FrontingSessionEncryptedFields>
+    ? true
+    : never;
+
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape for a single fronting session — derived from `ActiveFrontingSession`. */

--- a/packages/data/src/transforms/group.ts
+++ b/packages/data/src/transforms/group.ts
@@ -37,6 +37,10 @@ export interface GroupDecrypted {
   readonly updatedAt: UnixMillis;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertGroupFieldsSubset =
+  GroupEncryptedFields extends Pick<GroupDecrypted, keyof GroupEncryptedFields> ? true : never;
+
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape returned by `group.get` — derived from `GroupDecrypted`. */

--- a/packages/data/src/transforms/innerworld-canvas.ts
+++ b/packages/data/src/transforms/innerworld-canvas.ts
@@ -27,6 +27,10 @@ export interface CanvasEncryptedFields {
   readonly dimensions: { readonly width: number; readonly height: number };
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertCanvasFieldsSubset =
+  CanvasEncryptedFields extends Pick<InnerWorldCanvas, keyof CanvasEncryptedFields> ? true : never;
+
 // ── Validators ──────────────────────────────────────────────────────
 
 function assertCanvasEncryptedFields(raw: unknown): asserts raw is CanvasEncryptedFields {

--- a/packages/data/src/transforms/innerworld-region.ts
+++ b/packages/data/src/transforms/innerworld-region.ts
@@ -41,6 +41,15 @@ export interface InnerWorldRegionDecrypted {
   readonly updatedAt: UnixMillis;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertInnerWorldRegionFieldsSubset =
+  InnerWorldRegionEncryptedFields extends Pick<
+    InnerWorldRegionDecrypted,
+    keyof InnerWorldRegionEncryptedFields
+  >
+    ? true
+    : never;
+
 export type InnerWorldRegionRaw = Omit<
   InnerWorldRegionDecrypted,
   keyof InnerWorldRegionEncryptedFields | "archived"

--- a/packages/data/src/transforms/member.ts
+++ b/packages/data/src/transforms/member.ts
@@ -31,6 +31,10 @@ export interface MemberEncryptedFields {
   readonly boardMessageNotificationOnFront: boolean;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertMemberFieldsSubset =
+  MemberEncryptedFields extends Pick<Member, keyof MemberEncryptedFields> ? true : never;
+
 // ── Validator ─────────────────────────────────────────────────────────
 
 function assertMemberEncryptedFields(raw: unknown): asserts raw is MemberEncryptedFields {

--- a/packages/data/src/transforms/message.ts
+++ b/packages/data/src/transforms/message.ts
@@ -44,6 +44,10 @@ export interface MessageEncryptedFields {
   readonly senderId: MemberId;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertMessageFieldsSubset =
+  MessageEncryptedFields extends Pick<ChatMessage, keyof MessageEncryptedFields> ? true : never;
+
 // ── Validators ────────────────────────────────────────────────────────
 
 function assertMessageEncryptedFields(raw: unknown): asserts raw is MessageEncryptedFields {

--- a/packages/data/src/transforms/note.ts
+++ b/packages/data/src/transforms/note.ts
@@ -45,6 +45,10 @@ export interface NoteDecrypted {
   readonly updatedAt: UnixMillis;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertNoteFieldsSubset =
+  NoteEncryptedFields extends Pick<NoteDecrypted, keyof NoteEncryptedFields> ? true : never;
+
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape returned by `note.get` — derived from the `NoteDecrypted` domain type. */

--- a/packages/data/src/transforms/poll.ts
+++ b/packages/data/src/transforms/poll.ts
@@ -80,6 +80,16 @@ export interface PollVoteDecrypted {
   readonly archived: false;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertPollFieldsSubset =
+  PollEncryptedFields extends Pick<PollDecrypted, keyof PollEncryptedFields> ? true : never;
+
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertPollVoteFieldsSubset =
+  PollVoteEncryptedFields extends Pick<PollVoteDecrypted, keyof PollVoteEncryptedFields>
+    ? true
+    : never;
+
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape returned by `poll.get` — derived from `PollDecrypted`. */

--- a/packages/data/src/transforms/privacy-bucket.ts
+++ b/packages/data/src/transforms/privacy-bucket.ts
@@ -1,17 +1,19 @@
+import {
+  assertObjectBlob,
+  assertStringField,
+  decodeAndDecryptT1,
+  encryptInput,
+  encryptUpdate,
+} from "./decode-blob.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
 import type { Archived, PrivacyBucket, UnixMillis } from "@pluralscape/types";
 
-// ── Encrypted payload types ───────────────────────────────────────────
-
-/** The subset of PrivacyBucket fields stored encrypted on the server. */
-export interface BucketEncryptedFields {
-  readonly name: string;
-  readonly description: string | null;
-}
-
-// ── Wire types ────────────────────────────────────────────────────────
+// ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape returned by `privacyBucket.get` — derived from the `PrivacyBucket` domain type. */
-export type PrivacyBucketRaw = Omit<PrivacyBucket, "archived"> & {
+export type PrivacyBucketRaw = Omit<PrivacyBucket, keyof BucketEncryptedFields | "archived"> & {
+  readonly encryptedData: string;
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
 };
@@ -22,19 +24,44 @@ export interface PrivacyBucketPage {
   readonly nextCursor: string | null;
 }
 
+// ── Encrypted payload types ───────────────────────────────────────────
+
+/** The subset of PrivacyBucket fields stored encrypted on the server. */
+export interface BucketEncryptedFields {
+  readonly name: string;
+  readonly description: string | null;
+}
+
+// ── Validators ────────────────────────────────────────────────────────
+
+function assertBucketEncryptedFields(raw: unknown): asserts raw is BucketEncryptedFields {
+  const obj = assertObjectBlob(raw, "privacy bucket");
+  assertStringField(obj, "privacy bucket", "name");
+  if (obj["description"] !== null && typeof obj["description"] !== "string") {
+    throw new Error("Decrypted privacy bucket blob: description must be string or null");
+  }
+}
+
 // ── Transforms ────────────────────────────────────────────────────────
 
 /**
- * Narrow a single privacy bucket API result into a `PrivacyBucket` or `Archived<PrivacyBucket>`.
+ * Decrypt a single privacy bucket API result into a `PrivacyBucket`.
+ *
+ * The encrypted blob contains: `name`, `description`.
+ * All other fields pass through from the wire payload.
  */
-export function narrowPrivacyBucket(
+export function decryptPrivacyBucket(
   raw: PrivacyBucketRaw,
+  masterKey: KdfMasterKey,
 ): PrivacyBucket | Archived<PrivacyBucket> {
+  const plaintext = decodeAndDecryptT1(raw.encryptedData, masterKey);
+  assertBucketEncryptedFields(plaintext);
+
   const base = {
     id: raw.id,
     systemId: raw.systemId,
-    name: raw.name,
-    description: raw.description,
+    name: plaintext.name,
+    description: plaintext.description,
     version: raw.version,
     createdAt: raw.createdAt,
     updatedAt: raw.updatedAt,
@@ -48,14 +75,41 @@ export function narrowPrivacyBucket(
 }
 
 /**
- * Narrow a paginated privacy bucket list result.
+ * Decrypt a paginated privacy bucket list result.
  */
-export function narrowPrivacyBucketPage(raw: PrivacyBucketPage): {
-  data: (PrivacyBucket | Archived<PrivacyBucket>)[];
-  nextCursor: string | null;
-} {
+export function decryptPrivacyBucketPage(
+  raw: PrivacyBucketPage,
+  masterKey: KdfMasterKey,
+): { data: (PrivacyBucket | Archived<PrivacyBucket>)[]; nextCursor: string | null } {
   return {
-    data: raw.data.map(narrowPrivacyBucket),
+    data: raw.data.map((item) => decryptPrivacyBucket(item, masterKey)),
     nextCursor: raw.nextCursor,
   };
+}
+
+/**
+ * Encrypt privacy bucket plaintext fields for a create payload.
+ *
+ * Returns `{ encryptedData: string }` — pass the spread of this into the
+ * `CreateBucketBodySchema`.
+ */
+export function encryptBucketInput(
+  data: BucketEncryptedFields,
+  masterKey: KdfMasterKey,
+): { encryptedData: string } {
+  return encryptInput(data, masterKey);
+}
+
+/**
+ * Encrypt privacy bucket plaintext fields for an update payload.
+ *
+ * Returns `{ encryptedData: string; version: number }` — pass the spread of
+ * this into the `UpdateBucketBodySchema`.
+ */
+export function encryptBucketUpdate(
+  data: BucketEncryptedFields,
+  version: number,
+  masterKey: KdfMasterKey,
+): { encryptedData: string; version: number } {
+  return encryptUpdate(data, version, masterKey);
 }

--- a/packages/data/src/transforms/privacy-bucket.ts
+++ b/packages/data/src/transforms/privacy-bucket.ts
@@ -32,11 +32,18 @@ export interface BucketEncryptedFields {
   readonly description: string | null;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertBucketFieldsSubset =
+  BucketEncryptedFields extends Pick<PrivacyBucket, keyof BucketEncryptedFields> ? true : never;
+
 // ── Validators ────────────────────────────────────────────────────────
 
 function assertBucketEncryptedFields(raw: unknown): asserts raw is BucketEncryptedFields {
   const obj = assertObjectBlob(raw, "privacy bucket");
   assertStringField(obj, "privacy bucket", "name");
+  if (!("description" in obj)) {
+    throw new Error("Decrypted privacy bucket blob: missing required field: description");
+  }
   if (obj["description"] !== null && typeof obj["description"] !== "string") {
     throw new Error("Decrypted privacy bucket blob: description must be string or null");
   }
@@ -68,7 +75,7 @@ export function decryptPrivacyBucket(
   };
 
   if (raw.archived) {
-    if (raw.archivedAt === null) throw new Error("Archived privacyBucket missing archivedAt");
+    if (raw.archivedAt === null) throw new Error("Archived privacy bucket missing archivedAt");
     return { ...base, archived: true as const, archivedAt: raw.archivedAt };
   }
   return { ...base, archived: false as const };

--- a/packages/data/src/transforms/relationship.ts
+++ b/packages/data/src/transforms/relationship.ts
@@ -32,6 +32,12 @@ export interface RelationshipDecrypted {
   readonly archived: false;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertRelationshipFieldsSubset =
+  RelationshipEncryptedFields extends Pick<RelationshipDecrypted, keyof RelationshipEncryptedFields>
+    ? true
+    : never;
+
 export type RelationshipRaw = Omit<
   RelationshipDecrypted,
   keyof RelationshipEncryptedFields | "archived" | "sourceMemberId" | "targetMemberId"

--- a/packages/data/src/transforms/structure-entity-type.ts
+++ b/packages/data/src/transforms/structure-entity-type.ts
@@ -42,6 +42,15 @@ export interface StructureEntityTypeDecrypted {
   readonly updatedAt: UnixMillis;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertStructureEntityTypeFieldsSubset =
+  StructureEntityTypeEncryptedFields extends Pick<
+    StructureEntityTypeDecrypted,
+    keyof StructureEntityTypeEncryptedFields
+  >
+    ? true
+    : never;
+
 // ── Wire types ────────────────────────────────────────────────────────
 
 export type StructureEntityTypeRaw = Omit<

--- a/packages/data/src/transforms/structure-entity.ts
+++ b/packages/data/src/transforms/structure-entity.ts
@@ -41,6 +41,15 @@ export interface StructureEntityDecrypted {
   readonly updatedAt: UnixMillis;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertStructureEntityFieldsSubset =
+  StructureEntityEncryptedFields extends Pick<
+    StructureEntityDecrypted,
+    keyof StructureEntityEncryptedFields
+  >
+    ? true
+    : never;
+
 export type StructureEntityRaw = Omit<
   StructureEntityDecrypted,
   keyof StructureEntityEncryptedFields | "archived"

--- a/packages/data/src/transforms/timer-check-in.ts
+++ b/packages/data/src/transforms/timer-check-in.ts
@@ -16,6 +16,12 @@ export interface TimerConfigEncryptedFields {
   readonly promptText: string;
 }
 
+/** Compile-time check: encrypted fields must be a subset of the domain type. */
+export type AssertTimerConfigFieldsSubset =
+  TimerConfigEncryptedFields extends Pick<TimerConfig, keyof TimerConfigEncryptedFields>
+    ? true
+    : never;
+
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape returned by `timerConfig.get` — derived from the `TimerConfig` domain type. */


### PR DESCRIPTION
## Summary

- Privacy buckets were the only entity type missing a proper encrypt/decrypt cycle in `@pluralscape/data` — the old `narrowPrivacyBucket` read plaintext `name`/`description` from the wire type, but those fields don't exist on the wire
- Rewrote transforms to match the pattern used by all other entities: `PrivacyBucketRaw` carries `encryptedData`, `decryptPrivacyBucket`/`encryptBucketInput`/`encryptBucketUpdate` handle the T1 blob, and `assertBucketEncryptedFields` validates shape
- Removed orphaned `narrowPrivacyBucket`/`narrowPrivacyBucketPage` (exported but never imported anywhere)

Closes db-40md

## Test plan

- [x] `pnpm vitest run --project data` — 454 tests pass (33 files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] CI passes