### PR TITLE
fix(e2e): reject zombie server on :10099 and surface raw stderr

### DIFF
--- a/.beans/ps-73w5--e2e-bootstrap-reject-pre-existing-server-on-10099.md
+++ b/.beans/ps-73w5--e2e-bootstrap-reject-pre-existing-server-on-10099.md
@@ -1,12 +1,39 @@
 ---
 # ps-73w5
 title: "E2E bootstrap: reject pre-existing server on :10099 and surface non-JSON stderr"
-status: todo
+status: completed
 type: bug
 priority: normal
 created_at: 2026-04-19T19:12:07Z
-updated_at: 2026-04-19T19:12:07Z
+updated_at: 2026-04-20T00:33:04Z
 parent: ps-0enb
 ---
 
 Discovered while debugging ps-0enb batch PR 2026-04-19. Two latent bugs in apps/api-e2e/src/global-setup.ts: (1) pollHealth() accepts any process answering /health, including a zombie from a prior crashed run. Should refuse to proceed when port 10099 is already bound before spawn, or fingerprint the server. (2) stderr filter at lines 298-304 forwards only pino level:50/60 JSON. Raw stderr like Bun EADDRINUSE is swallowed. Either forward all stderr or add explicit post-spawn check for early exit / port conflict. These bugs let a zombie bun from an earlier crashed run cause 491/509 E2E test failures.
+
+## Todo
+
+- [x] Add assertPortFree helper + unit tests
+- [x] Widen pollHealth signature with early-exit detection + unit tests
+- [x] Wire into tooling/test-utils/src/e2e/api-server.ts
+- [x] Wire into apps/api-e2e/src/global-setup.ts (delete local pollHealth)
+- [x] Manual acceptance check with a port squatter
+- [x] Full verify suite green
+
+## Summary of Changes
+
+- Added `assertPortFree` helper in `tooling/test-utils/src/e2e/assert-port-free.ts`; unit-tested for free / busy / no-leak cases.
+- Widened `pollHealth` in `tooling/test-utils/src/e2e/api-server.ts` to an options-object signature with optional `child: ChildProcess` and `stderrTail: readonly string[]`; early child exit now rejects with exit code + signal + recent stderr instead of letting the poll loop time out or attach to a zombie. Early-exit detection is seeded from `child.exitCode` to handle children that already exited before pollHealth was called.
+- Updated `spawnApiServer` (test-utils) and `apps/api-e2e/src/global-setup.ts` to: call `assertPortFree(E2E_PORT)` pre-spawn, classify stderr per-line (so raw Bun errors in mixed chunks are no longer swallowed by the pino filter), forward everything that isn't well-formed pino INFO/DEBUG/WARN, and feed a bounded stderr tail into `pollHealth`.
+- Deleted the duplicated local `pollHealth` (and now-unused `HEALTH_POLL_MS`) from `apps/api-e2e/src/global-setup.ts`; both bootstrap paths now share the hardened helper.
+- Added unit coverage for `pollHealth` healthy-path, timeout, and early-exit behaviors.
+- Added `@pluralscape/test-utils` as a declared devDependency of `apps/api-e2e` (it was previously undeclared).
+- Exposed `@pluralscape/test-utils/e2e/assert-port-free` and `@pluralscape/test-utils/e2e/api-server` as sub-path exports so Playwright consumers can import the helpers directly without transitively pulling in `vitest/expect` via the main `/e2e` barrel. The barrel re-exports `ref-helpers.ts` which imports `expect` from vitest, and that import pollutes Playwright's `expect` with `Cannot redefine property: Symbol($$jest-matchers-object)`. Caught during manual acceptance (Task 5).
+
+## Manual acceptance
+
+With a dummy Bun server squatting on `:10099`, `pnpm test:e2e` now fails fast in global-setup with the new message (`Port 10099 is already in use ... lsof -iTCP:10099 -sTCP:LISTEN -nP / kill <pid>`) instead of running the suite against the zombie. With the squatter removed, setup completes normally and the API becomes healthy.
+
+## Verify suite (run 9771)
+
+All 9 steps green: format, lint, typecheck, unit, integration, e2e, e2e-slow, sp-import, pk-import.

--- a/.beans/ps-rg1u--pr-505-follow-up-classifier-extraction-and-review.md
+++ b/.beans/ps-rg1u--pr-505-follow-up-classifier-extraction-and-review.md
@@ -1,0 +1,60 @@
+---
+# ps-rg1u
+title: "PR #505 follow-up: classifier extraction and review hardening"
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-20T01:00:38Z
+updated_at: 2026-04-20T01:12:02Z
+---
+
+Follow-up to PR #505 addressing review findings from multi-agent review.
+
+Critical/important findings:
+
+- stderr classifier swallows ERROR logs whose msg contains literal "level":50 (line.includes bug)
+- Classifier splits on data events, not lines — partial JSON across chunks gets misclassified
+- stderrTail ring bounded by chunks loses diagnostics under burst stderr
+- Classifier logic duplicated across api-server.ts and global-setup.ts
+- Classifier has no unit coverage
+- Live onExit listener never exercised (all 3 pollHealth tests use exitCode !== null seed)
+- VITEST-strip regression (fixed in 703d94ac) has no assertion
+- E2E_PORT redeclared in global-setup.ts
+- setTimeout(r, 10) hard-sleep in poll-health.test.ts violates no-hard-sleeps
+- delete spawnEnv[VITEST] mutates fresh object unnecessarily
+- PollHealthOptions allows stderrTail without child (silently ignored)
+
+## Todo
+
+- [x] Extract createStderrClassifier helper (line-buffered, JSON.parse+level check)
+- [x] Extract inheritEnvWithoutVitest helper
+- [x] Narrow PollHealthOptions to discriminated union (stderrTail requires child)
+- [x] Refactor api-server.ts to use helpers + line-bounded stderrTail
+- [x] Refactor global-setup.ts to use helpers + import E2E_PORT
+- [x] Add sub-path exports for classify-pino-stderr and api-env
+- [x] Add classify-pino-stderr unit tests (JSON, embedded level, non-JSON, partial chunk)
+- [x] Add api-env unit tests (VITEST stripped, other keys preserved)
+- [x] Replace setTimeout hard-sleep with once(child, close) in poll-health.test.ts
+- [x] Add pollHealth live-onExit test (child exits DURING loop)
+- [x] Verify: typecheck, lint, unit tests
+- [x] Verify: typecheck + lint + unit (12595 pass) + e2e (507 pass)
+
+## Summary of Changes
+
+- Extracted stateful `createStderrClassifier` helper into `tooling/test-utils/src/e2e/classify-pino-stderr.ts`. Buffers partial lines across chunks, splits on `\n` / `\r\n`, parses each line with `JSON.parse`, and only suppresses when the outer `level` field is numeric and `< 50`. Everything else — non-JSON, missing level, non-numeric level, level >= 50 — falls through to forwarding. Replaces the old regex + `line.includes('"level":50')` classifier that was (a) fooled by ERROR logs whose msg contained the literal string `"level":50`, and (b) fooled by DEBUG logs whose msg happened to contain the same substring (forced-forward). Also exposes `flush()` to emit a trailing partial line on close.
+- Extracted `inheritEnvWithoutVitest` into `tooling/test-utils/src/e2e/api-env.ts`. Destructures `VITEST` out of `process.env` rather than mutating a freshly-built object, making intent self-documenting and the VITEST-strip behavior unit-testable.
+- Narrowed `PollHealthOptions` to a discriminated union: `stderrTail` can only be supplied alongside `child`. Previously `stderrTail` without `child` compiled but was silently ignored.
+- Line-bounded stderr tail via `STDERR_TAIL_MAX_LINES = 200`. pollHealth joins with `\n` when formatting the early-exit error message. Loses no diagnostics under bursty stderr.
+- Refactored both spawn sites (`tooling/test-utils/src/e2e/api-server.ts` and `apps/api-e2e/src/global-setup.ts`) to use the shared helpers: removed duplicated classifier logic, replaced `const spawnEnv = {...}; delete spawnEnv[VITEST]` with spread of `inheritEnvWithoutVitest()`, imported `E2E_PORT` from test-utils instead of redeclaring it.
+- Added sub-path exports `./e2e/api-env` and `./e2e/classify-pino-stderr` in `tooling/test-utils/package.json` to keep Playwright consumers from transitively importing `vitest/expect` through the main `/e2e` barrel (matches the pattern established in commit 1598fd3e).
+- Added 15 new unit tests for the classifier: valid pino ERROR/FATAL forwarded, level:30 suppressed, embedded level:50 substring in ERROR msg still forwarded, embedded level:50 substring in DEBUG msg still suppressed (regression guard for both old bugs), non-JSON forwarded, JSON without level forwarded, non-numeric level forwarded, JSON split across chunks accumulated and emitted on completion, mixed chunk (INFO + raw error) classified per-line, prefix applied to forwarded only, empty lines skipped, flush emits trailing partial line, CRLF handled, last incomplete line buffered across process/flush boundaries.
+- Added 6 new unit tests for `inheritEnvWithoutVitest` including a regression guard that `VITEST=true` in the parent never leaks to the result.
+- Added live-onExit pollHealth test: child sleeps 100ms and exits DURING the poll loop, exercising the `child.on("exit", ...)` listener path (all 3 previous tests seeded from `child.exitCode !== null`, never exercising the live listener or the finally-branch `off`).
+- Replaced `setTimeout(r, 10)` hard-sleep in poll-health.test.ts with `await once(child, "close")` (deterministic — fires after exit + stdio drain).
+
+## Verification
+
+- `pnpm typecheck` — 21/21 green
+- `pnpm lint` — 17/17 green, zero warnings
+- `pnpm test:unit` — 900 test files, 12595 tests pass
+- `pnpm test:e2e` — 507 tests pass, 2 skipped — confirms the refactored bootstrap still works against the live API server + Docker infra

--- a/apps/api-e2e/package.json
+++ b/apps/api-e2e/package.json
@@ -15,6 +15,7 @@
     "@pluralscape/api": "workspace:*",
     "@pluralscape/crypto": "workspace:*",
     "@pluralscape/sync": "workspace:*",
+    "@pluralscape/test-utils": "workspace:*",
     "@pluralscape/tsconfig": "workspace:*",
     "@pluralscape/types": "workspace:*",
     "@types/node": "^24.12.2",

--- a/apps/api-e2e/src/global-setup.ts
+++ b/apps/api-e2e/src/global-setup.ts
@@ -10,8 +10,10 @@ import { execFileSync, execSync, spawn, type ChildProcess } from "node:child_pro
 import crypto from "node:crypto";
 import path from "node:path";
 
-import { pollHealth } from "@pluralscape/test-utils/e2e/api-server";
+import { inheritEnvWithoutVitest } from "@pluralscape/test-utils/e2e/api-env";
+import { E2E_PORT, pollHealth } from "@pluralscape/test-utils/e2e/api-server";
 import { assertPortFree } from "@pluralscape/test-utils/e2e/assert-port-free";
+import { createStderrClassifier } from "@pluralscape/test-utils/e2e/classify-pino-stderr";
 import { MS_PER_SECOND } from "@pluralscape/types";
 
 import {
@@ -20,8 +22,8 @@ import {
   stopE2ECrowdinStub,
 } from "./crowdin-stub-lifecycle.js";
 
-const E2E_PORT = 10_099;
 const HEALTH_TIMEOUT_MS = 15_000;
+const STDERR_TAIL_MAX_LINES = 200;
 const PG_READY_POLL_MS = 200;
 const PG_READY_TIMEOUT_MS = 30_000;
 const DOCKER_CONTAINER_NAME = "pluralscape-e2e-pg";
@@ -258,13 +260,8 @@ async function globalSetup(): Promise<void> {
     // Spawn the API server
     await assertPortFree(E2E_PORT);
     console.info("[e2e] Starting API server on port", E2E_PORT);
-    // Strip VITEST from the inherited env — apps/api/src/index.ts gates its
-    // start() call on `!process.env["VITEST"]` to avoid an async teardown race
-    // when the module is `import`ed by unit tests. The spawned server is a
-    // separate process that SHOULD run start(); leaking a parent VITEST flag
-    // would silence start() and the health check times out.
     const spawnEnv: NodeJS.ProcessEnv = {
-      ...process.env,
+      ...inheritEnvWithoutVitest(),
       API_PORT: String(E2E_PORT),
       DB_DIALECT: "pg",
       DATABASE_URL: databaseUrl,
@@ -283,7 +280,6 @@ async function globalSetup(): Promise<void> {
       CROWDIN_DISTRIBUTION_HASH: E2E_CROWDIN_HASH,
       CROWDIN_OTA_BASE_URL: crowdinStub.baseUrl,
     };
-    delete spawnEnv["VITEST"];
     serverProcess = spawn("bun", ["run", "src/index.ts"], {
       cwd: API_DIR,
       env: spawnEnv,
@@ -291,28 +287,22 @@ async function globalSetup(): Promise<void> {
     });
 
     const stderrTail: string[] = [];
-    const STDERR_TAIL_MAX = 20;
+    const classifier = createStderrClassifier({ prefix: "[api-e2e] " });
     serverProcess.stderr?.on("data", (data: Buffer) => {
-      const msg = data.toString();
-      // Classify per-line. A single 'data' event can contain multiple records;
-      // testing the entire chunk would misclassify raw Bun errors that happen
-      // to share a chunk with a pino INFO/DEBUG/WARN line.
-      const lines = msg.split(/\r?\n/);
-      let forwarded = "";
-      for (const line of lines) {
-        if (line === "") continue;
-        const isPinoJson = /^\s*\{.*"level":\d+/.test(line);
-        const isLowLevelPino =
-          isPinoJson && !line.includes('"level":50') && !line.includes('"level":60');
-        if (!isLowLevelPino) {
-          forwarded += `[api-e2e] ${line}\n`;
-        }
+      const { forwarded, tailLines } = classifier.process(data.toString());
+      if (forwarded !== "") process.stderr.write(forwarded);
+      for (const line of tailLines) {
+        stderrTail.push(line);
+        if (stderrTail.length > STDERR_TAIL_MAX_LINES) stderrTail.shift();
       }
-      if (forwarded !== "") {
-        process.stderr.write(forwarded);
+    });
+    serverProcess.stderr?.on("end", () => {
+      const { forwarded, tailLines } = classifier.flush();
+      if (forwarded !== "") process.stderr.write(forwarded);
+      for (const line of tailLines) {
+        stderrTail.push(line);
+        if (stderrTail.length > STDERR_TAIL_MAX_LINES) stderrTail.shift();
       }
-      stderrTail.push(msg);
-      if (stderrTail.length > STDERR_TAIL_MAX) stderrTail.shift();
     });
 
     if (!serverProcess.pid) {

--- a/apps/api-e2e/src/global-setup.ts
+++ b/apps/api-e2e/src/global-setup.ts
@@ -258,28 +258,35 @@ async function globalSetup(): Promise<void> {
     // Spawn the API server
     await assertPortFree(E2E_PORT);
     console.info("[e2e] Starting API server on port", E2E_PORT);
+    // Strip VITEST from the inherited env — apps/api/src/index.ts gates its
+    // start() call on `!process.env["VITEST"]` to avoid an async teardown race
+    // when the module is `import`ed by unit tests. The spawned server is a
+    // separate process that SHOULD run start(); leaking a parent VITEST flag
+    // would silence start() and the health check times out.
+    const spawnEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      API_PORT: String(E2E_PORT),
+      DB_DIALECT: "pg",
+      DATABASE_URL: databaseUrl,
+      EMAIL_HASH_PEPPER: emailPepper,
+      WEBHOOK_PAYLOAD_ENCRYPTION_KEY:
+        process.env["WEBHOOK_PAYLOAD_ENCRYPTION_KEY"] ?? DEFAULT_TEST_WEBHOOK_KEY,
+      NODE_ENV: "test",
+      DISABLE_RATE_LIMIT: "1",
+      BLOB_STORAGE_S3_BUCKET: MINIO_BUCKET,
+      BLOB_STORAGE_S3_ENDPOINT: `http://localhost:${String(MINIO_PORT)}`,
+      BLOB_STORAGE_S3_FORCE_PATH_STYLE: "1",
+      AWS_ACCESS_KEY_ID: MINIO_ROOT_USER,
+      AWS_SECRET_ACCESS_KEY: MINIO_ROOT_PASSWORD,
+      // Wire the i18n proxy to the local stub so the suite exercises the
+      // full Crowdin contract against a controllable fixture.
+      CROWDIN_DISTRIBUTION_HASH: E2E_CROWDIN_HASH,
+      CROWDIN_OTA_BASE_URL: crowdinStub.baseUrl,
+    };
+    delete spawnEnv["VITEST"];
     serverProcess = spawn("bun", ["run", "src/index.ts"], {
       cwd: API_DIR,
-      env: {
-        ...process.env,
-        API_PORT: String(E2E_PORT),
-        DB_DIALECT: "pg",
-        DATABASE_URL: databaseUrl,
-        EMAIL_HASH_PEPPER: emailPepper,
-        WEBHOOK_PAYLOAD_ENCRYPTION_KEY:
-          process.env["WEBHOOK_PAYLOAD_ENCRYPTION_KEY"] ?? DEFAULT_TEST_WEBHOOK_KEY,
-        NODE_ENV: "test",
-        DISABLE_RATE_LIMIT: "1",
-        BLOB_STORAGE_S3_BUCKET: MINIO_BUCKET,
-        BLOB_STORAGE_S3_ENDPOINT: `http://localhost:${String(MINIO_PORT)}`,
-        BLOB_STORAGE_S3_FORCE_PATH_STYLE: "1",
-        AWS_ACCESS_KEY_ID: MINIO_ROOT_USER,
-        AWS_SECRET_ACCESS_KEY: MINIO_ROOT_PASSWORD,
-        // Wire the i18n proxy to the local stub so the suite exercises the
-        // full Crowdin contract against a controllable fixture.
-        CROWDIN_DISTRIBUTION_HASH: E2E_CROWDIN_HASH,
-        CROWDIN_OTA_BASE_URL: crowdinStub.baseUrl,
-      },
+      env: spawnEnv,
       stdio: "pipe",
     });
 

--- a/apps/api-e2e/src/global-setup.ts
+++ b/apps/api-e2e/src/global-setup.ts
@@ -10,7 +10,8 @@ import { execFileSync, execSync, spawn, type ChildProcess } from "node:child_pro
 import crypto from "node:crypto";
 import path from "node:path";
 
-import { assertPortFree, pollHealth } from "@pluralscape/test-utils/e2e";
+import { pollHealth } from "@pluralscape/test-utils/e2e/api-server";
+import { assertPortFree } from "@pluralscape/test-utils/e2e/assert-port-free";
 import { MS_PER_SECOND } from "@pluralscape/types";
 
 import {

--- a/apps/api-e2e/src/global-setup.ts
+++ b/apps/api-e2e/src/global-setup.ts
@@ -10,6 +10,7 @@ import { execFileSync, execSync, spawn, type ChildProcess } from "node:child_pro
 import crypto from "node:crypto";
 import path from "node:path";
 
+import { assertPortFree, pollHealth } from "@pluralscape/test-utils/e2e";
 import { MS_PER_SECOND } from "@pluralscape/types";
 
 import {
@@ -19,7 +20,6 @@ import {
 } from "./crowdin-stub-lifecycle.js";
 
 const E2E_PORT = 10_099;
-const HEALTH_POLL_MS = 100;
 const HEALTH_TIMEOUT_MS = 15_000;
 const PG_READY_POLL_MS = 200;
 const PG_READY_TIMEOUT_MS = 30_000;
@@ -47,20 +47,6 @@ const DEFAULT_TEST_WEBHOOK_KEY = crypto
   .digest("hex");
 
 let serverProcess: ChildProcess | null = null;
-
-async function pollHealth(baseUrl: string, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`${baseUrl}/health`);
-      if (res.ok) return;
-    } catch {
-      // Server not ready yet
-    }
-    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_MS));
-  }
-  throw new Error(`API server did not become healthy within ${String(timeoutMs)}ms`);
-}
 
 function dockerIsAvailable(): boolean {
   try {
@@ -269,6 +255,7 @@ async function globalSetup(): Promise<void> {
   // before re-throwing so the socket is released even on aborted setups.
   try {
     // Spawn the API server
+    await assertPortFree(E2E_PORT);
     console.info("[e2e] Starting API server on port", E2E_PORT);
     serverProcess = spawn("bun", ["run", "src/index.ts"], {
       cwd: API_DIR,
@@ -295,12 +282,29 @@ async function globalSetup(): Promise<void> {
       stdio: "pipe",
     });
 
+    const stderrTail: string[] = [];
+    const STDERR_TAIL_MAX = 20;
     serverProcess.stderr?.on("data", (data: Buffer) => {
       const msg = data.toString();
-      // Surface errors and fatals, not routine pino JSON logs
-      if (msg.includes('"level":50') || msg.includes('"level":60')) {
-        process.stderr.write(`[api-e2e] ${msg}`);
+      // Classify per-line. A single 'data' event can contain multiple records;
+      // testing the entire chunk would misclassify raw Bun errors that happen
+      // to share a chunk with a pino INFO/DEBUG/WARN line.
+      const lines = msg.split(/\r?\n/);
+      let forwarded = "";
+      for (const line of lines) {
+        if (line === "") continue;
+        const isPinoJson = /^\s*\{.*"level":\d+/.test(line);
+        const isLowLevelPino =
+          isPinoJson && !line.includes('"level":50') && !line.includes('"level":60');
+        if (!isLowLevelPino) {
+          forwarded += `[api-e2e] ${line}\n`;
+        }
       }
+      if (forwarded !== "") {
+        process.stderr.write(forwarded);
+      }
+      stderrTail.push(msg);
+      if (stderrTail.length > STDERR_TAIL_MAX) stderrTail.shift();
     });
 
     if (!serverProcess.pid) {
@@ -308,7 +312,12 @@ async function globalSetup(): Promise<void> {
     }
     process.env["E2E_SERVER_PID"] = String(serverProcess.pid);
 
-    await pollHealth(`http://localhost:${String(E2E_PORT)}`, HEALTH_TIMEOUT_MS);
+    await pollHealth({
+      baseUrl: `http://localhost:${String(E2E_PORT)}`,
+      timeoutMs: HEALTH_TIMEOUT_MS,
+      child: serverProcess,
+      stderrTail,
+    });
     console.info("[e2e] API server is healthy. Running tests...");
   } catch (err: unknown) {
     // Setup aborted — close the stub we already started so it doesn't leak.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       '@pluralscape/sync':
         specifier: workspace:*
         version: link:../../packages/sync
+      '@pluralscape/test-utils':
+        specifier: workspace:*
+        version: link:../../tooling/test-utils
       '@pluralscape/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig

--- a/tooling/test-utils/package.json
+++ b/tooling/test-utils/package.json
@@ -8,7 +8,9 @@
     "./db": "./src/db/index.ts",
     "./crypto": "./src/crypto/index.ts",
     "./factories": "./src/factories/index.ts",
-    "./e2e": "./src/e2e/index.ts"
+    "./e2e": "./src/e2e/index.ts",
+    "./e2e/assert-port-free": "./src/e2e/assert-port-free.ts",
+    "./e2e/api-server": "./src/e2e/api-server.ts"
   },
   "dependencies": {
     "@electric-sql/pglite": "catalog:",

--- a/tooling/test-utils/package.json
+++ b/tooling/test-utils/package.json
@@ -10,7 +10,9 @@
     "./factories": "./src/factories/index.ts",
     "./e2e": "./src/e2e/index.ts",
     "./e2e/assert-port-free": "./src/e2e/assert-port-free.ts",
-    "./e2e/api-server": "./src/e2e/api-server.ts"
+    "./e2e/api-server": "./src/e2e/api-server.ts",
+    "./e2e/api-env": "./src/e2e/api-env.ts",
+    "./e2e/classify-pino-stderr": "./src/e2e/classify-pino-stderr.ts"
   },
   "dependencies": {
     "@electric-sql/pglite": "catalog:",

--- a/tooling/test-utils/src/__tests__/api-env.test.ts
+++ b/tooling/test-utils/src/__tests__/api-env.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { inheritEnvWithoutVitest } from "../e2e/api-env.js";
+
+describe("inheritEnvWithoutVitest", () => {
+  const originalVitest = process.env["VITEST"];
+  afterEach(() => {
+    if (originalVitest === undefined) {
+      delete process.env["VITEST"];
+    } else {
+      process.env["VITEST"] = originalVitest;
+    }
+  });
+
+  it("returns a copy of process.env without the VITEST key", () => {
+    process.env["VITEST"] = "true";
+    const result = inheritEnvWithoutVitest();
+    expect("VITEST" in result).toBe(false);
+    expect(result["VITEST"]).toBeUndefined();
+  });
+
+  it("preserves other env vars", () => {
+    process.env["VITEST"] = "true";
+    process.env["PLURALSCAPE_TEST_MARKER_ABC"] = "keep-me";
+    try {
+      const result = inheritEnvWithoutVitest();
+      expect(result["PLURALSCAPE_TEST_MARKER_ABC"]).toBe("keep-me");
+      expect(result["PATH"]).toBe(process.env["PATH"]);
+    } finally {
+      delete process.env["PLURALSCAPE_TEST_MARKER_ABC"];
+    }
+  });
+
+  it("does not mutate process.env when caller mutates result", () => {
+    process.env["VITEST"] = "true";
+    const result = inheritEnvWithoutVitest();
+    result["NEW_KEY_FROM_RESULT"] = "x";
+    expect(process.env["NEW_KEY_FROM_RESULT"]).toBeUndefined();
+    expect(process.env["VITEST"]).toBe("true");
+  });
+
+  it("returns a fresh object each call", () => {
+    const a = inheritEnvWithoutVitest();
+    const b = inheritEnvWithoutVitest();
+    expect(a).not.toBe(b);
+  });
+
+  it("regression: strips VITEST even when explicitly set on parent", () => {
+    // The spawned API server gates start() on !process.env.VITEST.
+    // If the parent leaks it, the server never starts and the health
+    // check times out. Guard the fix here so the behavior can't silently
+    // regress.
+    process.env["VITEST"] = "1";
+    const result = inheritEnvWithoutVitest();
+    expect(result["VITEST"]).toBeUndefined();
+    expect("VITEST" in result).toBe(false);
+  });
+
+  it("works when VITEST is absent on the parent", () => {
+    delete process.env["VITEST"];
+    const result = inheritEnvWithoutVitest();
+    expect(result["VITEST"]).toBeUndefined();
+  });
+});

--- a/tooling/test-utils/src/__tests__/assert-port-free.test.ts
+++ b/tooling/test-utils/src/__tests__/assert-port-free.test.ts
@@ -1,0 +1,74 @@
+import net from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { assertPortFree } from "../e2e/assert-port-free.js";
+
+function listenEphemeral(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") {
+        reject(new Error("unexpected address shape"));
+        return;
+      }
+      // addr is now narrowed to net.AddressInfo
+      resolve({ server, port: addr.port });
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+describe("assertPortFree", () => {
+  const cleanup: net.Server[] = [];
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      const s = cleanup.pop();
+      if (s?.listening) {
+        await closeServer(s);
+      }
+    }
+  });
+
+  it("resolves when the port is free", async () => {
+    // Bind-then-release to obtain a port we know is usable, then assert.
+    const { server, port } = await listenEphemeral();
+    await closeServer(server);
+    await expect(assertPortFree(port)).resolves.toBeUndefined();
+  });
+
+  it("rejects with an actionable message when the port is in use", async () => {
+    const { server, port } = await listenEphemeral();
+    cleanup.push(server);
+    await expect(assertPortFree(port)).rejects.toThrow(/already in use/);
+    await expect(assertPortFree(port)).rejects.toThrow(`lsof -iTCP:${String(port)}`);
+  });
+
+  it("does not leak the probe port after a successful call", async () => {
+    const { server, port } = await listenEphemeral();
+    await closeServer(server);
+    await assertPortFree(port);
+    // Port must still be bindable afterwards — proves the probe closed.
+    const reuse = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      reuse.once("error", reject);
+      reuse.listen(port, "127.0.0.1", () => {
+        resolve();
+      });
+    });
+    cleanup.push(reuse);
+  });
+});

--- a/tooling/test-utils/src/__tests__/classify-pino-stderr.test.ts
+++ b/tooling/test-utils/src/__tests__/classify-pino-stderr.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { createStderrClassifier } from "../e2e/classify-pino-stderr.js";
+
+describe("createStderrClassifier", () => {
+  it("forwards valid pino ERROR (level:50) JSON lines", () => {
+    const classifier = createStderrClassifier();
+    const line = `{"level":50,"time":1,"msg":"boom"}`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe(`${line}\n`);
+    expect(result.tailLines).toEqual([line]);
+  });
+
+  it("forwards valid pino FATAL (level:60) JSON lines", () => {
+    const classifier = createStderrClassifier();
+    const line = `{"level":60,"time":1,"msg":"dead"}`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe(`${line}\n`);
+    expect(result.tailLines).toEqual([line]);
+  });
+
+  it("suppresses low-level pino (level:30 INFO) JSON lines", () => {
+    const classifier = createStderrClassifier();
+    const line = `{"level":30,"time":1,"msg":"starting up"}`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe("");
+    // Still captured in tail for diagnostic purposes
+    expect(result.tailLines).toEqual([line]);
+  });
+
+  it('forwards a pino ERROR whose msg contains the literal string "level":50', () => {
+    // Regression: old classifier used line.includes('"level":50') on
+    // the WHOLE line, so a true ERROR whose msg embedded that substring
+    // in a *different* context would still suppress. Worse: a DEBUG whose
+    // msg contained "level":50 would be force-forwarded. Parse-based
+    // classification on the outer level field must be unaffected by
+    // msg content.
+    const classifier = createStderrClassifier();
+    const line = `{"level":50,"msg":"query failed: WHERE \\"level\\":50"}`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe(`${line}\n`);
+  });
+
+  it('suppresses level:30 even when the msg contains the literal string "level":50', () => {
+    // The dangerous inverse of the above: old code would FORWARD this
+    // low-level line because the chunk-level `.includes('"level":50')`
+    // short-circuited the suppression branch. New classifier must
+    // look at the outer level field only.
+    const classifier = createStderrClassifier();
+    const line = `{"level":30,"msg":"received request with level:50 tag"}`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe("");
+    expect(result.tailLines).toEqual([line]);
+  });
+
+  it("forwards non-JSON lines (Bun EADDRINUSE / raw stderr)", () => {
+    const classifier = createStderrClassifier();
+    const line = "error: listen EADDRINUSE: address already in use 0.0.0.0:10099";
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe(`${line}\n`);
+    expect(result.tailLines).toEqual([line]);
+  });
+
+  it("forwards JSON without a level field (unknown structured output)", () => {
+    const classifier = createStderrClassifier();
+    const line = `{"msg":"no level here"}`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe(`${line}\n`);
+  });
+
+  it("forwards JSON where level is non-numeric (unknown shape)", () => {
+    const classifier = createStderrClassifier();
+    const line = `{"level":"info","msg":"string level"}`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe(`${line}\n`);
+  });
+
+  it("buffers a JSON line split across two chunks and emits it on completion", () => {
+    const classifier = createStderrClassifier();
+    const first = classifier.process(`{"level":50,"msg":"par`);
+    expect(first.forwarded).toBe("");
+    expect(first.tailLines).toEqual([]);
+
+    const second = classifier.process(`tial"}\n`);
+    expect(second.forwarded).toBe(`{"level":50,"msg":"partial"}\n`);
+    expect(second.tailLines).toEqual([`{"level":50,"msg":"partial"}`]);
+  });
+
+  it("classifies mixed chunk with pino INFO line and raw Bun error correctly", () => {
+    // Original bug: classifier ran on the entire chunk; a raw error
+    // sharing a `data` event with a pino INFO got suppressed because
+    // the whole chunk matched the low-level pino regex.
+    const classifier = createStderrClassifier();
+    const input = [
+      `{"level":30,"msg":"starting"}`,
+      `error: listen EADDRINUSE: 0.0.0.0:10099`,
+      "",
+    ].join("\n");
+    const result = classifier.process(input);
+    // INFO suppressed, raw error forwarded
+    expect(result.forwarded).toBe(`error: listen EADDRINUSE: 0.0.0.0:10099\n`);
+    expect(result.tailLines).toEqual([
+      `{"level":30,"msg":"starting"}`,
+      `error: listen EADDRINUSE: 0.0.0.0:10099`,
+    ]);
+  });
+
+  it("applies the configured prefix to forwarded lines only", () => {
+    const classifier = createStderrClassifier({ prefix: "[api-e2e] " });
+    const line = `error: something broke`;
+    const result = classifier.process(`${line}\n`);
+    expect(result.forwarded).toBe(`[api-e2e] ${line}\n`);
+    // Tail captures the raw line without the display prefix
+    expect(result.tailLines).toEqual([line]);
+  });
+
+  it("skips empty lines introduced by trailing \\n", () => {
+    const classifier = createStderrClassifier();
+    const result = classifier.process(`\n\n`);
+    expect(result.forwarded).toBe("");
+    expect(result.tailLines).toEqual([]);
+  });
+
+  it("flush() emits any trailing partial line", () => {
+    const classifier = createStderrClassifier();
+    const partial = classifier.process(`error: unterminated`);
+    expect(partial.forwarded).toBe("");
+    expect(partial.tailLines).toEqual([]);
+
+    const flushed = classifier.flush();
+    expect(flushed.forwarded).toBe(`error: unterminated\n`);
+    expect(flushed.tailLines).toEqual([`error: unterminated`]);
+  });
+
+  it("flush() is a no-op when the buffer is empty", () => {
+    const classifier = createStderrClassifier();
+    classifier.process(`complete\n`);
+    const flushed = classifier.flush();
+    expect(flushed.forwarded).toBe("");
+    expect(flushed.tailLines).toEqual([]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const classifier = createStderrClassifier();
+    const result = classifier.process(`error: windows\r\n`);
+    expect(result.forwarded).toBe(`error: windows\n`);
+    expect(result.tailLines).toEqual([`error: windows`]);
+  });
+
+  it("emits only fully-terminated lines even when the last line is incomplete", () => {
+    const classifier = createStderrClassifier();
+    const result = classifier.process(`first\nsecond incomplete`);
+    expect(result.forwarded).toBe(`first\n`);
+    expect(result.tailLines).toEqual([`first`]);
+    const flushed = classifier.flush();
+    expect(flushed.forwarded).toBe(`second incomplete\n`);
+  });
+});

--- a/tooling/test-utils/src/__tests__/poll-health.test.ts
+++ b/tooling/test-utils/src/__tests__/poll-health.test.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { pollHealth } from "../e2e/api-server.js";
+
+function startDummyHealthServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(200);
+        res.end("ok");
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") {
+        reject(new Error("unexpected address shape"));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        close: () =>
+          new Promise<void>((resolve2, reject2) => {
+            server.close((err) => {
+              if (err) reject2(err);
+              else resolve2();
+            });
+          }),
+      });
+    });
+  });
+}
+
+describe("pollHealth", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      const c = cleanups.pop();
+      if (c) await c();
+    }
+  });
+
+  it("resolves when /health returns 200 within the timeout", async () => {
+    const { port, close } = await startDummyHealthServer();
+    cleanups.push(close);
+    await expect(
+      pollHealth({ baseUrl: `http://127.0.0.1:${String(port)}`, timeoutMs: 2000 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws the classic timeout error when nothing answers and no child is provided", async () => {
+    // Port 1 is reserved/unbindable on most systems; fetch fails fast.
+    await expect(pollHealth({ baseUrl: "http://127.0.0.1:1", timeoutMs: 200 })).rejects.toThrow(
+      /did not become healthy within 200ms/,
+    );
+  });
+
+  it("throws with exit code and stderr tail when the child exits early", async () => {
+    const child = spawn(process.execPath, [
+      "-e",
+      'process.stderr.write("boom\\n"); process.exit(42);',
+    ]);
+    const stderrTail: string[] = [];
+    child.stderr.on("data", (d: Buffer) => {
+      stderrTail.push(d.toString());
+    });
+    cleanups.push(() => {
+      if (child.exitCode === null) child.kill("SIGKILL");
+      return Promise.resolve();
+    });
+
+    // Wait for the child to fully exit and for stderr to drain BEFORE
+    // calling pollHealth, so detection is deterministic (seeded via
+    // child.exitCode rather than a race against the 'exit' event).
+    await new Promise<void>((resolve) => {
+      if (child.exitCode !== null) resolve();
+      else
+        child.once("exit", () => {
+          resolve();
+        });
+    });
+    // Give the stderr 'data' handler a tick to flush.
+    await new Promise((r) => setTimeout(r, 10));
+
+    const err = await pollHealth({
+      baseUrl: "http://127.0.0.1:1",
+      timeoutMs: 5000,
+      child,
+      stderrTail,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toMatch(/exited before becoming healthy/);
+    expect(msg).toContain("code=42");
+    expect(msg).toContain("boom");
+  });
+});

--- a/tooling/test-utils/src/__tests__/poll-health.test.ts
+++ b/tooling/test-utils/src/__tests__/poll-health.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { once } from "node:events";
 import http from "node:http";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -68,25 +69,20 @@ describe("pollHealth", () => {
     ]);
     const stderrTail: string[] = [];
     child.stderr.on("data", (d: Buffer) => {
-      stderrTail.push(d.toString());
+      for (const line of d.toString().split(/\r?\n/)) {
+        if (line !== "") stderrTail.push(line);
+      }
     });
-    cleanups.push(() => {
-      if (child.exitCode === null) child.kill("SIGKILL");
-      return Promise.resolve();
+    cleanups.push(async () => {
+      if (child.exitCode === null) {
+        child.kill("SIGKILL");
+        await once(child, "close");
+      }
     });
 
-    // Wait for the child to fully exit and for stderr to drain BEFORE
-    // calling pollHealth, so detection is deterministic (seeded via
-    // child.exitCode rather than a race against the 'exit' event).
-    await new Promise<void>((resolve) => {
-      if (child.exitCode !== null) resolve();
-      else
-        child.once("exit", () => {
-          resolve();
-        });
-    });
-    // Give the stderr 'data' handler a tick to flush.
-    await new Promise((r) => setTimeout(r, 10));
+    // Wait for the child to fully close (fires after exit + stdio drain)
+    // so detection is deterministic — pollHealth sees exitCode !== null.
+    await once(child, "close");
 
     const err = await pollHealth({
       baseUrl: "http://127.0.0.1:1",
@@ -100,5 +96,46 @@ describe("pollHealth", () => {
     expect(msg).toMatch(/exited before becoming healthy/);
     expect(msg).toContain("code=42");
     expect(msg).toContain("boom");
+  });
+
+  it("throws via the live onExit listener when the child exits DURING the poll loop", async () => {
+    // The earlier test seeds earlyExit from child.exitCode because the
+    // child is already dead. This test covers the other branch: the
+    // 'exit' event fires while pollHealth is mid-loop, exercising the
+    // live onExit listener and the finally-branch off() cleanup.
+    const child = spawn(process.execPath, [
+      "-e",
+      'process.stderr.write("slow-boom\\n"); setTimeout(() => process.exit(7), 100);',
+    ]);
+    const stderrTail: string[] = [];
+    child.stderr.on("data", (d: Buffer) => {
+      for (const line of d.toString().split(/\r?\n/)) {
+        if (line !== "") stderrTail.push(line);
+      }
+    });
+    cleanups.push(async () => {
+      if (child.exitCode === null) {
+        child.kill("SIGKILL");
+        await once(child, "close");
+      }
+    });
+
+    // Child is still alive when pollHealth is called; it will exit
+    // ~100ms later, firing the 'exit' event that the live listener
+    // translates into earlyExit.
+    expect(child.exitCode).toBeNull();
+
+    const err = await pollHealth({
+      baseUrl: "http://127.0.0.1:1",
+      timeoutMs: 5000,
+      child,
+      stderrTail,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toMatch(/exited before becoming healthy/);
+    expect(msg).toContain("code=7");
+    expect(msg).toContain("slow-boom");
   });
 });

--- a/tooling/test-utils/src/e2e/api-env.ts
+++ b/tooling/test-utils/src/e2e/api-env.ts
@@ -1,0 +1,19 @@
+/**
+ * Environment helpers for spawning API server children from test bootstraps.
+ *
+ * `apps/api/src/index.ts` gates its `start()` call on `!process.env["VITEST"]`
+ * to avoid an async teardown race when the module is `import`ed by vitest
+ * unit tests. The spawned E2E server is a separate process that must run
+ * `start()`; inheriting a parent `VITEST` flag silences it and the health
+ * check times out.
+ *
+ * `inheritEnvWithoutVitest` returns a copy of `process.env` with the
+ * `VITEST` key absent (not just set to `undefined`), without mutating
+ * `process.env` itself.
+ */
+
+export function inheritEnvWithoutVitest(): NodeJS.ProcessEnv {
+  const { VITEST: _dropped, ...inherited } = process.env;
+  void _dropped;
+  return inherited;
+}

--- a/tooling/test-utils/src/e2e/api-server.ts
+++ b/tooling/test-utils/src/e2e/api-server.ts
@@ -8,7 +8,9 @@ import { execFileSync, execSync, spawn, type ChildProcess } from "node:child_pro
 import crypto from "node:crypto";
 import path from "node:path";
 
+import { inheritEnvWithoutVitest } from "./api-env.js";
 import { assertPortFree } from "./assert-port-free.js";
+import { createStderrClassifier } from "./classify-pino-stderr.js";
 import {
   DOCKER_CONTAINER_NAME,
   MINIO_BUCKET,
@@ -18,6 +20,7 @@ import {
 
 const HEALTH_POLL_MS = 100;
 const HEALTH_TIMEOUT_MS = 15_000;
+const STDERR_TAIL_MAX_LINES = 200;
 
 /** Stable 64-char hex pepper for local E2E tests (not used in production). */
 const DEFAULT_TEST_PEPPER = crypto.createHash("sha256").update("e2e-test-pepper").digest("hex");
@@ -25,24 +28,28 @@ const DEFAULT_TEST_PEPPER = crypto.createHash("sha256").update("e2e-test-pepper"
 export const E2E_PORT = 10_099;
 export const API_BASE_URL = `http://localhost:${String(E2E_PORT)}`;
 
-export interface PollHealthOptions {
+interface PollHealthBase {
   readonly baseUrl: string;
   readonly timeoutMs: number;
-  /**
-   * Optional spawned child to monitor. If the child exits before /health
-   * becomes healthy, the promise rejects immediately with the exit code
-   * and the most recent stderr chunks.
-   */
-  readonly child?: ChildProcess;
-  /**
-   * Bounded ring of recent stderr chunks captured by the caller. Used
-   * verbatim in the early-exit error message.
-   */
-  readonly stderrTail?: readonly string[];
 }
 
+/**
+ * Options for pollHealth. A discriminated union: when `child` is provided,
+ * `stderrTail` may accompany it and is used in the early-exit error
+ * message; when `child` is absent, `stderrTail` must also be absent (it
+ * would otherwise be silently ignored).
+ */
+export type PollHealthOptions =
+  | (PollHealthBase & { readonly child?: undefined; readonly stderrTail?: undefined })
+  | (PollHealthBase & {
+      readonly child: ChildProcess;
+      readonly stderrTail?: readonly string[];
+    });
+
 export async function pollHealth(options: PollHealthOptions): Promise<void> {
-  const { baseUrl, timeoutMs, child, stderrTail } = options;
+  const { baseUrl, timeoutMs } = options;
+  const child = options.child;
+  const stderrTail = options.stderrTail;
   // Seed earlyExit from exitCode/signalCode so a child that exited before
   // pollHealth was called is still detected — the 'exit' event never fires
   // retroactively, so the listener alone is insufficient.
@@ -56,7 +63,7 @@ export async function pollHealth(options: PollHealthOptions): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       if (earlyExit !== null) {
-        const tail = (stderrTail ?? []).join("");
+        const tail = (stderrTail ?? []).join("\n");
         throw new Error(
           `API server exited before becoming healthy (code=${String(earlyExit.code)}, signal=${String(earlyExit.signal)}).\n` +
             `Recent stderr:\n${tail}`,
@@ -116,13 +123,8 @@ export async function spawnApiServer(options: SpawnApiServerOptions): Promise<Sp
 
   await assertPortFree(E2E_PORT);
   log(`Starting API server on port ${String(E2E_PORT)}`);
-  // Strip VITEST from the inherited env — apps/api/src/index.ts gates its
-  // start() call on `!process.env["VITEST"]` to avoid an async teardown race
-  // when the module is `import`ed by unit tests. The spawned server is a
-  // separate process that SHOULD run start(); leaking the parent's VITEST
-  // flag silences start() and the health check times out.
   const spawnEnv: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...inheritEnvWithoutVitest(),
     API_PORT: String(E2E_PORT),
     DB_DIALECT: "pg",
     DATABASE_URL: databaseUrl,
@@ -135,7 +137,6 @@ export async function spawnApiServer(options: SpawnApiServerOptions): Promise<Sp
     AWS_ACCESS_KEY_ID: "minioadmin",
     AWS_SECRET_ACCESS_KEY: "minioadmin",
   };
-  delete spawnEnv["VITEST"];
   const serverProcess = spawn("bun", ["run", "src/index.ts"], {
     cwd: apiDir,
     env: spawnEnv,
@@ -143,28 +144,22 @@ export async function spawnApiServer(options: SpawnApiServerOptions): Promise<Sp
   });
 
   const stderrTail: string[] = [];
-  const STDERR_TAIL_MAX = 20;
+  const classifier = createStderrClassifier();
   serverProcess.stderr.on("data", (data: Buffer) => {
-    const msg = data.toString();
-    // Classify per-line. A single 'data' event can contain multiple records;
-    // testing the entire chunk would misclassify raw Bun errors that happen to
-    // share a chunk with a pino INFO/DEBUG/WARN line.
-    const lines = msg.split(/\r?\n/);
-    let forwarded = "";
-    for (const line of lines) {
-      if (line === "") continue;
-      const isPinoJson = /^\s*\{.*"level":\d+/.test(line);
-      const isLowLevelPino =
-        isPinoJson && !line.includes('"level":50') && !line.includes('"level":60');
-      if (!isLowLevelPino) {
-        forwarded += `${line}\n`;
-      }
+    const { forwarded, tailLines } = classifier.process(data.toString());
+    if (forwarded !== "") process.stderr.write(forwarded);
+    for (const line of tailLines) {
+      stderrTail.push(line);
+      if (stderrTail.length > STDERR_TAIL_MAX_LINES) stderrTail.shift();
     }
-    if (forwarded !== "") {
-      process.stderr.write(forwarded);
+  });
+  serverProcess.stderr.on("end", () => {
+    const { forwarded, tailLines } = classifier.flush();
+    if (forwarded !== "") process.stderr.write(forwarded);
+    for (const line of tailLines) {
+      stderrTail.push(line);
+      if (stderrTail.length > STDERR_TAIL_MAX_LINES) stderrTail.shift();
     }
-    stderrTail.push(msg);
-    if (stderrTail.length > STDERR_TAIL_MAX) stderrTail.shift();
   });
 
   if (!serverProcess.pid) {

--- a/tooling/test-utils/src/e2e/api-server.ts
+++ b/tooling/test-utils/src/e2e/api-server.ts
@@ -24,18 +24,55 @@ const DEFAULT_TEST_PEPPER = crypto.createHash("sha256").update("e2e-test-pepper"
 export const E2E_PORT = 10_099;
 export const API_BASE_URL = `http://localhost:${String(E2E_PORT)}`;
 
-export async function pollHealth(baseUrl: string, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`${baseUrl}/health`);
-      if (res.ok) return;
-    } catch {
-      // Server not ready yet
+export interface PollHealthOptions {
+  readonly baseUrl: string;
+  readonly timeoutMs: number;
+  /**
+   * Optional spawned child to monitor. If the child exits before /health
+   * becomes healthy, the promise rejects immediately with the exit code
+   * and the most recent stderr chunks.
+   */
+  readonly child?: ChildProcess;
+  /**
+   * Bounded ring of recent stderr chunks captured by the caller. Used
+   * verbatim in the early-exit error message.
+   */
+  readonly stderrTail?: readonly string[];
+}
+
+export async function pollHealth(options: PollHealthOptions): Promise<void> {
+  const { baseUrl, timeoutMs, child, stderrTail } = options;
+  // Seed earlyExit from exitCode/signalCode so a child that exited before
+  // pollHealth was called is still detected — the 'exit' event never fires
+  // retroactively, so the listener alone is insufficient.
+  let earlyExit: { code: number | null; signal: NodeJS.Signals | null } | null =
+    child && child.exitCode !== null ? { code: child.exitCode, signal: child.signalCode } : null;
+  const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    earlyExit = { code, signal };
+  };
+  child?.on("exit", onExit);
+  try {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (earlyExit !== null) {
+        const tail = (stderrTail ?? []).join("");
+        throw new Error(
+          `API server exited before becoming healthy (code=${String(earlyExit.code)}, signal=${String(earlyExit.signal)}).\n` +
+            `Recent stderr:\n${tail}`,
+        );
+      }
+      try {
+        const res = await fetch(`${baseUrl}/health`);
+        if (res.ok) return;
+      } catch {
+        // Server not ready yet
+      }
+      await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_MS));
     }
-    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_MS));
+    throw new Error(`API server did not become healthy within ${String(timeoutMs)}ms`);
+  } finally {
+    child?.off("exit", onExit);
   }
-  throw new Error(`API server did not become healthy within ${String(timeoutMs)}ms`);
 }
 
 export interface SpawnedServer {
@@ -114,7 +151,7 @@ export async function spawnApiServer(options: SpawnApiServerOptions): Promise<Sp
     throw new Error("Failed to spawn API server — pid is undefined");
   }
 
-  await pollHealth(API_BASE_URL, HEALTH_TIMEOUT_MS);
+  await pollHealth({ baseUrl: API_BASE_URL, timeoutMs: HEALTH_TIMEOUT_MS });
   log("API server is healthy. Running tests...");
 
   return { process: serverProcess, pid: serverProcess.pid };

--- a/tooling/test-utils/src/e2e/api-server.ts
+++ b/tooling/test-utils/src/e2e/api-server.ts
@@ -146,13 +146,22 @@ export async function spawnApiServer(options: SpawnApiServerOptions): Promise<Sp
   const STDERR_TAIL_MAX = 20;
   serverProcess.stderr.on("data", (data: Buffer) => {
     const msg = data.toString();
-    // Suppress only well-formed pino INFO/DEBUG/WARN JSON. Forward anything
-    // else (raw Bun errors, malformed JSON, ERROR/FATAL pino) so startup
-    // failures are visible instead of silently eaten.
-    const isPinoJson = /^\s*\{.*"level":\d+/.test(msg);
-    const isLowLevelPino = isPinoJson && !msg.includes('"level":50') && !msg.includes('"level":60');
-    if (!isLowLevelPino) {
-      process.stderr.write(msg);
+    // Classify per-line. A single 'data' event can contain multiple records;
+    // testing the entire chunk would misclassify raw Bun errors that happen to
+    // share a chunk with a pino INFO/DEBUG/WARN line.
+    const lines = msg.split(/\r?\n/);
+    let forwarded = "";
+    for (const line of lines) {
+      if (line === "") continue;
+      const isPinoJson = /^\s*\{.*"level":\d+/.test(line);
+      const isLowLevelPino =
+        isPinoJson && !line.includes('"level":50') && !line.includes('"level":60');
+      if (!isLowLevelPino) {
+        forwarded += `${line}\n`;
+      }
+    }
+    if (forwarded !== "") {
+      process.stderr.write(forwarded);
     }
     stderrTail.push(msg);
     if (stderrTail.length > STDERR_TAIL_MAX) stderrTail.shift();

--- a/tooling/test-utils/src/e2e/api-server.ts
+++ b/tooling/test-utils/src/e2e/api-server.ts
@@ -8,6 +8,7 @@ import { execFileSync, execSync, spawn, type ChildProcess } from "node:child_pro
 import crypto from "node:crypto";
 import path from "node:path";
 
+import { assertPortFree } from "./assert-port-free.js";
 import {
   DOCKER_CONTAINER_NAME,
   MINIO_BUCKET,
@@ -113,6 +114,7 @@ export async function spawnApiServer(options: SpawnApiServerOptions): Promise<Sp
     throw new Error(`Migration failed:\nstdout: ${stdout}\nstderr: ${stderr}`);
   }
 
+  await assertPortFree(E2E_PORT);
   log(`Starting API server on port ${String(E2E_PORT)}`);
   // Strip VITEST from the inherited env — apps/api/src/index.ts gates its
   // start() call on `!process.env["VITEST"]` to avoid an async teardown race
@@ -140,18 +142,32 @@ export async function spawnApiServer(options: SpawnApiServerOptions): Promise<Sp
     stdio: "pipe",
   });
 
+  const stderrTail: string[] = [];
+  const STDERR_TAIL_MAX = 20;
   serverProcess.stderr.on("data", (data: Buffer) => {
     const msg = data.toString();
-    if (msg.includes('"level":50') || msg.includes('"level":60')) {
+    // Suppress only well-formed pino INFO/DEBUG/WARN JSON. Forward anything
+    // else (raw Bun errors, malformed JSON, ERROR/FATAL pino) so startup
+    // failures are visible instead of silently eaten.
+    const isPinoJson = /^\s*\{.*"level":\d+/.test(msg);
+    const isLowLevelPino = isPinoJson && !msg.includes('"level":50') && !msg.includes('"level":60');
+    if (!isLowLevelPino) {
       process.stderr.write(msg);
     }
+    stderrTail.push(msg);
+    if (stderrTail.length > STDERR_TAIL_MAX) stderrTail.shift();
   });
 
   if (!serverProcess.pid) {
     throw new Error("Failed to spawn API server — pid is undefined");
   }
 
-  await pollHealth({ baseUrl: API_BASE_URL, timeoutMs: HEALTH_TIMEOUT_MS });
+  await pollHealth({
+    baseUrl: API_BASE_URL,
+    timeoutMs: HEALTH_TIMEOUT_MS,
+    child: serverProcess,
+    stderrTail,
+  });
   log("API server is healthy. Running tests...");
 
   return { process: serverProcess, pid: serverProcess.pid };

--- a/tooling/test-utils/src/e2e/assert-port-free.ts
+++ b/tooling/test-utils/src/e2e/assert-port-free.ts
@@ -1,0 +1,44 @@
+/**
+ * Assert that a TCP port on 127.0.0.1 is free by briefly binding to it.
+ *
+ * Used by E2E bootstrap to refuse to proceed when a stray API server from
+ * a prior crashed run is still listening on the test port — otherwise
+ * the health-poll loop silently attaches to the zombie.
+ *
+ * TOCTOU: there is a small window between this probe closing and the
+ * real server spawning in which a third party could claim the port.
+ * Acceptable for test infra on a single host; the spawned child's
+ * own EADDRINUSE would still be surfaced through the widened stderr
+ * forwarding in the caller.
+ */
+import net from "node:net";
+
+export function assertPortFree(port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.once("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        reject(
+          new Error(
+            `Port ${String(port)} is already in use — a stray API server from a prior run is likely squatting.\n` +
+              `Find and kill it:\n` +
+              `  lsof -iTCP:${String(port)} -sTCP:LISTEN -nP\n` +
+              `  kill <pid>`,
+          ),
+        );
+        return;
+      }
+      reject(err);
+    });
+    probe.once("listening", () => {
+      probe.close((closeErr) => {
+        if (closeErr) {
+          reject(closeErr);
+        } else {
+          resolve();
+        }
+      });
+    });
+    probe.listen(port, "127.0.0.1");
+  });
+}

--- a/tooling/test-utils/src/e2e/classify-pino-stderr.ts
+++ b/tooling/test-utils/src/e2e/classify-pino-stderr.ts
@@ -1,0 +1,78 @@
+/**
+ * Line-buffered classifier for API server stderr.
+ *
+ * Splits raw stderr bytes into complete lines (buffering partial lines
+ * across chunks) and classifies each line as "forward to stderr" or
+ * "suppress as low-level pino noise".
+ *
+ * Classification rule: parse each line as JSON. If the parsed value is
+ * an object with a numeric `level` field, forward only when `level >= 50`
+ * (pino ERROR/FATAL). Anything else — non-JSON, missing `level`, non-numeric
+ * `level` — falls through to forwarding (fail-open so unknown output is
+ * surfaced rather than silently swallowed).
+ *
+ * The tail always contains every non-empty complete line, classified or
+ * not; it feeds the early-exit diagnostic message in pollHealth.
+ */
+
+export interface StderrClassifierResult {
+  readonly forwarded: string;
+  readonly tailLines: readonly string[];
+}
+
+export interface StderrClassifier {
+  process(chunk: string): StderrClassifierResult;
+  flush(): StderrClassifierResult;
+}
+
+export interface StderrClassifierOptions {
+  readonly prefix?: string;
+}
+
+const PINO_ERROR_LEVEL = 50;
+
+function shouldForward(line: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return true;
+  }
+  if (typeof parsed !== "object" || parsed === null) return true;
+  const level = (parsed as { level?: unknown }).level;
+  if (typeof level !== "number") return true;
+  return level >= PINO_ERROR_LEVEL;
+}
+
+export function createStderrClassifier(options: StderrClassifierOptions = {}): StderrClassifier {
+  const prefix = options.prefix ?? "";
+  let buffer = "";
+
+  function emitLines(lines: readonly string[]): StderrClassifierResult {
+    let forwarded = "";
+    const tailLines: string[] = [];
+    for (const line of lines) {
+      if (line === "") continue;
+      tailLines.push(line);
+      if (shouldForward(line)) {
+        forwarded += `${prefix}${line}\n`;
+      }
+    }
+    return { forwarded, tailLines };
+  }
+
+  return {
+    process(chunk: string): StderrClassifierResult {
+      const combined = buffer + chunk;
+      const parts = combined.split(/\r?\n/);
+      buffer = parts.pop() ?? "";
+      return emitLines(parts);
+    },
+    flush(): StderrClassifierResult {
+      if (buffer === "") return { forwarded: "", tailLines: [] };
+      const remaining = buffer;
+      buffer = "";
+      return emitLines([remaining]);
+    },
+  };
+}

--- a/tooling/test-utils/src/e2e/index.ts
+++ b/tooling/test-utils/src/e2e/index.ts
@@ -18,6 +18,9 @@ export {
 export { E2E_PORT, API_BASE_URL, pollHealth, spawnApiServer, killServer } from "./api-server.js";
 export type { SpawnedServer } from "./api-server.js";
 
+// Port-probe helper
+export { assertPortFree } from "./assert-port-free.js";
+
 // Account registration
 export { registerTestAccount, getSystemId } from "./account.js";
 export type { RegisteredAccount } from "./account.js";

--- a/tooling/test-utils/src/e2e/index.ts
+++ b/tooling/test-utils/src/e2e/index.ts
@@ -16,7 +16,18 @@ export {
 
 // API server management
 export { E2E_PORT, API_BASE_URL, pollHealth, spawnApiServer, killServer } from "./api-server.js";
-export type { SpawnedServer } from "./api-server.js";
+export type { PollHealthOptions, SpawnedServer } from "./api-server.js";
+
+// Env helper (VITEST stripping)
+export { inheritEnvWithoutVitest } from "./api-env.js";
+
+// Stderr classifier
+export { createStderrClassifier } from "./classify-pino-stderr.js";
+export type {
+  StderrClassifier,
+  StderrClassifierOptions,
+  StderrClassifierResult,
+} from "./classify-pino-stderr.js";
 
 // Port-probe helper
 export { assertPortFree } from "./assert-port-free.js";


### PR DESCRIPTION
## Summary

Fixes bean **ps-73w5**. Two latent bugs in E2E bootstrap let a zombie `bun` from an earlier crashed run cause ~491/509 E2E test failures on 2026-04-19:

1. `pollHealth()` returned success on any `GET /health 200`, including a zombie on :10099 from a prior crashed run.
2. The stderr listener only forwarded pino `"level":50`/`"level":60` JSON, silently swallowing raw Bun errors like `EADDRINUSE error: Failed to start server`.

Both bootstrap paths — `tooling/test-utils/src/e2e/api-server.ts` (shared, used by `import-sp` / `import-pk` E2E suites) and `apps/api-e2e/src/global-setup.ts` (the Playwright suite) — were affected and are fixed consistently.

### What landed

- **`assertPortFree` helper** in `@pluralscape/test-utils/e2e/assert-port-free`. Probes the port with `net.createServer().listen()`; rejects with an actionable message (`lsof -iTCP:<port> -sTCP:LISTEN -nP` / `kill <pid>`) on `EADDRINUSE`.
- **Widened `pollHealth`** to an options object with optional `child: ChildProcess` + `stderrTail: readonly string[]`. Seeds `earlyExit` from `child.exitCode` at entry (so children that already exited are detected), attaches an `'exit'` listener for the mid-poll case, and rejects with `code=<N>`, `signal=<S>`, and recent stderr before the next fetch attempt.
- **Per-line stderr classifier** (replaces the old chunk-level pino filter). `data` events are not line-buffered, so the previous chunk-level regex misclassified mixed chunks and suppressed raw Bun errors that shared a chunk with a pino INFO line. Each non-empty line is now classified independently.
- **Deleted duplicate `pollHealth`** and now-unused `HEALTH_POLL_MS` from `apps/api-e2e/src/global-setup.ts`; both paths share the hardened helper.
- **`@pluralscape/test-utils`** declared as a dev dep of `apps/api-e2e` (was previously undeclared). Sub-path exports (`./e2e/assert-port-free`, `./e2e/api-server`) added so Playwright consumers can import the helpers without transitively pulling `vitest/expect` through the `/e2e` barrel — doing so pollutes Playwright's `expect` with `Cannot redefine property: Symbol($$jest-matchers-object)`.
- **`VITEST` stripped** from the spawn env in `apps/api-e2e/src/global-setup.ts`, mirroring `api-server.ts`. Prevents a silent 15 s health-poll timeout when invoked from a shell that inherited `VITEST` from a prior vitest run.

## Manual acceptance

With a dummy Bun server squatting on `:10099`:

```
Error: Port 10099 is already in use — a stray API server from a prior run is likely squatting.
Find and kill it:
  lsof -iTCP:10099 -sTCP:LISTEN -nP
  kill <pid>
```

Bootstrap fails fast (before any spec runs) and teardown still cleans up Postgres / MinIO / Crowdin-stub. Without the squatter, bootstrap completes normally and the API becomes healthy.

## Test plan

- [x] Unit: `assertPortFree` — free port resolves, busy port rejects with actionable message, no port leak
- [x] Unit: `pollHealth` — healthy resolve, classic timeout, early-exit with exit code + stderr substring
- [x] `/verify` full suite — format, lint, typecheck, unit, integration, e2e, e2e-slow, sp-import, pk-import (9/9 green)
- [x] Manual acceptance: zombie on :10099 → fails fast with new error; no zombie → happy path unchanged

## Non-goals (noted in spec)

- No `/health` fingerprinting nonce (test-only concern; would require API-server changes).
- No auto-kill of the stray process (may belong to a legit dev server).
- No deduplication of the two bootstrap paths. The api-e2e path layers in Crowdin stub + extra env that doesn't fit `spawnApiServer`'s interface; reconciling is a separate refactor.