### PR TITLE
chore(beans): 2026-04-20 comprehensive audit findings

### DIFF
--- a/.beans/api-0zzu--parallelise-s3-blob-cleanup-deletes.md
+++ b/.beans/api-0zzu--parallelise-s3-blob-cleanup-deletes.md
@@ -1,0 +1,12 @@
+---
+# api-0zzu
+title: Parallelise S3 blob cleanup deletes
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [P3] from audit 2026-04-20. apps/api/src/jobs/blob-s3-cleanup.ts:43-53. S3 deletes sequential in for-loop with per-item heartbeat. Fix: Promise.allSettled in batches of 10-20.

--- a/.beans/api-2wjc--validate-localenamespace-params-in-crowdin-cdn-rou.md
+++ b/.beans/api-2wjc--validate-localenamespace-params-in-crowdin-cdn-rou.md
@@ -1,0 +1,12 @@
+---
+# api-2wjc
+title: Validate locale/namespace params in Crowdin CDN routes
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [H1] from audit 2026-04-20. apps/api/src/services/crowdin-ota.service.ts:133, apps/api/src/routes/i18n/namespace.ts:36-37. No path-traversal guard on locale/namespace — allows .. segments into CDN URL. Fix: validate locale against [a-zA-Z]{2,3}(-[a-zA-Z]{2,4})? and namespace against [a-zA-Z0-9_-]+.

--- a/.beans/api-5y16--paginate-friend-dashboard-queryvisibleentities.md
+++ b/.beans/api-5y16--paginate-friend-dashboard-queryvisibleentities.md
@@ -1,0 +1,12 @@
+---
+# api-5y16
+title: Paginate friend dashboard queryVisibleEntities
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [P2] from audit 2026-04-20 (correctness at scale). apps/api/src/services/friend-dashboard.service.ts:149. Hard-capped at MAX_PAGE_LIMIT=100; systems with more members/custom-fronts/structure-entities silently truncate friend visibility. Fix: system-wide quota cap or dedicated pagination flow.

--- a/.beans/api-hgd2--replace-webhook-config-result-type-drift-with-bran.md
+++ b/.beans/api-hgd2--replace-webhook-config-result-type-drift-with-bran.md
@@ -1,0 +1,12 @@
+---
+# api-hgd2
+title: Replace Webhook Config result-type drift with branded types
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Findings [T1, T2, P1] from audit 2026-04-20. apps/api/src/services/webhook-config.service.ts:71,81. cryptoKeyId typed string|null should be ApiKeyId|null; secret typed string should be ServerSecret (opaque Uint8Array brand). Drift with canonical domain types in @pluralscape/types. Establish uniform branding across all \*Result interfaces.

--- a/.beans/api-k6as--test-coverage-snapshotservicets-has-zero-tests.md
+++ b/.beans/api-k6as--test-coverage-snapshotservicets-has-zero-tests.md
@@ -1,0 +1,12 @@
+---
+# api-k6as
+title: "Test coverage: snapshot.service.ts has zero tests"
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:36Z
+updated_at: 2026-04-20T09:21:36Z
+parent: api-v8zu
+---
+
+Finding [CG-01] from audit 2026-04-20. apps/api/src/services/snapshot.service.ts (190L). Zero test files at any level. Service handles encrypted blob CRUD with pagination and audit writes. Add unit + integration tests.

--- a/.beans/api-lr6o--test-coverage-key-grantservicets-has-zero-tests.md
+++ b/.beans/api-lr6o--test-coverage-key-grantservicets-has-zero-tests.md
@@ -1,0 +1,12 @@
+---
+# api-lr6o
+title: "Test coverage: key-grant.service.ts has zero tests"
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:36Z
+updated_at: 2026-04-20T09:21:36Z
+parent: api-v8zu
+---
+
+Finding [CG-02] from audit 2026-04-20. apps/api/src/services/key-grant.service.ts (67L). Zero test files. Manages auth key grants used in friend access. Add tests.

--- a/.beans/api-njhu--push-analytics-aggregation-into-db-10k-row-in-memo.md
+++ b/.beans/api-njhu--push-analytics-aggregation-into-db-10k-row-in-memo.md
@@ -1,0 +1,12 @@
+---
+# api-njhu
+title: Push analytics aggregation into DB (10K row in-memory sweep)
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [P1] from audit 2026-04-20. apps/api/src/services/analytics.service.ts:119-134. MAX_ANALYTICS_SESSIONS=10_000 rows fetched and processed in-process; all-time preset fetches without date filtering. Fix: GROUP BY / window functions in DB.

--- a/.beans/api-qcs0--device-transfer-completetransfer-status-check-is-w.md
+++ b/.beans/api-qcs0--device-transfer-completetransfer-status-check-is-w.md
@@ -1,0 +1,12 @@
+---
+# api-qcs0
+title: Device transfer completeTransfer status check is wrong
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [M1 elevated due to correctness] from audit 2026-04-20. apps/api/src/services/device-transfer.service.ts:232. completeTransfer checks status=pending but approveTransfer sets status=approved. Logic bug means approval step provides no actual gate. Fix: filter for status=approved; add end-to-end test.

--- a/.beans/api-qnn6--e2e-coverage-for-timer-configs-crud.md
+++ b/.beans/api-qnn6--e2e-coverage-for-timer-configs-crud.md
@@ -1,0 +1,12 @@
+---
+# api-qnn6
+title: E2E coverage for timer-configs CRUD
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [E2E-01] from audit 2026-04-20. apps/api/src/routes/timer-configs/ (8 route files). Only timers/timer-check-in.spec.ts covers check-in lifecycle. Add E2E coverage for create/update/archive/restore/delete of timer configs.

--- a/.beans/api-rdko--test-coverage-innerworld-regionservicets-needs-int.md
+++ b/.beans/api-rdko--test-coverage-innerworld-regionservicets-needs-int.md
@@ -1,0 +1,12 @@
+---
+# api-rdko
+title: "Test coverage: innerworld-region.service.ts needs integration tests"
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:36Z
+updated_at: 2026-04-20T09:21:36Z
+parent: api-v8zu
+---
+
+Finding [CG-03] from audit 2026-04-20. apps/api/src/services/innerworld-region.service.ts (544L). Unit test only (27 cases), no integration test against real DB. Most complex innerworld service.

--- a/.beans/api-trxh--move-anti-enum-salt-secret-to-envts-with-non-dev-v.md
+++ b/.beans/api-trxh--move-anti-enum-salt-secret-to-envts-with-non-dev-v.md
@@ -1,0 +1,12 @@
+---
+# api-trxh
+title: Move ANTI_ENUM_SALT_SECRET to env.ts with non-dev validation
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [H2] from audit 2026-04-20. apps/api/src/routes/auth/salt.ts:43. Secret read via process.env directly; deterministic dev fallback active in staging defeats anti-enumeration protection. Fix: add to env.ts with required-in-non-development validation.

--- a/.beans/api-uo21--cache-notificationconfigs-in-switch-alert-dispatch.md
+++ b/.beans/api-uo21--cache-notificationconfigs-in-switch-alert-dispatch.md
@@ -1,0 +1,12 @@
+---
+# api-uo21
+title: Cache notificationConfigs in switch-alert-dispatcher
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [P5] from audit 2026-04-20. apps/api/src/services/switch-alert-dispatcher.ts:53-65. Fire-and-forget on every fronting session create with no caching (unlike webhook configs which use QueryCache). Most frequent path. Add in-request or short-TTL cache.

--- a/.beans/api-v8zu--audit-remediation-appsapi-2026-04-20.md
+++ b/.beans/api-v8zu--audit-remediation-appsapi-2026-04-20.md
@@ -1,0 +1,12 @@
+---
+# api-v8zu
+title: "Audit remediation: apps/api (2026-04-20)"
+status: todo
+type: epic
+priority: high
+created_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T09:20:30Z
+parent: ps-h2gl
+---
+
+Remediation from comprehensive audit 2026-04-20. See docs/local-audits/comprehensive-audit-2026-04-20/api.md for full findings. Tracking: ps-g937.

--- a/.beans/api-vg8r--replace-hard-settimeout-sleeps-in-sse-integration.md
+++ b/.beans/api-vg8r--replace-hard-settimeout-sleeps-in-sse-integration.md
@@ -1,0 +1,12 @@
+---
+# api-vg8r
+title: Replace hard setTimeout sleeps in SSE integration test
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:21:35Z
+updated_at: 2026-04-20T09:21:35Z
+parent: api-v8zu
+---
+
+Finding [TQ-01] from audit 2026-04-20. apps/api/src/**tests**/routes/notifications/stream.integration.test.ts lines 121,175,219,226,253,300,378,380,400. 9 hard setTimeout sleeps (50-150ms). Real flakiness source under CI load. Fix: deadline-loop poll instead of fixed sleeps.

--- a/.beans/crypto-1mvo--accept-readablestream-in-crypto-blob-pipeline-true.md
+++ b/.beans/crypto-1mvo--accept-readablestream-in-crypto-blob-pipeline-true.md
@@ -1,0 +1,12 @@
+---
+# crypto-1mvo
+title: Accept ReadableStream in crypto blob pipeline (true streaming)
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: crypto-cpir
+---
+
+Finding [PERF-1] from audit 2026-04-20. packages/crypto/src/blob-pipeline/encrypt-blob.ts:40, packages/crypto/src/symmetric.ts:76-96. encryptStream receives complete Uint8Array; 'streaming' is chunked-in-memory only. Fix: accept ReadableStream / AsyncIterable<Uint8Array> for true backpressure.

--- a/.beans/crypto-5d49--move-qr-transfer-code-to-manual-entry-mitm-window.md
+++ b/.beans/crypto-5d49--move-qr-transfer-code-to-manual-entry-mitm-window.md
@@ -1,0 +1,12 @@
+---
+# crypto-5d49
+title: Move QR transfer code to manual entry (MITM window)
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:50Z
+updated_at: 2026-04-20T09:22:50Z
+parent: crypto-cpir
+---
+
+Finding [H1] from audit 2026-04-20. packages/crypto/src/device-transfer.ts:238-244. 10-digit code (~33.2 bits) and Argon2id salt both serialized into QR payload. Anyone photographing/capturing the QR derives the transfer key without additional secret. Fix: move code to manual entry; put only requestId+salt in QR.

--- a/.beans/crypto-cpir--audit-remediation-packagescrypto-2026-04-20.md
+++ b/.beans/crypto-cpir--audit-remediation-packagescrypto-2026-04-20.md
@@ -1,0 +1,12 @@
+---
+# crypto-cpir
+title: "Audit remediation: packages/crypto (2026-04-20)"
+status: todo
+type: epic
+priority: high
+created_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T09:20:30Z
+parent: ps-h2gl
+---
+
+Remediation from comprehensive audit 2026-04-20. 2 High findings (QR transfer MITM window, Argon2id params). See docs/local-audits/comprehensive-audit-2026-04-20/crypto.md. Tracking: ps-g937.

--- a/.beans/crypto-tirn--eliminate-second-pass-concat-in-decryptstream.md
+++ b/.beans/crypto-tirn--eliminate-second-pass-concat-in-decryptstream.md
@@ -1,0 +1,12 @@
+---
+# crypto-tirn
+title: Eliminate second-pass concat in decryptStream
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: crypto-cpir
+---
+
+Finding [PERF-2] from audit 2026-04-20. packages/crypto/src/symmetric.ts:104-128. Parts accumulate in array, then reduce + second loop copies into final Uint8Array. Fix: pre-allocate result using payload.totalLength and write directly per chunk.

--- a/.beans/crypto-z2eg--harden-argon2id-params-add-context-specific-profil.md
+++ b/.beans/crypto-z2eg--harden-argon2id-params-add-context-specific-profil.md
@@ -1,0 +1,12 @@
+---
+# crypto-z2eg
+title: Harden Argon2id params / add context-specific profiles
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:50Z
+updated_at: 2026-04-20T09:22:50Z
+parent: crypto-cpir
+---
+
+Finding [H2] from audit 2026-04-20. packages/crypto/src/crypto.constants.ts:72-75. PWHASH_OPSLIMIT_UNIFIED=4 with 64 MiB memory — meets OWASP threshold but applied to ALL contexts (PIN, transfer key, master key). SENSITIVE constant at 1 GiB exists but unused. Verify mobile memory limits; consider separate profiles for transfer vs master-key derivation.

--- a/.beans/db-3a27--partition-name-from-pg-inherits-used-unsanitized-i.md
+++ b/.beans/db-3a27--partition-name-from-pg-inherits-used-unsanitized-i.md
@@ -1,0 +1,12 @@
+---
+# db-3a27
+title: partition_name from pg_inherits used unsanitized in sql.raw()
+status: todo
+type: bug
+priority: critical
+created_at: 2026-04-20T09:21:02Z
+updated_at: 2026-04-20T09:21:02Z
+parent: db-bry7
+---
+
+Finding [C2] from audit 2026-04-20. packages/db/src/queries/partition-maintenance.ts:120-122. Raw partition_name from pg_inherits passed directly to DETACH PARTITION/DROP TABLE. Fix: reconstruct name from parsed year/month via formatPartitionName(options.table, parsed.year, parsed.month).

--- a/.beans/db-bry7--audit-remediation-packagesdb-2026-04-20.md
+++ b/.beans/db-bry7--audit-remediation-packagesdb-2026-04-20.md
@@ -1,0 +1,12 @@
+---
+# db-bry7
+title: "Audit remediation: packages/db (2026-04-20)"
+status: todo
+type: epic
+priority: critical
+created_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T09:20:30Z
+parent: ps-h2gl
+---
+
+Remediation from comprehensive audit 2026-04-20. 2 Critical + 2 High findings. See docs/local-audits/comprehensive-audit-2026-04-20/db.md. Tracking: ps-g937.

--- a/.beans/db-dpp7--audit-log-rls-blocks-nullified-rows-after-account.md
+++ b/.beans/db-dpp7--audit-log-rls-blocks-nullified-rows-after-account.md
@@ -1,0 +1,12 @@
+---
+# db-dpp7
+title: audit_log RLS blocks nullified rows after account deletion
+status: todo
+type: bug
+priority: critical
+created_at: 2026-04-20T09:21:02Z
+updated_at: 2026-04-20T09:21:02Z
+parent: db-bry7
+---
+
+Finding [C1] from audit 2026-04-20. packages/db/src/rls/policies.ts:65-73, packages/db/src/schema/pg/audit-log.ts:41-45. RLS requires account_id+system_id match but audit_log uses ON DELETE SET NULL — rows become permanently invisible post-deletion. Fix: privileged role exempt from RLS for audit log access, or USING clause that handles NULLs.

--- a/.beans/db-eigy--add-friend-side-read-policy-for-key-grants.md
+++ b/.beans/db-eigy--add-friend-side-read-policy-for-key-grants.md
@@ -1,0 +1,12 @@
+---
+# db-eigy
+title: Add friend-side read policy for key_grants
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:11Z
+updated_at: 2026-04-20T09:22:11Z
+parent: db-bry7
+---
+
+Finding [H2] from audit 2026-04-20. packages/db/src/schema/pg/privacy.ts:77-103, packages/db/src/rls/policies.ts:229. Compromised system context can enumerate all key grants including encryptedKey. Friend cannot read own received grants without originating system ID. Document intent, and add friend-side read path.

--- a/.beans/db-zy79--enforce-account-ownership-in-systems-rls-defence-i.md
+++ b/.beans/db-zy79--enforce-account-ownership-in-systems-rls-defence-i.md
@@ -1,0 +1,12 @@
+---
+# db-zy79
+title: Enforce account ownership in systems RLS (defence-in-depth)
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:11Z
+updated_at: 2026-04-20T09:22:11Z
+parent: db-bry7
+---
+
+Finding [H1] from audit 2026-04-20. packages/db/src/rls/policies.ts:45-49. Policy only checks id=app.current_system_id; attacker setting app.current_system_id to unowned system gains full access. Fix: id=current_system_id AND account_id=current_account_id.

--- a/.beans/mobile-76ql--scope-searchindex-updated-invalidation-instead-of.md
+++ b/.beans/mobile-76ql--scope-searchindex-updated-invalidation-instead-of.md
@@ -1,0 +1,12 @@
+---
+# mobile-76ql
+title: Scope search:index-updated invalidation instead of nuking all
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: mobile-e3l7
+---
+
+Finding [PERF-2] from audit 2026-04-20. apps/mobile/src/data/query-invalidator.ts:31. Every materialized document fires search:index-updated, nuking all ['search', ...] entries regardless of scope. Fix: scope invalidation by entity type or search query text.

--- a/.beans/mobile-79vz--narrow-materializeddocument-invalidation-to-affect.md
+++ b/.beans/mobile-79vz--narrow-materializeddocument-invalidation-to-affect.md
@@ -1,0 +1,12 @@
+---
+# mobile-79vz
+title: Narrow materialized:document invalidation to affected keys
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: mobile-e3l7
+---
+
+Finding [PERF-1] from audit 2026-04-20. apps/mobile/src/data/query-invalidator.ts:22. invalidateQueries({ queryKey: [tableName] }) marks every cached query stale on every sync document event. Cascades in high-frequency scenarios. Fix: narrow invalidation when document type maps 1:1 to entity ID, similar to per-entity path at line 28.

--- a/.beans/mobile-c01j--production-appjson-hardcodes-httplocalhost3000-api.md
+++ b/.beans/mobile-c01j--production-appjson-hardcodes-httplocalhost3000-api.md
@@ -1,0 +1,12 @@
+---
+# mobile-c01j
+title: Production app.json hardcodes http://localhost:3000 apiBaseUrl
+status: todo
+type: bug
+priority: critical
+created_at: 2026-04-20T09:21:02Z
+updated_at: 2026-04-20T09:21:02Z
+parent: mobile-e3l7
+---
+
+Finding [CRIT-1] from audit 2026-04-20. apps/mobile/app.json:23. Prod build without override communicates over plaintext HTTP, bypassing ws:// guard (WS-only check). Fix: remove apiBaseUrl from app.json; require eas.json/env-specific config injection.

--- a/.beans/mobile-e3l7--audit-remediation-appsmobile-2026-04-20.md
+++ b/.beans/mobile-e3l7--audit-remediation-appsmobile-2026-04-20.md
@@ -1,0 +1,12 @@
+---
+# mobile-e3l7
+title: "Audit remediation: apps/mobile (2026-04-20)"
+status: todo
+type: epic
+priority: critical
+created_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T09:20:30Z
+parent: ps-h2gl
+---
+
+Remediation from comprehensive audit 2026-04-20. 1 Critical (plaintext HTTP fallback) + 4 High. See docs/local-audits/comprehensive-audit-2026-04-20/mobile.md. Tracking: ps-g937.

--- a/.beans/mobile-h89l--hoist-i18nconfig-singletons-out-of-usememo.md
+++ b/.beans/mobile-h89l--hoist-i18nconfig-singletons-out-of-usememo.md
@@ -1,0 +1,12 @@
+---
+# mobile-h89l
+title: Hoist i18nConfig singletons out of useMemo
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: mobile-e3l7
+---
+
+Finding [PERF-3] from audit 2026-04-20. apps/mobile/app/\_layout.tsx:199-212. AsyncStorageI18nCache and createChainedBackend re-created on every locale change. Stateless singletons. Fix: module-level const or ref.

--- a/.beans/mobile-scko--set-keychainaccessible-on-sp-token-securestore.md
+++ b/.beans/mobile-scko--set-keychainaccessible-on-sp-token-securestore.md
@@ -1,0 +1,12 @@
+---
+# mobile-scko
+title: Set keychainAccessible on SP token SecureStore
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: mobile-e3l7
+---
+
+Finding [HIGH-1] from audit 2026-04-20. apps/mobile/src/features/import-sp/sp-token-storage.ts:34-37. SecureStore.setItemAsync with no options inherits AFTER_FIRST_UNLOCK — readable while device locked and may be included in iCloud/Google encrypted backups. Fix: add { keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY }.

--- a/.beans/ps-74xz--validate-bullmq-jobdata-with-zod-in-all-write-path.md
+++ b/.beans/ps-74xz--validate-bullmq-jobdata-with-zod-in-all-write-path.md
@@ -1,0 +1,12 @@
+---
+# ps-74xz
+title: Validate BullMQ job.data with Zod in all write-path methods
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: ps-v7el
+---
+
+Finding [Security H] from audit 2026-04-20. packages/queue/src/bullmq-job-queue.ts L338,387,417,491,530,644,659. Bare 'job.data as StoredJobData' casts in dequeue, acknowledge, fail, retry, cancel, heartbeat, findStalledJobs. Only getJob and listJobs run StoredJobDataSchema.safeParse. Corrupted job data in Redis bypasses validation. Fix: use StoredJobDataSchema.safeParse and throw QueueCorruptionError on failure.

--- a/.beans/ps-g937--comprehensive-codebase-audit-2026-04-20.md
+++ b/.beans/ps-g937--comprehensive-codebase-audit-2026-04-20.md
@@ -1,0 +1,35 @@
+---
+# ps-g937
+title: Comprehensive codebase audit (2026-04-20)
+status: completed
+type: epic
+priority: normal
+created_at: 2026-04-20T09:04:20Z
+updated_at: 2026-04-20T09:23:09Z
+parent: ps-h2gl
+---
+
+Full audit across security, performance, typing/patterns, testing, simplification for all packages. Methodology: docs/superpowers/specs/2026-04-14-comprehensive-codebase-audit-design.md. Plan: docs/superpowers/plans/2026-04-20-comprehensive-codebase-audit.md. Parented under Milestone 9 (ps-h2gl).
+
+## Summary of Changes
+
+Comprehensive codebase audit completed across all packages.
+
+**Reports produced:** 20 per-package audit reports + SUMMARY.md in docs/local-audits/comprehensive-audit-2026-04-20/ (gitignored local directory)
+
+**Remediation epics created (parented under Milestone 9, ps-h2gl):**
+
+- api-v8zu: apps/api — ~10 High findings
+- db-bry7: packages/db — 2 Critical + 2 High findings
+- sync-me6c: packages/sync — 2 High security + multiple perf/typing gaps
+- crypto-cpir: packages/crypto — 2 High findings
+- mobile-e3l7: apps/mobile — 1 Critical + 4 High findings
+- ps-v7el: packages/queue + import-pk — 1 High + 2 High (import-pk)
+
+**Individual beans created:** 3 critical + ~30 high-priority bugs/tasks, all parented under their package epic.
+
+**Methodology reused from:** docs/superpowers/specs/2026-04-14-comprehensive-codebase-audit-design.md
+**Plan:** docs/superpowers/plans/2026-04-20-comprehensive-codebase-audit.md
+**Scope:** 23 agents (5 deep-tier packages × 4 dimensions + 3 sweep-tier agents covering 15 packages/apps)
+
+See docs/local-audits/comprehensive-audit-2026-04-20/SUMMARY.md for top-10 priorities, recurring patterns, and remediation order.

--- a/.beans/ps-tfg2--fix-pk-error-classifier-numeric-status-comparison.md
+++ b/.beans/ps-tfg2--fix-pk-error-classifier-numeric-status-comparison.md
@@ -1,0 +1,12 @@
+---
+# ps-tfg2
+title: Fix pk-error-classifier numeric status comparison
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: ps-v7el
+---
+
+Finding [Typing H] from audit 2026-04-20 import-pk report. packages/import-pk/src/pk-error-classifier.ts. Compares thrown.status as string ('==="401"', .startsWith("5")); APIError.status from pkapi.js may be a number. If numeric, '==='"401"' always fails and all API errors fall through to recoverable-fatal default. Highest-impact typing gap in import-pk.

--- a/.beans/ps-ts6a--enforce-https-on-pluralkit-api-baseurl.md
+++ b/.beans/ps-ts6a--enforce-https-on-pluralkit-api-baseurl.md
@@ -1,0 +1,12 @@
+---
+# ps-ts6a
+title: Enforce HTTPS on PluralKit API baseUrl
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T09:22:51Z
+parent: ps-v7el
+---
+
+Finding [Security] from audit 2026-04-20 import-pk report. packages/import-pk/src/sources/pk-api-source.ts. No token validation before passing to pkapi.js, no HTTPS-enforcement equivalent to assertBaseUrlIsSafe (SP source). Rogue baseUrl could exfiltrate PK token over plain HTTP.

--- a/.beans/ps-v7el--audit-remediation-packagesqueue-imports-2026-04-20.md
+++ b/.beans/ps-v7el--audit-remediation-packagesqueue-imports-2026-04-20.md
@@ -1,0 +1,12 @@
+---
+# ps-v7el
+title: "Audit remediation: packages/queue + imports (2026-04-20)"
+status: todo
+type: epic
+priority: high
+created_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T09:20:30Z
+parent: ps-h2gl
+---
+
+Remediation from comprehensive audit 2026-04-20. Queue job.data casts + import-pk HTTPS guard/error-classifier. See docs/local-audits/comprehensive-audit-2026-04-20/queue.md and import-pk.md. Tracking: ps-g937.

--- a/.beans/sync-192t--optimise-diffentities-to-single-pass-hash.md
+++ b/.beans/sync-192t--optimise-diffentities-to-single-pass-hash.md
@@ -1,0 +1,12 @@
+---
+# sync-192t
+title: Optimise diffEntities to single-pass hash
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [PERF-01] from audit 2026-04-20. packages/sync/src/materializer/base-materializer.ts:49. rowHash() called once for currentMap and again per incoming row. Every update triggers O(n) JSON.stringify twice. Build hash map for incoming rows and compare maps directly.

--- a/.beans/sync-2yh3--scope-enforcetombstones-to-dirty-entity-types-only.md
+++ b/.beans/sync-2yh3--scope-enforcetombstones-to-dirty-entity-types-only.md
@@ -1,0 +1,12 @@
+---
+# sync-2yh3
+title: Scope enforceTombstones to dirty entity types only
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [PERF-03] from audit 2026-04-20. packages/sync/src/post-merge-validator.ts:131-176. Iterates ALL lww-map entities on every merge (20+ types, potentially thousands). Only run tombstone enforcement on entity types whose fields appear in the incoming change set.

--- a/.beans/sync-aefn--strongly-type-syncengine-session-map-remove-unknow.md
+++ b/.beans/sync-aefn--strongly-type-syncengine-session-map-remove-unknow.md
@@ -1,0 +1,12 @@
+---
+# sync-aefn
+title: Strongly type SyncEngine session map (remove unknown)
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [T-1] from audit 2026-04-20. packages/sync/src/engine/sync-engine.ts:72. sessions Map<SyncDocumentId, EncryptedSyncSession<unknown>>; getSession<T>() is caller-asserted cast. Root cause of all as DocRecord casts in post-merge-validator.ts. Introduce AnyDocumentSession union; narrow via parseDocumentId.

--- a/.beans/sync-f4ma--dirty-field-tracking-to-avoid-full-table-scans-per.md
+++ b/.beans/sync-f4ma--dirty-field-tracking-to-avoid-full-table-scans-per.md
@@ -1,0 +1,12 @@
+---
+# sync-f4ma
+title: Dirty-field tracking to avoid full-table scans per sync
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [PERF-02] from audit 2026-04-20. packages/sync/src/materializer/materialize-document.ts:41. Every entity type triggers queryAll<EntityRow>; system-core has ~25 entity types. SQLite queried 25x even if only one changed. Fix: pass dirty-field set from CRDT change to skip unchanged types.

--- a/.beans/sync-ge3a--remove-verify-envelope-signatures-kill-switch.md
+++ b/.beans/sync-ge3a--remove-verify-envelope-signatures-kill-switch.md
@@ -1,0 +1,12 @@
+---
+# sync-ge3a
+title: Remove VERIFY_ENVELOPE_SIGNATURES kill-switch
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [H1] from audit 2026-04-20. apps/api/src/ws/envelope-verification-config.ts:8-19. Env var disables all server-side Ed25519 signature checks on changes and snapshots. Operator misconfiguration silently allows unsigned/forged envelopes. Fix: always-on verification; remove kill-switch or gate on build-time flag for test infra only.

--- a/.beans/sync-ldoi--bind-authorpublickey-to-encryption-key-in-sync-env.md
+++ b/.beans/sync-ldoi--bind-authorpublickey-to-encryption-key-in-sync-env.md
@@ -1,0 +1,12 @@
+---
+# sync-ldoi
+title: Bind authorPublicKey to encryption key in sync envelopes
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [H2] from audit 2026-04-20. packages/sync/src/encrypted-sync.ts:35,73. Signature over ciphertext using signing key; no cryptographic binding between signing keypair and encryption key. verifyKeyOwnership checks registration but not that same key was used for encryption. Fix: bind via KDF or include encryption key's public representation in signed AD.

--- a/.beans/sync-me6c--audit-remediation-packagessync-2026-04-20.md
+++ b/.beans/sync-me6c--audit-remediation-packagessync-2026-04-20.md
@@ -1,0 +1,12 @@
+---
+# sync-me6c
+title: "Audit remediation: packages/sync (2026-04-20)"
+status: todo
+type: epic
+priority: high
+created_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T09:20:30Z
+parent: ps-h2gl
+---
+
+Remediation from comprehensive audit 2026-04-20. 2 High security + typing gaps. See docs/local-audits/comprehensive-audit-2026-04-20/sync.md. Tracking: ps-g937.

--- a/.beans/sync-orkv--type-applylocalchange-with-document-specific-gener.md
+++ b/.beans/sync-orkv--type-applylocalchange-with-document-specific-gener.md
@@ -1,0 +1,12 @@
+---
+# sync-orkv
+title: Type applyLocalChange with document-specific generic
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [T-2] from audit 2026-04-20. packages/sync/src/engine/sync-engine.ts:251. changeFn typed (doc: unknown)=>void; callers can mutate wrong document type without type error. Fix: <T>(docId, changeFn: (doc: T) => void) paired with T-1.

--- a/.beans/sync-qh8l--test-coverage-sync-materializer-has-zero-dedicated.md
+++ b/.beans/sync-qh8l--test-coverage-sync-materializer-has-zero-dedicated.md
@@ -1,0 +1,12 @@
+---
+# sync-qh8l
+title: "Test coverage: sync materializer/ has zero dedicated tests"
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [GAP-1] from audit 2026-04-20. packages/sync/src/materializer/base-materializer.ts (203L, diffEntities, entityToRow), materialize-document.ts, extract-entities.ts, entity-registry.ts, materializer-registry.ts, local-schema.ts. Document-to-SQLite projection layer untested.

--- a/.beans/sync-z99z--test-coverage-event-bus-has-no-test-file.md
+++ b/.beans/sync-z99z--test-coverage-event-bus-has-no-test-file.md
@@ -1,0 +1,12 @@
+---
+# sync-z99z
+title: "Test coverage: event-bus has no test file"
+status: todo
+type: task
+priority: high
+created_at: 2026-04-20T09:22:12Z
+updated_at: 2026-04-20T09:22:12Z
+parent: sync-me6c
+---
+
+Finding [GAP-2] from audit 2026-04-20. packages/sync/src/event-bus/event-bus.ts. createEventBus factory (error handler path, multiple listeners, unsubscribe-while-iterating) untested. event-map.ts and event-bus/index.ts also uncovered.


### PR DESCRIPTION
## Summary

Tracking beans from the 2026-04-20 comprehensive codebase audit. Full monorepo review across security, performance, typing/patterns, simplification, and testing dimensions — 23 agents across 5 deep-tier packages (api, db, sync, crypto, mobile) + 3 sweep-tier agents covering 15 packages/apps.

Tracking epic: [`ps-g937`](.beans/ps-g937--comprehensive-codebase-audit-2026-04-20.md) (completed, parented under Milestone 9).

### Findings

**3 Critical bugs:**
- [`db-3a27`](.beans/db-3a27--partition-name-from-pg-inherits-used-unsanitized-i.md) — `partition_name` from `pg_inherits` used unsanitized in `sql.raw()`
- [`db-dpp7`](.beans/db-dpp7--audit-log-rls-blocks-nullified-rows-after-account.md) — `audit_log` RLS blocks nullified rows after account deletion
- [`mobile-c01j`](.beans/mobile-c01j--production-appjson-hardcodes-httplocalhost3000-api.md) — Production `app.json` hardcodes `http://localhost:3000` apiBaseUrl

**35 High priority findings** across six package remediation epics (all parented under Milestone 9):

| Epic | Package | High count |
|------|---------|------------|
| `api-v8zu` | apps/api | 12 |
| `db-bry7` | packages/db | 2 |
| `sync-me6c` | packages/sync | 9 |
| `crypto-cpir` | packages/crypto | 4 |
| `mobile-e3l7` | apps/mobile | 4 |
| `ps-v7el` | packages/queue + import-pk | 3 |

Recurring patterns across multiple packages:
- Branded-type drift at API/DB boundaries
- Unvalidated single casts past type-system (ESLint catches `as unknown as` but not single casts)
- Env-var fallbacks silently active in staging (`ANTI_ENUM_SALT_SECRET`, `DEV_HMAC_KEY`, `VERIFY_ENVELOPE_SIGNATURES`)
- Magic values inline vs `<domain>.constants.ts`
- Sequential I/O that could be parallelised

Full per-package audit reports live in `docs/local-audits/comprehensive-audit-2026-04-20/` (gitignored, local only).

## Test plan

- [ ] Review bean priorities (reprioritise / scrap / split as needed)
- [ ] Sequence critical fixes ahead of non-blocking M9 work
- [ ] Consider cross-cutting beans for the recurring patterns (branded-ID drift, env-var fallbacks) once the package-scoped items land