### PR TITLE
refactor(import): route import-pk and import-sp mapped types through validation schemas

### DIFF
--- a/.beans/ps-86ya--route-import-pk-and-import-sp-mapped-types-through.md
+++ b/.beans/ps-86ya--route-import-pk-and-import-sp-mapped-types-through.md
@@ -1,0 +1,59 @@
+---
+# ps-86ya
+title: Route import-pk and import-sp mapped types through validation schemas
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-20T08:36:01Z
+updated_at: 2026-04-20T08:47:36Z
+parent: ps-h2gl
+---
+
+Align mapped-payload types in `packages/import-pk` (and close the same gap in `packages/import-sp`) with `@pluralscape/validation` `Create*BodySchema` shapes, so upstream plaintext-field additions produce compile errors in importers instead of silent drift.
+
+Design spec: `docs/superpowers/specs/2026-04-20-import-pk-validation-types-design.md` (local-only).
+
+## Pattern
+
+```ts
+export type MappedX = Omit<z.infer<typeof CreateXBodySchema>, "encryptedData" | ...> & {
+  readonly encrypted: XEncryptedFields;
+  // + engine-layer fields (bucketIds, fieldValues, memberIds, archived)
+};
+```
+
+## Files to edit (6)
+
+### import-pk
+
+- [x] `packages/import-pk/src/mappers/member.mapper.ts` — `PkMappedMember` via `Omit<z.infer<CreateMemberBodySchema>, "encryptedData">`
+- [x] `packages/import-pk/src/mappers/group.mapper.ts` — `PkMappedGroup` via `Omit<z.infer<CreateGroupBodySchema>, "encryptedData">`; widens `parentGroupId` and `sortOrder` from literals to schema types
+- [x] `packages/import-pk/src/mappers/switch.mapper.ts` — `PkMappedFrontingSession` via `Omit<..., "encryptedData" | "endTime">`; add `brandId<MemberId>(resolved)` at the `buildSession` call sites (pattern matches `packages/import-sp/src/mappers/fronting-session.mapper.ts:56`)
+- [x] `packages/import-pk/src/mappers/privacy-bucket-synthesis.ts` — `PkMappedPrivacyBucket` via `Omit<z.infer<CreateBucketBodySchema>, "encryptedData">`
+
+### import-sp (closes same drift gap)
+
+- [x] `packages/import-sp/src/mappers/member.mapper.ts` — `MappedMember` via Omit pattern
+- [x] `packages/import-sp/src/mappers/bucket.mapper.ts` — `MappedPrivacyBucket` via Omit pattern
+
+## Verification
+
+- [x] `pnpm typecheck`
+- [x] `pnpm vitest run --project import-pk`
+- [x] `pnpm vitest run --project import-pk-integration`
+- [x] `pnpm vitest run --project import-sp`
+- [x] `pnpm vitest run --project import-sp-integration`
+
+## Non-goals
+
+- No change to `*EncryptedFields` (already sourced from `@pluralscape/data`)
+- No change to engine, persister, dependency-order, validators, or source code
+- No runtime behavior change anywhere; pure type-shape refactor
+
+## Summary of Changes
+
+All four `packages/import-pk` mapper types (`PkMappedMember`, `PkMappedGroup`, `PkMappedFrontingSession`, `PkMappedPrivacyBucket`) and the two remaining hand-rolled `packages/import-sp` mapper types (`MappedMember`, `MappedPrivacyBucket`) now derive their schema-contributed fields via `Omit<z.infer<typeof Create*BodySchema>, "encryptedData" | ...>`. Upstream plaintext-field additions to `@pluralscape/validation` will now produce compile errors in both importers instead of silent drift.
+
+One small runtime-adjacent change in `packages/import-pk/src/mappers/switch.mapper.ts`: resolved member IDs are now wrapped with `brandId<MemberId>(...)` before entering `buildSession`, matching the pattern in `packages/import-sp/src/mappers/fronting-session.mapper.ts:56`. `brandId` is a type-only brand (runtime identity), so all existing tests pass unchanged.
+
+Verified with workspace-wide `pnpm typecheck`, `pnpm vitest` across `import-pk`, `import-pk-integration`, `import-sp`, `import-sp-integration` (536 passed, 12 skipped), `pnpm lint` on both packages, and live-API e2e runs (SP: 72 passed, PK: 34 passed).

--- a/packages/import-pk/src/mappers/group.mapper.ts
+++ b/packages/import-pk/src/mappers/group.mapper.ts
@@ -13,13 +13,13 @@ import { normalisePkColor } from "./pk-mapper-helpers.js";
 import type { PKGroup } from "../validators/pk-payload.js";
 import type { GroupEncryptedFields } from "@pluralscape/data";
 import type { MappingContext } from "@pluralscape/import-core";
+import type { CreateGroupBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface PkMappedGroup {
+export type PkMappedGroup = Omit<z.infer<typeof CreateGroupBodySchema>, "encryptedData"> & {
   readonly encrypted: GroupEncryptedFields;
-  readonly parentGroupId: null;
-  readonly sortOrder: 0;
   readonly memberIds: readonly string[];
-}
+};
 
 export function mapPkGroup(pk: PKGroup, ctx: MappingContext): MapperResult<PkMappedGroup> {
   if (typeof pk.name !== "string" || pk.name.trim().length === 0) {
@@ -71,7 +71,7 @@ export function mapPkGroup(pk: PKGroup, ctx: MappingContext): MapperResult<PkMap
   return mapped({
     encrypted,
     parentGroupId: null,
-    sortOrder: 0 as const,
+    sortOrder: 0,
     memberIds,
   });
 }

--- a/packages/import-pk/src/mappers/member.mapper.ts
+++ b/packages/import-pk/src/mappers/member.mapper.ts
@@ -17,13 +17,15 @@ import { normalisePkColor } from "./pk-mapper-helpers.js";
 import type { PKMember } from "../validators/pk-payload.js";
 import type { MemberEncryptedFields } from "@pluralscape/data";
 import type { MappingContext } from "@pluralscape/import-core";
+import type { CreateMemberBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface PkMappedMember {
+export type PkMappedMember = Omit<z.infer<typeof CreateMemberBodySchema>, "encryptedData"> & {
   readonly encrypted: MemberEncryptedFields;
   readonly archived: false;
   readonly fieldValues: readonly [];
   readonly bucketIds: readonly string[];
-}
+};
 
 export function mapPkMember(pk: PKMember, ctx: MappingContext): MapperResult<PkMappedMember> {
   if (typeof pk.name !== "string" || pk.name.trim().length === 0) {

--- a/packages/import-pk/src/mappers/privacy-bucket-synthesis.ts
+++ b/packages/import-pk/src/mappers/privacy-bucket-synthesis.ts
@@ -15,10 +15,14 @@ import { z } from "zod/v4";
 
 import type { BucketEncryptedFields } from "@pluralscape/data";
 import type { MappingContext } from "@pluralscape/import-core";
+import type { CreateBucketBodySchema } from "@pluralscape/validation";
 
-export interface PkMappedPrivacyBucket {
+export type PkMappedPrivacyBucket = Omit<
+  z.infer<typeof CreateBucketBodySchema>,
+  "encryptedData"
+> & {
   readonly encrypted: BucketEncryptedFields;
-}
+};
 
 /** All PK privacy fields to check for "private" values. */
 const PRIVACY_FIELDS = [

--- a/packages/import-pk/src/mappers/switch.mapper.ts
+++ b/packages/import-pk/src/mappers/switch.mapper.ts
@@ -16,20 +16,23 @@
  *    (endTime = null).
  */
 import { mapped, type BatchMapperOutput, type SourceDocument } from "@pluralscape/import-core";
+import { brandId } from "@pluralscape/types";
 
 import { PKSwitchSchema } from "../validators/pk-payload.js";
 
 import type { FrontingSessionEncryptedFields } from "@pluralscape/data";
 import type { MappingContext } from "@pluralscape/import-core";
+import type { MemberId } from "@pluralscape/types";
+import type { CreateFrontingSessionBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface PkMappedFrontingSession {
+export type PkMappedFrontingSession = Omit<
+  z.infer<typeof CreateFrontingSessionBodySchema>,
+  "encryptedData" | "endTime"
+> & {
   readonly encrypted: FrontingSessionEncryptedFields;
-  readonly startTime: number;
   readonly endTime: number | null;
-  readonly memberId: string | undefined;
-  readonly customFrontId: undefined;
-  readonly structureEntityId: undefined;
-}
+};
 
 interface ParsedSwitch {
   readonly timestampMs: number;
@@ -37,7 +40,7 @@ interface ParsedSwitch {
 }
 
 function buildSession(
-  memberId: string,
+  memberId: MemberId,
   startTime: number,
   endTime: number | null,
 ): PkMappedFrontingSession {
@@ -137,7 +140,7 @@ export function mapSwitchBatch(
         const endTime = sw.timestampMs === startTime ? sw.timestampMs + 1 : sw.timestampMs;
         outputs.push({
           sourceEntityId: `session:${pkMemberId}:${String(startTime)}`,
-          result: mapped(buildSession(resolved, startTime, endTime)),
+          result: mapped(buildSession(brandId<MemberId>(resolved), startTime, endTime)),
         });
         activeFronters.delete(pkMemberId);
       }
@@ -159,7 +162,7 @@ export function mapSwitchBatch(
     }
     outputs.push({
       sourceEntityId: `session:${pkMemberId}:${String(startTime)}`,
-      result: mapped(buildSession(resolved, startTime, null)),
+      result: mapped(buildSession(brandId<MemberId>(resolved), startTime, null)),
     });
   }
 

--- a/packages/import-sp/src/mappers/bucket.mapper.ts
+++ b/packages/import-sp/src/mappers/bucket.mapper.ts
@@ -20,11 +20,13 @@ import { mapped, skipped, type MapperResult } from "./mapper-result.js";
 import type { MappingContext } from "./context.js";
 import type { SPPrivacyBucket } from "../sources/sp-types.js";
 import type { BucketEncryptedFields } from "@pluralscape/data";
+import type { CreateBucketBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
 /** The Pluralscape-shaped bucket payload the persister consumes. */
-export interface MappedPrivacyBucket {
+export type MappedPrivacyBucket = Omit<z.infer<typeof CreateBucketBodySchema>, "encryptedData"> & {
   readonly encrypted: BucketEncryptedFields;
-}
+};
 
 export function mapBucket(
   sp: SPPrivacyBucket,

--- a/packages/import-sp/src/mappers/member.mapper.ts
+++ b/packages/import-sp/src/mappers/member.mapper.ts
@@ -29,8 +29,10 @@ import { failed, mapped, skipped, type MapperResult } from "./mapper-result.js";
 import type { MappingContext } from "./context.js";
 import type { SPMember } from "../sources/sp-types.js";
 import type { MemberEncryptedFields } from "@pluralscape/data";
+import type { CreateMemberBodySchema } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
-export interface MappedMember {
+export type MappedMember = Omit<z.infer<typeof CreateMemberBodySchema>, "encryptedData"> & {
   readonly encrypted: MemberEncryptedFields;
   readonly archived: boolean;
   readonly fieldValues: readonly ExtractedFieldValue[];
@@ -40,7 +42,7 @@ export interface MappedMember {
    * {@link MappingContext.translate} — consumers never need to re-resolve.
    */
   readonly bucketIds: readonly string[];
-}
+};
 
 /**
  * Resolve a member's privacy bucket source IDs.


### PR DESCRIPTION
## Summary

- Every mapped-payload type in `packages/import-pk` (`PkMappedMember`, `PkMappedGroup`, `PkMappedFrontingSession`, `PkMappedPrivacyBucket`) and the two remaining hand-rolled types in `packages/import-sp` (`MappedMember`, `MappedPrivacyBucket`) now derive their schema-contributed fields via `Omit<z.infer<typeof Create*BodySchema>, "encryptedData" | ...>` from `@pluralscape/validation`.
- Future plaintext-field additions to the create-body schemas (e.g. `archived`, `sortOrder`) will now produce compile errors in both importers instead of silently drifting.
- One runtime-adjacent change in `packages/import-pk/src/mappers/switch.mapper.ts`: resolved member IDs wrapped with `brandId<MemberId>(...)` before `buildSession`, matching the pattern used in `packages/import-sp/src/mappers/fronting-session.mapper.ts:56`. `brandId` is a type-only brand (runtime identity), so behavior is unchanged.

Closes bean `ps-86ya` (parent: `ps-h2gl` Milestone 9).

Design spec: `docs/superpowers/specs/2026-04-20-import-pk-validation-types-design.md` (local-only).

## Test plan

- [x] `pnpm typecheck` — workspace-wide, exit 0
- [x] `pnpm vitest run --project import-pk --project import-pk-integration --project import-sp --project import-sp-integration` — 536 passed, 12 skipped (SP live-API gates)
- [x] `pnpm --filter @pluralscape/import-pk lint` — zero warnings
- [x] `pnpm --filter @pluralscape/import-sp lint` — zero warnings
- [x] `pnpm test:e2e:sp-import` with `SP_TEST_LIVE_API=true` — 72 passed, 1 skipped
- [x] `pnpm test:e2e:pk-import` with `PK_TEST_LIVE_API=true` — 34 passed