### PR TITLE
fix(api): audit remediation — MIME validation, S3 size enforcement, session error codes

### DIFF
--- a/.beans/api-a6s6--distinguish-session-expired-from-unauthenticated-i.md
+++ b/.beans/api-a6s6--distinguish-session-expired-from-unauthenticated-i.md
@@ -1,11 +1,15 @@
 ---
 # api-a6s6
 title: Distinguish SESSION_EXPIRED from UNAUTHENTICATED in REST middleware
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-14T09:29:02Z
-updated_at: 2026-04-14T09:29:02Z
+updated_at: 2026-04-14T10:37:13Z
 ---
 
 AUDIT [API-S-H1] validateSession returns SESSION_EXPIRED or UNAUTHENTICATED but REST middleware collapses both to generic 401. Handled correctly in WebSocket but not REST. File: apps/api/src/middleware/auth.ts:81-83
+
+## Summary of Changes
+
+Changed REST auth middleware to pass through the specific error from validateSession instead of always using UNAUTHENTICATED. Expired sessions now return error code SESSION_EXPIRED with message 'Session has expired', while invalid/revoked sessions continue to return UNAUTHENTICATED. Updated existing test assertion to verify the distinct error codes.

--- a/.beans/api-ecz2--validate-blob-mime-type-against-per-purpose-allowl.md
+++ b/.beans/api-ecz2--validate-blob-mime-type-against-per-purpose-allowl.md
@@ -1,11 +1,15 @@
 ---
 # api-ecz2
 title: Validate blob MIME type against per-purpose allowlist
-status: todo
+status: completed
 type: bug
 priority: critical
 created_at: 2026-04-14T09:28:24Z
-updated_at: 2026-04-14T09:28:24Z
+updated_at: 2026-04-14T10:24:25Z
 ---
 
 AUDIT [API-S-C1] mimeType accepts any string up to 255 chars. Clients can declare text/html or application/javascript, creating stored XSS/content-injection risk. File: packages/validation/src/blob.ts:22, apps/api/src/services/blob.service.ts:84. Fix: Validate mimeType in CreateUploadUrlBodySchema against per-purpose allowlist.
+
+## Summary of Changes
+
+Added per-purpose MIME type allowlists to CreateUploadUrlBodySchema via superRefine validation. Each BlobPurpose maps to a strict set of allowed MIME types (e.g., avatars only accept image/png, image/jpeg, image/webp). Rejects dangerous types like text/html and application/javascript that could enable stored XSS. Exported ALLOWED_MIME_TYPES constant for reuse. Added comprehensive test coverage for all purpose/MIME combinations.

--- a/.beans/api-oq3d--enforce-s3-presigned-upload-content-length-range.md
+++ b/.beans/api-oq3d--enforce-s3-presigned-upload-content-length-range.md
@@ -1,11 +1,15 @@
 ---
 # api-oq3d
 title: Enforce S3 presigned upload content-length-range
-status: todo
+status: completed
 type: bug
 priority: critical
 created_at: 2026-04-14T09:28:28Z
-updated_at: 2026-04-14T09:28:28Z
+updated_at: 2026-04-14T10:32:45Z
 ---
 
 AUDIT [API-S-C2] PutObjectCommand signing hint is not S3-enforced. Client can upload much larger object than declared, bypassing size limit and quota. File: packages/storage/src/adapters/s3/s3-adapter.ts:196-201. Fix: Use S3 POST presigned policies with content-length-range condition.
+
+## Summary of Changes
+
+Switched S3 presigned upload from PutObject signing to POST policy via createPresignedPost with content-length-range condition. S3 now server-side enforces the declared file size, preventing quota bypass by uploading larger objects than declared. Updated PresignedUrlResult interface to include optional fields for POST-based uploads. Updated blob service to pass fields through to clients. Updated mobile upload hook to use POST with FormData when fields are present, with PUT fallback for non-S3 backends.

--- a/apps/api/src/__tests__/middleware/auth.test.ts
+++ b/apps/api/src/__tests__/middleware/auth.test.ts
@@ -245,7 +245,7 @@ describe("authMiddleware", () => {
     expect(body.error.message).toBe("Authentication required");
   });
 
-  it("returns 401 with generic UNAUTHENTICATED when session is expired", async () => {
+  it("returns 401 with SESSION_EXPIRED when session is expired", async () => {
     const mockDb = { update: mockDbUpdate };
     mockGetDb.mockResolvedValue(mockDb);
     mockValidateSession.mockResolvedValue({ ok: false, error: "SESSION_EXPIRED" });
@@ -257,8 +257,8 @@ describe("authMiddleware", () => {
 
     expect(res.status).toBe(401);
     const body = (await res.json()) as ApiErrorResponse;
-    expect(body.error.code).toBe("UNAUTHENTICATED");
-    expect(body.error.message).toBe("Authentication required");
+    expect(body.error.code).toBe("SESSION_EXPIRED");
+    expect(body.error.message).toBe("Session has expired");
   });
 
   it("sets auth context and calls next() on valid session", async () => {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -79,7 +79,11 @@ export function authMiddleware(): MiddlewareHandler<AuthEnv> {
 
     const result = await validateSession(db, token);
     if (!result.ok) {
-      throw new ApiHttpError(HTTP_UNAUTHORIZED, "UNAUTHENTICATED", "Authentication required");
+      throw new ApiHttpError(
+        HTTP_UNAUTHORIZED,
+        result.error,
+        result.error === "SESSION_EXPIRED" ? "Session has expired" : "Authentication required",
+      );
     }
 
     // Throttle lastActive updates: only update if stale > LAST_ACTIVE_THROTTLE_MS

--- a/apps/api/src/services/blob.service.ts
+++ b/apps/api/src/services/blob.service.ts
@@ -44,6 +44,8 @@ export interface UploadUrlResult {
   readonly blobId: BlobId;
   readonly uploadUrl: string;
   readonly expiresAt: UnixMillis;
+  /** Form fields required for POST-based presigned uploads. */
+  readonly fields?: Readonly<Record<string, string>>;
 }
 
 export interface BlobResult {
@@ -153,6 +155,7 @@ export async function createUploadUrl(
     blobId: blobId as BlobId,
     uploadUrl: presigned.url,
     expiresAt: presigned.expiresAt,
+    ...(presigned.fields ? { fields: presigned.fields } : {}),
   };
 }
 

--- a/apps/mobile/src/hooks/use-blobs.ts
+++ b/apps/mobile/src/hooks/use-blobs.ts
@@ -165,12 +165,26 @@ export function useBlobUpload(): BlobUploadState {
           if (gen !== genRef.current) return;
           setStatus("uploading");
 
-          // Step 2: PUT file to presigned URL
-          const response = await fetch(urlResult.uploadUrl, {
-            method: "PUT",
-            body: input.file,
-            headers: { "Content-Type": input.mimeType },
-          });
+          // Step 2: Upload file to presigned URL (POST with FormData or PUT fallback)
+          let response: Response;
+          if ("fields" in urlResult && urlResult.fields) {
+            const formData = new FormData();
+            for (const [key, value] of Object.entries(urlResult.fields)) {
+              formData.append(key, value);
+            }
+            const fileBlob = input.file instanceof Blob ? input.file : new Blob([input.file]);
+            formData.append("file", fileBlob);
+            response = await fetch(urlResult.uploadUrl, {
+              method: "POST",
+              body: formData,
+            });
+          } else {
+            response = await fetch(urlResult.uploadUrl, {
+              method: "PUT",
+              body: input.file,
+              headers: { "Content-Type": input.mimeType },
+            });
+          }
 
           if (!response.ok) {
             throw new Error(`Upload failed with status ${String(response.status)}`);

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1028.0",
+    "@aws-sdk/s3-presigned-post": "^3.1030.0",
     "@aws-sdk/s3-request-presigner": "^3.1028.0",
     "@pluralscape/types": "workspace:*"
   },

--- a/packages/storage/src/__tests__/s3-adapter.test.ts
+++ b/packages/storage/src/__tests__/s3-adapter.test.ts
@@ -30,6 +30,13 @@ import {
 import type { S3AdapterConfig } from "../adapters/s3/s3-config.js";
 import type { StorageKey } from "@pluralscape/types";
 
+// ── Mock @aws-sdk/s3-presigned-post ──────────────────────────────────────
+
+const mockCreatePresignedPost = vi.fn();
+vi.mock("@aws-sdk/s3-presigned-post", () => ({
+  createPresignedPost: (...args: unknown[]): unknown => mockCreatePresignedPost(...args),
+}));
+
 // ── Mock @aws-sdk/s3-request-presigner ────────────────────────────────────
 
 const mockGetSignedUrl = vi.fn();
@@ -74,6 +81,7 @@ const KEY = "sys/blob_test" as StorageKey;
 afterEach(() => {
   vi.restoreAllMocks();
   mockGetSignedUrl.mockReset();
+  mockCreatePresignedPost.mockReset();
 });
 
 // ── upload ────────────────────────────────────────────────────────────────
@@ -314,9 +322,17 @@ describe("S3BlobStorageAdapter.getMetadata", () => {
 // ── presigned URL helpers ─────────────────────────────────────────────────
 
 describe("S3BlobStorageAdapter.generatePresignedUploadUrl", () => {
-  it("returns supported url + expiresAt on success", async () => {
+  it("returns supported url + expiresAt + fields on success", async () => {
     const { adapter } = makeAdapter();
-    mockGetSignedUrl.mockResolvedValueOnce("https://signed.example/upload");
+    mockCreatePresignedPost.mockResolvedValueOnce({
+      url: "https://signed.example/upload",
+      fields: {
+        key: "sys/blob_test",
+        "Content-Type": "image/png",
+        policy: "abc",
+        "X-Amz-Signature": "sig",
+      },
+    });
     const result = await adapter.generatePresignedUploadUrl({
       storageKey: KEY,
       mimeType: "image/png",
@@ -326,12 +342,34 @@ describe("S3BlobStorageAdapter.generatePresignedUploadUrl", () => {
     if (result.supported) {
       expect(result.url).toBe("https://signed.example/upload");
       expect(result.expiresAt).toBeGreaterThan(Date.now());
+      expect(result.fields).toBeDefined();
+      expect(result.fields?.["Content-Type"]).toBe("image/png");
     }
+  });
+
+  it("passes content-length-range condition to createPresignedPost", async () => {
+    const { adapter } = makeAdapter();
+    mockCreatePresignedPost.mockResolvedValueOnce({
+      url: "https://signed.example/upload",
+      fields: { key: "sys/blob_test" },
+    });
+    await adapter.generatePresignedUploadUrl({
+      storageKey: KEY,
+      mimeType: "image/png",
+      sizeBytes: 2048,
+    });
+    expect(mockCreatePresignedPost).toHaveBeenCalledOnce();
+    const callArgs = mockCreatePresignedPost.mock.calls[0] as unknown[];
+    const options = callArgs[1] as { Conditions: unknown[] };
+    expect(options.Conditions).toEqual(expect.arrayContaining([["content-length-range", 1, 2048]]));
   });
 
   it("uses configured presignedUploadExpiryMs default when no override", async () => {
     const { adapter } = makeAdapter({ presignedUploadExpiryMs: 60_000 });
-    mockGetSignedUrl.mockResolvedValueOnce("https://signed.example/upload");
+    mockCreatePresignedPost.mockResolvedValueOnce({
+      url: "https://signed.example/upload",
+      fields: {},
+    });
     const before = Date.now();
     const result = await adapter.generatePresignedUploadUrl({
       storageKey: KEY,
@@ -346,7 +384,7 @@ describe("S3BlobStorageAdapter.generatePresignedUploadUrl", () => {
 
   it("propagates errors via mapS3Error", async () => {
     const { adapter } = makeAdapter();
-    mockGetSignedUrl.mockRejectedValueOnce(awsError("AccessDenied"));
+    mockCreatePresignedPost.mockRejectedValueOnce(awsError("AccessDenied"));
     await expect(
       adapter.generatePresignedUploadUrl({
         storageKey: KEY,

--- a/packages/storage/src/adapters/s3/s3-adapter.ts
+++ b/packages/storage/src/adapters/s3/s3-adapter.ts
@@ -5,6 +5,7 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
+import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { toUnixMillis } from "@pluralscape/types";
 import { now } from "@pluralscape/types/runtime";
@@ -193,21 +194,26 @@ export class S3BlobStorageAdapter implements BlobStorageAdapter {
     const expiryMs = params.expiresInMs ?? this.presignedUploadExpiryMs;
     const expiresInSeconds = Math.ceil(expiryMs / MS_PER_SECOND);
 
-    const command = new PutObjectCommand({
-      Bucket: this.bucket,
-      Key: params.storageKey,
-      ContentType: params.mimeType ?? "application/octet-stream",
-      ContentLength: params.sizeBytes,
-    });
-
     try {
-      const url = await getSignedUrl(this.client, command, { expiresIn: expiresInSeconds });
+      const { url, fields } = await createPresignedPost(this.client, {
+        Bucket: this.bucket,
+        Key: params.storageKey,
+        Expires: expiresInSeconds,
+        Conditions: [
+          ["content-length-range", 1, params.sizeBytes],
+          ["eq", "$Content-Type", params.mimeType ?? "application/octet-stream"],
+        ],
+        Fields: {
+          "Content-Type": params.mimeType ?? "application/octet-stream",
+        },
+      });
       const expiresAt = toUnixMillis(now() + expiryMs);
 
       return {
         supported: true,
         url,
         expiresAt,
+        fields,
       };
     } catch (err) {
       mapS3Error(err, params.storageKey);

--- a/packages/storage/src/interface.ts
+++ b/packages/storage/src/interface.ts
@@ -53,7 +53,13 @@ export interface PresignedDownloadParams {
  * return `{ supported: false }` since they have no concept of presigned URLs.
  */
 export type PresignedUrlResult =
-  | { readonly supported: true; readonly url: string; readonly expiresAt: UnixMillis }
+  | {
+      readonly supported: true;
+      readonly url: string;
+      readonly expiresAt: UnixMillis;
+      /** Form fields required for POST-based presigned uploads (S3 POST policy). */
+      readonly fields?: Readonly<Record<string, string>>;
+    }
   | { readonly supported: false };
 
 /**

--- a/packages/validation/src/__tests__/blob.test.ts
+++ b/packages/validation/src/__tests__/blob.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { ALLOWED_MIME_TYPES, CreateUploadUrlBodySchema } from "../blob.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function validPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    purpose: "avatar",
+    mimeType: "image/png",
+    sizeBytes: 1024,
+    encryptionTier: 1,
+    ...overrides,
+  };
+}
+
+// ── ALLOWED_MIME_TYPES export ────────────────────────────────────────
+
+describe("ALLOWED_MIME_TYPES", () => {
+  it("contains an entry for every BlobPurpose value", () => {
+    const purposes = [
+      "avatar",
+      "member-photo",
+      "journal-image",
+      "attachment",
+      "export",
+      "littles-safe-mode",
+    ] as const;
+    for (const purpose of purposes) {
+      expect(ALLOWED_MIME_TYPES[purpose]).toBeDefined();
+      expect(ALLOWED_MIME_TYPES[purpose].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── MIME type validation ────────────────────────────────────────────
+
+describe("CreateUploadUrlBodySchema MIME validation", () => {
+  it("accepts valid MIME type for avatar (image/png)", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(validPayload());
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid MIME type for avatar (image/jpeg)", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(validPayload({ mimeType: "image/jpeg" }));
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid MIME type for avatar (image/webp)", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(validPayload({ mimeType: "image/webp" }));
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts image/gif for journal-image", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(
+      validPayload({ purpose: "journal-image", mimeType: "image/gif" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts application/pdf for attachment", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(
+      validPayload({ purpose: "attachment", mimeType: "application/pdf" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts application/octet-stream for export", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(
+      validPayload({ purpose: "export", mimeType: "application/octet-stream" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects text/html (stored XSS vector)", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(validPayload({ mimeType: "text/html" }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      expect(issue).toBeDefined();
+      expect(issue?.message).toContain("text/html");
+      expect(issue?.message).toContain("not allowed");
+    }
+  });
+
+  it("rejects application/javascript (stored XSS vector)", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(
+      validPayload({ mimeType: "application/javascript" }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      expect(issue).toBeDefined();
+      expect(issue?.message).toContain("application/javascript");
+      expect(issue?.message).toContain("not allowed");
+    }
+  });
+
+  it("rejects cross-purpose MIME type (PDF not allowed for avatar)", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(
+      validPayload({ mimeType: "application/pdf" }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      expect(issue).toBeDefined();
+      expect(issue?.message).toContain("application/pdf");
+      expect(issue?.message).toContain("avatar");
+    }
+  });
+
+  it("rejects cross-purpose MIME type (image/gif not allowed for avatar)", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(validPayload({ mimeType: "image/gif" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects image/png for export purpose", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(
+      validPayload({ purpose: "export", mimeType: "image/png" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects application/octet-stream for avatar purpose", () => {
+    const result = CreateUploadUrlBodySchema.safeParse(
+      validPayload({ mimeType: "application/octet-stream" }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validation/src/blob.ts
+++ b/packages/validation/src/blob.ts
@@ -1,6 +1,8 @@
 import { toChecksumHex } from "@pluralscape/types";
 import { z } from "zod/v4";
 
+import type { BlobPurpose } from "@pluralscape/types";
+
 const BlobPurposeEnum = z.enum([
   "avatar",
   "member-photo",
@@ -16,6 +18,16 @@ const MAX_MIME_TYPE_LENGTH = 255;
 /** Checksum hex digest length (64 chars). */
 const CHECKSUM_HEX_LENGTH = 64;
 
+/** Strict per-purpose MIME type allowlists to prevent stored XSS via arbitrary content types. */
+export const ALLOWED_MIME_TYPES: Readonly<Record<BlobPurpose, readonly string[]>> = {
+  avatar: ["image/png", "image/jpeg", "image/webp"],
+  "member-photo": ["image/png", "image/jpeg", "image/webp"],
+  "journal-image": ["image/png", "image/jpeg", "image/webp", "image/gif"],
+  attachment: ["image/png", "image/jpeg", "image/webp", "image/gif", "application/pdf"],
+  export: ["application/octet-stream"],
+  "littles-safe-mode": ["image/png", "image/jpeg", "image/webp"],
+};
+
 export const CreateUploadUrlBodySchema = z
   .object({
     purpose: BlobPurposeEnum,
@@ -23,7 +35,17 @@ export const CreateUploadUrlBodySchema = z
     sizeBytes: z.int().min(1),
     encryptionTier: z.union([z.literal(1), z.literal(2)]),
   })
-  .readonly();
+  .readonly()
+  .superRefine((data, ctx) => {
+    const allowed = ALLOWED_MIME_TYPES[data.purpose as BlobPurpose];
+    if (!allowed.includes(data.mimeType)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["mimeType"],
+        message: `MIME type "${data.mimeType}" is not allowed for purpose "${data.purpose}". Allowed: ${allowed.join(", ")}`,
+      });
+    }
+  });
 
 export const ConfirmUploadBodySchema = z
   .object({

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -83,7 +83,7 @@ export {
   UpdateEntityBodySchema,
   UpdateCanvasBodySchema,
 } from "./innerworld.js";
-export { CreateUploadUrlBodySchema, ConfirmUploadBodySchema } from "./blob.js";
+export { CreateUploadUrlBodySchema, ConfirmUploadBodySchema, ALLOWED_MIME_TYPES } from "./blob.js";
 export {
   CreateFrontingSessionBodySchema,
   UpdateFrontingSessionBodySchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,6 +713,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1028.0
         version: 3.1030.0
+      '@aws-sdk/s3-presigned-post':
+        specifier: ^3.1030.0
+        version: 3.1030.0
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1028.0
         version: 3.1030.0
@@ -984,6 +987,10 @@ packages:
 
   '@aws-sdk/region-config-resolver@3.972.11':
     resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-presigned-post@3.1030.0':
+    resolution: {integrity: sha512-PsvTJjGTQ+HZ5B4e4V5/seHBLBQXsGa7vZgufdNhDHX6s45Pq6lLjkJ/YANxwNxUZ0EAUxVXuDQz4rwk0hExug==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1030.0':
@@ -7651,6 +7658,20 @@ snapshots:
       '@smithy/node-config-provider': 4.3.13
       '@smithy/types': 4.14.0
       tslib: 2.8.1
+
+  '@aws-sdk/s3-presigned-post@3.1030.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1030.0
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-format-url': 3.972.9
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/s3-request-presigner@3.1030.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Validate blob MIME type against per-purpose allowlist to prevent stored XSS via arbitrary content types (api-ecz2)
- Enforce S3 presigned upload content-length-range via POST policy to prevent quota bypass by uploading larger objects than declared (api-oq3d)
- Distinguish SESSION_EXPIRED from UNAUTHENTICATED in REST middleware so clients can detect expired sessions and prompt re-authentication (api-a6s6)

## Test plan
- [x] Validation tests pass with MIME allowlist enforcement (14 tests)
- [x] Storage tests pass with presigned POST + content-length-range assertions (4 tests)
- [x] API tests pass with session error distinction (updated existing test)
- [x] Full typecheck clean
- [x] Full lint clean
- [x] All 5116 unit tests pass across 412 test files