### PR TITLE
test(e2e): add E2E specs for analytics and fronting-reports

### DIFF
--- a/.beans/api-d421--add-e2e-tests-for-analytics-and-fronting-reports.md
+++ b/.beans/api-d421--add-e2e-tests-for-analytics-and-fronting-reports.md
@@ -1,11 +1,11 @@
 ---
 # api-d421
 title: Add E2E tests for analytics and fronting-reports
-status: done
+status: completed
 type: task
 priority: high
 created_at: 2026-04-14T09:29:19Z
-updated_at: 2026-04-14T09:29:19Z
+updated_at: 2026-04-14T11:27:18Z
 ---
 
 AUDIT [API-E2E-H1,H2] analytics/ (fronting analytics, co-fronting) and fronting-reports/ (full CRUD + archive/restore) have zero E2E specs. Both are core features with no end-to-end validation.
@@ -16,3 +16,7 @@ Added E2E specs for analytics endpoints and fronting reports CRUD lifecycle:
 
 - `apps/api-e2e/src/tests/analytics/fronting-analytics.spec.ts` — fronting analytics breakdown with date range presets/custom range, co-fronting analytics detecting overlapping sessions
 - `apps/api-e2e/src/tests/fronting-reports/fronting-reports.spec.ts` — full CRUD lifecycle (create, list, get, update, archive, restore, delete, 404 after deletion), format validation
+
+## Summary of Changes
+
+Added E2E specs for analytics endpoints and fronting reports CRUD lifecycle.

--- a/.beans/api-d421--add-e2e-tests-for-analytics-and-fronting-reports.md
+++ b/.beans/api-d421--add-e2e-tests-for-analytics-and-fronting-reports.md
@@ -1,7 +1,7 @@
 ---
 # api-d421
 title: Add E2E tests for analytics and fronting-reports
-status: todo
+status: done
 type: task
 priority: high
 created_at: 2026-04-14T09:29:19Z
@@ -9,3 +9,10 @@ updated_at: 2026-04-14T09:29:19Z
 ---
 
 AUDIT [API-E2E-H1,H2] analytics/ (fronting analytics, co-fronting) and fronting-reports/ (full CRUD + archive/restore) have zero E2E specs. Both are core features with no end-to-end validation.
+
+## Summary of Changes
+
+Added E2E specs for analytics endpoints and fronting reports CRUD lifecycle:
+
+- `apps/api-e2e/src/tests/analytics/fronting-analytics.spec.ts` — fronting analytics breakdown with date range presets/custom range, co-fronting analytics detecting overlapping sessions
+- `apps/api-e2e/src/tests/fronting-reports/fronting-reports.spec.ts` — full CRUD lifecycle (create, list, get, update, archive, restore, delete, 404 after deletion), format validation

--- a/apps/api-e2e/src/tests/analytics/fronting-analytics.spec.ts
+++ b/apps/api-e2e/src/tests/analytics/fronting-analytics.spec.ts
@@ -1,0 +1,248 @@
+import { expect, test } from "../../fixtures/auth.fixture.js";
+import { encryptForApi, ensureCryptoReady } from "../../fixtures/crypto.fixture.js";
+import { createMember, getSystemId } from "../../fixtures/entity-helpers.js";
+import { parseJsonBody } from "../../fixtures/http.constants.js";
+
+test.describe("Fronting Analytics", () => {
+  test.beforeAll(async () => {
+    await ensureCryptoReady();
+  });
+
+  test("fronting analytics returns breakdown for members with sessions", async ({
+    request,
+    authHeaders,
+  }) => {
+    const systemId = await getSystemId(request, authHeaders);
+    let memberAId: string;
+    let memberBId: string;
+
+    await test.step("create two members", async () => {
+      const memberA = await createMember(request, authHeaders, systemId, "Analytics Member A");
+      const memberB = await createMember(request, authHeaders, systemId, "Analytics Member B");
+      memberAId = memberA.id;
+      memberBId = memberB.id;
+    });
+
+    await test.step("create and end fronting sessions", async () => {
+      const now = Date.now();
+      const oneHourAgo = now - 3_600_000;
+
+      // Member A: session from 1h ago to now
+      const resA = await request.post(`/v1/systems/${systemId}/fronting-sessions`, {
+        headers: authHeaders,
+        data: {
+          encryptedData: encryptForApi({ note: "Analytics A" }),
+          startTime: oneHourAgo,
+          memberId: memberAId,
+        },
+      });
+      expect(resA.status()).toBe(201);
+      const sessionA = await parseJsonBody<{ data: { id: string } }>(resA);
+
+      await request.post(`/v1/systems/${systemId}/fronting-sessions/${sessionA.data.id}/end`, {
+        headers: authHeaders,
+        data: { endTime: now, version: 1 },
+      });
+
+      // Member B: session from 30min ago to now
+      const thirtyMinAgo = now - 1_800_000;
+      const resB = await request.post(`/v1/systems/${systemId}/fronting-sessions`, {
+        headers: authHeaders,
+        data: {
+          encryptedData: encryptForApi({ note: "Analytics B" }),
+          startTime: thirtyMinAgo,
+          memberId: memberBId,
+        },
+      });
+      expect(resB.status()).toBe(201);
+      const sessionB = await parseJsonBody<{ data: { id: string } }>(resB);
+
+      await request.post(`/v1/systems/${systemId}/fronting-sessions/${sessionB.data.id}/end`, {
+        headers: authHeaders,
+        data: { endTime: now, version: 1 },
+      });
+    });
+
+    await test.step("GET fronting analytics with last-7-days preset", async () => {
+      const res = await request.get(
+        `/v1/systems/${systemId}/analytics/fronting?preset=last-7-days`,
+        { headers: authHeaders },
+      );
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: {
+          systemId: string;
+          dateRange: { preset: string; start: number; end: number };
+          subjectBreakdowns: Array<{
+            subjectType: string;
+            subjectId: string;
+            totalDuration: number;
+            sessionCount: number;
+            averageSessionLength: number;
+            percentageOfTotal: number;
+          }>;
+          truncated: boolean;
+        };
+      }>(res);
+
+      expect(body.data.systemId).toBe(systemId);
+      expect(body.data.dateRange.preset).toBe("last-7-days");
+      expect(body.data.subjectBreakdowns.length).toBeGreaterThanOrEqual(2);
+      expect(body.data.truncated).toBe(false);
+
+      // Verify both members appear in breakdowns
+      const subjectIds = body.data.subjectBreakdowns.map((b) => b.subjectId);
+      expect(subjectIds).toContain(memberAId);
+      expect(subjectIds).toContain(memberBId);
+
+      // Verify each breakdown has expected structure
+      for (const breakdown of body.data.subjectBreakdowns) {
+        expect(breakdown.subjectType).toBeTruthy();
+        expect(breakdown.totalDuration).toBeGreaterThanOrEqual(0);
+        expect(breakdown.sessionCount).toBeGreaterThanOrEqual(1);
+        expect(breakdown.averageSessionLength).toBeGreaterThanOrEqual(0);
+        expect(breakdown.percentageOfTotal).toBeGreaterThanOrEqual(0);
+        expect(breakdown.percentageOfTotal).toBeLessThanOrEqual(100);
+      }
+    });
+
+    await test.step("GET fronting analytics defaults to last-30-days", async () => {
+      const res = await request.get(`/v1/systems/${systemId}/analytics/fronting`, {
+        headers: authHeaders,
+      });
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: { dateRange: { preset: string } };
+      }>(res);
+      expect(body.data.dateRange.preset).toBe("last-30-days");
+    });
+
+    await test.step("GET fronting analytics with custom date range", async () => {
+      const now = Date.now();
+      const oneDayAgo = now - 86_400_000;
+
+      const res = await request.get(
+        `/v1/systems/${systemId}/analytics/fronting?preset=custom&startDate=${String(oneDayAgo)}&endDate=${String(now)}`,
+        { headers: authHeaders },
+      );
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: { dateRange: { preset: string; start: number; end: number } };
+      }>(res);
+      expect(body.data.dateRange.preset).toBe("custom");
+      expect(body.data.dateRange.start).toBe(oneDayAgo);
+      expect(body.data.dateRange.end).toBe(now);
+    });
+  });
+
+  test("co-fronting analytics detects overlapping sessions", async ({ request, authHeaders }) => {
+    const systemId = await getSystemId(request, authHeaders);
+    let memberAId: string;
+    let memberBId: string;
+
+    await test.step("create two members", async () => {
+      const memberA = await createMember(request, authHeaders, systemId, "CoFront Member A");
+      const memberB = await createMember(request, authHeaders, systemId, "CoFront Member B");
+      memberAId = memberA.id;
+      memberBId = memberB.id;
+    });
+
+    await test.step("create overlapping fronting sessions", async () => {
+      const now = Date.now();
+      const twoHoursAgo = now - 7_200_000;
+      const oneHourAgo = now - 3_600_000;
+
+      // Member A: session from 2h ago to now
+      const resA = await request.post(`/v1/systems/${systemId}/fronting-sessions`, {
+        headers: authHeaders,
+        data: {
+          encryptedData: encryptForApi({ note: "CoFront A" }),
+          startTime: twoHoursAgo,
+          memberId: memberAId,
+        },
+      });
+      expect(resA.status()).toBe(201);
+      const sessionA = await parseJsonBody<{ data: { id: string } }>(resA);
+
+      await request.post(`/v1/systems/${systemId}/fronting-sessions/${sessionA.data.id}/end`, {
+        headers: authHeaders,
+        data: { endTime: now, version: 1 },
+      });
+
+      // Member B: session from 1h ago to now (overlaps with A for 1h)
+      const resB = await request.post(`/v1/systems/${systemId}/fronting-sessions`, {
+        headers: authHeaders,
+        data: {
+          encryptedData: encryptForApi({ note: "CoFront B" }),
+          startTime: oneHourAgo,
+          memberId: memberBId,
+        },
+      });
+      expect(resB.status()).toBe(201);
+      const sessionB = await parseJsonBody<{ data: { id: string } }>(resB);
+
+      await request.post(`/v1/systems/${systemId}/fronting-sessions/${sessionB.data.id}/end`, {
+        headers: authHeaders,
+        data: { endTime: now, version: 1 },
+      });
+    });
+
+    await test.step("GET co-fronting analytics", async () => {
+      const res = await request.get(
+        `/v1/systems/${systemId}/analytics/co-fronting?preset=last-7-days`,
+        { headers: authHeaders },
+      );
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: {
+          systemId: string;
+          dateRange: { preset: string };
+          coFrontingPercentage: number;
+          pairs: Array<{
+            memberA: string;
+            memberB: string;
+            totalDuration: number;
+            sessionCount: number;
+            percentageOfTotal: number;
+          }>;
+          truncated: boolean;
+        };
+      }>(res);
+
+      expect(body.data.systemId).toBe(systemId);
+      expect(body.data.dateRange.preset).toBe("last-7-days");
+      expect(body.data.coFrontingPercentage).toBeGreaterThan(0);
+      expect(body.data.pairs.length).toBeGreaterThanOrEqual(1);
+      expect(body.data.truncated).toBe(false);
+
+      // Find the pair containing our two members
+      const pair = body.data.pairs.find(
+        (p) =>
+          (p.memberA === memberAId && p.memberB === memberBId) ||
+          (p.memberA === memberBId && p.memberB === memberAId),
+      );
+      expect(pair).toBeDefined();
+
+      // Safe to access after toBeDefined assertion — structure validated above
+      const matchedPair = pair as NonNullable<typeof pair>;
+      expect(matchedPair.totalDuration).toBeGreaterThan(0);
+      expect(matchedPair.sessionCount).toBeGreaterThanOrEqual(1);
+    });
+
+    await test.step("co-fronting analytics defaults to last-30-days", async () => {
+      const res = await request.get(`/v1/systems/${systemId}/analytics/co-fronting`, {
+        headers: authHeaders,
+      });
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: { dateRange: { preset: string } };
+      }>(res);
+      expect(body.data.dateRange.preset).toBe("last-30-days");
+    });
+  });
+});

--- a/apps/api-e2e/src/tests/fronting-reports/fronting-reports.spec.ts
+++ b/apps/api-e2e/src/tests/fronting-reports/fronting-reports.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "../../fixtures/auth.fixture.js";
+import { encryptForApi, ensureCryptoReady } from "../../fixtures/crypto.fixture.js";
+import { getSystemId } from "../../fixtures/entity-helpers.js";
+import { parseJsonBody } from "../../fixtures/http.constants.js";
+
+test.describe("Fronting Reports", () => {
+  test.beforeAll(async () => {
+    await ensureCryptoReady();
+  });
+
+  test("fronting report lifecycle: create, list, get, update, archive, restore, delete", async ({
+    request,
+    authHeaders,
+  }) => {
+    const systemId = await getSystemId(request, authHeaders);
+    let reportId: string;
+
+    await test.step("create a fronting report", async () => {
+      const res = await request.post(`/v1/systems/${systemId}/fronting-reports`, {
+        headers: authHeaders,
+        data: {
+          encryptedData: encryptForApi({ title: "E2E Test Report" }),
+          format: "html",
+          generatedAt: Date.now(),
+        },
+      });
+      expect(res.status()).toBe(201);
+
+      const body = await parseJsonBody<{
+        data: {
+          id: string;
+          systemId: string;
+          format: string;
+          generatedAt: number;
+          version: number;
+          archivedAt: null;
+        };
+      }>(res);
+      expect(body.data).toHaveProperty("id");
+      expect(body.data.systemId).toBe(systemId);
+      expect(body.data.format).toBe("html");
+      expect(body.data.generatedAt).toBeTruthy();
+      expect(body.data.version).toBe(1);
+      expect(body.data.archivedAt).toBeNull();
+      reportId = body.data.id;
+    });
+
+    await test.step("list reports includes the new report", async () => {
+      const res = await request.get(`/v1/systems/${systemId}/fronting-reports`, {
+        headers: authHeaders,
+      });
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{ data: Array<{ id: string }> }>(res);
+      const ids = body.data.map((r) => r.id);
+      expect(ids).toContain(reportId);
+    });
+
+    await test.step("get report by ID", async () => {
+      const res = await request.get(`/v1/systems/${systemId}/fronting-reports/${reportId}`, {
+        headers: authHeaders,
+      });
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: { id: string; systemId: string; encryptedData: string };
+      }>(res);
+      expect(body.data.id).toBe(reportId);
+      expect(body.data.systemId).toBe(systemId);
+      expect(body.data.encryptedData).toBeTruthy();
+    });
+
+    await test.step("update report", async () => {
+      const res = await request.put(`/v1/systems/${systemId}/fronting-reports/${reportId}`, {
+        headers: authHeaders,
+        data: {
+          encryptedData: encryptForApi({ title: "Updated E2E Report" }),
+          version: 1,
+        },
+      });
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: { id: string; version: number };
+      }>(res);
+      expect(body.data.id).toBe(reportId);
+      expect(body.data.version).toBe(2);
+    });
+
+    await test.step("archive report", async () => {
+      const res = await request.post(
+        `/v1/systems/${systemId}/fronting-reports/${reportId}/archive`,
+        { headers: authHeaders },
+      );
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step("restore report", async () => {
+      const res = await request.post(
+        `/v1/systems/${systemId}/fronting-reports/${reportId}/restore`,
+        { headers: authHeaders },
+      );
+      expect(res.status()).toBe(200);
+
+      const body = await parseJsonBody<{
+        data: { id: string; archivedAt: null };
+      }>(res);
+      expect(body.data.id).toBe(reportId);
+      expect(body.data.archivedAt).toBeNull();
+    });
+
+    await test.step("delete report", async () => {
+      const res = await request.delete(`/v1/systems/${systemId}/fronting-reports/${reportId}`, {
+        headers: authHeaders,
+      });
+      expect(res.status()).toBe(204);
+    });
+
+    await test.step("verify deleted — 404", async () => {
+      const res = await request.get(`/v1/systems/${systemId}/fronting-reports/${reportId}`, {
+        headers: authHeaders,
+      });
+      expect(res.status()).toBe(404);
+    });
+  });
+
+  test("create fronting report with pdf format", async ({ request, authHeaders }) => {
+    const systemId = await getSystemId(request, authHeaders);
+
+    const res = await request.post(`/v1/systems/${systemId}/fronting-reports`, {
+      headers: authHeaders,
+      data: {
+        encryptedData: encryptForApi({ title: "PDF Report" }),
+        format: "pdf",
+        generatedAt: Date.now(),
+      },
+    });
+    expect(res.status()).toBe(201);
+
+    const body = await parseJsonBody<{ data: { format: string } }>(res);
+    expect(body.data.format).toBe("pdf");
+  });
+
+  test("create fronting report rejects invalid format", async ({ request, authHeaders }) => {
+    const systemId = await getSystemId(request, authHeaders);
+
+    const res = await request.post(`/v1/systems/${systemId}/fronting-reports`, {
+      headers: authHeaders,
+      data: {
+        encryptedData: encryptForApi({ title: "Bad Format" }),
+        format: "csv",
+        generatedAt: Date.now(),
+      },
+    });
+    expect(res.status()).toBe(422);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for fronting analytics and co-fronting analytics
- Add E2E tests for fronting reports full CRUD lifecycle + archive/restore
- Fix type and lint errors in WS handlers and tests (branded types in verifyEnvelopeOrError, null-safe correlationId, key ownership mock data)

## Test plan
- [x] Typecheck and lint clean
- [x] All unit tests pass (851 files, 11890 tests)
- [ ] E2E tests pass (to be verified on main after merge)