### PR TITLE
fix(i18n): pipefail in crowdin-config + rename author_not_bot

### DIFF
--- a/.github/workflows/crowdin-config.yml
+++ b/.github/workflows/crowdin-config.yml
@@ -36,12 +36,17 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Apply project configuration
+        shell: bash
         env:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           DEEPL_API_KEY: ${{ secrets.DEEPL_API_KEY }}
           GOOGLE_TRANSLATE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_TRANSLATE_SERVICE_ACCOUNT_JSON }}
         run: |
+          # pipefail is critical: without it, `crowdin:setup | tee` masks a
+          # non-zero exit from the setup script because tee always exits 0,
+          # making the whole job report success on a real failure.
+          set -eo pipefail
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             pnpm crowdin:setup --dry-run --json
           else

--- a/scripts/__tests__/crowdin/automerge-evaluate.test.ts
+++ b/scripts/__tests__/crowdin/automerge-evaluate.test.ts
@@ -54,10 +54,18 @@ describe("evaluatePr — eligible path", () => {
 });
 
 describe("evaluatePr — skip reasons", () => {
-  it("rejects non-bot authors", () => {
+  it("rejects human authors with author_not_crowdin_bot", () => {
     const result = evaluatePr(basePr({ author: "someone-else" }));
     expect(result.eligible).toBe(false);
-    if (!result.eligible) expect(result.skipReason).toBe("author_not_bot");
+    if (!result.eligible) expect(result.skipReason).toBe("author_not_crowdin_bot");
+  });
+
+  it("rejects other bots (renovate, dependabot) with author_not_crowdin_bot", () => {
+    for (const bot of ["renovate[bot]", "dependabot[bot]"]) {
+      const result = evaluatePr(basePr({ author: bot }));
+      expect(result.eligible).toBe(false);
+      if (!result.eligible) expect(result.skipReason).toBe("author_not_crowdin_bot");
+    }
   });
 
   it("rejects mismatched head ref", () => {

--- a/scripts/crowdin/automerge/evaluate.ts
+++ b/scripts/crowdin/automerge/evaluate.ts
@@ -23,7 +23,7 @@ export const EXPECTED_BASE_REF = "main";
 export const KILL_SWITCH_LABEL = "do-not-automerge";
 
 export type SkipReason =
-  | "author_not_bot"
+  | "author_not_crowdin_bot"
   | "branch_mismatch"
   | "kill_switch_active"
   | "no_files"
@@ -131,7 +131,7 @@ function extractLocale(p: string): string | undefined {
  */
 export function evaluatePr(pr: PrContext): EvaluationResult {
   if (pr.author !== BOT_AUTHOR) {
-    return { eligible: false, skipReason: "author_not_bot" };
+    return { eligible: false, skipReason: "author_not_crowdin_bot" };
   }
   if (pr.headRef !== EXPECTED_HEAD_REF || pr.baseRef !== EXPECTED_BASE_REF) {
     return { eligible: false, skipReason: "branch_mismatch" };


### PR DESCRIPTION
## Summary

Two distinct Crowdin automation bugs surfaced after PR #468 merged:

1. **`crowdin-config.yml` pipefail** — the apply step ran `pnpm crowdin:setup --json | tee crowdin-setup-output.json` without `set -eo pipefail`. When `crowdin:setup` failed (e.g. missing `DEEPL_API_KEY` secret), `tee` exited 0 and the job reported green, masking the real failure. Added `set -eo pipefail` at the top of the step.
2. **`author_not_bot` skip reason was misleading** — Renovate and Dependabot PRs triggered it, but they ARE bots (`renovate[bot]`, `dependabot[bot]`), just not the Crowdin bot we accept. Renamed the skip reason to `author_not_crowdin_bot` so the log/comment accurately describes what the guard actually checks (equality against `github-actions[bot]`).

## Test plan

- [x] Typecheck clean
- [x] 254/254 scripts tests pass (new test covers the renovate/dependabot → `author_not_crowdin_bot` case)
- [ ] On CI: next sync workflow pipeline proves the pipefail fix by surfacing the actual error on any real failure