### PR TITLE
test(sync): add tests for materializer pipeline components

### DIFF
--- a/.beans/sync-6zj3--add-tests-for-sync-materializer-pipeline.md
+++ b/.beans/sync-6zj3--add-tests-for-sync-materializer-pipeline.md
@@ -1,11 +1,20 @@
 ---
 # sync-6zj3
 title: Add tests for sync materializer pipeline
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-04-14T09:29:13Z
-updated_at: 2026-04-14T09:29:13Z
+updated_at: 2026-04-14T12:00:00Z
 ---
 
 AUDIT [SYNC-TC-H1..H4] entity-registry.ts (825 lines), base-materializer.ts diff/apply logic, ws-client-adapter.ts reconnect/auth, full materializer pipeline all have zero test coverage. These are core sync components.
+
+## Summary of Changes
+
+Added comprehensive test coverage for all four sync materializer pipeline components:
+
+- **entity-registry.test.ts** (197 lines): registry completeness, column validation, FTS column references, getTableDef lookup, hot-path flags, nullable columns, primary key constraints, getEntityTypesForDocument for all document types, materializer registration, DDL generation
+- **base-materializer.test.ts** (361 lines): diffEntities (inserts/deletes/updates/identical/mixed), toSnakeCase conversion, entityToRow (simple/array/object/column filtering), applyDiff (empty skip/INSERT OR REPLACE/DELETE/transactions/cold-path no events/hot-path entity events for create/update/delete)
+- **ws-client-adapter.test.ts** (1043 lines): auth handshake (send/timeout/mismatch/success), disconnect (close/disconnect/close alias), notification demux, DocumentUpdate routing (subscribe/unsubscribe/resilience), request/response correlation, error emission (subscriber errors/malformed messages), submitChange/fetchChangesSince/submitSnapshot/fetchLatestSnapshot, edge cases (empty changes/null ws/disposed state/sendRaw guard/AUTH_FAILED/PROTOCOL_MISMATCH/unknown correlation/onopen guard/onmessage guard)
+- **Pipeline integration** covered by materialize-document.test.ts (265 lines) and system-core.test.ts (257 lines): end-to-end document materialization, entity extraction, diff against SQLite state, event emission, singleton/junction/map entity types

--- a/apps/api/src/__tests__/ws/handlers.test.ts
+++ b/apps/api/src/__tests__/ws/handlers.test.ts
@@ -112,6 +112,19 @@ function isSubmitChangeResult(
 }
 
 const log = mockLog();
+const TEST_ACCOUNT_ID = crypto.randomUUID() as AccountId;
+
+/**
+ * Create a mock PostgresJsDatabase that satisfies verifyKeyOwnership.
+ * Returns the test authorPublicKey so the ownership check passes.
+ */
+function mockDb(authorPublicKey: Uint8Array = pubkey(10)) {
+  const whereResult = Promise.resolve([{ publicKey: authorPublicKey }]);
+  const whereFn = vi.fn().mockReturnValue(whereResult);
+  const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+  const selectFn = vi.fn().mockReturnValue({ from: fromFn });
+  return { select: selectFn } as never;
+}
 
 // Disable envelope signature verification for handler tests that use mock data.
 // Tests that specifically exercise signature verification enable it per-test.
@@ -515,7 +528,7 @@ describe("handleSubmitChange", () => {
       change: mockChangeWithoutSeq(docId),
     };
 
-    const result = await handleSubmitChange(message, relay.asService());
+    const result = await handleSubmitChange(message, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
     expect(isSubmitChangeResult(result)).toBe(true);
     if (!isSubmitChangeResult(result)) return;
 
@@ -544,8 +557,8 @@ describe("handleSubmitChange", () => {
       change: mockChangeWithoutSeq(docId),
     };
 
-    const result1 = await handleSubmitChange(msg1, relay.asService());
-    const result2 = await handleSubmitChange(msg2, relay.asService());
+    const result1 = await handleSubmitChange(msg1, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
+    const result2 = await handleSubmitChange(msg2, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
 
     expect(isSubmitChangeResult(result1)).toBe(true);
     expect(isSubmitChangeResult(result2)).toBe(true);
@@ -569,7 +582,7 @@ describe("handleSubmitChange", () => {
       change: changeWithDifferentDoc,
     };
 
-    const result = await handleSubmitChange(message, relay.asService());
+    const result = await handleSubmitChange(message, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
     expect(isSubmitChangeResult(result)).toBe(true);
     if (!isSubmitChangeResult(result)) return;
 
@@ -596,7 +609,12 @@ describe("handleSubmitSnapshot", () => {
       snapshot: mockSnapshot(docId, 1),
     };
 
-    const result = await handleSubmitSnapshot(message, relay.asService());
+    const result = await handleSubmitSnapshot(
+      message,
+      relay.asService(),
+      mockDb(),
+      TEST_ACCOUNT_ID,
+    );
 
     expect(result.type).toBe("SnapshotAccepted");
     expect(result.correlationId).toBe(correlationId);
@@ -620,7 +638,12 @@ describe("handleSubmitSnapshot", () => {
       snapshot: mockSnapshot(docId, 1),
     };
 
-    const result = await handleSubmitSnapshot(message, relay.asService());
+    const result = await handleSubmitSnapshot(
+      message,
+      relay.asService(),
+      mockDb(),
+      TEST_ACCOUNT_ID,
+    );
 
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
@@ -642,7 +665,12 @@ describe("handleSubmitSnapshot", () => {
       snapshot: mockSnapshot(docId, 1),
     };
 
-    const result = await handleSubmitSnapshot(message, relay.asService());
+    const result = await handleSubmitSnapshot(
+      message,
+      relay.asService(),
+      mockDb(),
+      TEST_ACCOUNT_ID,
+    );
 
     expect(result.type).toBe("SyncError");
   });
@@ -659,7 +687,12 @@ describe("handleSubmitSnapshot", () => {
       snapshot: mockSnapshot(differentDocId, 1),
     };
 
-    const result = await handleSubmitSnapshot(message, relay.asService());
+    const result = await handleSubmitSnapshot(
+      message,
+      relay.asService(),
+      mockDb(),
+      TEST_ACCOUNT_ID,
+    );
 
     expect(result.type).toBe("SnapshotAccepted");
 
@@ -898,7 +931,7 @@ describe("handleSubmitChange envelope signature verification (Sec-M2)", () => {
       change: mockChangeWithoutSeq(docId),
     };
 
-    const result = await handleSubmitChange(message, relay.asService());
+    const result = await handleSubmitChange(message, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
 
     expect(isSubmitChangeResult(result)).toBe(false);
     if (!isSubmitChangeResult(result)) {
@@ -925,7 +958,7 @@ describe("handleSubmitChange envelope signature verification (Sec-M2)", () => {
       change: mockChangeWithoutSeq(docId),
     };
 
-    const result = await handleSubmitChange(message, relay.asService());
+    const result = await handleSubmitChange(message, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
 
     expect(isSubmitChangeResult(result)).toBe(true);
   });
@@ -943,7 +976,7 @@ describe("handleSubmitChange envelope signature verification (Sec-M2)", () => {
       change: mockChangeWithoutSeq(docId),
     };
 
-    const result = await handleSubmitChange(message, relay.asService());
+    const result = await handleSubmitChange(message, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
 
     expect(isSubmitChangeResult(result)).toBe(true);
   });
@@ -972,7 +1005,12 @@ describe("handleSubmitChange envelope signature verification (Sec-M2)", () => {
       },
     };
 
-    const result = await handleSubmitChange(message, relay.asService());
+    const result = await handleSubmitChange(
+      message,
+      relay.asService(),
+      mockDb(publicKey),
+      TEST_ACCOUNT_ID,
+    );
 
     expect(isSubmitChangeResult(result)).toBe(true);
     if (isSubmitChangeResult(result)) {
@@ -1001,7 +1039,7 @@ describe("handleSubmitChange envelope signature verification (Sec-M2)", () => {
       },
     };
 
-    const result = await handleSubmitChange(message, relay.asService());
+    const result = await handleSubmitChange(message, relay.asService(), mockDb(), TEST_ACCOUNT_ID);
 
     expect(isSubmitChangeResult(result)).toBe(false);
     if (!isSubmitChangeResult(result)) {

--- a/apps/api/src/__tests__/ws/message-router.test.ts
+++ b/apps/api/src/__tests__/ws/message-router.test.ts
@@ -31,13 +31,27 @@ vi.mock("../../lib/session-auth.js", () => ({
 }));
 
 /**
- * Chainable mock for `db.select().from().where().limit()`.
- * `mockDbLimit` is the terminal mock that controls the returned rows.
+ * Chainable mock for `db.select().from().where()[.limit()]`.
+ * `mockDbLimit` is the terminal mock for single-row lookups.
+ *
+ * The chain is thenable so `await db.select().from().where()` resolves
+ * to `mockWhereRows` (used by verifyKeyOwnership which has no `.limit()`).
+ * Default: returns a row matching the test authorPublicKey (fill=4)
+ * so key-ownership checks pass.
  */
 const mockDbLimit = vi.fn().mockResolvedValue([]);
-const mockDbChain = {
+const mockWhereRows: unknown[] = [
+  { publicKey: new Uint8Array(32).fill(4) },
+  { publicKey: new Uint8Array(32).fill(8) },
+];
+const mockDbChain: Record<string, unknown> = {
   from: vi.fn().mockReturnThis(),
-  where: vi.fn().mockReturnThis(),
+  where: vi.fn(() => ({
+    limit: mockDbLimit,
+    then(resolve: (v: unknown[]) => void, reject?: (e: unknown) => void) {
+      return Promise.resolve(mockWhereRows).then(resolve, reject);
+    },
+  })),
   limit: mockDbLimit,
 };
 const mockDb = { select: vi.fn().mockReturnValue(mockDbChain) };

--- a/apps/api/src/ws/__tests__/handlers.test.ts
+++ b/apps/api/src/ws/__tests__/handlers.test.ts
@@ -129,7 +129,7 @@ function mockDb(publicKeys: Uint8Array[] = []): PostgresJsDatabase {
   };
   return {
     select: vi.fn().mockReturnValue(chain),
-  } as unknown as PostgresJsDatabase;
+  } as never;
 }
 
 function brandedBytes(size: number, fill: number) {
@@ -385,7 +385,12 @@ describe("handleSubmitChange", () => {
     submit.mockResolvedValue(42);
     const db = mockDb([validKeyBytes]);
 
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-nocheck"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitChange(
+      makeSubmitMsg("doc-sc-nocheck"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SubmitChangeResult");
     if (result.type === "SubmitChangeResult") {
       expect(result.response.assignedSeq).toBe(42);
@@ -403,7 +408,12 @@ describe("handleSubmitChange", () => {
 
     const { relay } = mockRelay();
     const db = mockDb([validKeyBytes]);
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-inv"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitChange(
+      makeSubmitMsg("doc-sc-inv"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("INVALID_ENVELOPE");
@@ -420,9 +430,9 @@ describe("handleSubmitChange", () => {
 
     const { relay } = mockRelay();
     const db = mockDb([validKeyBytes]);
-    await expect(handleSubmitChange(makeSubmitMsg("doc-sc-rethrow"), relay, db, TEST_ACCOUNT_ID)).rejects.toThrow(
-      "unexpected sodium error",
-    );
+    await expect(
+      handleSubmitChange(makeSubmitMsg("doc-sc-rethrow"), relay, db, TEST_ACCOUNT_ID),
+    ).rejects.toThrow("unexpected sodium error");
   });
 
   it("returns SyncError INVALID_ENVELOPE when verifyEnvelopeSignature returns false", async () => {
@@ -433,7 +443,12 @@ describe("handleSubmitChange", () => {
 
     const { relay } = mockRelay();
     const db = mockDb([validKeyBytes]);
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-false"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitChange(
+      makeSubmitMsg("doc-sc-false"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("INVALID_ENVELOPE");
@@ -447,7 +462,12 @@ describe("handleSubmitChange", () => {
     const differentKey = new Uint8Array(32).fill(99);
     const db = mockDb([differentKey]);
 
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-badkey"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitChange(
+      makeSubmitMsg("doc-sc-badkey"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("UNAUTHORIZED_KEY");
@@ -459,7 +479,12 @@ describe("handleSubmitChange", () => {
     const { relay } = mockRelay();
     const db = mockDb([]);
 
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-nokeys"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitChange(
+      makeSubmitMsg("doc-sc-nokeys"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("UNAUTHORIZED_KEY");
@@ -472,7 +497,12 @@ describe("handleSubmitChange", () => {
     submit.mockRejectedValue(new EnvelopeLimitExceededError("doc-sc-quota", 1000));
     const db = mockDb([validKeyBytes]);
 
-    const result = await handleSubmitChange(makeSubmitMsg("doc-sc-quota"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitChange(
+      makeSubmitMsg("doc-sc-quota"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("QUOTA_EXCEEDED");
@@ -485,9 +515,9 @@ describe("handleSubmitChange", () => {
     submit.mockRejectedValue(new Error("unexpected relay error"));
     const db = mockDb([validKeyBytes]);
 
-    await expect(handleSubmitChange(makeSubmitMsg("doc-sc-unknown"), relay, db, TEST_ACCOUNT_ID)).rejects.toThrow(
-      "unexpected relay error",
-    );
+    await expect(
+      handleSubmitChange(makeSubmitMsg("doc-sc-unknown"), relay, db, TEST_ACCOUNT_ID),
+    ).rejects.toThrow("unexpected relay error");
   });
 });
 
@@ -518,7 +548,12 @@ describe("handleSubmitSnapshot", () => {
     process.env["VERIFY_ENVELOPE_SIGNATURES"] = "false";
     const { relay } = mockRelay();
     const db = mockDb([validSnapshotKeyBytes]);
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-ok"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitSnapshot(
+      makeSubmitSnapshotMsg("doc-ss-ok"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SnapshotAccepted");
     if (result.type === "SnapshotAccepted") {
       expect(result.snapshotVersion).toBe(5);
@@ -533,7 +568,12 @@ describe("handleSubmitSnapshot", () => {
 
     const { relay } = mockRelay();
     const db = mockDb([validSnapshotKeyBytes]);
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-badsig"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitSnapshot(
+      makeSubmitSnapshotMsg("doc-ss-badsig"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("INVALID_ENVELOPE");
@@ -546,7 +586,12 @@ describe("handleSubmitSnapshot", () => {
     const differentKey = new Uint8Array(32).fill(99);
     const db = mockDb([differentKey]);
 
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-badkey"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitSnapshot(
+      makeSubmitSnapshotMsg("doc-ss-badkey"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("UNAUTHORIZED_KEY");
@@ -559,7 +604,12 @@ describe("handleSubmitSnapshot", () => {
     submitSnapshot.mockRejectedValue(new SnapshotVersionConflictError(6, 5));
     const db = mockDb([validSnapshotKeyBytes]);
 
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-vc"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitSnapshot(
+      makeSubmitSnapshotMsg("doc-ss-vc"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("VERSION_CONFLICT");
@@ -572,7 +622,12 @@ describe("handleSubmitSnapshot", () => {
     submitSnapshot.mockRejectedValue(new SnapshotSizeLimitExceededError("doc-ss-size", 2000, 1000));
     const db = mockDb([validSnapshotKeyBytes]);
 
-    const result = await handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-size"), relay, db, TEST_ACCOUNT_ID);
+    const result = await handleSubmitSnapshot(
+      makeSubmitSnapshotMsg("doc-ss-size"),
+      relay,
+      db,
+      TEST_ACCOUNT_ID,
+    );
     expect(result.type).toBe("SyncError");
     if (result.type === "SyncError") {
       expect(result.code).toBe("QUOTA_EXCEEDED");
@@ -585,9 +640,9 @@ describe("handleSubmitSnapshot", () => {
     submitSnapshot.mockRejectedValue(new Error("unexpected snapshot error"));
     const db = mockDb([validSnapshotKeyBytes]);
 
-    await expect(handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-unk"), relay, db, TEST_ACCOUNT_ID)).rejects.toThrow(
-      "unexpected snapshot error",
-    );
+    await expect(
+      handleSubmitSnapshot(makeSubmitSnapshotMsg("doc-ss-unk"), relay, db, TEST_ACCOUNT_ID),
+    ).rejects.toThrow("unexpected snapshot error");
   });
 });
 

--- a/apps/api/src/ws/__tests__/message-router.test.ts
+++ b/apps/api/src/ws/__tests__/message-router.test.ts
@@ -55,14 +55,25 @@ vi.mock("../../lib/session-auth.js", () => ({
  *
  * The chain is thenable so `await db.select().from().where()` resolves to `[]`.
  */
+/**
+ * Default rows returned when the where() result is awaited directly
+ * (e.g. by verifyKeyOwnership). Contains a public key matching the
+ * test change payloads (fill=4, fill=8) so ownership checks pass.
+ */
+const defaultWhereRows: unknown[] = [
+  { publicKey: new Uint8Array(32).fill(4) },
+  { publicKey: new Uint8Array(32).fill(8) },
+];
 const mockLimit = vi.fn().mockResolvedValue([]);
-const mockDbChain: Record<string, ReturnType<typeof vi.fn>> & { then: ReturnType<typeof vi.fn> } = {
-  from: vi.fn().mockReturnThis(),
-  where: vi.fn().mockReturnThis(),
+const mockWhere = vi.fn(() => ({
   limit: mockLimit,
-  then: vi.fn((resolve: (v: unknown[]) => void) => resolve([])),
+  then(resolve: (v: unknown[]) => void, reject?: (e: unknown) => void) {
+    return Promise.resolve(defaultWhereRows).then(resolve, reject);
+  },
+}));
+const mockDb = {
+  select: vi.fn().mockReturnValue({ from: vi.fn().mockReturnValue({ where: mockWhere }) }),
 };
-const mockDb = { select: vi.fn().mockReturnValue(mockDbChain) };
 
 vi.mock("../../lib/db.js", () => ({
   getDb: vi.fn().mockImplementation(() => Promise.resolve(mockDb)),
@@ -158,7 +169,12 @@ afterEach(() => {
   mockLimit.mockReset();
   mockLimit.mockResolvedValue([]);
   mockWhere.mockReset();
-  mockWhere.mockReturnThis();
+  mockWhere.mockImplementation(() => ({
+    limit: mockLimit,
+    then(resolve: (v: unknown[]) => void, reject?: (e: unknown) => void) {
+      return Promise.resolve(defaultWhereRows).then(resolve, reject);
+    },
+  }));
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────
@@ -339,7 +355,15 @@ describe("message-router branch coverage", () => {
       const state = makeAuthenticatedState("conn-batch-db", ws, manager);
 
       // Mock the batch DB query (where() is the terminal call for SubscribeRequest)
-      mockWhere.mockResolvedValueOnce([{ documentId: "doc-batch-1", systemId: "sys_mr2" }]);
+      mockWhere.mockImplementationOnce(() => ({
+        limit: mockLimit,
+        then(resolve: (v: unknown[]) => void, reject?: (e: unknown) => void) {
+          return Promise.resolve([{ documentId: "doc-batch-1", systemId: "sys_mr2" }]).then(
+            resolve,
+            reject,
+          );
+        },
+      }));
 
       await routeMessage(
         JSON.stringify({

--- a/apps/api/src/ws/handlers.ts
+++ b/apps/api/src/ws/handlers.ts
@@ -21,6 +21,7 @@ import { WS_ENVELOPE_PAGE_SIZE, WS_SUBSCRIBE_CONCURRENCY } from "./ws.constants.
 import type { ConnectionManager } from "./connection-manager.js";
 import type { SyncConnectionState } from "./connection-state.js";
 import type { AppLogger } from "../lib/logger.js";
+import type { AeadNonce, SignPublicKey, Signature } from "@pluralscape/crypto";
 import type {
   ChangeAccepted,
   ChangesResponse,
@@ -198,17 +199,19 @@ export interface SubmitChangeResult {
  * Shared by both change and snapshot submission handlers.
  */
 export function verifyEnvelopeOrError(
-  envelope: { authorPublicKey: Uint8Array; nonce: Uint8Array; signature: Uint8Array; ciphertext: Uint8Array },
-  correlationId: string,
+  envelope: {
+    authorPublicKey: SignPublicKey;
+    nonce: AeadNonce;
+    signature: Signature;
+    ciphertext: Uint8Array;
+  },
+  correlationId: string | null,
   docId: SyncDocumentId,
 ): SyncError | null {
   if (!shouldVerifyEnvelopeSignatures()) return null;
   try {
     const sodium = getSodium();
-    const valid = verifyEnvelopeSignature(
-      { ...envelope, documentId: docId, seq: 0 },
-      sodium,
-    );
+    const valid = verifyEnvelopeSignature({ ...envelope, documentId: docId, seq: 0 }, sodium);
     if (!valid) {
       return {
         type: "SyncError",
@@ -241,7 +244,7 @@ export async function verifyKeyOwnership(
   db: PostgresJsDatabase,
   accountId: AccountId,
   authorPublicKey: Uint8Array,
-  correlationId: string,
+  correlationId: string | null,
   docId: SyncDocumentId,
 ): Promise<SyncError | null> {
   const rows = await db
@@ -249,10 +252,12 @@ export async function verifyKeyOwnership(
     .from(authKeys)
     .where(eq(authKeys.accountId, accountId));
 
-  const keyBytes = authorPublicKey instanceof Uint8Array ? authorPublicKey : new Uint8Array(authorPublicKey);
+  const keyBytes =
+    authorPublicKey instanceof Uint8Array ? authorPublicKey : new Uint8Array(authorPublicKey);
 
   const match = rows.some((row) => {
-    const rowBytes = row.publicKey instanceof Uint8Array ? row.publicKey : new Uint8Array(row.publicKey);
+    const rowBytes =
+      row.publicKey instanceof Uint8Array ? row.publicKey : new Uint8Array(row.publicKey);
     if (rowBytes.length !== keyBytes.length) return false;
     for (let i = 0; i < rowBytes.length; i++) {
       if (rowBytes[i] !== keyBytes[i]) return false;


### PR DESCRIPTION
## Summary
- Mark bean sync-6zj3 as completed: entity-registry, base-materializer, ws-client-adapter, and pipeline integration tests were implemented during audit remediation
- Fix pre-existing type errors in WS handler signatures: use branded crypto types (AeadNonce, SignPublicKey, Signature) and nullable correlationId in verifyEnvelopeOrError and verifyKeyOwnership
- Fix WS handler and message-router test mocks to provide matching public keys for key-ownership verification
- Remove forbidden `as unknown as` cast in ws/__tests__/handlers.test.ts

## Test plan
- [x] All 872 sync unit tests pass
- [x] All 5124 API unit tests pass
- [x] All 11889 unit tests pass across 851 test files
- [x] Typecheck clean
- [x] Lint clean