### PR TITLE
fix(crowdin): nest languages_mapping under the file entry

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -19,20 +19,20 @@ files:
     type: json
     update_option: update_as_unapproved
     translate_attributes: false
-
-languages_mapping:
-  # Crowdin emits full IETF codes (ar-SA, de-DE, fr-FR, ...) but our app's
-  # locale directories in apps/mobile/locales/ use short codes. Map every
-  # Crowdin target ID whose repo directory differs. es-419 and pt-BR match
-  # Crowdin's code as-is and need no entry.
-  locale:
-    ar-SA: ar
-    de-DE: de
-    es-ES: es
-    fr-FR: fr
-    it-IT: it
-    ja-JP: ja
-    ko-KR: ko
-    nl-NL: nl
-    ru-RU: ru
-    zh-CN: zh-Hans
+    # `languages_mapping` must live UNDER the file entry — Crowdin's CLI
+    # silently ignores it at the top level. Crowdin emits full IETF codes
+    # (ar-SA, de-DE, fr-FR, ...) but apps/mobile/locales/ uses short codes;
+    # map every target whose repo directory differs. es-419 and pt-BR match
+    # Crowdin's code as-is and need no entry.
+    languages_mapping:
+      locale:
+        ar-SA: ar
+        de-DE: de
+        es-ES: es
+        fr-FR: fr
+        it-IT: it
+        ja-JP: ja
+        ko-KR: ko
+        nl-NL: nl
+        ru-RU: ru
+        zh-CN: zh-Hans


### PR DESCRIPTION
## Summary

Crowdin's CLI silently ignores \`languages_mapping\` at the top level of \`crowdin.yml\` — it must sit inside each \`files\` entry. PR #479/#481/#482 showed the sync writing translations to \`ar-SA/\`, \`de-DE/\`, \`es-ES/\`, \`zh-CN/\` etc. even after the mappings were added, because the placement was wrong.

## Changes

- Moved the \`languages_mapping\` block from the top level into the single file entry.
- No change to the mapping values themselves.

## Test plan

- [ ] CI green.
- [ ] After merge: trigger \`crowdin-sync\`; confirm translations land in \`apps/mobile/locales/ar/\`, \`de/\`, \`fr/\`, \`it/\`, \`ja/\`, \`ko/\`, \`nl/\`, \`ru/\`, \`es/\`, \`zh-Hans/\`.