### PR TITLE
fix(sync): audit remediation — auth key binding, snapshot signatures, document authorization

### DIFF
--- a/.beans/sync-3lb6--validate-authorpublickey-against-authenticated-ses.md
+++ b/.beans/sync-3lb6--validate-authorpublickey-against-authenticated-ses.md
@@ -1,11 +1,15 @@
 ---
 # sync-3lb6
 title: Validate authorPublicKey against authenticated session identity
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-14T09:28:37Z
-updated_at: 2026-04-14T09:28:37Z
+updated_at: 2026-04-14T10:28:36Z
 ---
 
 AUDIT [SYNC-S-H1] handleSubmitChange verifies envelope signature using envelope.authorPublicKey but never checks it matches the authenticated system's registered signing key. Attacker can submit envelopes claiming any authorPublicKey. File: apps/api/src/ws/handlers.ts
+
+## Summary of Changes
+
+Added key ownership check to handleSubmitChange. The verifyKeyOwnership helper queries the auth_keys table to verify the envelope's authorPublicKey belongs to the authenticated account. Added UNAUTHORIZED_KEY error code to SyncErrorCode.

--- a/.beans/sync-kf0y--add-signature-verification-for-snapshot-submission.md
+++ b/.beans/sync-kf0y--add-signature-verification-for-snapshot-submission.md
@@ -1,11 +1,15 @@
 ---
 # sync-kf0y
 title: Add signature verification for snapshot submissions
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-14T09:28:45Z
-updated_at: 2026-04-14T09:28:45Z
+updated_at: 2026-04-14T10:29:03Z
 ---
 
 AUDIT [SYNC-S-M2] handleSubmitSnapshot calls relay.submitSnapshot with no envelope signature verification. Change envelopes are verified; snapshots are not. File: apps/api/src/ws/handlers.ts:270
+
+## Summary of Changes
+
+Extracted verifyEnvelopeOrError helper from handleSubmitChange. Applied signature verification and key ownership check to handleSubmitSnapshot (was previously unverified). Both change and snapshot submissions now share the same verification pipeline.

--- a/.beans/sync-zznf--add-per-document-authorization-to-sync-fetchsubmit.md
+++ b/.beans/sync-zznf--add-per-document-authorization-to-sync-fetchsubmit.md
@@ -1,11 +1,15 @@
 ---
 # sync-zznf
 title: Add per-document authorization to sync fetch/submit
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-14T09:28:59Z
-updated_at: 2026-04-14T09:28:59Z
+updated_at: 2026-04-14T10:29:30Z
 ---
 
 AUDIT [SYNC-S-M3] No check that requesting client's systemId is authorized to access docId on FetchChanges, SubmitChange, FetchSnapshot, SubmitSnapshot. Any authenticated user who knows a documentId can fetch or push.
+
+## Summary of Changes
+
+Per-document authorization was already implemented in the message router via checkAccess(), which verifies sync_documents.system_id matches the authenticated system for all four sync handlers (FetchSnapshot, FetchChanges, SubmitChange, SubmitSnapshot) plus DocumentLoad and Subscribe. Uses in-memory ownership cache with DB fallback on cache miss.

--- a/apps/api/src/ws/__tests__/handlers.test.ts
+++ b/apps/api/src/ws/__tests__/handlers.test.ts
@@ -10,9 +10,14 @@
  *   - handleSubmitChange: verifyEnvelopeSignature returns false → SyncError
  *   - handleSubmitChange: EnvelopeLimitExceededError → SyncError QUOTA_EXCEEDED
  *   - handleSubmitChange: relay.submit throws unknown error → rethrows
+ *   - handleSubmitChange: UNAUTHORIZED_KEY when authorPublicKey not in account keys
  *   - handleSubmitSnapshot: SnapshotVersionConflictError → SyncError VERSION_CONFLICT
  *   - handleSubmitSnapshot: SnapshotSizeLimitExceededError → SyncError QUOTA_EXCEEDED
  *   - handleSubmitSnapshot: success path
+ *   - handleSubmitSnapshot: INVALID_ENVELOPE when snapshot signature is invalid
+ *   - handleSubmitSnapshot: UNAUTHORIZED_KEY when snapshot authorPublicKey not in account keys
+ *   - verifyEnvelopeOrError: disabled path, invalid sig, valid sig
+ *   - verifyKeyOwnership: matching key, no match, empty keys, multiple keys
  *   - handleSubscribeRequest: addSubscription returns false (drop)
  *   - handleSubscribeRequest: hasNewerSnapshot true / false
  *   - handleSubscribeRequest: catchup fetch throws → drops doc
@@ -50,6 +55,8 @@ import {
   handleSubscribeRequest,
   handleUnsubscribeRequest,
   shouldVerifyEnvelopeSignatures,
+  verifyEnvelopeOrError,
+  verifyKeyOwnership,
 } from "../handlers.js";
 
 import type { AppLogger } from "../../lib/logger.js";
@@ -67,6 +74,7 @@ import type {
   DocumentLoadRequest,
 } from "@pluralscape/sync";
 import type { SyncDocumentId, SystemId, AccountId, SessionId } from "@pluralscape/types";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Harness helpers ───────────────────────────────────────────────────
 
@@ -104,6 +112,24 @@ function mockRelay(): {
     getManifest,
   };
   return { relay, submit, getEnvelopesSince, submitSnapshot, getLatestSnapshot, getManifest };
+}
+
+const TEST_ACCOUNT_ID = "acct_h_test" as AccountId;
+
+/**
+ * Create a mock DB that returns the given public keys for the test account.
+ * Uses the drizzle query-builder chain pattern: db.select().from().where() → rows.
+ */
+function mockDb(publicKeys: Uint8Array[] = []): PostgresJsDatabase {
+  const rows = publicKeys.map((pk) => ({ publicKey: pk }));
+  const chain = {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  };
+  return {
+    select: vi.fn().mockReturnValue(chain),
+  } as unknown as PostgresJsDatabase;
 }
 
 function brandedBytes(size: number, fill: number) {
@@ -350,12 +376,16 @@ describe("handleSubmitChange", () => {
     };
   }
 
+  /** Key bytes used by makeSubmitMsg (fill=1, size=32). */
+  const validKeyBytes = new Uint8Array(32).fill(1);
+
   it("skips verification and returns SubmitChangeResult when verification disabled", async () => {
     process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay, submit } = mockRelay();
     submit.mockResolvedValue(42);
+    const db = mockDb([validKeyBytes]);
 
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-nocheck"), relay);
+    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-nocheck"), relay, db, TEST_ACCOUNT_ID);
     expect(result.type).toBe("SubmitChangeResult");
     if (result.type === "SubmitChangeResult") {
       expect(result.response.assignedSeq).toBe(42);
@@ -372,7 +402,8 @@ describe("handleSubmitChange", () => {
     });
 
     const { relay } = mockRelay();
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-inv"), relay);
+    const db = mockDb([validKeyBytes]);
+    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-inv"), relay, db, TEST_ACCOUNT_ID);
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("INVALID_ENVELOPE");
@@ -388,7 +419,8 @@ describe("handleSubmitChange", () => {
     });
 
     const { relay } = mockRelay();
-    await expect(handleSubmitChange(makeSubmitMsg("doc-sc-rethrow"), relay)).rejects.toThrow(
+    const db = mockDb([validKeyBytes]);
+    await expect(handleSubmitChange(makeSubmitMsg("doc-sc-rethrow"), relay, db, TEST_ACCOUNT_ID)).rejects.toThrow(
       "unexpected sodium error",
     );
   });
@@ -400,10 +432,37 @@ describe("handleSubmitChange", () => {
     vi.spyOn(syncModule, "verifyEnvelopeSignature").mockReturnValue(false);
 
     const { relay } = mockRelay();
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-false"), relay);
+    const db = mockDb([validKeyBytes]);
+    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-false"), relay, db, TEST_ACCOUNT_ID);
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("INVALID_ENVELOPE");
+    }
+  });
+
+  it("returns SyncError UNAUTHORIZED_KEY when authorPublicKey does not match account keys", async () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
+    const { relay } = mockRelay();
+    // DB returns a different key than the one in the envelope
+    const differentKey = new Uint8Array(32).fill(99);
+    const db = mockDb([differentKey]);
+
+    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-badkey"), relay, db, TEST_ACCOUNT_ID);
+    expect(result.type).toBe("SyncError");
+    if (result.type === "SyncError") {
+      expect(result.code).toBe("UNAUTHORIZED_KEY");
+    }
+  });
+
+  it("returns SyncError UNAUTHORIZED_KEY when account has no keys", async () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
+    const { relay } = mockRelay();
+    const db = mockDb([]);
+
+    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-nokeys"), relay, db, TEST_ACCOUNT_ID);
+    expect(result.type).toBe("SyncError");
+    if (result.type === "SyncError") {
+      expect(result.code).toBe("UNAUTHORIZED_KEY");
     }
   });
 
@@ -411,8 +470,9 @@ describe("handleSubmitChange", () => {
     process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay, submit } = mockRelay();
     submit.mockRejectedValue(new EnvelopeLimitExceededError("doc-sc-quota", 1000));
+    const db = mockDb([validKeyBytes]);
 
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-quota"), relay);
+    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-quota"), relay, db, TEST_ACCOUNT_ID);
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("QUOTA_EXCEEDED");
@@ -423,8 +483,9 @@ describe("handleSubmitChange", () => {
     process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay, submit } = mockRelay();
     submit.mockRejectedValue(new Error("unexpected relay error"));
+    const db = mockDb([validKeyBytes]);
 
-    await expect(handleSubmitChange(makeSubmitMsg("doc-sc-unknown"), relay)).rejects.toThrow(
+    await expect(handleSubmitChange(makeSubmitMsg("doc-sc-unknown"), relay, db, TEST_ACCOUNT_ID)).rejects.toThrow(
       "unexpected relay error",
     );
   });
@@ -433,6 +494,9 @@ describe("handleSubmitChange", () => {
 // ── handleSubmitSnapshot ──────────────────────────────────────────────
 
 describe("handleSubmitSnapshot", () => {
+  /** Key bytes used by makeSubmitSnapshotMsg (fill=1, size=32). */
+  const validSnapshotKeyBytes = new Uint8Array(32).fill(1);
+
   function makeSubmitSnapshotMsg(docId = "doc-ss-1"): SubmitSnapshotRequest {
     const { nonce, sig, key, ct } = brandedBytes(32, 1);
     return {
@@ -451,19 +515,51 @@ describe("handleSubmitSnapshot", () => {
   }
 
   it("returns SnapshotAccepted on success", async () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay } = mockRelay();
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-ok"), relay);
+    const db = mockDb([validSnapshotKeyBytes]);
+    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-ok"), relay, db, TEST_ACCOUNT_ID);
     expect(result.type).toBe("SnapshotAccepted");
     if (result.type === "SnapshotAccepted") {
       expect(result.snapshotVersion).toBe(5);
     }
   });
 
+  it("returns SyncError INVALID_ENVELOPE when snapshot signature is invalid", async () => {
+    delete process.env["VERIFY_ENVELOPE_SIGNATURES"];
+
+    const syncModule = await import("@pluralscape/sync");
+    vi.spyOn(syncModule, "verifyEnvelopeSignature").mockReturnValue(false);
+
+    const { relay } = mockRelay();
+    const db = mockDb([validSnapshotKeyBytes]);
+    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-badsig"), relay, db, TEST_ACCOUNT_ID);
+    expect(result.type).toBe("SyncError");
+    if (result.type === "SyncError") {
+      expect(result.code).toBe("INVALID_ENVELOPE");
+    }
+  });
+
+  it("returns SyncError UNAUTHORIZED_KEY when snapshot authorPublicKey does not match account", async () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
+    const { relay } = mockRelay();
+    const differentKey = new Uint8Array(32).fill(99);
+    const db = mockDb([differentKey]);
+
+    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-badkey"), relay, db, TEST_ACCOUNT_ID);
+    expect(result.type).toBe("SyncError");
+    if (result.type === "SyncError") {
+      expect(result.code).toBe("UNAUTHORIZED_KEY");
+    }
+  });
+
   it("returns SyncError VERSION_CONFLICT on SnapshotVersionConflictError", async () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay, submitSnapshot } = mockRelay();
     submitSnapshot.mockRejectedValue(new SnapshotVersionConflictError(6, 5));
+    const db = mockDb([validSnapshotKeyBytes]);
 
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-vc"), relay);
+    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-vc"), relay, db, TEST_ACCOUNT_ID);
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("VERSION_CONFLICT");
@@ -471,10 +567,12 @@ describe("handleSubmitSnapshot", () => {
   });
 
   it("returns SyncError QUOTA_EXCEEDED on SnapshotSizeLimitExceededError", async () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay, submitSnapshot } = mockRelay();
     submitSnapshot.mockRejectedValue(new SnapshotSizeLimitExceededError("doc-ss-size", 2000, 1000));
+    const db = mockDb([validSnapshotKeyBytes]);
 
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-size"), relay);
+    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-size"), relay, db, TEST_ACCOUNT_ID);
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("QUOTA_EXCEEDED");
@@ -482,10 +580,12 @@ describe("handleSubmitSnapshot", () => {
   });
 
   it("rethrows unknown errors from relay.submitSnapshot", async () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay, submitSnapshot } = mockRelay();
     submitSnapshot.mockRejectedValue(new Error("unexpected snapshot error"));
+    const db = mockDb([validSnapshotKeyBytes]);
 
-    await expect(handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-unk"), relay)).rejects.toThrow(
+    await expect(handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-unk"), relay, db, TEST_ACCOUNT_ID)).rejects.toThrow(
       "unexpected snapshot error",
     );
   });
@@ -674,5 +774,113 @@ describe("handleDocumentLoad", () => {
     expect(changesResp.changes).toHaveLength(0);
     // sinceSeq should be snapshotVersion=15 when snapshot exists
     expect(getEnvelopesSince).toHaveBeenCalledWith("doc-dl-2", 15, expect.any(Number));
+  });
+});
+
+// ── verifyEnvelopeOrError ────────────────────────────────────────────
+
+describe("verifyEnvelopeOrError", () => {
+  it("returns null when verification is disabled", () => {
+    process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
+    const { nonce, sig, key, ct } = brandedBytes(32, 1);
+    const result = verifyEnvelopeOrError(
+      { authorPublicKey: key, nonce, signature: sig, ciphertext: ct },
+      "corr-ve-1",
+      "doc-ve-1" as SyncDocumentId,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns SyncError INVALID_ENVELOPE when signature is invalid", async () => {
+    delete process.env["VERIFY_ENVELOPE_SIGNATURES"];
+    const syncModule = await import("@pluralscape/sync");
+    vi.spyOn(syncModule, "verifyEnvelopeSignature").mockReturnValue(false);
+
+    const { nonce, sig, key, ct } = brandedBytes(32, 1);
+    const result = verifyEnvelopeOrError(
+      { authorPublicKey: key, nonce, signature: sig, ciphertext: ct },
+      "corr-ve-2",
+      "doc-ve-2" as SyncDocumentId,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.code).toBe("INVALID_ENVELOPE");
+  });
+
+  it("returns null when signature is valid", async () => {
+    delete process.env["VERIFY_ENVELOPE_SIGNATURES"];
+    const syncModule = await import("@pluralscape/sync");
+    vi.spyOn(syncModule, "verifyEnvelopeSignature").mockReturnValue(true);
+
+    const { nonce, sig, key, ct } = brandedBytes(32, 1);
+    const result = verifyEnvelopeOrError(
+      { authorPublicKey: key, nonce, signature: sig, ciphertext: ct },
+      "corr-ve-3",
+      "doc-ve-3" as SyncDocumentId,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ── verifyKeyOwnership ───────────────────────────────────────────────
+
+describe("verifyKeyOwnership", () => {
+  it("returns null when authorPublicKey matches an account key", async () => {
+    const key = new Uint8Array(32).fill(7);
+    const db = mockDb([key]);
+
+    const result = await verifyKeyOwnership(
+      db,
+      TEST_ACCOUNT_ID,
+      key,
+      "corr-ko-1",
+      "doc-ko-1" as SyncDocumentId,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns SyncError UNAUTHORIZED_KEY when no keys match", async () => {
+    const envelopeKey = new Uint8Array(32).fill(7);
+    const accountKey = new Uint8Array(32).fill(8);
+    const db = mockDb([accountKey]);
+
+    const result = await verifyKeyOwnership(
+      db,
+      TEST_ACCOUNT_ID,
+      envelopeKey,
+      "corr-ko-2",
+      "doc-ko-2" as SyncDocumentId,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.code).toBe("UNAUTHORIZED_KEY");
+  });
+
+  it("returns SyncError UNAUTHORIZED_KEY when account has no keys", async () => {
+    const envelopeKey = new Uint8Array(32).fill(7);
+    const db = mockDb([]);
+
+    const result = await verifyKeyOwnership(
+      db,
+      TEST_ACCOUNT_ID,
+      envelopeKey,
+      "corr-ko-3",
+      "doc-ko-3" as SyncDocumentId,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.code).toBe("UNAUTHORIZED_KEY");
+  });
+
+  it("matches when account has multiple keys and one matches", async () => {
+    const envelopeKey = new Uint8Array(32).fill(7);
+    const otherKey = new Uint8Array(32).fill(8);
+    const db = mockDb([otherKey, envelopeKey]);
+
+    const result = await verifyKeyOwnership(
+      db,
+      TEST_ACCOUNT_ID,
+      envelopeKey,
+      "corr-ko-4",
+      "doc-ko-4" as SyncDocumentId,
+    );
+    expect(result).toBeNull();
   });
 });

--- a/apps/api/src/ws/__tests__/message-router.test.ts
+++ b/apps/api/src/ws/__tests__/message-router.test.ts
@@ -49,15 +49,18 @@ vi.mock("../../lib/session-auth.js", () => ({
 
 /**
  * Chainable mock for db.select().from().where()[.limit()].
- * `mockWhere` is the terminal mock that controls the returned rows for SubscribeRequest.
+ * `mockWhere` is the terminal mock that controls the returned rows for SubscribeRequest
+ * and verifyKeyOwnership (which awaits `.where()` directly without `.limit()`).
  * `mockLimit` is the terminal mock for single-row lookups (FetchSnapshot, etc.).
+ *
+ * The chain is thenable so `await db.select().from().where()` resolves to `[]`.
  */
 const mockLimit = vi.fn().mockResolvedValue([]);
-const mockWhere = vi.fn().mockReturnThis();
-const mockDbChain = {
+const mockDbChain: Record<string, ReturnType<typeof vi.fn>> & { then: ReturnType<typeof vi.fn> } = {
   from: vi.fn().mockReturnThis(),
-  where: mockWhere,
+  where: vi.fn().mockReturnThis(),
   limit: mockLimit,
+  then: vi.fn((resolve: (v: unknown[]) => void) => resolve([])),
 };
 const mockDb = { select: vi.fn().mockReturnValue(mockDbChain) };
 

--- a/apps/api/src/ws/handlers.ts
+++ b/apps/api/src/ws/handlers.ts
@@ -5,12 +5,14 @@
  * into a single module for import simplicity.
  */
 import { getSodium, InvalidInputError } from "@pluralscape/crypto";
+import { authKeys } from "@pluralscape/db/pg";
 import {
   EnvelopeLimitExceededError,
   SnapshotSizeLimitExceededError,
   SnapshotVersionConflictError,
   verifyEnvelopeSignature,
 } from "@pluralscape/sync";
+import { eq } from "drizzle-orm";
 
 import { logger } from "../lib/logger.js";
 
@@ -40,7 +42,8 @@ import type {
   SyncRelayService,
   UnsubscribeRequest,
 } from "@pluralscape/sync";
-import type { SyncDocumentId } from "@pluralscape/types";
+import type { AccountId, SyncDocumentId } from "@pluralscape/types";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Manifest ────────────────────────────────────────────────────────
 
@@ -188,48 +191,118 @@ export interface SubmitChangeResult {
   readonly sequencedEnvelope: EncryptedChangeEnvelope;
 }
 
+// ── Shared verification helpers ────────────────────────────────────
+
+/**
+ * Verify an envelope signature and return a SyncError on failure, or null on success.
+ * Shared by both change and snapshot submission handlers.
+ */
+export function verifyEnvelopeOrError(
+  envelope: { authorPublicKey: Uint8Array; nonce: Uint8Array; signature: Uint8Array; ciphertext: Uint8Array },
+  correlationId: string,
+  docId: SyncDocumentId,
+): SyncError | null {
+  if (!shouldVerifyEnvelopeSignatures()) return null;
+  try {
+    const sodium = getSodium();
+    const valid = verifyEnvelopeSignature(
+      { ...envelope, documentId: docId, seq: 0 },
+      sodium,
+    );
+    if (!valid) {
+      return {
+        type: "SyncError",
+        correlationId,
+        code: "INVALID_ENVELOPE",
+        message: "Envelope signature verification failed",
+        docId,
+      };
+    }
+  } catch (err: unknown) {
+    if (err instanceof InvalidInputError) {
+      return {
+        type: "SyncError",
+        correlationId,
+        code: "INVALID_ENVELOPE",
+        message: "Envelope signature verification failed",
+        docId,
+      };
+    }
+    throw err;
+  }
+  return null;
+}
+
+/**
+ * Verify that the given authorPublicKey belongs to the authenticated account.
+ * Queries the auth_keys table to find a matching signing key.
+ */
+export async function verifyKeyOwnership(
+  db: PostgresJsDatabase,
+  accountId: AccountId,
+  authorPublicKey: Uint8Array,
+  correlationId: string,
+  docId: SyncDocumentId,
+): Promise<SyncError | null> {
+  const rows = await db
+    .select({ publicKey: authKeys.publicKey })
+    .from(authKeys)
+    .where(eq(authKeys.accountId, accountId));
+
+  const keyBytes = authorPublicKey instanceof Uint8Array ? authorPublicKey : new Uint8Array(authorPublicKey);
+
+  const match = rows.some((row) => {
+    const rowBytes = row.publicKey instanceof Uint8Array ? row.publicKey : new Uint8Array(row.publicKey);
+    if (rowBytes.length !== keyBytes.length) return false;
+    for (let i = 0; i < rowBytes.length; i++) {
+      if (rowBytes[i] !== keyBytes[i]) return false;
+    }
+    return true;
+  });
+
+  if (!match) {
+    return {
+      type: "SyncError",
+      correlationId,
+      code: "UNAUTHORIZED_KEY",
+      message: "Author public key does not belong to the authenticated account",
+      docId,
+    };
+  }
+  return null;
+}
+
+// ── Submit ──────────────────────────────────────────────────────────
+
 /**
  * Handle a SubmitChangeRequest. Returns ChangeAccepted and the sequenced envelope.
  *
  * When envelope signature verification is enabled (VERIFY_ENVELOPE_SIGNATURES env var),
  * the server verifies the envelope signature before storing/broadcasting. On failure,
  * returns a SyncError with code INVALID_ENVELOPE and the envelope is dropped.
+ *
+ * After signature verification, validates that the authorPublicKey belongs to the
+ * authenticated account's registered signing keys.
  */
 export async function handleSubmitChange(
   message: SubmitChangeRequest,
   relay: SyncRelayService,
+  db: PostgresJsDatabase,
+  accountId: AccountId,
 ): Promise<SubmitChangeResult | SyncError> {
   // Sec-M2: Server-side envelope signature verification
-  if (shouldVerifyEnvelopeSignatures()) {
-    let valid: boolean;
-    try {
-      const sodium = getSodium();
-      valid = verifyEnvelopeSignature(
-        { ...message.change, documentId: message.docId, seq: 0 },
-        sodium,
-      );
-    } catch (err: unknown) {
-      if (err instanceof InvalidInputError) {
-        return {
-          type: "SyncError",
-          correlationId: message.correlationId,
-          code: "INVALID_ENVELOPE",
-          message: "Envelope signature verification failed",
-          docId: message.docId,
-        };
-      }
-      throw err;
-    }
-    if (!valid) {
-      return {
-        type: "SyncError",
-        correlationId: message.correlationId,
-        code: "INVALID_ENVELOPE",
-        message: "Envelope signature verification failed",
-        docId: message.docId,
-      };
-    }
-  }
+  const sigError = verifyEnvelopeOrError(message.change, message.correlationId, message.docId);
+  if (sigError) return sigError;
+
+  // Sec-S-H1: Verify authorPublicKey belongs to the authenticated account
+  const keyError = await verifyKeyOwnership(
+    db,
+    accountId,
+    message.change.authorPublicKey,
+    message.correlationId,
+    message.docId,
+  );
+  if (keyError) return keyError;
 
   let assignedSeq: number;
   try {
@@ -266,11 +339,32 @@ export async function handleSubmitChange(
   };
 }
 
-/** Handle a SubmitSnapshotRequest. Returns SnapshotAccepted or SyncError on conflict. */
+/**
+ * Handle a SubmitSnapshotRequest. Returns SnapshotAccepted or SyncError on conflict.
+ *
+ * Verifies envelope signature (when enabled) and authorPublicKey ownership
+ * before persisting the snapshot.
+ */
 export async function handleSubmitSnapshot(
   message: SubmitSnapshotRequest,
   relay: SyncRelayService,
+  db: PostgresJsDatabase,
+  accountId: AccountId,
 ): Promise<SnapshotAccepted | SyncError> {
+  // Sec-S-M2: Server-side snapshot signature verification
+  const sigError = verifyEnvelopeOrError(message.snapshot, message.correlationId, message.docId);
+  if (sigError) return sigError;
+
+  // Sec-S-H1: Verify authorPublicKey belongs to the authenticated account
+  const keyError = await verifyKeyOwnership(
+    db,
+    accountId,
+    message.snapshot.authorPublicKey,
+    message.correlationId,
+    message.docId,
+  );
+  if (keyError) return keyError;
+
   try {
     await relay.submitSnapshot({ ...message.snapshot, documentId: message.docId });
     return {

--- a/apps/api/src/ws/message-router.ts
+++ b/apps/api/src/ws/message-router.ts
@@ -560,7 +560,8 @@ export async function routeMessage(
       )
         return;
       try {
-        const result = await handleSubmitChange(msg, relay);
+        const db = await getDb();
+        const result = await handleSubmitChange(msg, relay, db, state.auth.accountId);
         if (result.type === "SyncError") {
           send(state, result, log);
           return;
@@ -634,7 +635,8 @@ export async function routeMessage(
       )
         return;
       try {
-        const response = await handleSubmitSnapshot(msg, relay);
+        const db = await getDb();
+        const response = await handleSubmitSnapshot(msg, relay, db, state.auth.accountId);
         if (!send(state, response, log)) return;
         // Post-success: set ownership only on non-error responses
         if (response.type !== "SyncError") {

--- a/packages/sync/docs/protocol-messages.md
+++ b/packages/sync/docs/protocol-messages.md
@@ -403,6 +403,7 @@ type SyncErrorCode =
   | "QUOTA_EXCEEDED" // Storage budget exceeded (see document-lifecycle.md §6)
   | "RATE_LIMITED" // Submitting changes too rapidly
   | "INVALID_ENVELOPE" // Envelope signature verification failed; envelope dropped
+  | "UNAUTHORIZED_KEY" // authorPublicKey does not belong to the authenticated account
   | "PROTOCOL_MISMATCH" // Client protocolVersion != SYNC_PROTOCOL_VERSION
   | "INTERNAL_ERROR"; // Server-side error; retry after backoff
 ```
@@ -422,6 +423,7 @@ type SyncErrorCode =
 | `QUOTA_EXCEEDED`       | Surface to user; evict archived documents, then retry                 |
 | `RATE_LIMITED`         | Exponential backoff starting at 1 second                              |
 | `INVALID_ENVELOPE`     | Inspect change construction; verify signing key; do not retry as-is   |
+| `UNAUTHORIZED_KEY`     | Verify correct signing key is selected; re-fetch key list if needed   |
 | `PROTOCOL_MISMATCH`    | Upgrade client; do not retry                                          |
 | `INTERNAL_ERROR`       | Exponential backoff starting at 5 seconds                             |
 

--- a/packages/sync/src/__tests__/protocol.test.ts
+++ b/packages/sync/src/__tests__/protocol.test.ts
@@ -26,7 +26,7 @@ describe("SYNC_PROTOCOL_VERSION", () => {
 // ── SyncErrorCode ────────────────────────────────────────────────────
 
 describe("SyncErrorCode", () => {
-  it("exhaustive array of all 13 codes compiles as SyncErrorCode[]", () => {
+  it("exhaustive array of all 14 codes compiles as SyncErrorCode[]", () => {
     const allCodes: SyncErrorCode[] = [
       "AUTH_FAILED",
       "AUTH_EXPIRED",
@@ -39,10 +39,11 @@ describe("SyncErrorCode", () => {
       "QUOTA_EXCEEDED",
       "RATE_LIMITED",
       "INVALID_ENVELOPE",
+      "UNAUTHORIZED_KEY",
       "PROTOCOL_MISMATCH",
       "INTERNAL_ERROR",
     ];
-    expect(allCodes).toHaveLength(13);
+    expect(allCodes).toHaveLength(14);
   });
 
   it("includes DOCUMENT_LOAD_DENIED", () => {

--- a/packages/sync/src/protocol.ts
+++ b/packages/sync/src/protocol.ts
@@ -87,6 +87,7 @@ export type SyncErrorCode =
   | "QUOTA_EXCEEDED" // Storage budget exceeded (see document-lifecycle.md §6)
   | "RATE_LIMITED" // Submitting changes too rapidly
   | "INVALID_ENVELOPE" // Envelope signature verification failed; envelope dropped
+  | "UNAUTHORIZED_KEY" // authorPublicKey does not belong to the authenticated account
   | "PROTOCOL_MISMATCH" // Client protocolVersion != SYNC_PROTOCOL_VERSION
   | "INTERNAL_ERROR"; // Server-side error; retry after backoff
 


### PR DESCRIPTION
## Summary
- Validate authorPublicKey against authenticated account's registered keys (sync-3lb6)
- Add signature verification to snapshot submissions, previously missing (sync-kf0y)
- Confirm per-document authorization covers all sync fetch/submit handlers (sync-zznf)

## Changes
- Added `UNAUTHORIZED_KEY` error code to `SyncErrorCode` union
- Extracted `verifyEnvelopeOrError` helper shared by change and snapshot handlers
- Added `verifyKeyOwnership` helper that queries `auth_keys` table to match envelope key to account
- Updated `handleSubmitChange` and `handleSubmitSnapshot` to accept `db` and `accountId` parameters
- Updated message router to pass auth context through to handlers
- Per-document authorization was already implemented via `checkAccess()` in the message router

## Test plan
- [x] API unit tests pass (5116 tests)
- [x] New tests for key ownership rejection (forged key, no keys, valid key)
- [x] New tests for snapshot signature verification (invalid sig rejected)
- [x] New tests for verifyEnvelopeOrError and verifyKeyOwnership helpers
- [x] Typecheck clean
- [x] Lint clean