### PR TITLE
ci,security: email ReDoS fix, CodeQL v4 alignment, setup-pnpm composite

### DIFF
--- a/.beans/infra-487m--improve-ci-workflows-replace-crowdin-automerge-wit.md
+++ b/.beans/infra-487m--improve-ci-workflows-replace-crowdin-automerge-wit.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: normal
 created_at: 2026-04-19T01:43:35Z
-updated_at: 2026-04-19T01:48:17Z
+updated_at: 2026-04-19T02:03:15Z
 ---
 
 Replace custom crowdin-automerge workflow with native gh pr merge --auto + branch ruleset scoped to github-actions[bot]. Extract composite setup action, drop needs:[lint,typecheck] gates on fast jobs, refine concurrency cancel-in-progress. Keep separate crowdin workflows (responsibility boundary). Larger runners skipped (paid tier on public repos).
@@ -29,14 +29,14 @@ See `docs/superpowers/specs/2026-04-18-ci-workflow-improvements-design.md` (loca
 
 ### Part B — CI structural changes
 
-- [ ] Create .github/actions/setup-pnpm/action.yml composite
-- [ ] Replace boilerplate in ci.yml jobs with composite use
-- [ ] Drop needs:[lint,typecheck] from: migrations, security, openapi, trpc-parity, scope-check
-- [ ] Refine concurrency.cancel-in-progress to PR-only in ci.yml and codeql.yml
+- [x] Create .github/actions/setup-pnpm/action.yml composite (PR #474, commit 997cbda8)
+- [x] Replace boilerplate in ci.yml jobs with composite use (PR #474, commit 5798be94)
+- [x] Drop needs:[lint,typecheck] from: migrations, security, openapi, trpc-parity, scope-check (PR #474, commit d14f9dc4)
+- [x] Refine concurrency.cancel-in-progress to PR-only in ci.yml and codeql.yml (PR #474, commit 1c9b718c)
 
 ### Rollout order
 
-- [ ] Land Part B first (lower risk)
+- [x] Land Part B first (PR #474 open, waiting for CI)
 - [ ] Create ruleset in evaluate mode
 - [ ] Flip ruleset to active after first clean run
 - [ ] Land Part A in one PR (workflow change + deletes)

--- a/.beans/infra-487m--improve-ci-workflows-replace-crowdin-automerge-wit.md
+++ b/.beans/infra-487m--improve-ci-workflows-replace-crowdin-automerge-wit.md
@@ -1,0 +1,43 @@
+---
+# infra-487m
+title: "Improve CI workflows: replace crowdin-automerge with native auto-merge + moderate optimizations"
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-04-19T01:43:35Z
+updated_at: 2026-04-19T01:48:17Z
+---
+
+Replace custom crowdin-automerge workflow with native gh pr merge --auto + branch ruleset scoped to github-actions[bot]. Extract composite setup action, drop needs:[lint,typecheck] gates on fast jobs, refine concurrency cancel-in-progress. Keep separate crowdin workflows (responsibility boundary). Larger runners skipped (paid tier on public repos).
+
+## Spec
+
+See `docs/superpowers/specs/2026-04-18-ci-workflow-improvements-design.md` (local-only, gitignored).
+
+## Todos
+
+### Part A — Replace crowdin-automerge
+
+- [ ] Create branch ruleset via `gh api` (enforcement: evaluate first, then active)
+- [ ] Enable native auto-merge in repo Settings
+- [ ] Add `gh pr merge --auto` step to crowdin-sync.yml
+- [ ] Delete crowdin-automerge.yml workflow
+- [ ] Delete scripts/crowdin-automerge-guard.ts
+- [ ] Delete scripts/crowdin/automerge/evaluate.ts and gh.ts + tests
+- [ ] Remove crowdin:automerge-guard script from package.json
+- [ ] Remove CROWDIN_AUTOMERGE_DRY_RUN repo variable (after first successful auto-merge)
+
+### Part B — CI structural changes
+
+- [ ] Create .github/actions/setup-pnpm/action.yml composite
+- [ ] Replace boilerplate in ci.yml jobs with composite use
+- [ ] Drop needs:[lint,typecheck] from: migrations, security, openapi, trpc-parity, scope-check
+- [ ] Refine concurrency.cancel-in-progress to PR-only in ci.yml and codeql.yml
+
+### Rollout order
+
+- [ ] Land Part B first (lower risk)
+- [ ] Create ruleset in evaluate mode
+- [ ] Flip ruleset to active after first clean run
+- [ ] Land Part A in one PR (workflow change + deletes)
+- [ ] Manually trigger crowdin-sync to validate end-to-end

--- a/.beans/ps-ww2e--fix-redos-in-emailconstantsts-make-codeql-fail-ci.md
+++ b/.beans/ps-ww2e--fix-redos-in-emailconstantsts-make-codeql-fail-ci.md
@@ -1,0 +1,20 @@
+---
+# ps-ww2e
+title: Fix ReDoS in email.constants.ts + make CodeQL fail CI on high-severity
+status: in-progress
+type: bug
+priority: high
+created_at: 2026-04-19T00:50:48Z
+updated_at: 2026-04-19T00:52:25Z
+---
+
+Two CodeQL alerts (js/polynomial-redos, security_severity=high) open on main at packages/email/src/email.constants.ts:38,42. The EMAIL_REGEX /^[^\s@]+@[^\s@]+\.[^\s@]+$/ has polynomial backtracking because `.` is inside [^\s@], creating ambiguous partitions around the final `\.`.
+
+Also: CodeQL's default setup runs on every PR but always reports check conclusion `success` regardless of alert severity, so branch protection cannot block. Need a CI gate that fails on high+ severity.
+
+## Tasks
+
+- [x] Replace EMAIL_REGEX with a non-backtracking linear validator
+- [x] Add test cases covering ReDoS-style inputs (e.g. '!@' + '!.'.repeat(N)) to prove linear behavior
+- [ ] Add CI job that fails on open high/critical CodeQL alerts for the PR's head SHA
+- [ ] Verify alerts close after fix lands on main

--- a/.beans/ps-ww2e--fix-redos-in-emailconstantsts-make-codeql-fail-ci.md
+++ b/.beans/ps-ww2e--fix-redos-in-emailconstantsts-make-codeql-fail-ci.md
@@ -5,7 +5,7 @@ status: in-progress
 type: bug
 priority: high
 created_at: 2026-04-19T00:50:48Z
-updated_at: 2026-04-19T00:52:25Z
+updated_at: 2026-04-19T00:55:52Z
 ---
 
 Two CodeQL alerts (js/polynomial-redos, security_severity=high) open on main at packages/email/src/email.constants.ts:38,42. The EMAIL_REGEX /^[^\s@]+@[^\s@]+\.[^\s@]+$/ has polynomial backtracking because `.` is inside [^\s@], creating ambiguous partitions around the final `\.`.
@@ -16,5 +16,5 @@ Also: CodeQL's default setup runs on every PR but always reports check conclusio
 
 - [x] Replace EMAIL_REGEX with a non-backtracking linear validator
 - [x] Add test cases covering ReDoS-style inputs (e.g. '!@' + '!.'.repeat(N)) to prove linear behavior
-- [ ] Add CI job that fails on open high/critical CodeQL alerts for the PR's head SHA
+- [x] Switch to advanced CodeQL setup with SARIF gate failing on security-severity >= 7.0 (high/critical)
 - [ ] Verify alerts close after fix lands on main

--- a/.beans/ps-xk9u--fix-crowdin-sdk-default-import-breaking-crowdin-co.md
+++ b/.beans/ps-xk9u--fix-crowdin-sdk-default-import-breaking-crowdin-co.md
@@ -1,0 +1,20 @@
+---
+# ps-xk9u
+title: Fix Crowdin SDK default-import breaking crowdin-config CI
+status: completed
+type: bug
+priority: high
+created_at: 2026-04-19T01:19:00Z
+updated_at: 2026-04-19T01:19:00Z
+---
+
+Node 22+ changed ESM-CJS default-import interop: `import X from 'cjs'` resolves to the full module.exports namespace object instead of exports.default, even when \_\_esModule is set. The Crowdin SDK exports Client via both `exports.default` and `exports.Client`, so the default import gives us an object of API classes and `new CrowdinClientCtor(...)` throws 'is not a constructor'.
+
+The bug has been latent — crowdin-config CI was masking it until 30bcd3ab added `set -eo pipefail` (tee exits 0). Now the real failure surfaces.
+
+## Summary of Changes
+
+- scripts/crowdin/client.ts: switch to named import `{ Client as CrowdinClientCtor }`
+- scripts/**tests**/crowdin/client.test.ts: regression test verifying createCrowdinClient returns a real Client instance
+
+Known limitation: vitest's bundler synthesizes default exports differently than Node's native ESM, so the vitest test does not reproduce the specific interop quirk — it only catches general `createCrowdinClient` regressions. The tsx-executed crowdin-config workflow is what surfaces the interop issue end-to-end.

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,11 +1,9 @@
 name: Setup pnpm + Node
-description: Checkout the repo, install pnpm, install Node 24 with pnpm store caching, and run `pnpm install --frozen-lockfile`.
+description: Install pnpm, install Node 24 with pnpm store caching, and run `pnpm install --frozen-lockfile`. Requires `actions/checkout` to have run first so GitHub can load this local composite action.
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
     - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
 
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,17 @@
+name: Setup pnpm + Node
+description: Checkout the repo, install pnpm, install Node 24 with pnpm store caching, and run `pnpm install --frozen-lockfile`.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+
+    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Check formatting
         run: pnpm format
@@ -39,16 +30,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Typecheck
         run: pnpm typecheck
@@ -80,16 +62,7 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Run all tests with coverage
         env:
@@ -130,16 +103,7 @@ jobs:
     needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Generate migrations
         working-directory: packages/db
@@ -173,16 +137,7 @@ jobs:
     needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Audit dependencies
         run: pnpm audit --audit-level=moderate --ignore-registry-errors
@@ -192,16 +147,7 @@ jobs:
     needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Check spec matches code routes
         run: pnpm openapi:check
@@ -211,16 +157,7 @@ jobs:
     needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Check tRPC parity with REST
         run: pnpm trpc:parity
@@ -230,16 +167,7 @@ jobs:
     needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Check scope coverage
         run: pnpm scope:check
@@ -263,18 +191,9 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 24
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers (mobile-web-e2e)
         run: pnpm --filter @pluralscape/mobile-web-e2e exec playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
 
   migrations:
     name: Migration Freshness
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/actions/setup-pnpm
@@ -134,7 +133,6 @@ jobs:
 
   security:
     name: Security Audit
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/actions/setup-pnpm
@@ -144,7 +142,6 @@ jobs:
 
   openapi:
     name: OpenAPI Spec Reconciliation
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/actions/setup-pnpm
@@ -154,7 +151,6 @@ jobs:
 
   trpc-parity:
     name: tRPC Parity Check
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/actions/setup-pnpm
@@ -164,7 +160,6 @@ jobs:
 
   scope-check:
     name: Scope Coverage Check
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Check formatting
@@ -30,6 +32,8 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Typecheck
@@ -62,6 +66,8 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Run all tests with coverage
@@ -102,6 +108,8 @@ jobs:
     name: Migration Freshness
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Generate migrations
@@ -135,6 +143,8 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Audit dependencies
@@ -144,6 +154,8 @@ jobs:
     name: OpenAPI Spec Reconciliation
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Check spec matches code routes
@@ -153,6 +165,8 @@ jobs:
     name: tRPC Parity Check
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Check tRPC parity with REST
@@ -162,6 +176,8 @@ jobs:
     name: Scope Coverage Check
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Check scope coverage
@@ -186,6 +202,8 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - uses: ./.github/actions/setup-pnpm
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,32 +22,34 @@ jobs:
     timeout-minutes: 30
     permissions:
       security-events: write
+      packages: read
       actions: read
       contents: read
-      packages: read
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - javascript-typescript
-          - actions
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: /language:${{ matrix.language }}
           output: sarif-results
-          upload: always
 
       - name: Gate on high/critical severity
         env:
@@ -55,7 +57,6 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          # Emits one line per high/critical finding: "<ruleId>\t<severity>\t<uri>\t<line>\t<message>"
           read -r -d '' JQ_FILTER <<'JQ' || true
           .runs[] as $run
           | $run.results[]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,94 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - actions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          category: /language:${{ matrix.language }}
+          output: sarif-results
+          upload: always
+
+      - name: Gate on high/critical severity
+        env:
+          LANG_CATEGORY: ${{ matrix.language }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          # Emits one line per high/critical finding: "<ruleId>\t<severity>\t<uri>\t<line>\t<message>"
+          read -r -d '' JQ_FILTER <<'JQ' || true
+          .runs[] as $run
+          | $run.results[]
+          | . as $r
+          | [ $run.tool.driver.rules[] | select(.id == $r.ruleId) ][0] as $rule
+          | (
+              ($r.properties["security-severity"] // $rule.properties["security-severity"] // "0")
+              | tonumber
+            ) as $sev
+          | select($sev >= 7.0)
+          | [
+              $r.ruleId,
+              ($sev | tostring),
+              ($r.locations[0].physicalLocation.artifactLocation.uri // "unknown"),
+              ($r.locations[0].physicalLocation.region.startLine // 0 | tostring),
+              ($r.message.text | gsub("[\n\t]"; " "))
+            ] | @tsv
+          JQ
+          total=0
+          for f in sarif-results/*.sarif; do
+            mapfile -t findings < <(jq -r "$JQ_FILTER" "$f")
+            if [ "${#findings[@]}" -gt 0 ]; then
+              echo "::group::$(basename "$f") — ${#findings[@]} high/critical finding(s)"
+              for line in "${findings[@]}"; do
+                IFS=$'\t' read -r rule sev uri lineno msg <<<"$line"
+                echo "  [$rule severity=$sev] $uri:$lineno — $msg"
+              done
+              echo "::endgroup::"
+              total=$((total + ${#findings[@]}))
+            fi
+          done
+          if [ "$total" -gt 0 ]; then
+            echo "::error::${total} high/critical severity CodeQL finding(s) in ${LANG_CATEGORY}. Fix them, or dismiss with justification in the Security tab if a false positive."
+            exit 1
+          fi
+          echo "No high/critical CodeQL findings in ${LANG_CATEGORY}."

--- a/packages/email/src/__tests__/validate-send-params.test.ts
+++ b/packages/email/src/__tests__/validate-send-params.test.ts
@@ -122,4 +122,35 @@ describe("validateSendParams", () => {
       validateSendParams({ to: "a@example.com", subject: "Hello" });
     }).not.toThrow();
   });
+
+  it.each([
+    "no-at-sign",
+    "@leading-at.com",
+    "trailing-at@",
+    "two@at@signs.com",
+    "spaces @example.com",
+    "with space@example.com",
+    "tab\t@example.com",
+    "no-dot@example",
+    "leading-dot@.example.com",
+    "trailing-dot@example.",
+  ])("rejects malformed from address %p", (bad) => {
+    expect(() => {
+      validateSendParams({ to: "a@example.com", subject: "Hello", from: bad });
+    }).toThrow(InvalidRecipientError);
+  });
+
+  it("runs in linear time on ReDoS-style inputs (js/polynomial-redos regression)", () => {
+    // The previous regex /^[^\s@]+@[^\s@]+\.[^\s@]+$/ was flagged by CodeQL as
+    // polynomial ReDoS on strings like "!@" + "!.".repeat(n) because `.` was
+    // part of the negated class, creating ambiguous partitions. The replacement
+    // must validate such an input in linear time.
+    const adversarial = "!@" + "!.".repeat(50_000);
+    const start = performance.now();
+    expect(() => {
+      validateSendParams({ to: "a@example.com", subject: "Hello", from: adversarial });
+    }).toThrow(InvalidRecipientError);
+    const elapsedMs = performance.now() - start;
+    expect(elapsedMs).toBeLessThan(100);
+  });
 });

--- a/packages/email/src/email.constants.ts
+++ b/packages/email/src/email.constants.ts
@@ -9,8 +9,35 @@ export const MAX_RECIPIENTS = 50;
 /** Maximum subject line length in characters. */
 export const MAX_SUBJECT_LENGTH = 998;
 
-/** Basic email format check (not exhaustive, just prevents obvious mistakes). */
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/**
+ * Basic email format check (not exhaustive, just prevents obvious mistakes).
+ *
+ * Implemented as a linear split rather than a regex to avoid polynomial-time
+ * backtracking on adversarial inputs (CodeQL js/polynomial-redos).
+ */
+function isValidEmailShape(value: string): boolean {
+  const atIndex = value.indexOf("@");
+  if (atIndex <= 0 || atIndex !== value.lastIndexOf("@")) return false;
+
+  const local = value.slice(0, atIndex);
+  const domain = value.slice(atIndex + 1);
+  if (domain.length === 0) return false;
+
+  for (const ch of local) {
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") return false;
+  }
+
+  let sawDot = false;
+  for (let i = 0; i < domain.length; i++) {
+    const ch = domain[i];
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r" || ch === "@") return false;
+    if (ch === ".") {
+      if (i === 0 || i === domain.length - 1) return false;
+      sawDot = true;
+    }
+  }
+  return sawDot;
+}
 
 /**
  * Validates send parameters against package constraints.
@@ -35,11 +62,11 @@ export function validateSendParams(params: {
     throw new EmailValidationError("Subject length", params.subject.length, MAX_SUBJECT_LENGTH);
   }
 
-  if (params.from !== undefined && !EMAIL_REGEX.test(params.from)) {
+  if (params.from !== undefined && !isValidEmailShape(params.from)) {
     throw new InvalidRecipientError(params.from);
   }
 
-  if (params.replyTo !== undefined && !EMAIL_REGEX.test(params.replyTo)) {
+  if (params.replyTo !== undefined && !isValidEmailShape(params.replyTo)) {
     throw new InvalidRecipientError(params.replyTo);
   }
 }

--- a/scripts/__tests__/crowdin/client.test.ts
+++ b/scripts/__tests__/crowdin/client.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { createCrowdinClient } from "../../crowdin/client.js";
+import type { CrowdinEnv } from "../../crowdin/env.js";
+
+// Regression test for: the Crowdin SDK ships as CJS with both
+// `exports.default = Client` and `exports.Client = Client`. Under Node 22+
+// the ESM-CJS interop resolves `import X from "cjs"` to the full
+// `module.exports` namespace object rather than `exports.default`, so a
+// default import is NOT a constructor. This test executes the real
+// constructor path so a regression (e.g. someone flipping back to a default
+// import) surfaces immediately instead of only in the Crowdin CI step.
+describe("createCrowdinClient", () => {
+  it("constructs a real Client instance (not the SDK namespace object)", () => {
+    const env = {
+      projectId: 1,
+      token: "fake-token-for-unit-test",
+    } as CrowdinEnv;
+
+    const client = createCrowdinClient(env);
+
+    expect(client.constructor.name).toBe("Client");
+    expect(typeof client.projectsGroupsApi).toBe("object");
+    expect(typeof client.glossariesApi).toBe("object");
+  });
+});

--- a/scripts/crowdin/client.ts
+++ b/scripts/crowdin/client.ts
@@ -1,9 +1,11 @@
-import CrowdinClientCtor from "@crowdin/crowdin-api-client";
+import { Client as CrowdinClientCtor } from "@crowdin/crowdin-api-client";
 
 import type { CrowdinEnv } from "./env.js";
 
-// The SDK ships as a CJS module; the ESM default import resolves directly to
-// the constructor class (confirmed at runtime: `typeof import === "function"`).
+// The SDK is CJS with both `exports.default = Client` and `exports.Client = Client`.
+// Under Node 22+, the ESM-CJS interop resolves `import X from "cjs"` to the full
+// `module.exports` namespace object rather than `exports.default`, so the default
+// import is not a constructor. Use the named import, which resolves correctly.
 export type CrowdinClient = InstanceType<typeof CrowdinClientCtor>;
 
 export function createCrowdinClient(env: CrowdinEnv): CrowdinClient {


### PR DESCRIPTION
## Summary

This branch combines two complementary tracks of work already scoped by the branch name `fix/security-and-ci-fixes`.

**Security fixes (already on branch):**
- `fix(email)` — Replace ReDoS-vulnerable email regex with a linear splitter
- `ci(codeql)` — Advanced setup with SARIF severity gate + alignment with GitHub's template (v4 action)
- `fix(crowdin)` — Use named import for SDK Client to restore `crowdin-config` CI

**CI structural improvements (Phase B of `infra-487m`):**
- `ci(actions)` — Add `.github/actions/setup-pnpm` composite action
- `ci` — Collapse the 4-step checkout/pnpm/node/install boilerplate across all nine `ci.yml` jobs into a single `- uses: ./.github/actions/setup-pnpm`
- `ci` — Drop `needs: [lint, typecheck]` from `migrations`, `security`, `openapi`, `trpc-parity`, `scope-check` (fast independent jobs; let them run in parallel with lint/typecheck)
- `ci` — Scope `concurrency.cancel-in-progress` to `pull_request` events in `ci.yml` and `codeql.yml` so pushes to `main` aren't cancelled mid-run

Phase A of `infra-487m` (replace the custom `crowdin-automerge` workflow with native `gh pr merge --auto` + a branch ruleset) will land as a separate follow-up PR after this one and after the ruleset is created and verified in `evaluate` mode.

Spec + plan: see bean `infra-487m`.

## Test plan

- [ ] All required CI checks pass on this PR
- [ ] In the Actions UI, observe that `migrations`, `security`, `openapi`, `trpc-parity`, and `scope-check` start in parallel with `lint`/`typecheck` (rather than waiting for them)
- [ ] Spot-check the `test-e2e` job still runs `setup-bun` after the composite and does not regress