### PR TITLE
feat(infra): GCP billing kill-switch terraform module

### DIFF
--- a/.beans/infra-4vqc--add-terraform-gitignore-review-gcp-billing-kill-sw.md
+++ b/.beans/infra-4vqc--add-terraform-gitignore-review-gcp-billing-kill-sw.md
@@ -1,0 +1,29 @@
+---
+# infra-4vqc
+title: Add terraform .gitignore + review GCP billing kill-switch README
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-19T21:32:09Z
+updated_at: 2026-04-19T21:34:28Z
+---
+
+User added scripts/infra/gcp-billing-kill-switch/ — a terraform module that detaches GCP billing if month-to-date spend exceeds threshold (default $1, used to keep Crowdin → Google Translate within free tier). Tasks: review the README, add appropriate .gitignore entries for terraform (root + local), propose README improvements, push to a new branch.
+
+## Summary of Changes
+
+**Root .gitignore** — added repo-wide Terraform section: `**/.terraform/`, state/plan files, tfvars (with `!*.tfvars.example`), override files, terraformrc, crash logs.
+
+**Local .gitignore** (`scripts/infra/gcp-billing-kill-switch/.gitignore`) — slimmed to module-specific patterns: `terraform/.build/` (zip output dir from `function.tf`), terraform override files, python dev artifacts. Removed redundant patterns now covered by root.
+
+**README improvements**:
+
+- Latency caveat callout under "How it works" — emphasizes multi-hour budget eval cadence (soft cap, not instant).
+- New "What this creates" inventory section listing every resource Terraform stands up.
+- New "Cost" section noting the kill switch itself fits in GCP free tier.
+- Added `gcloud config set project` to deploy step 1 so later commands don't need `--project`.
+- Step 4 now points to step 5 for email verification (verification email arrives during first apply).
+- Filled in the previously empty "End-to-end test (optional, destructive)" section with concrete steps + recommendation to skip.
+- Recovery section gained a re-trigger-risk callout: re-linking billing while month-to-date spend > threshold will fire again within hours.
+
+**Verified**: `git ls-files --others --exclude-standard scripts/infra/` shows clean output — `.terraform.lock.hcl` and `terraform.tfvars.example` will be committed (correct), no state/real tfvars/.build/ leak.

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,22 @@ bun.lockb
 .codeql-db/
 .codeql-results/
 
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.tfvars
+!*.tfvars.example
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+crash.log
+crash.*.log
+
 # Databases
 *.db
 *.db-shm

--- a/scripts/infra/gcp-billing-kill-switch/.gitignore
+++ b/scripts/infra/gcp-billing-kill-switch/.gitignore
@@ -1,0 +1,17 @@
+# Repo-wide terraform patterns live in the root .gitignore. Module-specific
+# entries below.
+
+# Function source build artifact (zip created by archive_file in function.tf)
+terraform/.build/
+
+# Terraform local override files (not committed by convention)
+terraform/override.tf
+terraform/override.tf.json
+terraform/*_override.tf
+terraform/*_override.tf.json
+
+# Python (function source local dev only)
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/

--- a/scripts/infra/gcp-billing-kill-switch/README.md
+++ b/scripts/infra/gcp-billing-kill-switch/README.md
@@ -1,0 +1,200 @@
+# GCP Billing Kill Switch
+
+Auto-detaches billing from a single GCP project when month-to-date spend exceeds
+a threshold (default **$1 USD**). Confirms the kill via email.
+
+Design: [`docs/superpowers/specs/2026-04-18-gcp-billing-kill-switch-design.md`](../../docs/superpowers/specs/2026-04-18-gcp-billing-kill-switch-design.md)
+
+## How it works
+
+```
+Month-to-date spend > threshold
+  → GCP Billing evaluates budget (multi-hour cadence — NOT real-time)
+  → Budget publishes to Pub/Sub topic
+  → Cloud Function receives, detaches billing via updateBillingInfo
+  → Function logs event=billing_disabled
+  → Log-based metric → alert policy → email to notify_email
+```
+
+> **Latency caveat.** Budget evaluation runs on GCP's schedule (typically every
+> few hours), so this is a _soft_ cap, not an instant cutoff. Spend can keep
+> accruing between the threshold being crossed and the next budget evaluation.
+> Sized to the Crowdin → Google Translate free-tier use case where the worst
+> realistic overshoot is single-digit dollars.
+
+## What this creates
+
+All resources live inside `var.project_id` (and the linked billing account):
+
+- 1 Pub/Sub topic (`<name_prefix>-budget`) — budget delivery
+- 1 GCS bucket (`<project>-<name_prefix>-source`) — function source zip
+- 1 Cloud Functions Gen 2 (`<name_prefix>-fn`, python312, max 1 instance)
+- 1 service account (`<name_prefix>-sa`) with `roles/billing.projectManager`
+  on the target project plus `roles/run.invoker` and `roles/eventarc.eventReceiver`
+- 1 billing budget on `billing_account_id`, scoped to this project only
+- 1 log-based metric + 2 alert policies (success + error) + 1 email channel
+- 11 service APIs enabled (see `apis.tf`)
+
+## Cost
+
+The kill switch itself is designed to fit within GCP's always-free tier:
+Cloud Functions Gen 2, Pub/Sub, Cloud Logging, and Cloud Monitoring all
+have free monthly quotas that comfortably cover a single function invoked
+a handful of times per month. Cloud Storage charges a few cents per month
+for the source bucket. There is no free tier for **billing budgets** but
+they are themselves free to create.
+
+## Prerequisites
+
+- `gcloud` CLI authenticated as a user with:
+  - `roles/owner` (or equivalent) on the target project
+  - `roles/billing.admin` on the billing account
+- `terraform` >= 1.5
+- Python 3.12 (only needed to run unit tests locally)
+
+## Deploy
+
+1. Authenticate Application Default Credentials. Terraform's google provider
+   uses ADC, not your `gcloud` session, and the billingbudgets API requires a
+   quota project — without it, `terraform apply` fails with a 403:
+
+   ```bash
+   gcloud config set project <project-id>
+   gcloud auth application-default login
+   gcloud auth application-default set-quota-project <project-id>
+   ```
+
+   Use the same `<project-id>` you'll set as `project_id` in `terraform.tfvars`.
+   Setting the active project up front lets the later `gcloud` commands in
+   this README run without `--project` flags.
+
+2. Enable the Cloud Resource Manager API **once, by hand**. Terraform itself
+   calls this API to read/write service states, so it can't bootstrap it:
+
+   ```bash
+   gcloud services enable cloudresourcemanager.googleapis.com --project=<project-id>
+   ```
+
+   Wait ~30-60 seconds for propagation before continuing.
+
+3. Provide variables. Two options:
+
+   **Option A — `terraform.tfvars` file:**
+
+   ```bash
+   cd terraform
+   cp terraform.tfvars.example terraform.tfvars
+   $EDITOR terraform.tfvars
+   ```
+
+   **Option B — `TF_VAR_*` env vars** (works with direnv, 1Password CLI, etc.):
+
+   ```bash
+   export TF_VAR_project_id=<project-id>
+   export TF_VAR_billing_account_id=01ABCD-23EFGH-456IJK
+   export TF_VAR_notify_email=you@example.com
+   ```
+
+   You can mix both — tfvars file sets defaults, env vars override per-shell.
+
+   Find your billing account ID with:
+
+   ```bash
+   gcloud billing accounts list
+   ```
+
+4. Initial deploy **in dry-run mode** (the default):
+
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+   This first apply sends a verification email to `notify_email` for the
+   monitoring channel — see step 5.
+
+5. **Verify the email notification channel**: GCP sends a verification email
+   to `notify_email` during the first apply. Click the link in that email.
+   Until verified, alerts will **not** deliver — the kill could fire silently.
+
+6. **Test the pipeline in dry-run**:
+
+   ```bash
+   TOPIC=$(terraform output -raw budget_topic)
+
+   gcloud pubsub topics publish "$TOPIC" --message='{
+     "budgetDisplayName": "billing-kill-budget",
+     "costAmount": 2.0,
+     "budgetAmount": 1.0,
+     "currencyCode": "USD"
+   }'
+   ```
+
+   Then in Cloud Logging, filter by the function name and confirm a log entry
+   with `jsonPayload.event="dry_run_would_disable"` appears within a minute or
+   two (first invocation adds ~30-60s of cold start).
+
+7. **Arm** the kill switch:
+
+   ```bash
+   terraform apply -var dry_run=false
+   ```
+
+   Confirm the output shows `dry_run = false`.
+
+## End-to-end test (optional, destructive)
+
+The dry-run pipeline test in step 6 above exercises every component
+**except** the final `updateBillingInfo` call. The only way to fully
+verify the live path is to let the threshold actually trigger — which
+detaches billing and breaks any service depending on it.
+
+If you decide to do this:
+
+1. Run `terraform apply -var dry_run=false` to arm the switch.
+2. Generate enough billable activity to cross the threshold (e.g., make
+   `threshold_usd` very small first, then incur a tiny billable cost).
+3. Wait for the next budget evaluation — typically a few hours, sometimes
+   longer. There is no way to force this.
+4. Confirm: project shows "billing disabled" in the GCP console, the
+   success email arrives, and `jsonPayload.event="billing_disabled"`
+   appears in Cloud Logging.
+5. Recover (see below) and reset `threshold_usd` if you changed it.
+
+For most callers the dry-run test is sufficient confidence — skip this.
+
+## Recovery after a kill
+
+```bash
+gcloud beta billing projects link <project-id> \
+  --billing-account=<billing-account-id>
+```
+
+> **Re-trigger risk.** Budgets track _month-to-date_ spend. If you re-link
+> billing while month-to-date spend is still above `threshold_usd`, the next
+> budget evaluation will fire the kill again within hours. Either wait for
+> the month to roll over, or `terraform apply -var threshold_usd=<higher>`
+> before re-linking.
+
+The kill switch auto-rearms on the next billing cycle (budgets reset
+month-to-date).
+
+## Teardown
+
+```bash
+cd terraform
+terraform destroy
+```
+
+This removes the budget, Pub/Sub, function, SA, metric, and alert policies.
+It does NOT re-attach billing if the kill already fired.
+
+## Running unit tests
+
+```bash
+cd terraform/function_source
+python3 -m venv .venv
+.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/pytest tests/ -v
+```

--- a/scripts/infra/gcp-billing-kill-switch/terraform/.terraform.lock.hcl
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:faTJQOetP9/RYuHwA3r2SWnuYoyzQNm4tUWZrZggcgY=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:uxh4ME3hhSzVjmiWgA1IQqYqg25MV6FMVArHyA6Ki5o=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/apis.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/apis.tf
@@ -1,0 +1,27 @@
+locals {
+  required_apis = [
+    # cloudresourcemanager must be enabled manually BEFORE first apply —
+    # terraform itself calls it to read/write service states, so it can't
+    # bootstrap it. Listed here so it's tracked and won't drift after the
+    # initial manual enable. See README "Prerequisites".
+    "cloudresourcemanager.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "billingbudgets.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "pubsub.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "eventarc.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "apis" {
+  for_each = toset(local.required_apis)
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/budget.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/budget.tf
@@ -1,0 +1,27 @@
+resource "google_billing_budget" "kill_switch" {
+  billing_account = var.billing_account_id
+  display_name    = local.budget_name
+
+  budget_filter {
+    projects = ["projects/${data.google_project.target.number}"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = tostring(var.threshold_usd)
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "CURRENT_SPEND"
+  }
+
+  all_updates_rule {
+    pubsub_topic   = google_pubsub_topic.budget.id
+    schema_version = "1.0"
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/function.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/function.tf
@@ -1,0 +1,87 @@
+locals {
+  # Hash of source-file contents only (not mtimes). archive_file's output_md5
+  # churns every apply because zip entries embed mtimes; hashing the source
+  # files directly keeps the bucket-object name stable across re-applies.
+  fn_source_files = fileset("${path.module}/function_source", "**")
+  fn_source_included = [
+    for f in local.fn_source_files : f
+    if !can(regex("^(tests/|__pycache__/|requirements-dev\\.txt$|\\.venv/)", f))
+  ]
+  fn_source_hash = substr(sha256(join("", [
+    for f in local.fn_source_included :
+    "${f}:${filesha256("${path.module}/function_source/${f}")}"
+  ])), 0, 16)
+}
+
+data "archive_file" "fn_source" {
+  type        = "zip"
+  source_dir  = "${path.module}/function_source"
+  output_path = "${path.module}/.build/function_source.zip"
+  excludes    = ["tests", "tests/*", ".venv", ".venv/*", "requirements-dev.txt", "__pycache__", "__pycache__/*"]
+}
+
+resource "google_storage_bucket" "fn_source" {
+  project  = var.project_id
+  name     = "${var.project_id}-${var.name_prefix}-source"
+  location = var.region
+
+  uniform_bucket_level_access = true
+  force_destroy               = true
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_storage_bucket_object" "fn_source" {
+  name   = "function_source-${local.fn_source_hash}.zip"
+  bucket = google_storage_bucket.fn_source.name
+  source = data.archive_file.fn_source.output_path
+}
+
+resource "google_cloudfunctions2_function" "kill_switch" {
+  project  = var.project_id
+  location = var.region
+  name     = local.function_name
+
+  build_config {
+    runtime     = "python312"
+    entry_point = "kill_billing"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.fn_source.name
+        object = google_storage_bucket_object.fn_source.name
+      }
+    }
+  }
+
+  service_config {
+    max_instance_count    = 1
+    min_instance_count    = 0
+    available_memory      = "256M"
+    timeout_seconds       = 60
+    service_account_email = google_service_account.fn.email
+
+    environment_variables = {
+      TARGET_PROJECT_ID = var.project_id
+      DRY_RUN           = tostring(var.dry_run)
+    }
+  }
+
+  event_trigger {
+    trigger_region = var.region
+    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
+    # Kill is idempotent (we check current state before acting) and error-alert-backed,
+    # so retries aren't needed for safety — and a permanent bug (IAM gap, API outage)
+    # would otherwise retry for up to 7 days. Investigate + re-publish manually.
+    retry_policy          = "RETRY_POLICY_DO_NOT_RETRY"
+    pubsub_topic          = google_pubsub_topic.budget.id
+    service_account_email = google_service_account.fn.email
+  }
+
+  depends_on = [
+    google_project_iam_member.fn_invoker,
+    google_project_iam_member.fn_event_receiver,
+    google_project_iam_member.fn_billing,
+    google_service_account_iam_member.pubsub_token_creator,
+  ]
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/function_source/main.py
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/function_source/main.py
@@ -1,0 +1,50 @@
+"""GCP billing kill switch — detaches billing from the project on budget event."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+
+from google.cloud.billing import CloudBillingClient, ProjectBillingInfo
+
+PROJECT_ID = os.environ["TARGET_PROJECT_ID"]
+
+
+def _dry_run() -> bool:
+    return os.environ.get("DRY_RUN", "false").lower() == "true"
+
+
+def _emit(event: str, severity: str = "INFO", **fields) -> None:
+    print(json.dumps({"severity": severity, "event": event, **fields}), flush=True)
+
+
+def kill_billing(cloud_event) -> None:
+    """Entrypoint. Triggered by Pub/Sub event from a billing budget."""
+    raw = cloud_event.data["message"]["data"]
+    payload = json.loads(base64.b64decode(raw))
+
+    cost = float(payload["costAmount"])
+    budget = float(payload["budgetAmount"])
+
+    if cost < budget:
+        _emit("threshold_not_crossed", cost=cost, budget=budget)
+        return
+
+    client = CloudBillingClient()
+    project_name = f"projects/{PROJECT_ID}"
+    current = client.get_project_billing_info(name=project_name)
+
+    if not current.billing_account_name:
+        _emit("billing_already_detached", project=PROJECT_ID)
+        return
+
+    if _dry_run():
+        _emit("dry_run_would_disable", project=PROJECT_ID, cost=cost, budget=budget)
+        return
+
+    client.update_project_billing_info(
+        name=project_name,
+        project_billing_info=ProjectBillingInfo(billing_account_name=""),
+    )
+    _emit("billing_disabled", project=PROJECT_ID, cost=cost, budget=budget)

--- a/scripts/infra/gcp-billing-kill-switch/terraform/function_source/requirements-dev.txt
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/function_source/requirements-dev.txt
@@ -1,0 +1,3 @@
+google-cloud-billing==1.14.0
+functions-framework==3.8.1
+pytest==8.3.3

--- a/scripts/infra/gcp-billing-kill-switch/terraform/function_source/requirements.txt
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/function_source/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-billing==1.14.0
+functions-framework==3.8.1

--- a/scripts/infra/gcp-billing-kill-switch/terraform/function_source/tests/conftest.py
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/function_source/tests/conftest.py
@@ -1,0 +1,44 @@
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    # Required at import time by main.py
+    monkeypatch.setenv("TARGET_PROJECT_ID", "test-project")
+    # Cleared so test order can't leak state between cases
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+
+def make_event(cost: float, budget: float):
+    payload = json.dumps({"costAmount": cost, "budgetAmount": budget}).encode()
+    return _event_from_bytes(payload)
+
+
+def make_raw_event(raw: bytes):
+    return _event_from_bytes(raw)
+
+
+def _event_from_bytes(raw: bytes):
+    encoded = base64.b64encode(raw).decode()
+
+    class FakeEvent:
+        data = {"message": {"data": encoded}}
+
+    return FakeEvent()
+
+
+@pytest.fixture
+def budget_event():
+    return make_event
+
+
+@pytest.fixture
+def raw_budget_event():
+    return make_raw_event

--- a/scripts/infra/gcp-billing-kill-switch/terraform/function_source/tests/test_main.py
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/function_source/tests/test_main.py
@@ -1,0 +1,145 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _last_log(capsys) -> dict:
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out, "expected structured log output"
+    return json.loads(out[-1])
+
+
+def _logs(capsys) -> list[dict]:
+    return [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+
+
+@patch("main.CloudBillingClient")
+def test_threshold_not_crossed_is_noop(mock_client_cls, budget_event, capsys):
+    import main
+
+    main.kill_billing(budget_event(cost=0.5, budget=1.0))
+
+    mock_client_cls.return_value.get_project_billing_info.assert_not_called()
+    mock_client_cls.return_value.update_project_billing_info.assert_not_called()
+    log = _last_log(capsys)
+    assert log["event"] == "threshold_not_crossed"
+    assert log["severity"] == "INFO"
+    assert log["cost"] == 0.5
+    assert log["budget"] == 1.0
+
+
+@patch("main.CloudBillingClient")
+def test_already_detached_is_noop(mock_client_cls, budget_event, monkeypatch, capsys):
+    monkeypatch.setenv("DRY_RUN", "false")
+    import main
+
+    client = mock_client_cls.return_value
+    client.get_project_billing_info.return_value = MagicMock(billing_account_name="")
+
+    main.kill_billing(budget_event(cost=1.0, budget=1.0))
+
+    client.update_project_billing_info.assert_not_called()
+    assert _last_log(capsys)["event"] == "billing_already_detached"
+
+
+@patch("main.CloudBillingClient")
+def test_dry_run_does_not_call_update(mock_client_cls, budget_event, monkeypatch, capsys):
+    monkeypatch.setenv("DRY_RUN", "true")
+    import main
+
+    client = mock_client_cls.return_value
+    client.get_project_billing_info.return_value = MagicMock(
+        billing_account_name="billingAccounts/XXXXXX-XXXXXX-XXXXXX"
+    )
+
+    main.kill_billing(budget_event(cost=1.0, budget=1.0))
+
+    client.update_project_billing_info.assert_not_called()
+    log = _last_log(capsys)
+    assert log["event"] == "dry_run_would_disable"
+    assert log["project"] == "test-project"
+
+
+@patch("main.CloudBillingClient")
+def test_kill_detaches_billing(mock_client_cls, budget_event, monkeypatch, capsys):
+    monkeypatch.setenv("DRY_RUN", "false")
+    import main
+
+    client = mock_client_cls.return_value
+    client.get_project_billing_info.return_value = MagicMock(
+        billing_account_name="billingAccounts/XXXXXX-XXXXXX-XXXXXX"
+    )
+
+    main.kill_billing(budget_event(cost=1.5, budget=1.0))
+
+    client.update_project_billing_info.assert_called_once()
+    call = client.update_project_billing_info.call_args
+    assert call.kwargs["name"] == "projects/test-project"
+    assert call.kwargs["project_billing_info"].billing_account_name == ""
+
+    log = _last_log(capsys)
+    assert log["event"] == "billing_disabled"
+    assert log["severity"] == "INFO"
+    assert log["project"] == "test-project"
+    assert log["cost"] == 1.5
+    assert log["budget"] == 1.0
+
+
+@patch("main.CloudBillingClient")
+def test_missing_cost_amount_raises(mock_client_cls, raw_budget_event):
+    import main
+
+    with pytest.raises(KeyError):
+        main.kill_billing(raw_budget_event(b'{"budgetAmount": 1.0}'))
+    mock_client_cls.return_value.update_project_billing_info.assert_not_called()
+
+
+@patch("main.CloudBillingClient")
+def test_missing_budget_amount_raises(mock_client_cls, raw_budget_event):
+    import main
+
+    with pytest.raises(KeyError):
+        main.kill_billing(raw_budget_event(b'{"costAmount": 2.0}'))
+    mock_client_cls.return_value.update_project_billing_info.assert_not_called()
+
+
+@patch("main.CloudBillingClient")
+def test_non_numeric_cost_raises(mock_client_cls, raw_budget_event):
+    import main
+
+    with pytest.raises(ValueError):
+        main.kill_billing(raw_budget_event(b'{"costAmount": "abc", "budgetAmount": 1.0}'))
+    mock_client_cls.return_value.update_project_billing_info.assert_not_called()
+
+
+@patch("main.CloudBillingClient")
+def test_get_billing_info_api_failure_propagates(mock_client_cls, budget_event, monkeypatch):
+    monkeypatch.setenv("DRY_RUN", "false")
+    import main
+
+    client = mock_client_cls.return_value
+    client.get_project_billing_info.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        main.kill_billing(budget_event(cost=1.5, budget=1.0))
+    client.update_project_billing_info.assert_not_called()
+
+
+@patch("main.CloudBillingClient")
+def test_update_billing_info_api_failure_propagates(mock_client_cls, budget_event, monkeypatch, capsys):
+    monkeypatch.setenv("DRY_RUN", "false")
+    import main
+
+    client = mock_client_cls.return_value
+    client.get_project_billing_info.return_value = MagicMock(
+        billing_account_name="billingAccounts/XXXXXX-XXXXXX-XXXXXX"
+    )
+    client.update_project_billing_info.side_effect = RuntimeError("api down")
+
+    with pytest.raises(RuntimeError, match="api down"):
+        main.kill_billing(budget_event(cost=1.5, budget=1.0))
+
+    # billing_disabled must NOT have been logged — detach did not succeed
+    events = [log["event"] for log in _logs(capsys)]
+    assert "billing_disabled" not in events

--- a/scripts/infra/gcp-billing-kill-switch/terraform/iam.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/iam.tf
@@ -1,0 +1,42 @@
+resource "google_service_account" "fn" {
+  project      = var.project_id
+  account_id   = local.sa_account_id
+  display_name = "Billing kill switch function runtime"
+  description  = "Runtime SA for the billing kill switch Cloud Function. Needs permission to detach billing from the target project."
+
+  depends_on = [google_project_service.apis]
+}
+
+# Grant billing.projectManager on the target project so the SA can update its
+# billing info (detach). billing.projectManager is a project-level role — it
+# grants billing.resourceAssociations.{create,delete,list} scoped to this
+# project's billing link. This mirrors GCP's official "disable billing"
+# Cloud Function sample.
+resource "google_project_iam_member" "fn_billing" {
+  project = var.project_id
+  role    = "roles/billing.projectManager"
+  member  = "serviceAccount:${google_service_account.fn.email}"
+}
+
+# Eventarc trigger needs to invoke the Gen 2 function.
+resource "google_project_iam_member" "fn_invoker" {
+  project = var.project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.fn.email}"
+}
+
+# Pub/Sub-to-Eventarc on Gen 2 needs the SA to receive events.
+resource "google_project_iam_member" "fn_event_receiver" {
+  project = var.project_id
+  role    = "roles/eventarc.eventReceiver"
+  member  = "serviceAccount:${google_service_account.fn.email}"
+}
+
+# Gen 2 Pub/Sub triggers require the Pub/Sub service agent to impersonate the
+# runtime SA when delivering events. Missing this binding is the most common
+# cause of "events published but function never runs" on a fresh project.
+resource "google_service_account_iam_member" "pubsub_token_creator" {
+  service_account_id = google_service_account.fn.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_project_service_identity.pubsub.email}"
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/main.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+
+  # user_project_override + billing_project tell the provider to send
+  # project_id as the quota project for API calls. Without this, APIs
+  # that require a quota project (billingbudgets, serviceusage, ...)
+  # reject user-ADC requests with 403 "quota project not set".
+  user_project_override = true
+  billing_project       = var.project_id
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+
+  user_project_override = true
+  billing_project       = var.project_id
+}
+
+locals {
+  topic_name      = "${var.name_prefix}-budget"
+  function_name   = "${var.name_prefix}-fn"
+  sa_account_id   = "${var.name_prefix}-sa"
+  budget_name     = "${var.name_prefix}-budget"
+  log_metric_name = "${var.name_prefix}_disabled"
+  success_policy  = "${var.name_prefix}-success"
+  error_policy    = "${var.name_prefix}-errors"
+  channel_name    = "${var.name_prefix}-email"
+}
+
+data "google_project" "target" {
+  project_id = var.project_id
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/monitoring.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/monitoring.tf
@@ -1,0 +1,101 @@
+resource "google_monitoring_notification_channel" "email" {
+  project      = var.project_id
+  display_name = local.channel_name
+  type         = "email"
+
+  labels = {
+    email_address = var.notify_email
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# Log-based metric: increments each time the function emits event=billing_disabled.
+resource "google_logging_metric" "billing_disabled" {
+  project = var.project_id
+  name    = local.log_metric_name
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="${local.function_name}"
+    jsonPayload.event="billing_disabled"
+  EOT
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+  }
+
+  depends_on = [google_cloudfunctions2_function.kill_switch]
+}
+
+# Alert policy 1: success — fires when the log metric increments.
+resource "google_monitoring_alert_policy" "success" {
+  project      = var.project_id
+  display_name = local.success_policy
+  combiner     = "OR"
+
+  conditions {
+    display_name = "billing_disabled log observed"
+
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${local.log_metric_name}\" AND resource.type=\"cloud_run_revision\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_COUNT"
+      }
+    }
+  }
+
+  # No alert_strategy.notification_rate_limit here — GCP rejects that block on
+  # metric-threshold policies; only log-match policies (like the error alert
+  # below) support it. The 60s ALIGN_COUNT window already throttles re-alerts.
+
+  notification_channels = [google_monitoring_notification_channel.email.id]
+
+  documentation {
+    content   = "The billing kill switch successfully detached billing from project ${var.project_id}."
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [google_logging_metric.billing_disabled]
+}
+
+# Alert policy 2: errors — fires on any ERROR log from the function.
+resource "google_monitoring_alert_policy" "errors" {
+  project      = var.project_id
+  display_name = local.error_policy
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Function error log"
+
+    condition_matched_log {
+      filter = <<-EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="${local.function_name}"
+        severity="ERROR"
+      EOT
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email.id]
+
+  documentation {
+    content   = "The billing kill switch function for ${var.project_id} logged an error. If this fired after a budget threshold was crossed, billing may NOT have been detached — investigate immediately."
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [google_cloudfunctions2_function.kill_switch]
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/outputs.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/outputs.tf
@@ -1,0 +1,30 @@
+output "budget_topic" {
+  description = "Pub/Sub topic receiving budget events (publish to this for manual tests)."
+  value       = google_pubsub_topic.budget.id
+}
+
+output "function_name" {
+  description = "Cloud Function name."
+  value       = google_cloudfunctions2_function.kill_switch.name
+}
+
+output "function_sa" {
+  description = "Runtime service account email."
+  value       = google_service_account.fn.email
+}
+
+output "notification_channel" {
+  description = "Email notification channel resource ID. Verify email at first apply."
+  value       = google_monitoring_notification_channel.email.id
+}
+
+output "notify_email" {
+  description = "Email that receives kill-confirmation and error alerts."
+  value       = var.notify_email
+  sensitive   = true
+}
+
+output "dry_run" {
+  description = "Whether the kill switch is in dry-run mode (true = armed-safe, false = live)."
+  value       = var.dry_run
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/pubsub.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/pubsub.tf
@@ -1,0 +1,17 @@
+resource "google_pubsub_topic" "budget" {
+  project = var.project_id
+  name    = local.topic_name
+
+  depends_on = [google_project_service.apis]
+}
+
+# Pub/Sub service agent. Needed so we can grant it tokenCreator on the function
+# runtime SA below — without this binding, Eventarc delivery fails silently on
+# the first apply in a fresh project.
+resource "google_project_service_identity" "pubsub" {
+  provider = google-beta
+  project  = var.project_id
+  service  = "pubsub.googleapis.com"
+
+  depends_on = [google_project_service.apis]
+}

--- a/scripts/infra/gcp-billing-kill-switch/terraform/terraform.tfvars.example
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
+
+project_id         = "your-gcp-project-id"
+billing_account_id = "01ABCD-23EFGH-456IJK"
+notify_email       = "you@example.com"
+
+# Optional overrides
+# threshold_usd = 1
+# dry_run       = true
+# region        = "us-central1"
+# name_prefix   = "billing-kill"

--- a/scripts/infra/gcp-billing-kill-switch/terraform/variables.tf
+++ b/scripts/infra/gcp-billing-kill-switch/terraform/variables.tf
@@ -1,0 +1,48 @@
+variable "project_id" {
+  description = "Target project whose billing will be detached on trigger."
+  type        = string
+}
+
+variable "billing_account_id" {
+  description = "Billing account ID (e.g., 01ABCD-23EFGH-456IJK). The target project is linked to this account."
+  type        = string
+}
+
+variable "notify_email" {
+  description = "Email recipient for kill-confirmation and error alerts."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", var.notify_email))
+    error_message = "notify_email must be a valid email address."
+  }
+}
+
+variable "threshold_usd" {
+  description = "Month-to-date spend threshold in whole USD that triggers the kill."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = floor(var.threshold_usd) == var.threshold_usd && var.threshold_usd > 0
+    error_message = "threshold_usd must be a positive whole number (fractional dollars not supported)."
+  }
+}
+
+variable "dry_run" {
+  description = "When true, function logs its intent but does not actually detach billing."
+  type        = bool
+  default     = true
+}
+
+variable "region" {
+  description = "Region for Cloud Function and Pub/Sub."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "name_prefix" {
+  description = "Prefix applied to all resource names."
+  type        = string
+  default     = "billing-kill"
+}


### PR DESCRIPTION
## Summary

Adds a self-contained Terraform module at `scripts/infra/gcp-billing-kill-switch/` that auto-detaches billing from a single GCP project when month-to-date spend crosses a threshold (default \$1 USD). Sized for the Crowdin → Google Translate free-tier budget — if usage spikes, billing detaches before we leave free tier.

Pipeline: Billing budget → Pub/Sub → Cloud Function → `updateBillingInfo`, with success + error alerts via email and a log-based metric.

Includes:
- 11 `.tf` files covering APIs, IAM, function, budget, monitoring, outputs
- Cloud Function source (`function_source/main.py`) plus pytest unit tests
- Module-local `.gitignore` for build/override artifacts
- README covering deploy, dry-run pipeline test, end-to-end (destructive) test, recovery, teardown
- Repo-wide Terraform `.gitignore` block (state, plans, tfvars, override files, terraformrc, crash logs)

## Test plan

- [x] Module deployable end-to-end via the README steps (verified manually in dry-run mode by author)
- [x] `pytest tests/ -v` in `function_source/` — all unit tests passing
- [x] `git ls-files --others --exclude-standard scripts/infra/` — no state/secrets/build artifacts leaking
- [ ] User verifies the README "What this creates" inventory matches their deployed stack

Closes infra-4vqc.