### PR TITLE
fix(crowdin): map all full-IETF Crowdin codes to short app locale dirs

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -21,9 +21,18 @@ files:
     translate_attributes: false
 
 languages_mapping:
-  # Only codes where the Crowdin target ID differs from our repo dir need an
-  # entry. Everything else (ar, de, es-419, fr, it, ja, ko, nl, pt-BR, ru)
-  # uses Crowdin's code as-is.
+  # Crowdin emits full IETF codes (ar-SA, de-DE, fr-FR, ...) but our app's
+  # locale directories in apps/mobile/locales/ use short codes. Map every
+  # Crowdin target ID whose repo directory differs. es-419 and pt-BR match
+  # Crowdin's code as-is and need no entry.
   locale:
+    ar-SA: ar
+    de-DE: de
     es-ES: es
+    fr-FR: fr
+    it-IT: it
+    ja-JP: ja
+    ko-KR: ko
+    nl-NL: nl
+    ru-RU: ru
     zh-CN: zh-Hans


### PR DESCRIPTION
## Summary

Crowdin's Arabic/German/French/etc. target IDs are full IETF codes (ar-SA, de-DE, fr-FR, it-IT, ja-JP, ko-KR, nl-NL, ru-RU), but apps/mobile/locales/ uses short codes. The daily sync was dropping translations into directories our i18n loader doesn't read (observed on PR #479, now closed). The prior languages_mapping only covered es-ES to es and zh-CN to zh-Hans.

## Changes

- Added mappings for every Crowdin target whose repo directory differs: ar-SA to ar, de-DE to de, fr-FR to fr, it-IT to it, ja-JP to ja, ko-KR to ko, nl-NL to nl, ru-RU to ru.
- es-419 and pt-BR already match Crowdin's code and need no entry.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: re-trigger crowdin-sync; confirm translations land under apps/mobile/locales/ar/, de/, fr/, ... (short codes).