### PR TITLE
fix(import): security bounds, type safety, dedup, and test coverage

### DIFF
--- a/.beans/ps-k7g5--pr-456-review-fixes-import-hardening-improvements.md
+++ b/.beans/ps-k7g5--pr-456-review-fixes-import-hardening-improvements.md
@@ -1,0 +1,34 @@
+---
+# ps-k7g5
+title: "PR #456 review fixes: import hardening improvements"
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-16T12:15:19Z
+updated_at: 2026-04-16T12:21:42Z
+---
+
+Implement fixes from multi-agent review of PR #456 (fix/m9-import-hardening). 3 important issues + 7 suggestions covering response size guards, error handling, type safety, and tests.
+
+## Tasks
+
+- [x] Step 1: Unify response size guard (I1+I2) in api-source.ts
+- [x] Step 2: Guard recordError in failed branch (I3)
+- [x] Step 3: Hoist singleStateRef (S1)
+- [x] Step 4: Extract CheckpointStateRef type (S2)
+- [x] Step 5: Replace upsert switch with map (S3)
+- [x] Step 6: Add boundary/edge-case response size tests (S4)
+- [x] Step 7: Add persistMapperResult integration tests (S5)
+- [x] Step 8-9: Verify PK coverage + PrivacyRecordSchema (no code changes)
+
+## Summary of Changes
+
+**import-sp/src/sources/api-source.ts** — Unified response size guard: all responses now go through `response.text()` + `new Blob([text]).size` + `JSON.parse`, preventing lying Content-Length from bypassing the size check. Removed dead `response.json()` path.
+
+**import-core/src/import-engine.ts** — (1) Wrapped `persister.recordError()` in the mapper-failed branch with try-catch to prevent contract violations from escalating. (2) Extracted `CheckpointStateRef` type and annotated both call sites. (3) Replaced 14-line upsert switch with `UPSERT_ACTION_TO_DELTA` map lookup. (4) Hoisted `singleStateRef` before the `for await` loop, reusing the object each iteration.
+
+**import-sp tests** — Added exact 50 MiB boundary test, non-numeric Content-Length fallback test, and updated text fallback test to stub Blob instead of TextEncoder.
+
+**import-core tests** — Added 2 focused persistMapperResult integration tests verifying stateRef propagation on fatal abort and non-fatal mapper failure.
+
+**Steps 8-9** — No code changes needed (existing coverage confirmed adequate; PrivacyRecordSchema looseness is by design).

--- a/packages/import-core/src/__tests__/import-engine.test.ts
+++ b/packages/import-core/src/__tests__/import-engine.test.ts
@@ -2087,6 +2087,95 @@ describe("runImportEngine", () => {
     });
   });
 
+  // -----------------------------------------------------------------------
+  // persistMapperResult stateRef propagation
+  // -----------------------------------------------------------------------
+
+  describe("persistMapperResult stateRef propagation", () => {
+    it("returns aborted result with correct checkpoint state on fatal persister error", async () => {
+      const source = createFakeImportSource({
+        members: [
+          { _id: "m1", name: "Aria" },
+          { _id: "m2", name: "Blake" },
+          { _id: "m3", name: "Cass" },
+        ],
+      });
+      const { persister } = createInMemoryPersister({
+        throwOn: [
+          {
+            entityType: "member",
+            sourceEntityId: "m2",
+            error: new SyntaxError("fatal write"),
+            fatal: true,
+          },
+        ],
+      });
+
+      const result = await runImportEngine({
+        source,
+        persister,
+        sourceFormat: "simply-plural",
+        mapperDispatch: {
+          members: { entityType: "member", map: (doc: unknown) => mapped(doc) },
+        },
+        dependencyOrder: ["members"],
+        collectionToEntityType: () => "member",
+        options: { selectedCategories: {}, avatarMode: "skip" },
+        onProgress: noopProgress,
+      });
+
+      expect(result.outcome).toBe("aborted");
+      // Checkpoint should reflect m1 imported; m2 fatal abort exits before
+      // advancing the checkpoint, so the fatal entity is not counted in totals.
+      expect(result.finalState.totals.perCollection["member"]?.imported).toBe(1);
+      expect(result.finalState.totals.perCollection["member"]?.total).toBe(1);
+      // The fatal error is still recorded in the errors array
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.fatal).toBe(true);
+    });
+
+    it("reflects failure delta in checkpoint state for non-fatal mapper failed status", async () => {
+      const source = createFakeImportSource({
+        members: [
+          { _id: "m1", name: "Aria" },
+          { _id: "m2", name: "" },
+          { _id: "m3", name: "Cass" },
+        ],
+      });
+      const { persister } = createInMemoryPersister();
+
+      const result = await runImportEngine({
+        source,
+        persister,
+        sourceFormat: "simply-plural",
+        mapperDispatch: {
+          members: {
+            entityType: "member",
+            map: (doc: unknown) => {
+              const record = doc as Record<string, unknown>;
+              if (!record["name"])
+                return failed({ kind: "validation-failed", message: "empty name" });
+              return mapped(doc);
+            },
+          },
+        },
+        dependencyOrder: ["members"],
+        collectionToEntityType: () => "member",
+        options: { selectedCategories: {}, avatarMode: "skip" },
+        onProgress: noopProgress,
+      });
+
+      expect(result.outcome).toBe("completed");
+      // Checkpoint should reflect 2 imported + 1 failed
+      expect(result.finalState.totals.perCollection["member"]?.imported).toBe(2);
+      expect(result.finalState.totals.perCollection["member"]?.failed).toBe(1);
+      expect(result.finalState.totals.perCollection["member"]?.total).toBe(3);
+      // The failure should be recorded
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.entityId).toBe("m2");
+    });
+  });
+
   describe("empty dependencyOrder", () => {
     it("throws when dependencyOrder is empty", async () => {
       const source = createFakeImportSource({});

--- a/packages/import-core/src/__tests__/import-engine.test.ts
+++ b/packages/import-core/src/__tests__/import-engine.test.ts
@@ -2086,4 +2086,24 @@ describe("runImportEngine", () => {
       }
     });
   });
+
+  describe("empty dependencyOrder", () => {
+    it("throws when dependencyOrder is empty", async () => {
+      const source = createFakeImportSource({});
+      const { persister } = createInMemoryPersister();
+
+      await expect(
+        runImportEngine({
+          source,
+          persister,
+          sourceFormat: "simply-plural",
+          mapperDispatch: {},
+          dependencyOrder: [],
+          collectionToEntityType: SIMPLE_COLLECTION_TO_ENTITY_TYPE,
+          options: { selectedCategories: {}, avatarMode: "skip" },
+          onProgress: noopProgress,
+        }),
+      ).rejects.toThrow(/dependency order is empty/i);
+    });
+  });
 });

--- a/packages/import-core/src/import-engine.ts
+++ b/packages/import-core/src/import-engine.ts
@@ -42,7 +42,7 @@ import { isBatchMapper, type MapperDispatchEntry, type SourceDocument } from "./
 
 import type { ErrorClassifier } from "./engine-errors.js";
 import type { MapperResult } from "./mapper-result.js";
-import type { PersistableEntity, Persister } from "./persister.types.js";
+import type { PersistableEntity, Persister, PersisterUpsertAction } from "./persister.types.js";
 import type { ImportDataSource } from "./source.types.js";
 import type {
   ImportAvatarMode,
@@ -216,6 +216,14 @@ export async function runImportEngine<TCollection extends string>(
   const ctx = createMappingContext({ sourceMode: source.mode });
   const errors: ImportError[] = [];
 
+  type CheckpointStateRef = { current: ImportCheckpointState };
+
+  const UPSERT_ACTION_TO_DELTA: Record<PersisterUpsertAction, AdvanceDelta> = {
+    created: delta("imported"),
+    updated: delta("updated"),
+    skipped: delta("skipped"),
+  };
+
   /**
    * Process a single mapper result (skipped/failed/mapped) through the
    * persist-and-checkpoint pipeline. Shared by both the batch and single
@@ -228,7 +236,7 @@ export async function runImportEngine<TCollection extends string>(
     sourceEntityId: string,
     entityType: ImportCollectionType,
     persistedSourceIds: string[],
-    stateRef: { current: ImportCheckpointState },
+    stateRef: CheckpointStateRef,
   ): Promise<boolean> {
     if (result.status === "skipped") {
       stateRef.current = advanceWithinCollection(stateRef.current, {
@@ -248,7 +256,11 @@ export async function runImportEngine<TCollection extends string>(
         fatal: false,
       };
       errors.push(error);
-      await persister.recordError(error);
+      try {
+        await persister.recordError(error);
+      } catch {
+        /* contract violation — swallow */
+      }
       stateRef.current = advanceWithinCollection(stateRef.current, {
         entityType,
         lastSourceId: sourceEntityId,
@@ -264,22 +276,7 @@ export async function runImportEngine<TCollection extends string>(
       );
       ctx.register(entityType, sourceEntityId, upsert.pluralscapeEntityId);
       persistedSourceIds.push(sourceEntityId);
-      let upsertDelta: AdvanceDelta;
-      switch (upsert.action) {
-        case "created":
-          upsertDelta = delta("imported");
-          break;
-        case "updated":
-          upsertDelta = delta("updated");
-          break;
-        case "skipped":
-          upsertDelta = delta("skipped");
-          break;
-        default: {
-          const _exhaustive: never = upsert.action;
-          throw new Error(`Unhandled upsert action: ${String(_exhaustive)}`);
-        }
-      }
+      const upsertDelta = UPSERT_ACTION_TO_DELTA[upsert.action];
       stateRef.current = advanceWithinCollection(stateRef.current, {
         entityType,
         lastSourceId: sourceEntityId,
@@ -475,7 +472,7 @@ export async function runImportEngine<TCollection extends string>(
           // Process all accumulated documents in a single batch call.
           const batchResults = entry.mapBatch(accumulated, ctx);
 
-          const stateRef = { current: state };
+          const stateRef: CheckpointStateRef = { current: state };
           for (const batchItem of batchResults) {
             if (isAborted(args.abortSignal)) {
               state = stateRef.current;
@@ -525,6 +522,7 @@ export async function runImportEngine<TCollection extends string>(
         // Single mapper path: process documents one at a time.
         // ---------------------------------------------------------------
         try {
+          const singleStateRef: CheckpointStateRef = { current: state };
           for await (const event of source.iterate(collection)) {
             if (!pastResumeCutoff) {
               if (event.sourceId === resumeCutoffSourceId) {
@@ -566,7 +564,7 @@ export async function runImportEngine<TCollection extends string>(
 
             const doc = event;
             const result = entry.map(doc.document, ctx);
-            const singleStateRef = { current: state };
+            singleStateRef.current = state;
 
             const fatal = await persistMapperResult(
               result,

--- a/packages/import-core/src/import-engine.ts
+++ b/packages/import-core/src/import-engine.ts
@@ -41,6 +41,7 @@ import { CHECKPOINT_CHUNK_SIZE } from "./import-core.constants.js";
 import { isBatchMapper, type MapperDispatchEntry, type SourceDocument } from "./mapper-dispatch.js";
 
 import type { ErrorClassifier } from "./engine-errors.js";
+import type { MapperResult } from "./mapper-result.js";
 import type { PersistableEntity, Persister } from "./persister.types.js";
 import type { ImportDataSource } from "./source.types.js";
 import type {
@@ -223,10 +224,7 @@ export async function runImportEngine<TCollection extends string>(
    * Returns `true` when a fatal error aborted the collection.
    */
   async function persistMapperResult(
-    result:
-      | { readonly status: "skipped"; readonly kind: string; readonly reason: string }
-      | { readonly status: "failed"; readonly kind: string; readonly message: string }
-      | { readonly status: "mapped"; readonly payload: unknown },
+    result: MapperResult<unknown>,
     sourceEntityId: string,
     entityType: ImportCollectionType,
     persistedSourceIds: string[],
@@ -337,14 +335,15 @@ export async function runImportEngine<TCollection extends string>(
       }
     }
 
-    if (dependencyOrder.length === 0) {
+    const firstCollection = dependencyOrder[0];
+    if (firstCollection === undefined) {
       throw new Error("Import dependency order is empty — no collections to process");
     }
 
     let state: ImportCheckpointState =
       args.initialCheckpoint ??
       emptyCheckpointState({
-        firstEntityType: collectionToEntityType(dependencyOrder[0]),
+        firstEntityType: collectionToEntityType(firstCollection),
         selectedCategories: options.selectedCategories,
         avatarMode: options.avatarMode,
       });

--- a/packages/import-core/src/import-engine.ts
+++ b/packages/import-core/src/import-engine.ts
@@ -249,10 +249,14 @@ export async function runImportEngine<TCollection extends string>(
       }
     }
 
+    if (dependencyOrder.length === 0) {
+      throw new Error("Import dependency order is empty — no collections to process");
+    }
+
     let state: ImportCheckpointState =
       args.initialCheckpoint ??
       emptyCheckpointState({
-        firstEntityType: collectionToEntityType(dependencyOrder[0] ?? "unknown"),
+        firstEntityType: collectionToEntityType(dependencyOrder[0]),
         selectedCategories: options.selectedCategories,
         avatarMode: options.avatarMode,
       });

--- a/packages/import-core/src/import-engine.ts
+++ b/packages/import-core/src/import-engine.ts
@@ -215,6 +215,94 @@ export async function runImportEngine<TCollection extends string>(
   const ctx = createMappingContext({ sourceMode: source.mode });
   const errors: ImportError[] = [];
 
+  /**
+   * Process a single mapper result (skipped/failed/mapped) through the
+   * persist-and-checkpoint pipeline. Shared by both the batch and single
+   * mapper paths to eliminate duplicated error-handling and upsert logic.
+   *
+   * Returns `true` when a fatal error aborted the collection.
+   */
+  async function persistMapperResult(
+    result:
+      | { readonly status: "skipped"; readonly kind: string; readonly reason: string }
+      | { readonly status: "failed"; readonly kind: string; readonly message: string }
+      | { readonly status: "mapped"; readonly payload: unknown },
+    sourceEntityId: string,
+    entityType: ImportCollectionType,
+    persistedSourceIds: string[],
+    stateRef: { current: ImportCheckpointState },
+  ): Promise<boolean> {
+    if (result.status === "skipped") {
+      stateRef.current = advanceWithinCollection(stateRef.current, {
+        entityType,
+        lastSourceId: sourceEntityId,
+        delta: delta("skipped"),
+      });
+      return false;
+    }
+
+    if (result.status === "failed") {
+      const error: ImportError = {
+        entityType,
+        entityId: sourceEntityId,
+        message: result.message,
+        kind: result.kind,
+        fatal: false,
+      };
+      errors.push(error);
+      await persister.recordError(error);
+      stateRef.current = advanceWithinCollection(stateRef.current, {
+        entityType,
+        lastSourceId: sourceEntityId,
+        delta: delta("failed"),
+      });
+      return false;
+    }
+
+    // status === "mapped"
+    try {
+      const upsert = await persister.upsertEntity(
+        buildPersistableEntity(entityType, sourceEntityId, sourceFormat, result.payload),
+      );
+      ctx.register(entityType, sourceEntityId, upsert.pluralscapeEntityId);
+      persistedSourceIds.push(sourceEntityId);
+      let upsertDelta: AdvanceDelta;
+      switch (upsert.action) {
+        case "created":
+          upsertDelta = delta("imported");
+          break;
+        case "updated":
+          upsertDelta = delta("updated");
+          break;
+        case "skipped":
+          upsertDelta = delta("skipped");
+          break;
+        default: {
+          const _exhaustive: never = upsert.action;
+          throw new Error(`Unhandled upsert action: ${String(_exhaustive)}`);
+        }
+      }
+      stateRef.current = advanceWithinCollection(stateRef.current, {
+        entityType,
+        lastSourceId: sourceEntityId,
+        delta: upsertDelta,
+      });
+    } catch (thrown) {
+      const error = classify(thrown, { entityType, entityId: sourceEntityId });
+      errors.push(error);
+      await persister.recordError(error);
+      if (isFatalError(error)) {
+        return true;
+      }
+      stateRef.current = advanceWithinCollection(stateRef.current, {
+        entityType,
+        lastSourceId: sourceEntityId,
+        delta: delta("failed"),
+      });
+    }
+    return false;
+  }
+
   /** Set of collection names the engine iterates. Computed once per run. */
   const knownDependencyOrderSet = new Set<string>(dependencyOrder);
 
@@ -388,94 +476,35 @@ export async function runImportEngine<TCollection extends string>(
           // Process all accumulated documents in a single batch call.
           const batchResults = entry.mapBatch(accumulated, ctx);
 
+          const stateRef = { current: state };
           for (const batchItem of batchResults) {
             if (isAborted(args.abortSignal)) {
+              state = stateRef.current;
               return abortedResult(state, ctx, errors);
             }
 
-            const result = batchItem.result;
-
-            if (result.status === "skipped") {
-              state = advanceWithinCollection(state, {
-                entityType,
-                lastSourceId: batchItem.sourceEntityId,
-                delta: delta("skipped"),
-              });
-            } else if (result.status === "failed") {
-              const error: ImportError = {
-                entityType,
-                entityId: batchItem.sourceEntityId,
-                message: result.message,
-                kind: result.kind,
-                fatal: false,
-              };
-              errors.push(error);
-              await persister.recordError(error);
-              state = advanceWithinCollection(state, {
-                entityType,
-                lastSourceId: batchItem.sourceEntityId,
-                delta: delta("failed"),
-              });
-            } else {
-              // status === "mapped"
-              try {
-                const upsert = await persister.upsertEntity(
-                  buildPersistableEntity(
-                    entityType,
-                    batchItem.sourceEntityId,
-                    sourceFormat,
-                    result.payload,
-                  ),
-                );
-                ctx.register(entityType, batchItem.sourceEntityId, upsert.pluralscapeEntityId);
-                persistedSourceIds.push(batchItem.sourceEntityId);
-                let upsertDelta: AdvanceDelta;
-                switch (upsert.action) {
-                  case "created":
-                    upsertDelta = delta("imported");
-                    break;
-                  case "updated":
-                    upsertDelta = delta("updated");
-                    break;
-                  case "skipped":
-                    upsertDelta = delta("skipped");
-                    break;
-                  default: {
-                    const _exhaustive: never = upsert.action;
-                    throw new Error(`Unhandled upsert action: ${String(_exhaustive)}`);
-                  }
-                }
-                state = advanceWithinCollection(state, {
-                  entityType,
-                  lastSourceId: batchItem.sourceEntityId,
-                  delta: upsertDelta,
-                });
-              } catch (thrown) {
-                const error = classify(thrown, {
-                  entityType,
-                  entityId: batchItem.sourceEntityId,
-                });
-                errors.push(error);
-                await persister.recordError(error);
-                if (isFatalError(error)) {
-                  collectionAborted = true;
-                  break;
-                }
-                state = advanceWithinCollection(state, {
-                  entityType,
-                  lastSourceId: batchItem.sourceEntityId,
-                  delta: delta("failed"),
-                });
-              }
+            const fatal = await persistMapperResult(
+              batchItem.result,
+              batchItem.sourceEntityId,
+              entityType,
+              persistedSourceIds,
+              stateRef,
+            );
+            if (fatal) {
+              collectionAborted = true;
+              state = stateRef.current;
+              break;
             }
 
             docsSinceCheckpoint += 1;
             if (docsSinceCheckpoint >= CHECKPOINT_CHUNK_SIZE) {
+              state = stateRef.current;
               await persister.flush();
               await onProgress(state);
               docsSinceCheckpoint = 0;
             }
           }
+          state = stateRef.current;
         } catch (thrown) {
           // Source iteration itself threw — always fatal.
           const classified = classify(thrown, { entityType, entityId: null });
@@ -538,73 +567,19 @@ export async function runImportEngine<TCollection extends string>(
 
             const doc = event;
             const result = entry.map(doc.document, ctx);
+            const singleStateRef = { current: state };
 
-            if (result.status === "skipped") {
-              state = advanceWithinCollection(state, {
-                entityType,
-                lastSourceId: doc.sourceId,
-                delta: delta("skipped"),
-              });
-            } else if (result.status === "failed") {
-              const error: ImportError = {
-                entityType,
-                entityId: doc.sourceId,
-                message: result.message,
-                kind: result.kind,
-                fatal: false,
-              };
-              errors.push(error);
-              await persister.recordError(error);
-              state = advanceWithinCollection(state, {
-                entityType,
-                lastSourceId: doc.sourceId,
-                delta: delta("failed"),
-              });
-            } else {
-              // status === "mapped"
-              try {
-                const upsert = await persister.upsertEntity(
-                  buildPersistableEntity(entityType, doc.sourceId, sourceFormat, result.payload),
-                );
-                ctx.register(entityType, doc.sourceId, upsert.pluralscapeEntityId);
-                persistedSourceIds.push(doc.sourceId);
-                let upsertDelta: AdvanceDelta;
-                switch (upsert.action) {
-                  case "created":
-                    upsertDelta = delta("imported");
-                    break;
-                  case "updated":
-                    upsertDelta = delta("updated");
-                    break;
-                  case "skipped":
-                    upsertDelta = delta("skipped");
-                    break;
-                  default: {
-                    const _exhaustive: never = upsert.action;
-                    throw new Error(`Unhandled upsert action: ${String(_exhaustive)}`);
-                  }
-                }
-                state = advanceWithinCollection(state, {
-                  entityType,
-                  lastSourceId: doc.sourceId,
-                  delta: upsertDelta,
-                });
-              } catch (thrown) {
-                const error = classify(thrown, { entityType, entityId: doc.sourceId });
-                errors.push(error);
-                await persister.recordError(error);
-                if (isFatalError(error)) {
-                  collectionAborted = true;
-                  break;
-                }
-                // Non-fatal persister failure: record and continue with this
-                // doc marked as failed in the checkpoint.
-                state = advanceWithinCollection(state, {
-                  entityType,
-                  lastSourceId: doc.sourceId,
-                  delta: delta("failed"),
-                });
-              }
+            const fatal = await persistMapperResult(
+              result,
+              doc.sourceId,
+              entityType,
+              persistedSourceIds,
+              singleStateRef,
+            );
+            state = singleStateRef.current;
+            if (fatal) {
+              collectionAborted = true;
+              break;
             }
 
             docsSinceCheckpoint += 1;

--- a/packages/import-pk/src/__tests__/validators/pk-payload.test.ts
+++ b/packages/import-pk/src/__tests__/validators/pk-payload.test.ts
@@ -233,3 +233,46 @@ describe("PKPayloadSchema", () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe("prototype pollution resistance", () => {
+  it("does not pollute Object.prototype via __proto__ key in member", () => {
+    const payload = JSON.parse(
+      '{"version":2,"id":"sys01","members":[{"id":"m1","name":"Evil","__proto__":{"polluted":"yes"}}],"groups":[],"switches":[]}',
+    );
+    const result = PKPayloadSchema.safeParse(payload);
+    // Should parse successfully (looseObject tolerates extra keys)
+    expect(result.success).toBe(true);
+    // But must NOT pollute Object.prototype
+    expect(Object.prototype).not.toHaveProperty("polluted");
+  });
+
+  it("does not pollute via constructor key in member", () => {
+    const payload = JSON.parse(
+      '{"version":2,"id":"sys01","members":[{"id":"m1","name":"Evil","constructor":{"prototype":{"injected":"yes"}}}],"groups":[],"switches":[]}',
+    );
+    const result = PKPayloadSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    expect(Object.prototype).not.toHaveProperty("injected");
+  });
+
+  it("does not pollute via __proto__ key in group", () => {
+    const payload = JSON.parse(
+      '{"version":2,"id":"sys01","members":[],"groups":[{"id":"g1","name":"Bad","__proto__":{"gpolluted":"yes"}}],"switches":[]}',
+    );
+    const result = PKPayloadSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    expect(Object.prototype).not.toHaveProperty("gpolluted");
+  });
+
+  it("does not pollute via nested __proto__ in privacy fields", () => {
+    const payload = JSON.parse(
+      '{"version":2,"id":"sys01","members":[{"id":"m1","name":"Tricky","privacy":{"__proto__":{"deep":"yes"}}}],"groups":[],"switches":[]}',
+    );
+    // Parse the payload — we only care that it doesn't pollute, not whether
+    // the __proto__ key inside privacy passes or fails validation.
+    PKPayloadSchema.safeParse(payload);
+    // Privacy field has strict enum keys, so __proto__ should either be
+    // stripped or ignored by the schema. Either way, no pollution.
+    expect(Object.prototype).not.toHaveProperty("deep");
+  });
+});

--- a/packages/import-pk/src/sources/pk-file-source.ts
+++ b/packages/import-pk/src/sources/pk-file-source.ts
@@ -99,9 +99,7 @@ export function createPkFileImportSource(args: PkFileImportSourceArgs): ImportDa
           // synthesise a "PK Private" bucket.
           const members = payload.members.map((m) => ({
             pkMemberId: m.id,
-            // Widening from PKPrivacySchema (validated enum fields) to Record<string, string>
-            // for the privacy-scan document, which uses string values for field inspection.
-            privacy: m.privacy as Record<string, string> | undefined,
+            privacy: m.privacy,
           }));
           yield {
             kind: "doc",

--- a/packages/import-sp/src/__tests__/sources/api-source.test.ts
+++ b/packages/import-sp/src/__tests__/sources/api-source.test.ts
@@ -541,4 +541,92 @@ describe("createApiImportSource", () => {
     const [url] = fetchMock.mock.calls[0] ?? [];
     expect(url).toBe("https://api.test/v1/notes/sys_abc/m3");
   });
+
+  describe("response size limit", () => {
+    it("rejects responses exceeding MAX_RESPONSE_BYTES via Content-Length header", async () => {
+      const hugeLength = String(51 * 1_024 * 1_024);
+      fetchMock.mockResolvedValueOnce(
+        new Response("[]", {
+          status: 200,
+          headers: { "Content-Length": hugeLength, "Content-Type": "application/json" },
+        }),
+      );
+
+      const source = createApiImportSource(DEFAULT_INPUT);
+      let caught: unknown;
+      try {
+        await drain(source, "members");
+      } catch (err) {
+        caught = err;
+      }
+      await source.close();
+
+      expect(caught).toBeInstanceOf(ApiSourcePermanentError);
+      if (caught instanceof ApiSourcePermanentError) {
+        expect(caught.message).toMatch(/response size/i);
+      }
+    });
+
+    it("rejects responses exceeding MAX_RESPONSE_BYTES when Content-Length is absent (text fallback)", async () => {
+      // Build a body that exceeds 50 MiB. We only need to verify the check
+      // fires, so we mock `response.text()` to return a string whose
+      // `.length` exceeds the limit without actually allocating 50 MiB.
+      const fakeResponse = new Response(null, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      // Stub .text() to report oversized content
+      const oversizedText = JSON.stringify({ data: "x".repeat(100) });
+      vi.spyOn(fakeResponse, "text").mockResolvedValue(oversizedText);
+      // Override byte-length calculation: pretend the text is 51 MiB
+      const oversizedByteLength = 51 * 1_024 * 1_024;
+      const originalEncoder = globalThis.TextEncoder;
+      const fakeEncoder = {
+        encode: () => new Uint8Array(oversizedByteLength),
+      };
+      vi.stubGlobal(
+        "TextEncoder",
+        class {
+          encode(input: string): Uint8Array {
+            if (input === oversizedText) return fakeEncoder.encode();
+            return new originalEncoder().encode(input);
+          }
+        },
+      );
+
+      fetchMock.mockResolvedValueOnce(fakeResponse);
+
+      const source = createApiImportSource(DEFAULT_INPUT);
+      let caught: unknown;
+      try {
+        await drain(source, "members");
+      } catch (err) {
+        caught = err;
+      }
+      await source.close();
+
+      expect(caught).toBeInstanceOf(ApiSourcePermanentError);
+      if (caught instanceof ApiSourcePermanentError) {
+        expect(caught.message).toMatch(/response size/i);
+      }
+    });
+
+    it("allows responses within the 50 MiB limit", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify([{ _id: "m1", name: "OK" }]), {
+          status: 200,
+          headers: {
+            "Content-Length": String(49 * 1_024 * 1_024),
+            "Content-Type": "application/json",
+          },
+        }),
+      );
+
+      const source = createApiImportSource(DEFAULT_INPUT);
+      const out = await drain(source, "members");
+      await source.close();
+
+      expect(out).toEqual(["m1"]);
+    });
+  });
 });

--- a/packages/import-sp/src/__tests__/sources/api-source.test.ts
+++ b/packages/import-sp/src/__tests__/sources/api-source.test.ts
@@ -570,7 +570,7 @@ describe("createApiImportSource", () => {
     it("rejects responses exceeding MAX_RESPONSE_BYTES when Content-Length is absent (text fallback)", async () => {
       // Build a body that exceeds 50 MiB. We only need to verify the check
       // fires, so we mock `response.text()` to return a string whose
-      // `.length` exceeds the limit without actually allocating 50 MiB.
+      // Blob size exceeds the limit without actually allocating 50 MiB.
       const fakeResponse = new Response(null, {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -578,18 +578,14 @@ describe("createApiImportSource", () => {
       // Stub .text() to report oversized content
       const oversizedText = JSON.stringify({ data: "x".repeat(100) });
       vi.spyOn(fakeResponse, "text").mockResolvedValue(oversizedText);
-      // Override byte-length calculation: pretend the text is 51 MiB
+      // Override Blob so .size reports 51 MiB
       const oversizedByteLength = 51 * 1_024 * 1_024;
-      const originalEncoder = globalThis.TextEncoder;
-      const fakeEncoder = {
-        encode: () => new Uint8Array(oversizedByteLength),
-      };
+      const OriginalBlob = globalThis.Blob;
       vi.stubGlobal(
-        "TextEncoder",
-        class {
-          encode(input: string): Uint8Array {
-            if (input === oversizedText) return fakeEncoder.encode();
-            return new originalEncoder().encode(input);
+        "Blob",
+        class FakeBlob extends OriginalBlob {
+          override get size(): number {
+            return oversizedByteLength;
           }
         },
       );
@@ -609,6 +605,42 @@ describe("createApiImportSource", () => {
       if (caught instanceof ApiSourcePermanentError) {
         expect(caught.message).toMatch(/response size/i);
       }
+    });
+
+    it("allows responses at the exact 50 MiB boundary", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify([{ _id: "m1", name: "Boundary" }]), {
+          status: 200,
+          headers: {
+            "Content-Length": String(50 * 1_024 * 1_024),
+            "Content-Type": "application/json",
+          },
+        }),
+      );
+
+      const source = createApiImportSource(DEFAULT_INPUT);
+      const out = await drain(source, "members");
+      await source.close();
+
+      expect(out).toEqual(["m1"]);
+    });
+
+    it("falls through to text-based check when Content-Length is non-numeric", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify([{ _id: "m1", name: "OK" }]), {
+          status: 200,
+          headers: {
+            "Content-Length": "garbage",
+            "Content-Type": "application/json",
+          },
+        }),
+      );
+
+      const source = createApiImportSource(DEFAULT_INPUT);
+      const out = await drain(source, "members");
+      await source.close();
+
+      expect(out).toEqual(["m1"]);
     });
 
     it("allows responses within the 50 MiB limit", async () => {

--- a/packages/import-sp/src/__tests__/sources/file-source.test.ts
+++ b/packages/import-sp/src/__tests__/sources/file-source.test.ts
@@ -341,4 +341,70 @@ describe("createFileImportSource", () => {
     const parseErr = err as InstanceType<typeof FileSourceParseError>;
     expect(parseErr.message).toContain('Collection "members" had a non-array value');
   });
+
+  describe("corrupted prescan state", () => {
+    it("throws FileSourceParseError for non-JSON input (binary noise)", async () => {
+      const source = createFileImportSource({
+        stream: stringToStream("\x00\x01\x02\xFF"),
+      });
+      const err = await (async () => {
+        try {
+          for await (const e of source.iterate("members")) {
+            void e;
+          }
+          return null;
+        } catch (thrown) {
+          return thrown;
+        }
+      })();
+      expect(err).toBeInstanceOf(FileSourceParseError);
+    });
+
+    it("throws FileSourceParseError when root is an array instead of object", async () => {
+      const source = createFileImportSource({
+        stream: stringToStream('[{"_id": "m1"}]'),
+      });
+      const err = await (async () => {
+        try {
+          for await (const e of source.iterate("members")) {
+            void e;
+          }
+          return null;
+        } catch (thrown) {
+          return thrown;
+        }
+      })();
+      expect(err).toBeInstanceOf(FileSourceParseError);
+    });
+
+    it("throws FileSourceParseError for a bare scalar root", async () => {
+      const source = createFileImportSource({
+        stream: stringToStream('"just a string"'),
+      });
+      const err = await (async () => {
+        try {
+          await source.listCollections();
+          return null;
+        } catch (thrown) {
+          return thrown;
+        }
+      })();
+      expect(err).toBeInstanceOf(FileSourceParseError);
+    });
+
+    it("throws FileSourceParseError for empty input", async () => {
+      const source = createFileImportSource({
+        stream: stringToStream(""),
+      });
+      const err = await (async () => {
+        try {
+          await source.listCollections();
+          return null;
+        } catch (thrown) {
+          return thrown;
+        }
+      })();
+      expect(err).toBeInstanceOf(FileSourceParseError);
+    });
+  });
 });

--- a/packages/import-sp/src/import-sp.constants.ts
+++ b/packages/import-sp/src/import-sp.constants.ts
@@ -23,6 +23,19 @@ export const SP_API_BACKOFF_MAX_MS = 16_000;
 /** Default per-request timeout for SP API calls in milliseconds. */
 export const SP_API_REQUEST_TIMEOUT_MS = 30_000;
 
+/** Bytes per mebibyte. */
+const BYTES_PER_MIB = 1_024 * 1_024;
+
+/**
+ * Maximum permitted size of an API response body (50 MiB).
+ *
+ * SP streams entire collections in a single response. Bounding the body size
+ * prevents OOM from unexpectedly large payloads or corrupted Content-Length
+ * headers. 50 MiB accommodates even the largest personal exports while keeping
+ * peak resident memory under control.
+ */
+export const SP_API_MAX_RESPONSE_BYTES = 50 * BYTES_PER_MIB;
+
 // ── SP CustomFieldType numeric enum values ────────────────────────────────────
 // Sourced from SP's `typeConverters` array in
 // `src/api/base/user/generateReports.ts`. Used in the exhaustive switch in

--- a/packages/import-sp/src/sources/api-source.ts
+++ b/packages/import-sp/src/sources/api-source.ts
@@ -265,19 +265,15 @@ export function createApiImportSource(input: ApiSourceInput): ImportDataSource {
         }
       }
 
-      // When Content-Length is absent, read as text and check byte length.
-      if (contentLength === null) {
-        const text = await response.text();
-        const byteLength = new TextEncoder().encode(text).byteLength;
-        if (byteLength > SP_API_MAX_RESPONSE_BYTES) {
-          throw new ApiSourcePermanentError(
-            `SP API response size ${String(byteLength)} bytes exceeds limit of ${String(SP_API_MAX_RESPONSE_BYTES)} bytes`,
-          );
-        }
-        return JSON.parse(text) as unknown;
+      // Always read as text and verify byte length — Content-Length can lie.
+      const text = await response.text();
+      const byteLength = new Blob([text]).size;
+      if (byteLength > SP_API_MAX_RESPONSE_BYTES) {
+        throw new ApiSourcePermanentError(
+          `SP API response size ${String(byteLength)} bytes exceeds limit of ${String(SP_API_MAX_RESPONSE_BYTES)} bytes`,
+        );
       }
-
-      return (await response.json()) as unknown;
+      return JSON.parse(text) as unknown;
     }
     // Unreachable — the loop exits via `return` or a thrown error — but
     // keep an explicit throw so TypeScript's control-flow analysis is happy.

--- a/packages/import-sp/src/sources/api-source.ts
+++ b/packages/import-sp/src/sources/api-source.ts
@@ -1,6 +1,7 @@
 import {
   SP_API_BACKOFF_BASE_MS,
   SP_API_BACKOFF_MAX_MS,
+  SP_API_MAX_RESPONSE_BYTES,
   SP_API_MAX_RETRIES,
   SP_API_REQUEST_TIMEOUT_MS,
 } from "../import-sp.constants.js";
@@ -251,6 +252,29 @@ export function createApiImportSource(input: ApiSourceInput): ImportDataSource {
         throw new ApiSourceTransientError(
           `SP API returned ${String(response.status)} (${response.statusText})`,
         );
+      }
+
+      // Guard against oversized responses to prevent OOM.
+      const contentLength = response.headers.get("Content-Length");
+      if (contentLength !== null) {
+        const declaredBytes = Number(contentLength);
+        if (!Number.isNaN(declaredBytes) && declaredBytes > SP_API_MAX_RESPONSE_BYTES) {
+          throw new ApiSourcePermanentError(
+            `SP API response size ${String(declaredBytes)} bytes exceeds limit of ${String(SP_API_MAX_RESPONSE_BYTES)} bytes`,
+          );
+        }
+      }
+
+      // When Content-Length is absent, read as text and check byte length.
+      if (contentLength === null) {
+        const text = await response.text();
+        const byteLength = new TextEncoder().encode(text).byteLength;
+        if (byteLength > SP_API_MAX_RESPONSE_BYTES) {
+          throw new ApiSourcePermanentError(
+            `SP API response size ${String(byteLength)} bytes exceeds limit of ${String(SP_API_MAX_RESPONSE_BYTES)} bytes`,
+          );
+        }
+        return JSON.parse(text) as unknown;
       }
 
       return (await response.json()) as unknown;


### PR DESCRIPTION
## Summary

- Bound API source response size to 50 MiB before JSON parsing
- Remove widening privacy cast in PK file source
- Throw on empty dependencyOrder instead of "unknown" fallback
- Extract shared mapper result processing helper to reduce duplication
- Add tests for corrupted prescan, proto injection, empty dependencies

## Beans

Completes `ps-jdl9` (Phase 2 of M9 audit remediation).

## Test plan

- [x] import-sp: 375 tests pass
- [x] import-pk: 111 tests pass
- [x] import-core: 119 tests pass
- [x] Typecheck, lint, format: all clean
- [ ] E2E tests (CI)