### PR TITLE
fix(crowdin): read languages_mapping from nested file entry in locale-parity test

### DIFF
--- a/scripts/__tests__/crowdin/locale-parity.test.ts
+++ b/scripts/__tests__/crowdin/locale-parity.test.ts
@@ -14,8 +14,11 @@ import { TARGET_LANGUAGE_IDS } from "../../crowdin/languages.js";
  *
  * If one changes and the others don't, the pipeline silently drops a locale.
  */
-interface CrowdinYmlMapping {
+interface CrowdinYmlFile {
   languages_mapping?: { locale?: Record<string, string> };
+}
+interface CrowdinYml {
+  files?: CrowdinYmlFile[];
 }
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..", "..");
@@ -23,9 +26,12 @@ const MOBILE_LOCALES_DIR = path.join(REPO_ROOT, "apps", "mobile", "locales");
 const SOURCE_LOCALE = "en";
 
 function loadCrowdinMapping(): Record<string, string> {
+  // Crowdin's CLI reads `languages_mapping` only when nested inside a file
+  // entry — top-level placement is silently ignored. Read it from the first
+  // (only) file entry so this test stays aligned with the production config.
   const file = path.join(REPO_ROOT, "crowdin.yml");
-  const parsed = parse(readFileSync(file, "utf8")) as CrowdinYmlMapping;
-  return parsed.languages_mapping?.locale ?? {};
+  const parsed = parse(readFileSync(file, "utf8")) as CrowdinYml;
+  return parsed.files?.[0]?.languages_mapping?.locale ?? {};
 }
 
 function listDiskTranslationLocales(): string[] {


### PR DESCRIPTION
## Summary

After the languages_mapping placement fix (#483), the Crowdin CLI only honors the block when nested under a \`files\` entry. The locale-parity guard test still read it from the top level of \`crowdin.yml\`, so \`loadCrowdinMapping()\` returned \`{}\` and flagged every mapped locale (\`es-ES → es\`, \`zh-CN → zh-Hans\`) as missing.

Update the loader to read from \`parsed.files[0].languages_mapping.locale\` so the test reflects the production config.

## Test plan

- [x] \`pnpm vitest run --project scripts scripts/__tests__/crowdin/locale-parity.test.ts\` passes locally.
- [ ] CI green on this PR.