### PR TITLE
fix(deps): override dompurify to >=3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
       "handlebars": ">=4.7.9",
       "vite": "8.0.8",
       "@tanstack/query-core": "5.99.0",
-      "follow-redirects": ">=1.16.0"
+      "follow-redirects": ">=1.16.0",
+      "dompurify": ">=3.4.0"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3-multiple-ciphers",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   vite: 8.0.8
   '@tanstack/query-core': 5.99.0
   follow-redirects: '>=1.16.0'
+  dompurify: '>=3.4.0'
 
 importers:
 
@@ -115,7 +116,7 @@ importers:
         specifier: ^0.45.1
         version: 0.45.2(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3-multiple-ciphers@12.8.0)(bun-types@1.3.12)(expo-sqlite@55.0.15(expo@55.0.15)(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(postgres@3.4.9)
       hono:
-        specifier: ^4.12.14
+        specifier: ^4.12.12
         version: 4.12.14
       pino:
         specifier: ^10.0.0
@@ -4240,8 +4241,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -11300,7 +11301,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -13685,7 +13686,7 @@ snapshots:
       classnames: 2.5.1
       core-js: 3.49.0
       decko: 1.2.0
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       eventemitter3: 5.0.4
       json-pointer: 0.6.2
       lunr: 2.3.9


### PR DESCRIPTION
## Summary
- Adds pnpm override for dompurify >=3.4.0
- Fixes GHSA-39q2-94rc-95cp (ADD_TAGS bypass of FORBID_TAGS)
- Transitive via @redocly/cli > redoc > dompurify
- `pnpm audit --audit-level moderate` now clean