### PR TITLE
fix(crowdin): route es-419 to no MT engine (human-translate only)

### DIFF
--- a/scripts/__tests__/crowdin/mt.test.ts
+++ b/scripts/__tests__/crowdin/mt.test.ts
@@ -65,14 +65,19 @@ describe("ENGINE_ROUTING", () => {
     expect(routedKeys).toEqual(targetKeys);
   });
 
-  it("routes es-419 and ar to Google, everything else to DeepL", () => {
-    const byEngine: Record<"deepl" | "google", TargetLanguageId[]> = { deepl: [], google: [] };
+  it("routes ar to Google, es-419 to no MT engine, everything else to DeepL", () => {
+    const byEngine: Record<"deepl" | "google" | "null", TargetLanguageId[]> = {
+      deepl: [],
+      google: [],
+      null: [],
+    };
     for (const [id, engine] of Object.entries(ENGINE_ROUTING) as Array<
-      [TargetLanguageId, "deepl" | "google"]
+      [TargetLanguageId, "deepl" | "google" | null]
     >) {
-      byEngine[engine].push(id);
+      byEngine[engine ?? "null"].push(id);
     }
-    expect(byEngine.google.sort()).toEqual(["ar", "es-419"]);
+    expect(byEngine.google.sort()).toEqual(["ar"]);
+    expect(byEngine.null.sort()).toEqual(["es-419"]);
     expect(byEngine.deepl.sort()).toEqual([
       "de",
       "es-ES",

--- a/scripts/__tests__/crowdin/pretranslate-planner.test.ts
+++ b/scripts/__tests__/crowdin/pretranslate-planner.test.ts
@@ -22,9 +22,23 @@ describe("planPretranslatePasses", () => {
   });
 
   it("returns TM + Google only when only Google-routed languages are requested", () => {
-    const passes = planPretranslatePasses({ ...defaultOpts, languageIds: ["ar", "es-419"] });
+    const passes = planPretranslatePasses({ ...defaultOpts, languageIds: ["ar"] });
     expect(passes.map((p) => p.label)).toEqual(["TM", "MT (Google)"]);
-    expect(passes[1]?.languageIds).toEqual(["ar", "es-419"]);
+    expect(passes[1]?.languageIds).toEqual(["ar"]);
+  });
+
+  it("keeps null-routed languages (e.g., es-419) in the TM pass but excludes them from MT passes", () => {
+    const passes = planPretranslatePasses({ ...defaultOpts, languageIds: ["es-419", "ar", "de"] });
+    expect(passes.map((p) => p.label)).toEqual(["TM", "MT (DeepL)", "MT (Google)"]);
+    expect(passes[0]?.languageIds).toEqual(["es-419", "ar", "de"]);
+    expect(passes[1]?.languageIds).toEqual(["de"]);
+    expect(passes[2]?.languageIds).toEqual(["ar"]);
+  });
+
+  it("returns TM only when every requested language is null-routed", () => {
+    const passes = planPretranslatePasses({ ...defaultOpts, languageIds: ["es-419"] });
+    expect(passes.map((p) => p.label)).toEqual(["TM"]);
+    expect(passes[0]?.languageIds).toEqual(["es-419"]);
   });
 
   it("defaults to all 12 target languages when languageIds is omitted", () => {

--- a/scripts/crowdin/mt.ts
+++ b/scripts/crowdin/mt.ts
@@ -28,16 +28,23 @@ export interface MtClient {
 export type Engine = "deepl" | "google";
 
 /**
- * Maps Crowdin target-language IDs to MT engines.
- * DeepL Free supports most European languages + Japanese/Korean/Chinese but not Arabic.
- * Google Translate covers the remaining locales including Arabic and dialectal Spanish.
+ * Maps Crowdin target-language IDs to MT engines, or `null` when no MT engine
+ * we configure supports that target and the language must be left for human
+ * translation. `null` routes are still included in the TM pretranslate pass
+ * but excluded from every MT pass.
  *
- * Typed as `Record<TargetLanguageId, Engine>` so the compiler enforces
+ * - DeepL Free supports most European languages + Japanese/Korean/Chinese but
+ *   not Arabic, and only a single "Spanish" locale (no es-419).
+ * - Google's Crowdin integration accepts Arabic but rejects `es-419`
+ *   ("Languages [es-419] are not supported by Mt Engine" — HTTP 400 on
+ *   applyPreTranslation). LatAm Spanish therefore stays human-translated.
+ *
+ * Typed as `Record<TargetLanguageId, Engine | null>` so the compiler enforces
  * exhaustive coverage whenever `TARGET_LANGUAGE_IDS` changes.
  */
-export const ENGINE_ROUTING: Record<TargetLanguageId, Engine> = {
+export const ENGINE_ROUTING: Record<TargetLanguageId, Engine | null> = {
   ar: "google",
-  "es-419": "google",
+  "es-419": null,
   de: "deepl",
   "es-ES": "deepl",
   fr: "deepl",

--- a/scripts/crowdin/pretranslate.ts
+++ b/scripts/crowdin/pretranslate.ts
@@ -75,7 +75,11 @@ export function planPretranslatePasses(opts: PretranslateOptions): PretranslateP
   const targets = opts.languageIds ?? TARGET_LANGUAGE_IDS;
   const byEngine: Record<Engine, string[]> = { deepl: [], google: [] };
   for (const id of targets) {
-    byEngine[ENGINE_ROUTING[id as TargetLanguageId]].push(id);
+    const engine = ENGINE_ROUTING[id as TargetLanguageId];
+    // `null`-routed languages (e.g., es-419) participate in the TM pass but are
+    // excluded from every MT pass — no configured engine accepts them.
+    if (engine === null) continue;
+    byEngine[engine].push(id);
   }
 
   const passes: PretranslatePass[] = [{ method: "tm", languageIds: targets, label: "TM" }];


### PR DESCRIPTION
## Summary

- Crowdin's Google MT integration rejects es-419 with HTTP 400 (\"Languages [es-419] are not supported by Mt Engine\"), which fails the MT (Google) pretranslate pass and blocks the whole sync.
- DeepL has no Latin American Spanish variant either — no configured engine can pretranslate es-419.
- Widens \`ENGINE_ROUTING\` to \`Record<TargetLanguageId, Engine | null>\` and maps \`es-419\` to \`null\`.
- \`planPretranslatePasses\` includes null-routed languages in the TM pass (translation memory still applies) but excludes them from every MT pass — LatAm Spanish stays human-translated while every other locale continues to pretranslate.
- Operator tried adding es-419 to the Google engine in the Crowdin UI but the engine still refused the language, so we work around it in code.

## Test plan

- [x] Typecheck clean
- [x] Planner + runner + mt unit tests pass locally (29 tests)
- [ ] CI green on this PR
- [ ] After merge: re-trigger \`crowdin-sync\`; MT (Google) pass accepts \`ar\` and skips \`es-419\`; PR #479 auto-merges once all required checks pass.