### PR TITLE
fix(crowdin): resolve every project file when --files is omitted

### DIFF
--- a/scripts/crowdin-pretranslate.ts
+++ b/scripts/crowdin-pretranslate.ts
@@ -1,11 +1,32 @@
 import { parseArgs } from "node:util";
 
 import { parseCsvEnum, parseCsvPositiveInts } from "./crowdin/args.js";
-import { createCrowdinClient } from "./crowdin/client.js";
+import { createCrowdinClient, type CrowdinClient } from "./crowdin/client.js";
 import { loadCrowdinEnv } from "./crowdin/env.js";
 import { TARGET_LANGUAGE_IDS, type TargetLanguageId } from "./crowdin/languages.js";
 import { findMtEngineIds } from "./crowdin/mt.js";
+import { LIST_PAGE_SIZE, MAX_PAGES } from "./crowdin/pagination.constants.js";
 import { planPretranslatePasses, runPretranslate } from "./crowdin/pretranslate.js";
+
+async function listAllFileIds(client: CrowdinClient, projectId: number): Promise<number[]> {
+  const ids: number[] = [];
+  let pages = 0;
+  for (let offset = 0; ; offset += LIST_PAGE_SIZE) {
+    if (pages >= MAX_PAGES) {
+      throw new Error(
+        `crowdin:pretranslate: exceeded MAX_PAGES=${String(MAX_PAGES)} while listing files (offset=${String(offset)}).`,
+      );
+    }
+    const response = await client.sourceFilesApi.listProjectFiles(projectId, {
+      limit: LIST_PAGE_SIZE,
+      offset,
+    });
+    for (const entry of response.data) ids.push(entry.data.id);
+    pages += 1;
+    if (response.data.length < LIST_PAGE_SIZE) break;
+  }
+  return ids;
+}
 
 async function main(): Promise<void> {
   const { values } = parseArgs({
@@ -56,10 +77,21 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Crowdin's applyPreTranslation rejects an empty fileIds array with HTTP 400
+  // ("Value is required and can't be empty"). When --files isn't passed, list
+  // every source file in the project so pretranslate covers the whole project.
+  const resolvedFileIds = fileIds ?? (await listAllFileIds(client, env.projectId));
+  if (resolvedFileIds.length === 0) {
+    console.error(
+      "crowdin:pretranslate: project has no source files to pretranslate. Run `crowdin upload sources` first.",
+    );
+    process.exit(1);
+  }
+
   const result = await runPretranslate(client, env.projectId, {
     deeplMtId: ids.deeplId,
     googleMtId: ids.googleId,
-    fileIds,
+    fileIds: resolvedFileIds,
     languageIds,
   });
 


### PR DESCRIPTION
## Summary

- \`applyPreTranslation\` rejects an empty \`fileIds\` array with HTTP 400 (\"Value is required and can't be empty\"), which surfaced on the first scheduled \`crowdin-sync\` pretranslate run after #477 merged.
- When \`--files\` isn't passed (the CI case), list every source file in the project via \`sourceFilesApi.listProjectFiles\` (paginated with \`LIST_PAGE_SIZE\` / \`MAX_PAGES\` guard) and hand those ids to \`runPretranslate\`.
- Exit non-zero with a \`crowdin push sources\` pointer when the project has zero files, so the scheduled sync fails loudly instead of silently calling the API with \`[]\`.

## Test plan

- [x] \`pnpm crowdin:pretranslate --dry-run\` locally — plan renders the 3 passes correctly.
- [x] Existing \`pretranslate-runner\` + \`pretranslate-planner\` + \`mt\` unit tests still pass.
- [ ] CI green on this PR.
- [ ] After merge: re-trigger \`crowdin-sync\` workflow manually, confirm pretranslate call succeeds.