### PR TITLE
fix: email error types, i18n defaults, storage observability

### DIFF
--- a/.beans/ps-wsiw--design-i18n-and-error-handling-cleanup.md
+++ b/.beans/ps-wsiw--design-i18n-and-error-handling-cleanup.md
@@ -1,11 +1,11 @@
 ---
 # ps-wsiw
 title: Design, i18n, and error handling cleanup
-status: todo
+status: completed
 type: task
 priority: low
 created_at: 2026-04-16T06:59:12Z
-updated_at: 2026-04-16T06:59:12Z
+updated_at: 2026-04-16T12:33:32Z
 parent: ps-0enb
 ---
 
@@ -21,3 +21,13 @@ Low-severity design, i18n, and error handling findings from comprehensive audit.
 - [ ] [I18N-T-L1] nomenclature.ts contains "Alter"/"Alters" in PRESET_PLURAL_RULES
 - [ ] [STORAGE-S-L1] Quota TOCTOU acknowledged but not enforced
 - [ ] [STORAGE-S-L2] getMetadata silently swallows parse errors on sidecar JSON
+
+## Summary of Changes
+
+Fixed PR #458 review issues:
+
+- Fixed dead else branch in createI18nInstance branching logic — now throws when missingKeyMode is 'warn' without a logger
+- Fixed stale JSDoc default in I18nConfig (warn → throw)
+- Fixed i18n tests to explicitly pass missingKeyMode: 'warn' and added behavioral tests for throw mode default and warn-without-logger
+- Added structured fields (field, actual, max) to EmailValidationError with tests
+- Added reserveQuota boundary test in quota-service

--- a/packages/email/src/__tests__/validate-send-params.test.ts
+++ b/packages/email/src/__tests__/validate-send-params.test.ts
@@ -64,4 +64,33 @@ describe("validateSendParams", () => {
       `Subject length ${String(MAX_SUBJECT_LENGTH + 1)} exceeds maximum of ${String(MAX_SUBJECT_LENGTH)}`,
     );
   });
+
+  it("exposes structured fields for recipient violation", () => {
+    const recipients = Array.from(
+      { length: MAX_RECIPIENTS + 1 },
+      (_, i) => `user${String(i)}@example.com`,
+    );
+    try {
+      validateSendParams({ to: recipients, subject: "Hello" });
+      expect.fail("Should have thrown");
+    } catch (err) {
+      if (!(err instanceof EmailValidationError)) throw err;
+      expect(err.field).toBe("Recipient count");
+      expect(err.actual).toBe(MAX_RECIPIENTS + 1);
+      expect(err.max).toBe(MAX_RECIPIENTS);
+    }
+  });
+
+  it("exposes structured fields for subject violation", () => {
+    const subject = "a".repeat(MAX_SUBJECT_LENGTH + 1);
+    try {
+      validateSendParams({ to: "a@example.com", subject });
+      expect.fail("Should have thrown");
+    } catch (err) {
+      if (!(err instanceof EmailValidationError)) throw err;
+      expect(err.field).toBe("Subject length");
+      expect(err.actual).toBe(MAX_SUBJECT_LENGTH + 1);
+      expect(err.max).toBe(MAX_SUBJECT_LENGTH);
+    }
+  });
 });

--- a/packages/email/src/__tests__/validate-send-params.test.ts
+++ b/packages/email/src/__tests__/validate-send-params.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { MAX_RECIPIENTS, MAX_SUBJECT_LENGTH, validateSendParams } from "../email.constants.js";
-import { EmailDeliveryError, InvalidRecipientError } from "../errors.js";
+import { EmailValidationError } from "../errors.js";
 
 describe("validateSendParams", () => {
   it("passes with a single recipient and valid subject", () => {
@@ -20,14 +20,26 @@ describe("validateSendParams", () => {
     }).not.toThrow();
   });
 
-  it("throws InvalidRecipientError when recipients exceed MAX_RECIPIENTS", () => {
+  it("throws EmailValidationError when recipients exceed MAX_RECIPIENTS", () => {
     const recipients = Array.from(
       { length: MAX_RECIPIENTS + 1 },
       (_, i) => `user${String(i)}@example.com`,
     );
     expect(() => {
       validateSendParams({ to: recipients, subject: "Hello" });
-    }).toThrow(InvalidRecipientError);
+    }).toThrow(EmailValidationError);
+  });
+
+  it("includes recipient count in over-limit error message", () => {
+    const recipients = Array.from(
+      { length: MAX_RECIPIENTS + 1 },
+      (_, i) => `user${String(i)}@example.com`,
+    );
+    expect(() => {
+      validateSendParams({ to: recipients, subject: "Hello" });
+    }).toThrow(
+      `Recipient count ${String(MAX_RECIPIENTS + 1)} exceeds maximum of ${String(MAX_RECIPIENTS)}`,
+    );
   });
 
   it("passes with subject at MAX_SUBJECT_LENGTH", () => {
@@ -37,11 +49,11 @@ describe("validateSendParams", () => {
     }).not.toThrow();
   });
 
-  it("throws EmailDeliveryError when subject exceeds MAX_SUBJECT_LENGTH", () => {
+  it("throws EmailValidationError when subject exceeds MAX_SUBJECT_LENGTH", () => {
     const subject = "a".repeat(MAX_SUBJECT_LENGTH + 1);
     expect(() => {
       validateSendParams({ to: "a@example.com", subject });
-    }).toThrow(EmailDeliveryError);
+    }).toThrow(EmailValidationError);
   });
 
   it("includes subject length in error message", () => {

--- a/packages/email/src/email.constants.ts
+++ b/packages/email/src/email.constants.ts
@@ -1,4 +1,4 @@
-import { EmailDeliveryError, InvalidRecipientError } from "./errors.js";
+import { EmailValidationError } from "./errors.js";
 
 /** Default sender address used when `from` is not specified in EmailSendParams. */
 export const DEFAULT_FROM_ADDRESS = "noreply@pluralscape.app";
@@ -12,8 +12,8 @@ export const MAX_SUBJECT_LENGTH = 998;
 /**
  * Validates send parameters against package constraints.
  *
- * Throws InvalidRecipientError if too many recipients are provided.
- * Throws EmailDeliveryError if the subject line exceeds the maximum length.
+ * Throws EmailValidationError if too many recipients are provided or
+ * if the subject line exceeds the maximum length.
  */
 export function validateSendParams(params: {
   readonly to: string | readonly string[];
@@ -21,14 +21,13 @@ export function validateSendParams(params: {
 }): void {
   const recipientCount = typeof params.to === "string" ? 1 : params.to.length;
   if (recipientCount > MAX_RECIPIENTS) {
-    const firstRecipient = typeof params.to === "string" ? params.to : (params.to[0] ?? "unknown");
-    throw new InvalidRecipientError(firstRecipient);
+    throw new EmailValidationError(
+      `Recipient count ${String(recipientCount)} exceeds maximum of ${String(MAX_RECIPIENTS)}.`,
+    );
   }
 
   if (params.subject.length > MAX_SUBJECT_LENGTH) {
-    const firstRecipient = typeof params.to === "string" ? params.to : (params.to[0] ?? "unknown");
-    throw new EmailDeliveryError(
-      firstRecipient,
+    throw new EmailValidationError(
       `Subject length ${String(params.subject.length)} exceeds maximum of ${String(MAX_SUBJECT_LENGTH)} characters.`,
     );
   }

--- a/packages/email/src/email.constants.ts
+++ b/packages/email/src/email.constants.ts
@@ -21,14 +21,10 @@ export function validateSendParams(params: {
 }): void {
   const recipientCount = typeof params.to === "string" ? 1 : params.to.length;
   if (recipientCount > MAX_RECIPIENTS) {
-    throw new EmailValidationError(
-      `Recipient count ${String(recipientCount)} exceeds maximum of ${String(MAX_RECIPIENTS)}.`,
-    );
+    throw new EmailValidationError("Recipient count", recipientCount, MAX_RECIPIENTS);
   }
 
   if (params.subject.length > MAX_SUBJECT_LENGTH) {
-    throw new EmailValidationError(
-      `Subject length ${String(params.subject.length)} exceeds maximum of ${String(MAX_SUBJECT_LENGTH)} characters.`,
-    );
+    throw new EmailValidationError("Subject length", params.subject.length, MAX_SUBJECT_LENGTH);
   }
 }

--- a/packages/email/src/errors.ts
+++ b/packages/email/src/errors.ts
@@ -38,6 +38,13 @@ export class EmailRateLimitError extends Error {
 }
 
 /**
+ * Thrown when send parameters fail validation (e.g., too many recipients, subject too long).
+ */
+export class EmailValidationError extends Error {
+  override readonly name = "EmailValidationError" as const;
+}
+
+/**
  * Thrown when the recipient email address is invalid or rejected by the provider.
  */
 export class InvalidRecipientError extends Error {

--- a/packages/email/src/errors.ts
+++ b/packages/email/src/errors.ts
@@ -42,6 +42,22 @@ export class EmailRateLimitError extends Error {
  */
 export class EmailValidationError extends Error {
   override readonly name = "EmailValidationError" as const;
+  readonly field: string;
+  readonly actual: number;
+  readonly max: number;
+
+  constructor(
+    field: string,
+    actual: number,
+    max: number,
+    message?: string,
+    options?: ErrorOptions,
+  ) {
+    super(message ?? `${field} ${String(actual)} exceeds maximum of ${String(max)}.`, options);
+    this.field = field;
+    this.actual = actual;
+    this.max = max;
+  }
 }
 
 /**

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -8,6 +8,7 @@ export {
   EmailDeliveryError,
   EmailConfigurationError,
   EmailRateLimitError,
+  EmailValidationError,
   InvalidRecipientError,
 } from "./errors.js";
 

--- a/packages/i18n/src/__tests__/create-i18n.test.ts
+++ b/packages/i18n/src/__tests__/create-i18n.test.ts
@@ -8,13 +8,13 @@ const mockWarnLogger = { warn: vi.fn() };
 
 describe("createI18nInstance", () => {
   it("creates a new i18next instance", () => {
-    const instance = createI18nInstance({ logger: mockWarnLogger });
+    const instance = createI18nInstance({ missingKeyMode: "warn", logger: mockWarnLogger });
     expect(instance).toBeDefined();
     expect(instance.isInitialized).toBeFalsy();
   });
 
   it("sets saveMissing via the 3rdParty plugin", async () => {
-    const instance = createI18nInstance({ logger: mockWarnLogger });
+    const instance = createI18nInstance({ missingKeyMode: "warn", logger: mockWarnLogger });
     instance.use(initReactI18next);
 
     await instance.init({
@@ -29,7 +29,7 @@ describe("createI18nInstance", () => {
   });
 
   it("caller sets fallbackLng via init (not the factory)", async () => {
-    const instance = createI18nInstance({ logger: mockWarnLogger });
+    const instance = createI18nInstance({ missingKeyMode: "warn", logger: mockWarnLogger });
     instance.use(initReactI18next);
 
     await instance.init({
@@ -79,5 +79,20 @@ describe("createI18nInstance", () => {
 
     expect(instance.isInitialized).toBe(true);
     expect(instance.options.saveMissing).toBe(true);
+
+    const handler = instance.options.missingKeyHandler as (
+      lngs: readonly string[],
+      ns: string,
+      key: string,
+    ) => void;
+    expect(() => {
+      handler(["en"], "common", "nonexistent");
+    }).toThrow("Missing translation key: common:nonexistent");
+  });
+
+  it("throws when missingKeyMode is 'warn' without a logger", () => {
+    expect(() => {
+      createI18nInstance({ missingKeyMode: "warn" });
+    }).toThrow("Logger is required when missingKeyMode is 'warn'");
   });
 });

--- a/packages/i18n/src/__tests__/create-i18n.test.ts
+++ b/packages/i18n/src/__tests__/create-i18n.test.ts
@@ -64,4 +64,20 @@ describe("createI18nInstance", () => {
     const instance = createI18nInstance({ missingKeyMode: "throw" });
     expect(instance).toBeDefined();
   });
+
+  it("defaults to throw mode when called with no arguments", async () => {
+    const instance = createI18nInstance();
+    instance.use(initReactI18next);
+
+    await instance.init({
+      lng: "en",
+      fallbackLng: DEFAULT_LOCALE,
+      defaultNS: DEFAULT_NAMESPACE,
+      ns: [...NAMESPACES],
+      resources: { en: { common: { hello: "Hello" } } },
+    });
+
+    expect(instance.isInitialized).toBe(true);
+    expect(instance.options.saveMissing).toBe(true);
+  });
 });

--- a/packages/i18n/src/create-i18n.ts
+++ b/packages/i18n/src/create-i18n.ts
@@ -16,17 +16,18 @@ export function createI18nInstance(options?: CreateI18nOptions): i18n {
   const instance = i18next.createInstance();
   const mode = options?.missingKeyMode ?? "throw";
 
+  const logger = options?.logger;
+  if (mode === "warn" && !logger) {
+    throw new Error("Logger is required when missingKeyMode is 'warn'");
+  }
+
   instance.use({
     type: "3rdParty" as const,
     init(i18nInstance: i18n) {
-      let handler: (key: string, namespace: string) => void;
-      if (mode === "throw") {
-        handler = createMissingKeyHandler(mode);
-      } else if (options?.logger) {
-        handler = createMissingKeyHandler(mode, options.logger);
-      } else {
-        handler = createMissingKeyHandler("throw");
-      }
+      const handler =
+        mode === "warn" && logger
+          ? createMissingKeyHandler("warn", logger)
+          : createMissingKeyHandler("throw");
       i18nInstance.options.saveMissing = true;
       i18nInstance.options.missingKeyHandler = (
         _lngs: readonly string[],

--- a/packages/i18n/src/create-i18n.ts
+++ b/packages/i18n/src/create-i18n.ts
@@ -14,7 +14,7 @@ export type CreateI18nOptions = Pick<I18nConfig, "missingKeyMode" | "logger">;
  */
 export function createI18nInstance(options?: CreateI18nOptions): i18n {
   const instance = i18next.createInstance();
-  const mode = options?.missingKeyMode ?? "warn";
+  const mode = options?.missingKeyMode ?? "throw";
 
   instance.use({
     type: "3rdParty" as const,
@@ -25,7 +25,7 @@ export function createI18nInstance(options?: CreateI18nOptions): i18n {
       } else if (options?.logger) {
         handler = createMissingKeyHandler(mode, options.logger);
       } else {
-        throw new Error("Logger is required when missingKeyMode is 'warn'");
+        handler = createMissingKeyHandler("throw");
       }
       i18nInstance.options.saveMissing = true;
       i18nInstance.options.missingKeyHandler = (

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -15,7 +15,7 @@ export interface I18nConfig {
   readonly fallbackLocale: Locale;
   /** Translation resources keyed by namespace. */
   readonly resources: Record<string, TranslationResources>;
-  /** Missing key handling mode. Defaults to "warn". */
+  /** Missing key handling mode. Defaults to "throw". */
   readonly missingKeyMode?: "warn" | "throw";
   /** Logger for missing key warnings. Only used when missingKeyMode is "warn". */
   readonly logger?: Pick<Logger, "warn">;

--- a/packages/storage/src/__tests__/filesystem-adapter.test.ts
+++ b/packages/storage/src/__tests__/filesystem-adapter.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FilesystemBlobStorageAdapter } from "../adapters/filesystem/filesystem-adapter.js";
 import { BlobTooLargeError, StorageBackendError } from "../errors.js";
@@ -200,6 +200,50 @@ describe("FilesystemBlobStorageAdapter-specific", () => {
       const downloaded2 = await adapter.download(params2.storageKey);
       expect(downloaded1).toEqual(makeBytes(1));
       expect(downloaded2).toEqual(makeBytes(2));
+    });
+  });
+
+  // ── Metadata parse failure logging ──────────────────────────────────
+
+  describe("metadata parse failure logging", () => {
+    it("logs a warning and returns null when sidecar JSON is corrupt", async () => {
+      const warnFn = vi.fn();
+      const logger = { info: vi.fn(), warn: warnFn, error: vi.fn() };
+      const adapter = new FilesystemBlobStorageAdapter({ storageRoot, logger });
+      const params = makeBlobData(makeBytes(0xab, 32));
+      await adapter.upload(params);
+
+      // Corrupt the sidecar file
+      const parts = params.storageKey.split("/");
+      const metaPath = join(storageRoot, ...parts) + ".meta.json";
+      await writeFile(metaPath, "NOT VALID JSON", { mode: 0o600 });
+
+      const result = await adapter.getMetadata(params.storageKey);
+      expect(result).toBeNull();
+      expect(warnFn).toHaveBeenCalledOnce();
+      expect(warnFn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to parse sidecar metadata JSON"),
+        expect.objectContaining({ metaPath }),
+      );
+    });
+
+    it("returns null without logging when sidecar file is missing", async () => {
+      const warnFn = vi.fn();
+      const logger = { info: vi.fn(), warn: warnFn, error: vi.fn() };
+      const adapter = new FilesystemBlobStorageAdapter({ storageRoot, logger });
+      const params = makeBlobData(makeBytes(0xab, 32));
+      await adapter.upload(params);
+
+      // Delete the sidecar file but keep the blob
+      const parts = params.storageKey.split("/");
+      const metaPath = join(storageRoot, ...parts) + ".meta.json";
+      const { unlink } = await import("node:fs/promises");
+      await unlink(metaPath);
+
+      const result = await adapter.getMetadata(params.storageKey);
+      expect(result).toBeNull();
+      // Missing file is not a parse failure — should not warn
+      expect(warnFn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/storage/src/__tests__/quota-service.test.ts
+++ b/packages/storage/src/__tests__/quota-service.test.ts
@@ -130,6 +130,11 @@ describe("BlobQuotaService", () => {
       await expect(service.reserveQuota("sys_abc" as SystemId, 500)).resolves.toBeUndefined();
     });
 
+    it("resolves at exact quota boundary", async () => {
+      const service = new BlobQuotaService({ defaultQuotaBytes: 1000 }, mockUsageQuery(500));
+      await expect(service.reserveQuota("sys_abc" as SystemId, 500)).resolves.toBeUndefined();
+    });
+
     it("throws QuotaExceededError when over quota", async () => {
       const service = new BlobQuotaService({ defaultQuotaBytes: 1000 }, mockUsageQuery(900));
       await expect(service.reserveQuota("sys_abc" as SystemId, 200)).rejects.toThrow(

--- a/packages/storage/src/__tests__/quota-service.test.ts
+++ b/packages/storage/src/__tests__/quota-service.test.ts
@@ -124,6 +124,20 @@ describe("BlobQuotaService", () => {
     });
   });
 
+  describe("reserveQuota (advisory)", () => {
+    it("resolves when upload is within quota", async () => {
+      const service = new BlobQuotaService({ defaultQuotaBytes: 1000 }, mockUsageQuery(100));
+      await expect(service.reserveQuota("sys_abc" as SystemId, 500)).resolves.toBeUndefined();
+    });
+
+    it("throws QuotaExceededError when over quota", async () => {
+      const service = new BlobQuotaService({ defaultQuotaBytes: 1000 }, mockUsageQuery(900));
+      await expect(service.reserveQuota("sys_abc" as SystemId, 200)).rejects.toThrow(
+        QuotaExceededError,
+      );
+    });
+  });
+
   describe("error propagation", () => {
     it("propagates usage query errors through getUsage", async () => {
       const failingQuery: BlobUsageQuery = {

--- a/packages/storage/src/adapters/filesystem/filesystem-adapter.ts
+++ b/packages/storage/src/adapters/filesystem/filesystem-adapter.ts
@@ -17,7 +17,7 @@ import type {
   PresignedUrlResult,
   StoredBlobMetadata,
 } from "../../interface.js";
-import type { StorageKey, UnixMillis } from "@pluralscape/types";
+import type { Logger, StorageKey, UnixMillis } from "@pluralscape/types";
 
 interface SidecarMetadata {
   mimeType: string | null;
@@ -43,10 +43,20 @@ export class FilesystemBlobStorageAdapter implements BlobStorageAdapter {
 
   private readonly storageRoot: string;
   private readonly maxSizeBytes: number | null;
+  private readonly logger: Logger | null;
 
-  constructor({ storageRoot, maxSizeBytes }: { storageRoot: string; maxSizeBytes?: number }) {
+  constructor({
+    storageRoot,
+    maxSizeBytes,
+    logger,
+  }: {
+    storageRoot: string;
+    maxSizeBytes?: number;
+    logger?: Logger;
+  }) {
     this.storageRoot = resolve(storageRoot);
     this.maxSizeBytes = maxSizeBytes ?? null;
+    this.logger = logger ?? null;
   }
 
   async upload(params: BlobUploadParams): Promise<StoredBlobMetadata> {
@@ -139,7 +149,14 @@ export class FilesystemBlobStorageAdapter implements BlobStorageAdapter {
     try {
       const raw = await readFile(metaPath, "utf-8");
       sidecar = JSON.parse(raw) as SidecarMetadata;
-    } catch {
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return null;
+      }
+      this.logger?.warn("Failed to parse sidecar metadata JSON, returning null", {
+        metaPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
 

--- a/packages/storage/src/quota/quota-service.ts
+++ b/packages/storage/src/quota/quota-service.ts
@@ -78,6 +78,27 @@ export class BlobQuotaService {
     }
   }
 
+  /**
+   * Reserves quota for an upload by performing an advisory check.
+   *
+   * This method checks current usage and throws {@link QuotaExceededError} if the
+   * upload would exceed the system's quota. It is functionally equivalent to
+   * {@link assertQuota} today but exists as the future integration point for
+   * database-level advisory locks.
+   *
+   * **TOCTOU limitation:** Without advisory locks (not yet available in the
+   * current infrastructure), a concurrent upload could pass the check before
+   * either is committed. The API layer should wrap the reserve + upload in a
+   * serializable transaction when advisory locks become available.
+   *
+   * TODO(ps-wsiw): Acquire a pg_advisory_xact_lock on the system ID before
+   * checking usage, ensuring the quota check and the subsequent blob insert
+   * are atomic within the same transaction.
+   */
+  async reserveQuota(systemId: SystemId, additionalBytes: number): Promise<void> {
+    await this.assertQuota(systemId, additionalBytes);
+  }
+
   private getQuotaForSystem(systemId: SystemId): number {
     return this.config.perSystemOverrides?.[systemId] ?? this.config.defaultQuotaBytes;
   }


### PR DESCRIPTION
## Summary

- Create `EmailValidationError` for input validation instead of using delivery/recipient errors
- Default `createI18nInstance()` to throw mode when no logger provided
- Add Headmate/Headmates preset to plural rules (Alter/Alters kept as community synonym)
- Add `reserveQuota` method with advisory lock pattern documentation
- Log warning on sidecar metadata JSON parse failure instead of silent swallow

## Beans

Completes `ps-wsiw` (Phase 2 of M9 audit remediation).

## Test plan

- [x] email: 128 tests pass
- [x] i18n: 122 tests pass
- [x] storage: 138 tests pass
- [x] Typecheck, lint, format: all clean
- [ ] E2E tests (CI)