### PR TITLE
chore(audit-m9): packages/queue + imports security fixes

### DIFF
--- a/.beans/api-k6as--test-coverage-snapshotservicets-has-zero-tests.md
+++ b/.beans/api-k6as--test-coverage-snapshotservicets-has-zero-tests.md
@@ -5,8 +5,8 @@ status: todo
 type: task
 priority: high
 created_at: 2026-04-20T09:21:36Z
-updated_at: 2026-04-20T09:21:36Z
-parent: api-v8zu
+updated_at: 2026-04-20T11:42:32Z
+parent: ps-9u4w
 ---
 
 Finding [CG-01] from audit 2026-04-20. apps/api/src/services/snapshot.service.ts (190L). Zero test files at any level. Service handles encrypted blob CRUD with pagination and audit writes. Add unit + integration tests.

--- a/.beans/api-lr6o--test-coverage-key-grantservicets-has-zero-tests.md
+++ b/.beans/api-lr6o--test-coverage-key-grantservicets-has-zero-tests.md
@@ -5,8 +5,8 @@ status: todo
 type: task
 priority: high
 created_at: 2026-04-20T09:21:36Z
-updated_at: 2026-04-20T09:21:36Z
-parent: api-v8zu
+updated_at: 2026-04-20T11:42:32Z
+parent: ps-9u4w
 ---
 
 Finding [CG-02] from audit 2026-04-20. apps/api/src/services/key-grant.service.ts (67L). Zero test files. Manages auth key grants used in friend access. Add tests.

--- a/.beans/api-qnn6--e2e-coverage-for-timer-configs-crud.md
+++ b/.beans/api-qnn6--e2e-coverage-for-timer-configs-crud.md
@@ -5,8 +5,8 @@ status: todo
 type: task
 priority: high
 created_at: 2026-04-20T09:21:35Z
-updated_at: 2026-04-20T09:21:35Z
-parent: api-v8zu
+updated_at: 2026-04-20T11:42:32Z
+parent: ps-9u4w
 ---
 
 Finding [E2E-01] from audit 2026-04-20. apps/api/src/routes/timer-configs/ (8 route files). Only timers/timer-check-in.spec.ts covers check-in lifecycle. Add E2E coverage for create/update/archive/restore/delete of timer configs.

--- a/.beans/api-rdko--test-coverage-innerworld-regionservicets-needs-int.md
+++ b/.beans/api-rdko--test-coverage-innerworld-regionservicets-needs-int.md
@@ -5,8 +5,8 @@ status: todo
 type: task
 priority: high
 created_at: 2026-04-20T09:21:36Z
-updated_at: 2026-04-20T09:21:36Z
-parent: api-v8zu
+updated_at: 2026-04-20T11:42:32Z
+parent: ps-9u4w
 ---
 
 Finding [CG-03] from audit 2026-04-20. apps/api/src/services/innerworld-region.service.ts (544L). Unit test only (27 cases), no integration test against real DB. Most complex innerworld service.

--- a/.beans/ps-74xz--validate-bullmq-jobdata-with-zod-in-all-write-path.md
+++ b/.beans/ps-74xz--validate-bullmq-jobdata-with-zod-in-all-write-path.md
@@ -1,12 +1,18 @@
 ---
 # ps-74xz
 title: Validate BullMQ job.data with Zod in all write-path methods
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-20T09:22:51Z
-updated_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T11:50:35Z
 parent: ps-v7el
 ---
 
 Finding [Security H] from audit 2026-04-20. packages/queue/src/bullmq-job-queue.ts L338,387,417,491,530,644,659. Bare 'job.data as StoredJobData' casts in dequeue, acknowledge, fail, retry, cancel, heartbeat, findStalledJobs. Only getJob and listJobs run StoredJobDataSchema.safeParse. Corrupted job data in Redis bypasses validation. Fix: use StoredJobDataSchema.safeParse and throw QueueCorruptionError on failure.
+
+## Summary of Changes
+
+Extracted parseJobDataOrThrow(job: BullMQJob): StoredJobData helper in packages/queue/src/adapters/bullmq/bullmq-job-queue.ts that runs StoredJobDataSchema.safeParse and throws QueueCorruptionError on failure. Replaced 7 bare 'job.data as StoredJobData' casts in dequeue, acknowledge, fail, retry, cancel, heartbeat, and findStalledJobs — each method now fails closed when stored job data disagrees with the discriminated schema.
+
+Added 7 integration tests (one per method) in bullmq-queue.integration.test.ts that seed a corrupted (type, payload) pair in the BullMQ hash and assert QueueCorruptionError. findStalledJobs was rewritten to parse once per job and reuse the validated shape (both reads were casts).

--- a/.beans/ps-hlq3--pr-524-remediation-queueimports-review-fixes.md
+++ b/.beans/ps-hlq3--pr-524-remediation-queueimports-review-fixes.md
@@ -1,0 +1,67 @@
+---
+# ps-hlq3
+title: "PR #524 remediation: queue+imports review fixes"
+status: completed
+type: task
+priority: high
+created_at: 2026-04-20T13:39:00Z
+updated_at: 2026-04-20T13:58:15Z
+parent: ps-h2gl
+---
+
+Address the 5-agent review on PR #524 (chore/audit-m9-queue-imports). Two important issues + ~12 suggestions.
+
+## Important
+
+- [x] I1. IPv6 `[::1]` loopback never matches — strip brackets in both pk-api-source & import-sp api-source
+- [x] I2. findStalledJobs fail-closed blast-radius comment + mixed-batch integration test
+
+## Suggestions
+
+- [x] S1. Tighten StoredJobDataSchema to drop 16 `as StoredJobData` casts (may need JOB_TYPE_VALUES / JOB_STATUS_VALUES tuples in packages/types)
+- [x] S2. Drop dead `typeof token !== "string"` check in pk-api-source
+- [x] S3. normaliseStatus edge-case tests (NaN/Infinity/negatives/zero/hex/partial/whitespace)
+- [x] S4. Token whitespace: keep guard semantics, add test + docstring
+- [x] S5. Replace `JSON.parse as Record` cast with narrowing guard in integration test
+- [x] S6. Embed Zod issues in QueueCorruptionError message; update all call sites
+- [x] S7. Preserve cause on `new URL` rethrow in both pk-api-source & import-sp api-source
+- [x] S8. Inline single-use HTTP constants in error-classifier; keep range bounds
+- [x] S9. Broaden isServerError → isRetryableHttpStatus (covers 429/404/5xx)
+- [x] S10. Parameterise 7 corruption tests via it.each
+- [x] S11. Narrow messageSuffix coercion via formatStatusSuffix helper
+
+## Verification
+
+- [x] `pnpm vitest run --project queue` passes — 278 tests
+- [x] `pnpm vitest run --project queue-integration` passes (Valkey) — 128 tests
+- [x] `pnpm vitest run --project import-pk` passes — 144 tests
+- [x] `pnpm vitest run --project import-sp` passes — 384 tests
+- [x] `pnpm typecheck` clean
+- [x] `pnpm lint` clean
+- [x] `grep -rn "as StoredJobData" packages/queue/src/` returns 0 hits
+
+Worktree: /home/theprismsystem/git/pluralscape-mono-queue-imports
+Branch: chore/audit-m9-queue-imports
+
+## Summary of Changes
+
+**Important issues**
+
+- I1: IPv6 loopback `[::1]` now accepted in both pk-api-source and import-sp api-source (`URL.hostname` returns `[::1]` — strip brackets before LOOPBACK_HOSTS lookup).
+- I2: `findStalledJobs` fail-closed blast radius documented at the method header + mixed-batch test (3 enqueued, 1 corrupted, whole sweep aborts).
+
+**Suggestions**
+
+- S1: `StoredJobDataSchema` tightened. Added `JOB_TYPE_VALUES`/`JOB_STATUS_VALUES` const tuples to `@pluralscape/types`. Moved schema to `job-mapper.ts` so worker can validate too. Dropped all 16 `as StoredJobData` casts.
+- S2: Dead `typeof token !== "string"` check removed.
+- S3: Added `NaN`/`Infinity`/`-Infinity`/negative/`0`/hex/partial/empty/whitespace edge-case tests for `normaliseStatus`.
+- S4: Token whitespace guard semantics preserved (reject whitespace-only, keep surrounding whitespace). New test + docstring.
+- S5: `JSON.parse as Record` in integration test replaced with type-guard narrowing.
+- S6: `QueueCorruptionError` now accepts optional `details` string; Zod issues embedded via `formatZodIssues` helper; all call sites updated.
+- S7: `new URL` catch now passes `{ cause }` in both sources.
+- S8: `DECIMAL_RADIX` inlined as `10`; kept HTTP-status constants (lint `no-magic-numbers` forbids bare literals).
+- S9: `isServerError` → `isRetryableHttpStatus` (covers 429/404/5xx).
+- S10: 7 corruption tests consolidated via `it.each` with typed case array.
+- S11: `formatStatusSuffix` helper added; refuses non-primitive status shapes.
+
+**Verification** — all test projects green, typecheck + lint clean.

--- a/.beans/ps-tfg2--fix-pk-error-classifier-numeric-status-comparison.md
+++ b/.beans/ps-tfg2--fix-pk-error-classifier-numeric-status-comparison.md
@@ -1,12 +1,18 @@
 ---
 # ps-tfg2
 title: Fix pk-error-classifier numeric status comparison
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-20T09:22:51Z
-updated_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T11:57:50Z
 parent: ps-v7el
 ---
 
 Finding [Typing H] from audit 2026-04-20 import-pk report. packages/import-pk/src/pk-error-classifier.ts. Compares thrown.status as string ('==="401"', .startsWith("5")); APIError.status from pkapi.js may be a number. If numeric, '==='"401"' always fails and all API errors fall through to recoverable-fatal default. Highest-impact typing gap in import-pk.
+
+## Summary of Changes
+
+pk-error-classifier now normalises thrown.status (number | string | undefined) to number via a dedicated normaliseStatus helper before comparison. Numeric statuses from pkapi.js (sourced from axios response.status at runtime despite the string type declaration) now classify correctly into 401/403 fatal, 429/404/5xx non-fatal, rather than falling through to the fatal-recoverable default. 5xx detection uses a numeric range (>= 500 && < 600) instead of a String.startsWith check that broke on numbers. HTTP status codes extracted to named constants.
+
+Added 20 tests in **tests**/engine/error-classifier.test.ts covering every classification path for both string and numeric status shapes, plus missing/malformed status fallbacks.

--- a/.beans/ps-ts6a--enforce-https-on-pluralkit-api-baseurl.md
+++ b/.beans/ps-ts6a--enforce-https-on-pluralkit-api-baseurl.md
@@ -1,12 +1,18 @@
 ---
 # ps-ts6a
 title: Enforce HTTPS on PluralKit API baseUrl
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-20T09:22:51Z
-updated_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T11:52:04Z
 parent: ps-v7el
 ---
 
 Finding [Security] from audit 2026-04-20 import-pk report. packages/import-pk/src/sources/pk-api-source.ts. No token validation before passing to pkapi.js, no HTTPS-enforcement equivalent to assertBaseUrlIsSafe (SP source). Rogue baseUrl could exfiltrate PK token over plain HTTP.
+
+## Summary of Changes
+
+pk-api-source now asserts HTTPS on baseUrl (when caller overrides the pkapi.js default) and rejects empty/whitespace tokens before invoking pkapi.js. Matches the import-sp assertBaseUrlIsSafe pattern — HTTPS is required for non-loopback hosts; http:// is permitted only for localhost/127.0.0.1/::1 for local dev. Also rejects malformed URLs and non-http(s) protocol schemes (ftp://, file://, etc.) that would otherwise slip past the pkapi.js Authorization header.
+
+Added 8 unit tests in **tests**/sources/pk-api-source.test.ts covering: https://, http://localhost, http://127.0.0.1, http://remote (rejected), ftp:// (rejected), malformed URL (rejected), empty token, whitespace token.

--- a/.beans/ps-v7el--audit-remediation-packagesqueue-imports-2026-04-20.md
+++ b/.beans/ps-v7el--audit-remediation-packagesqueue-imports-2026-04-20.md
@@ -1,11 +1,11 @@
 ---
 # ps-v7el
 title: "Audit remediation: packages/queue + imports (2026-04-20)"
-status: todo
+status: in-progress
 type: epic
 priority: high
 created_at: 2026-04-20T09:20:30Z
-updated_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T11:44:40Z
 parent: ps-h2gl
 ---
 

--- a/.beans/ps-v7el--audit-remediation-packagesqueue-imports-2026-04-20.md
+++ b/.beans/ps-v7el--audit-remediation-packagesqueue-imports-2026-04-20.md
@@ -1,12 +1,20 @@
 ---
 # ps-v7el
 title: "Audit remediation: packages/queue + imports (2026-04-20)"
-status: in-progress
+status: completed
 type: epic
 priority: high
 created_at: 2026-04-20T09:20:30Z
-updated_at: 2026-04-20T11:44:40Z
+updated_at: 2026-04-20T11:58:11Z
 parent: ps-h2gl
 ---
 
 Remediation from comprehensive audit 2026-04-20. Queue job.data casts + import-pk HTTPS guard/error-classifier. See docs/local-audits/comprehensive-audit-2026-04-20/queue.md and import-pk.md. Tracking: ps-g937.
+
+## Summary of Changes
+
+Completed 3 high-priority audit findings:
+
+- ps-74xz: fix(queue) — parseJobDataOrThrow helper replaces 7 bare StoredJobData casts in write paths; each method now throws QueueCorruptionError on corrupt job.data instead of silently producing a malformed JobDefinition. 7 new integration tests.
+- ps-ts6a: fix(import-pk) — assertBaseUrlIsSafe + assertTokenIsSane guards at createPkApiImportSource entry match the import-sp pattern; prevents PK token exfiltration over plain HTTP or blank Authorization headers. 8 new unit tests.
+- ps-tfg2: fix(import-pk) — pk-error-classifier normalises thrown.status (number | string | undefined) before comparison; numeric statuses from pkapi.js (via axios) now classify correctly into 401/403/5xx instead of falling through to fatal-recoverable. 20 new unit tests.

--- a/packages/import-pk/src/__tests__/engine/error-classifier.test.ts
+++ b/packages/import-pk/src/__tests__/engine/error-classifier.test.ts
@@ -10,46 +10,127 @@ const CTX: ClassifyContext = { entityType: "member", entityId: "test-1" };
 /** Minimal fake API instance for APIError constructor. */
 const FAKE_API = new PKAPI({ token: "test-token" });
 
-function makeApiError(status: string): APIError {
-  return new APIError(FAKE_API, { status });
+/**
+ * APIError's constructor signature declares `status: string` but the runtime
+ * implementation just copies `data.status` through from axios' response. This
+ * helper sets the field from either a string or a number so tests exercise
+ * both shapes observed in the wild.
+ */
+function makeApiError(status: string | number | undefined): APIError {
+  const err = new APIError(FAKE_API, { status });
+  return err;
 }
 
 describe("classifyPkError", () => {
-  it("classifies 401 as fatal", () => {
-    expect(classifyPkError(makeApiError("401"), CTX).fatal).toBe(true);
+  describe("string statuses (legacy pkapi.js path)", () => {
+    it("classifies '401' as fatal and non-recoverable", () => {
+      const r = classifyPkError(makeApiError("401"), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: false });
+    });
+
+    it("classifies '403' as fatal and non-recoverable", () => {
+      const r = classifyPkError(makeApiError("403"), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: false });
+    });
+
+    it("classifies '429' as non-fatal", () => {
+      expect(classifyPkError(makeApiError("429"), CTX).fatal).toBe(false);
+    });
+
+    it("classifies '404' as non-fatal", () => {
+      expect(classifyPkError(makeApiError("404"), CTX).fatal).toBe(false);
+    });
+
+    it("classifies '500' as non-fatal (5xx range)", () => {
+      expect(classifyPkError(makeApiError("500"), CTX).fatal).toBe(false);
+    });
+
+    it("classifies '502' as non-fatal (5xx range)", () => {
+      expect(classifyPkError(makeApiError("502"), CTX).fatal).toBe(false);
+    });
+
+    it("classifies '599' as non-fatal (5xx upper bound inclusive)", () => {
+      expect(classifyPkError(makeApiError("599"), CTX).fatal).toBe(false);
+    });
+
+    it("classifies '418' as fatal but recoverable (unknown status)", () => {
+      const r = classifyPkError(makeApiError("418"), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
   });
 
-  it("classifies 403 as fatal", () => {
-    expect(classifyPkError(makeApiError("403"), CTX).fatal).toBe(true);
+  describe("numeric statuses (actual pkapi.js runtime path via axios)", () => {
+    // pkapi.js types status as `string` but the constructor receives
+    // e.response from axios, where response.status is a number. The
+    // classifier must handle both shapes identically.
+
+    it("classifies numeric 401 as fatal and non-recoverable", () => {
+      const r = classifyPkError(makeApiError(401), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: false });
+    });
+
+    it("classifies numeric 403 as fatal and non-recoverable", () => {
+      const r = classifyPkError(makeApiError(403), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: false });
+    });
+
+    it("classifies numeric 429 as non-fatal", () => {
+      expect(classifyPkError(makeApiError(429), CTX).fatal).toBe(false);
+    });
+
+    it("classifies numeric 404 as non-fatal", () => {
+      expect(classifyPkError(makeApiError(404), CTX).fatal).toBe(false);
+    });
+
+    it("classifies numeric 500 as non-fatal (5xx range)", () => {
+      expect(classifyPkError(makeApiError(500), CTX).fatal).toBe(false);
+    });
+
+    it("classifies numeric 503 as non-fatal (5xx range)", () => {
+      expect(classifyPkError(makeApiError(503), CTX).fatal).toBe(false);
+    });
+
+    it("classifies numeric 599 as non-fatal (5xx upper bound inclusive)", () => {
+      expect(classifyPkError(makeApiError(599), CTX).fatal).toBe(false);
+    });
+
+    it("classifies numeric 600 as fatal-recoverable (outside 5xx)", () => {
+      const r = classifyPkError(makeApiError(600), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("classifies numeric 418 as fatal but recoverable (unknown status)", () => {
+      const r = classifyPkError(makeApiError(418), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
   });
 
-  it("classifies 429 as non-fatal", () => {
-    expect(classifyPkError(makeApiError("429"), CTX).fatal).toBe(false);
+  describe("missing / malformed status", () => {
+    it("falls through to fatal-recoverable when status is the literal '???'", () => {
+      const r = classifyPkError(makeApiError("???"), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("falls through to fatal-recoverable when status is undefined", () => {
+      const r = classifyPkError(makeApiError(undefined), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("falls through to fatal-recoverable when status is a non-numeric string", () => {
+      const r = classifyPkError(makeApiError("not-a-status"), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
   });
 
-  it("classifies 500 as non-fatal", () => {
-    expect(classifyPkError(makeApiError("500"), CTX).fatal).toBe(false);
-  });
+  describe("non-APIError delegation", () => {
+    it("delegates a generic Error to the default classifier", () => {
+      const result = classifyPkError(new Error("generic"), CTX);
+      expect(result.fatal).toBe(false);
+      expect(result.message).toBe("generic");
+    });
 
-  it("classifies 502 as non-fatal", () => {
-    expect(classifyPkError(makeApiError("502"), CTX).fatal).toBe(false);
-  });
-
-  it("classifies 404 as non-fatal", () => {
-    expect(classifyPkError(makeApiError("404"), CTX).fatal).toBe(false);
-  });
-
-  it("classifies unknown status as fatal", () => {
-    expect(classifyPkError(makeApiError("418"), CTX).fatal).toBe(true);
-  });
-
-  it("delegates non-APIError to default classifier", () => {
-    const result = classifyPkError(new Error("generic"), CTX);
-    expect(result.fatal).toBe(false);
-    expect(result.message).toBe("generic");
-  });
-
-  it("classifies SyntaxError as fatal (via default)", () => {
-    expect(classifyPkError(new SyntaxError("bad json"), CTX).fatal).toBe(true);
+    it("classifies SyntaxError as fatal (via default classifier)", () => {
+      expect(classifyPkError(new SyntaxError("bad json"), CTX).fatal).toBe(true);
+    });
   });
 });

--- a/packages/import-pk/src/__tests__/engine/error-classifier.test.ts
+++ b/packages/import-pk/src/__tests__/engine/error-classifier.test.ts
@@ -120,6 +120,53 @@ describe("classifyPkError", () => {
       const r = classifyPkError(makeApiError("not-a-status"), CTX);
       expect(r).toMatchObject({ fatal: true, recoverable: true });
     });
+
+    it("treats NaN as unknown (normalise rejects non-finite)", () => {
+      const r = classifyPkError(makeApiError(Number.NaN), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("treats Infinity as unknown (normalise rejects non-finite)", () => {
+      const r = classifyPkError(makeApiError(Number.POSITIVE_INFINITY), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("treats -Infinity as unknown (normalise rejects non-finite)", () => {
+      const r = classifyPkError(makeApiError(Number.NEGATIVE_INFINITY), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("treats a negative numeric status as unknown (no HTTP status is <0)", () => {
+      const r = classifyPkError(makeApiError(-401), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("treats 0 as unknown (falls below the 5xx range)", () => {
+      const r = classifyPkError(makeApiError(0), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("parses hex-prefixed strings as the leading integer (base-10)", () => {
+      // `parseInt("0x1A4", 10)` returns `0` — the prefix is not a valid base-10 char.
+      const r = classifyPkError(makeApiError("0x1A4"), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("parses partial numeric strings using parseInt's prefix rule", () => {
+      // `parseInt("401abc", 10)` returns `401` — classifies as fatal non-recoverable.
+      const r = classifyPkError(makeApiError("401abc"), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: false });
+    });
+
+    it("treats an empty string as unknown (parseInt returns NaN)", () => {
+      const r = classifyPkError(makeApiError(""), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
+
+    it("treats whitespace-only strings as unknown (parseInt returns NaN)", () => {
+      const r = classifyPkError(makeApiError("  "), CTX);
+      expect(r).toMatchObject({ fatal: true, recoverable: true });
+    });
   });
 
   describe("non-APIError delegation", () => {

--- a/packages/import-pk/src/__tests__/sources/pk-api-source.test.ts
+++ b/packages/import-pk/src/__tests__/sources/pk-api-source.test.ts
@@ -121,6 +121,23 @@ describe("createPkApiImportSource", () => {
       ).not.toThrow();
     });
 
+    it("allows http://[::1] — IPv6 loopback with URL-bracket syntax", () => {
+      // Node's URL parser returns `[::1]` for the hostname; the guard strips
+      // the brackets before comparing against LOOPBACK_HOSTS.
+      expect(() =>
+        createPkApiImportSource({ token: "test-token", baseUrl: "http://[::1]:8080" }),
+      ).not.toThrow();
+    });
+
+    it("rejects a non-loopback IPv6 host over plaintext http", () => {
+      expect(() =>
+        createPkApiImportSource({
+          token: "test-token",
+          baseUrl: "http://[2001:db8::1]:8080",
+        }),
+      ).toThrow(/refusing to send API token to a non-HTTPS baseUrl/);
+    });
+
     it("rejects http:// baseUrl on a remote host", () => {
       expect(() =>
         createPkApiImportSource({ token: "test-token", baseUrl: "http://api.example.com" }),
@@ -151,6 +168,12 @@ describe("createPkApiImportSource", () => {
       expect(() => createPkApiImportSource({ token: "   " })).toThrow(
         /token must be a non-empty string/,
       );
+    });
+
+    it("preserves surrounding whitespace on an otherwise-valid token", () => {
+      // Tokens are opaque; silently trimming them would hide copy-paste bugs.
+      // The guard rejects empty-or-whitespace-only, not "has whitespace".
+      expect(() => createPkApiImportSource({ token: "  valid  " })).not.toThrow();
     });
   });
 

--- a/packages/import-pk/src/__tests__/sources/pk-api-source.test.ts
+++ b/packages/import-pk/src/__tests__/sources/pk-api-source.test.ts
@@ -101,6 +101,59 @@ describe("createPkApiImportSource", () => {
     expect(source.mode).toBe("api");
   });
 
+  describe("baseUrl safety", () => {
+    it("allows a default (undefined) baseUrl — pkapi.js applies its own HTTPS default", () => {
+      expect(() => createPkApiImportSource({ token: "test-token" })).not.toThrow();
+    });
+
+    it("allows an https:// baseUrl", () => {
+      expect(() =>
+        createPkApiImportSource({ token: "test-token", baseUrl: "https://api.example.com" }),
+      ).not.toThrow();
+    });
+
+    it("allows http://localhost for local dev against a mock or self-hosted PK", () => {
+      expect(() =>
+        createPkApiImportSource({ token: "test-token", baseUrl: "http://localhost:8080" }),
+      ).not.toThrow();
+      expect(() =>
+        createPkApiImportSource({ token: "test-token", baseUrl: "http://127.0.0.1:8080" }),
+      ).not.toThrow();
+    });
+
+    it("rejects http:// baseUrl on a remote host", () => {
+      expect(() =>
+        createPkApiImportSource({ token: "test-token", baseUrl: "http://api.example.com" }),
+      ).toThrow(/refusing to send API token to a non-HTTPS baseUrl/);
+    });
+
+    it("rejects non-http(s) protocol schemes", () => {
+      expect(() =>
+        createPkApiImportSource({ token: "test-token", baseUrl: "ftp://api.example.com" }),
+      ).toThrow(/refusing to send API token to a non-HTTPS baseUrl/);
+    });
+
+    it("rejects malformed baseUrl strings", () => {
+      expect(() => createPkApiImportSource({ token: "test-token", baseUrl: "not a url" })).toThrow(
+        /not a valid URL/,
+      );
+    });
+  });
+
+  describe("token safety", () => {
+    it("rejects an empty-string token", () => {
+      expect(() => createPkApiImportSource({ token: "" })).toThrow(
+        /token must be a non-empty string/,
+      );
+    });
+
+    it("rejects a whitespace-only token", () => {
+      expect(() => createPkApiImportSource({ token: "   " })).toThrow(
+        /token must be a non-empty string/,
+      );
+    });
+  });
+
   describe("member iteration", () => {
     it("yields doc events for each member", async () => {
       const membersMap = new Map([["abcde", makeMember()]]);

--- a/packages/import-pk/src/engine/error-classifier.ts
+++ b/packages/import-pk/src/engine/error-classifier.ts
@@ -4,20 +4,17 @@ import { APIError } from "pkapi.js";
 import type { ClassifyContext } from "@pluralscape/import-core";
 import type { ImportError } from "@pluralscape/types";
 
-/** HTTP 401 Unauthorized — bearer token missing or invalid. Fatal: no retry helps. */
+/** 401 Unauthorized / 403 Forbidden — fatal: no retry helps. */
 const HTTP_UNAUTHORIZED = 401;
-/** HTTP 403 Forbidden — token lacks permission. Fatal: no retry helps. */
 const HTTP_FORBIDDEN = 403;
-/** HTTP 404 Not Found — may be transient when the engine is mid-sync. Non-fatal. */
+/** 404 may resolve mid-sync as the engine completes prerequisite steps. */
 const HTTP_NOT_FOUND = 404;
-/** HTTP 429 Too Many Requests — PK is rate-limiting us. Non-fatal. */
+/** 429 — rate-limit, retry with backoff. */
 const HTTP_RATE_LIMITED = 429;
 /** Lower bound of the HTTP 5xx server-error range (inclusive). */
 const HTTP_SERVER_ERROR_MIN = 500;
 /** Upper bound of the HTTP 5xx server-error range (exclusive — next family starts at 600). */
 const HTTP_SERVER_ERROR_MAX_EXCLUSIVE = 600;
-/** Base for parseInt() on HTTP status codes. */
-const DECIMAL_RADIX = 10;
 
 /**
  * Normalise a pkapi.js `APIError.status` to a fixed numeric | undefined shape.
@@ -33,23 +30,40 @@ function normaliseStatus(raw: unknown): number | undefined {
     return Number.isFinite(raw) ? raw : undefined;
   }
   if (typeof raw === "string") {
-    const parsed = Number.parseInt(raw, DECIMAL_RADIX);
+    const parsed = Number.parseInt(raw, 10);
     return Number.isFinite(parsed) ? parsed : undefined;
   }
   return undefined;
 }
 
-function isServerError(status: number): boolean {
+/**
+ * A status the engine should retry rather than surface as fatal: 429 (rate
+ * limit), 404 (may resolve when the engine finishes a prior step), and any
+ * 5xx (transient server-side failure).
+ */
+function isRetryableHttpStatus(status: number | undefined): boolean {
+  if (status === undefined) return false;
+  if (status === HTTP_RATE_LIMITED || status === HTTP_NOT_FOUND) return true;
   return status >= HTTP_SERVER_ERROR_MIN && status < HTTP_SERVER_ERROR_MAX_EXCLUSIVE;
+}
+
+/**
+ * Build a stable suffix for the error message without coercing non-primitive
+ * `thrown.status` shapes (arrays, objects) via String(). Falls back to `???`
+ * rather than producing `[object Object]`.
+ */
+function formatStatusSuffix(normalised: number | undefined, raw: unknown): string {
+  if (normalised !== undefined) return String(normalised);
+  if (typeof raw === "string" || typeof raw === "number") return String(raw);
+  return "???";
 }
 
 export function classifyPkError(thrown: unknown, ctx: ClassifyContext): ImportError {
   if (thrown instanceof APIError) {
     const status = normaliseStatus(thrown.status);
-    const messageSuffix = status ?? thrown.status ?? "???";
-    const message = thrown.message ?? `PK API error (${String(messageSuffix)})`;
+    const message = thrown.message ?? `PK API error (${formatStatusSuffix(status, thrown.status)})`;
 
-    // Auth failures are fatal and not recoverable — no point retrying with the same credentials
+    // 401/403: auth failures — no retry will succeed with the same credentials.
     if (status === HTTP_UNAUTHORIZED || status === HTTP_FORBIDDEN) {
       return {
         entityType: ctx.entityType,
@@ -60,12 +74,8 @@ export function classifyPkError(thrown: unknown, ctx: ClassifyContext): ImportEr
       };
     }
 
-    // Rate limit, server errors, and 404 are non-fatal — may resolve on retry
-    if (
-      status === HTTP_RATE_LIMITED ||
-      status === HTTP_NOT_FOUND ||
-      (status !== undefined && isServerError(status))
-    ) {
+    // 429 rate limit, 404 mid-sync, and 5xx transient failures — may resolve on retry.
+    if (isRetryableHttpStatus(status)) {
       return { entityType: ctx.entityType, entityId: ctx.entityId, message, fatal: false };
     }
 

--- a/packages/import-pk/src/engine/error-classifier.ts
+++ b/packages/import-pk/src/engine/error-classifier.ts
@@ -4,13 +4,53 @@ import { APIError } from "pkapi.js";
 import type { ClassifyContext } from "@pluralscape/import-core";
 import type { ImportError } from "@pluralscape/types";
 
+/** HTTP 401 Unauthorized — bearer token missing or invalid. Fatal: no retry helps. */
+const HTTP_UNAUTHORIZED = 401;
+/** HTTP 403 Forbidden — token lacks permission. Fatal: no retry helps. */
+const HTTP_FORBIDDEN = 403;
+/** HTTP 404 Not Found — may be transient when the engine is mid-sync. Non-fatal. */
+const HTTP_NOT_FOUND = 404;
+/** HTTP 429 Too Many Requests — PK is rate-limiting us. Non-fatal. */
+const HTTP_RATE_LIMITED = 429;
+/** Lower bound of the HTTP 5xx server-error range (inclusive). */
+const HTTP_SERVER_ERROR_MIN = 500;
+/** Upper bound of the HTTP 5xx server-error range (exclusive — next family starts at 600). */
+const HTTP_SERVER_ERROR_MAX_EXCLUSIVE = 600;
+/** Base for parseInt() on HTTP status codes. */
+const DECIMAL_RADIX = 10;
+
+/**
+ * Normalise a pkapi.js `APIError.status` to a fixed numeric | undefined shape.
+ *
+ * pkapi.js types `status` as `string`, but the runtime value is copied from
+ * axios' `response.status` — a number. Depending on fallback paths it can
+ * also arrive as the literal string `"???"`, a number stringified, or
+ * undefined. Normalising once at the top keeps every comparison branch
+ * agnostic to the original shape.
+ */
+function normaliseStatus(raw: unknown): number | undefined {
+  if (typeof raw === "number") {
+    return Number.isFinite(raw) ? raw : undefined;
+  }
+  if (typeof raw === "string") {
+    const parsed = Number.parseInt(raw, DECIMAL_RADIX);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function isServerError(status: number): boolean {
+  return status >= HTTP_SERVER_ERROR_MIN && status < HTTP_SERVER_ERROR_MAX_EXCLUSIVE;
+}
+
 export function classifyPkError(thrown: unknown, ctx: ClassifyContext): ImportError {
   if (thrown instanceof APIError) {
-    const status = thrown.status ?? "???";
-    const message = thrown.message ?? `PK API error (${status})`;
+    const status = normaliseStatus(thrown.status);
+    const messageSuffix = status ?? thrown.status ?? "???";
+    const message = thrown.message ?? `PK API error (${String(messageSuffix)})`;
 
     // Auth failures are fatal and not recoverable — no point retrying with the same credentials
-    if (status === "401" || status === "403") {
+    if (status === HTTP_UNAUTHORIZED || status === HTTP_FORBIDDEN) {
       return {
         entityType: ctx.entityType,
         entityId: ctx.entityId,
@@ -21,11 +61,16 @@ export function classifyPkError(thrown: unknown, ctx: ClassifyContext): ImportEr
     }
 
     // Rate limit, server errors, and 404 are non-fatal — may resolve on retry
-    if (status === "429" || status === "404" || status.startsWith("5")) {
+    if (
+      status === HTTP_RATE_LIMITED ||
+      status === HTTP_NOT_FOUND ||
+      (status !== undefined && isServerError(status))
+    ) {
       return { entityType: ctx.entityType, entityId: ctx.entityId, message, fatal: false };
     }
 
-    // Unknown API status — treat as fatal but potentially recoverable
+    // Unknown API status (including missing/malformed) — treat as fatal but
+    // potentially recoverable so the engine surfaces it without retry-looping.
     return {
       entityType: ctx.entityType,
       entityId: ctx.entityId,

--- a/packages/import-pk/src/sources/pk-api-source.ts
+++ b/packages/import-pk/src/sources/pk-api-source.ts
@@ -30,6 +30,42 @@ export interface PkApiImportSourceArgs {
   readonly baseUrl?: string;
 }
 
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/**
+ * Refuse to send the PK API token to a plaintext-HTTP baseUrl. The only
+ * exception is loopback, for local dev against a mock or self-hosted PK
+ * instance on the same machine. Mirrors the assertBaseUrlIsSafe guard in
+ * packages/import-sp/src/sources/api-source.ts — the last-line safety net
+ * that prevents a token from ever leaving the device over cleartext.
+ */
+function assertBaseUrlIsSafe(baseUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(`PK import: baseUrl is not a valid URL: ${baseUrl}`);
+  }
+  if (parsed.protocol === "https:") return;
+  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname)) return;
+  throw new Error(
+    `PK import: refusing to send API token to a non-HTTPS baseUrl (${baseUrl}). ` +
+      `Use https:// for remote hosts; http:// is only permitted for loopback (localhost, 127.0.0.1, ::1).`,
+  );
+}
+
+/**
+ * Reject obviously-invalid tokens before they reach pkapi.js. pkapi.js happily
+ * sends empty/whitespace tokens and surfaces a server 401 only after a round
+ * trip — which leaves a blank Authorization header on the wire. This guard
+ * short-circuits at the source boundary.
+ */
+function assertTokenIsSane(token: string): void {
+  if (typeof token !== "string" || token.trim().length === 0) {
+    throw new Error("PK import: token must be a non-empty string");
+  }
+}
+
 interface CollectedMemberPrivacy {
   readonly pkMemberId: string;
   readonly privacy?: Record<string, string>;
@@ -57,6 +93,12 @@ function extractTimestamp(sw: PkSwitch): string {
 }
 
 export function createPkApiImportSource(args: PkApiImportSourceArgs): ImportDataSource {
+  assertTokenIsSane(args.token);
+  // Only validate baseUrl when caller overrides the pkapi.js default — the
+  // SDK's built-in default (https://api.pluralkit.me) is already HTTPS and
+  // leaving `undefined` alone lets pkapi.js apply its own fallback.
+  if (args.baseUrl !== undefined) assertBaseUrlIsSafe(args.baseUrl);
+
   const api = new PKAPI({
     token: args.token,
     base_url: args.baseUrl,

--- a/packages/import-pk/src/sources/pk-api-source.ts
+++ b/packages/import-pk/src/sources/pk-api-source.ts
@@ -43,11 +43,14 @@ function assertBaseUrlIsSafe(baseUrl: string): void {
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
-  } catch {
-    throw new Error(`PK import: baseUrl is not a valid URL: ${baseUrl}`);
+  } catch (cause) {
+    throw new Error(`PK import: baseUrl is not a valid URL: ${baseUrl}`, { cause });
   }
+  // `URL.hostname` preserves the `[...]` brackets for IPv6 literals (e.g.
+  // `[::1]`). Strip them so the bare address compares against LOOPBACK_HOSTS.
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
   if (parsed.protocol === "https:") return;
-  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname)) return;
+  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(host)) return;
   throw new Error(
     `PK import: refusing to send API token to a non-HTTPS baseUrl (${baseUrl}). ` +
       `Use https:// for remote hosts; http:// is only permitted for loopback (localhost, 127.0.0.1, ::1).`,
@@ -59,9 +62,14 @@ function assertBaseUrlIsSafe(baseUrl: string): void {
  * sends empty/whitespace tokens and surfaces a server 401 only after a round
  * trip — which leaves a blank Authorization header on the wire. This guard
  * short-circuits at the source boundary.
+ *
+ * Note: the guard rejects empty-or-whitespace-only tokens but preserves any
+ * surrounding whitespace on an otherwise-valid token. Tokens are opaque
+ * secrets; silently trimming them is surprising and can mask copy-paste bugs
+ * that the caller should see as a 401 rather than a silent rewrite.
  */
 function assertTokenIsSane(token: string): void {
-  if (typeof token !== "string" || token.trim().length === 0) {
+  if (token.trim().length === 0) {
     throw new Error("PK import: token must be a non-empty string");
   }
 }

--- a/packages/import-sp/src/__tests__/sources/api-source.test.ts
+++ b/packages/import-sp/src/__tests__/sources/api-source.test.ts
@@ -82,6 +82,20 @@ describe("createApiImportSource — baseUrl safety", () => {
     ).not.toThrow();
   });
 
+  it("accepts plaintext http:// for [::1] (IPv6 loopback with URL brackets)", () => {
+    // Node's URL parser returns `[::1]` for the hostname; the guard strips
+    // the brackets before comparing against LOOPBACK_HOSTS.
+    expect(() =>
+      createApiImportSource({ ...DEFAULT_INPUT, baseUrl: "http://[::1]:4000" }),
+    ).not.toThrow();
+  });
+
+  it("rejects a non-loopback IPv6 host over plaintext http", () => {
+    expect(() =>
+      createApiImportSource({ ...DEFAULT_INPUT, baseUrl: "http://[2001:db8::1]:4000" }),
+    ).toThrow(/refusing to send API token to a non-HTTPS baseUrl/);
+  });
+
   it("throws on malformed baseUrl", () => {
     expect(() => createApiImportSource({ ...DEFAULT_INPUT, baseUrl: "not-a-url" })).toThrow(
       /baseUrl is not a valid URL/,

--- a/packages/import-sp/src/sources/api-source.ts
+++ b/packages/import-sp/src/sources/api-source.ts
@@ -177,11 +177,14 @@ function assertBaseUrlIsSafe(baseUrl: string): void {
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
-  } catch {
-    throw new Error(`SP import: baseUrl is not a valid URL: ${baseUrl}`);
+  } catch (cause) {
+    throw new Error(`SP import: baseUrl is not a valid URL: ${baseUrl}`, { cause });
   }
+  // `URL.hostname` preserves the `[...]` brackets for IPv6 literals (e.g.
+  // `[::1]`). Strip them so the bare address compares against LOOPBACK_HOSTS.
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
   if (parsed.protocol === "https:") return;
-  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(parsed.hostname)) return;
+  if (parsed.protocol === "http:" && LOOPBACK_HOSTS.has(host)) return;
   throw new Error(
     `SP import: refusing to send API token to a non-HTTPS baseUrl (${baseUrl}). ` +
       `Use https:// for remote hosts; http:// is only permitted for loopback (localhost, 127.0.0.1, ::1).`,

--- a/packages/queue/src/__tests__/bullmq-queue.integration.test.ts
+++ b/packages/queue/src/__tests__/bullmq-queue.integration.test.ts
@@ -780,6 +780,120 @@ describe.skipIf(!ctx.available)("BullMQJobQueue — branch coverage", () => {
     await expect(q.cancel(fakeId)).rejects.toBeInstanceOf(QueueCorruptionError);
   });
 
+  // ── Write-path fail-closed coverage (ps-74xz) ──────────────────────
+  //
+  // Every method that reads `job.data` from BullMQ must surface a typed
+  // QueueCorruptionError when the stored shape fails schema validation —
+  // the write paths must not silently accept a malformed StoredJobData.
+  //
+  // Pattern: enqueue a real job so BullMQ sets up its hash, drive the job
+  // to the status the method requires (if any), then rewrite the stored
+  // `data` hash field so its (type, payload) disagrees with the discriminated
+  // schema. All callers must then throw QueueCorruptionError.
+
+  async function corruptJobData(
+    redisConn: IORedis,
+    queueName: string,
+    jobId: JobId,
+  ): Promise<void> {
+    const rawKey = `bull:${queueName}:${jobId}`;
+    const current = await redisConn.hget(rawKey, "data");
+    if (current === null) throw new Error("expected BullMQ hash to contain `data`");
+    const parsed = JSON.parse(current) as Record<string, unknown>;
+    parsed["type"] = "webhook-deliver";
+    parsed["payload"] = { notADeliveryId: true };
+    await redisConn.hset(rawKey, "data", JSON.stringify(parsed));
+  }
+
+  it("dequeue throws QueueCorruptionError when next job has corrupt data", async () => {
+    const q = createQueue();
+    activeQueues.push(q);
+    if (redis === null) throw new Error("Valkey not available");
+
+    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
+    await corruptJobData(redis, q.name, job.id);
+
+    await expect(q.dequeue()).rejects.toBeInstanceOf(QueueCorruptionError);
+  });
+
+  it("acknowledge throws QueueCorruptionError when stored data is corrupt", async () => {
+    const q = createQueue();
+    activeQueues.push(q);
+    if (redis === null) throw new Error("Valkey not available");
+
+    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
+    // Drive job to 'running' before corrupting so acknowledge's status check
+    // is reachable; then rewrite data so the parse step fails first.
+    await dequeueOrFail(q);
+    await corruptJobData(redis, q.name, job.id);
+
+    await expect(q.acknowledge(job.id, {})).rejects.toBeInstanceOf(QueueCorruptionError);
+  });
+
+  it("fail throws QueueCorruptionError when stored data is corrupt", async () => {
+    const q = createQueue();
+    activeQueues.push(q);
+    if (redis === null) throw new Error("Valkey not available");
+
+    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
+    await dequeueOrFail(q);
+    await corruptJobData(redis, q.name, job.id);
+
+    await expect(q.fail(job.id, "boom")).rejects.toBeInstanceOf(QueueCorruptionError);
+  });
+
+  it("retry throws QueueCorruptionError when BullMQ-store data is corrupt", async () => {
+    const q = createQueue();
+    activeQueues.push(q);
+    if (redis === null) throw new Error("Valkey not available");
+
+    // Produce a job with stored data corruption while still in BullMQ (not
+    // yet promoted to the cancelled store). retry() reads via queue.getJob
+    // and must surface QueueCorruptionError rather than a raw ZodError.
+    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
+    await corruptJobData(redis, q.name, job.id);
+
+    await expect(q.retry(job.id)).rejects.toBeInstanceOf(QueueCorruptionError);
+  });
+
+  it("cancel throws QueueCorruptionError when BullMQ-store data is corrupt", async () => {
+    const q = createQueue();
+    activeQueues.push(q);
+    if (redis === null) throw new Error("Valkey not available");
+
+    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
+    await corruptJobData(redis, q.name, job.id);
+
+    await expect(q.cancel(job.id)).rejects.toBeInstanceOf(QueueCorruptionError);
+  });
+
+  it("heartbeat throws QueueCorruptionError when stored data is corrupt", async () => {
+    const q = createQueue();
+    activeQueues.push(q);
+    if (redis === null) throw new Error("Valkey not available");
+
+    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
+    await dequeueOrFail(q);
+    await corruptJobData(redis, q.name, job.id);
+
+    await expect(q.heartbeat(job.id)).rejects.toBeInstanceOf(QueueCorruptionError);
+  });
+
+  it("findStalledJobs throws QueueCorruptionError when an active job has corrupt data", async () => {
+    const q = createQueue();
+    activeQueues.push(q);
+    if (redis === null) throw new Error("Valkey not available");
+
+    // A job in BullMQ's "active" state with corrupt stored data must fail
+    // closed — findStalledJobs used to silently skip these, hiding potential
+    // stalled-detection gaps from operators.
+    const job = await q.enqueue(makeJobParams({ type: "sync-push", timeoutMs: 1 }));
+    await dequeueOrFail(q);
+    await corruptJobData(redis, q.name, job.id);
+
+    await expect(q.findStalledJobs()).rejects.toBeInstanceOf(QueueCorruptionError);
+  });
+
   it("findStalledJobs skips a job whose stored status differs from running", async () => {
     const q = createQueue();
     activeQueues.push(q);

--- a/packages/queue/src/__tests__/bullmq-queue.integration.test.ts
+++ b/packages/queue/src/__tests__/bullmq-queue.integration.test.ts
@@ -503,11 +503,15 @@ describe.skipIf(!ctx.available)("BullMQJobQueue — branch coverage", () => {
     const rawKey = `bull:${q.name}:${job.id}`;
     const current = await redis.hget(rawKey, "data");
     if (current !== null) {
-      const parsed = JSON.parse(current) as Record<string, unknown>;
-      parsed["lastHeartbeatAt"] = null;
-      parsed["startedAt"] = null;
-      parsed["status"] = "running";
-      await redis.hset(rawKey, "data", JSON.stringify(parsed));
+      const parsed: unknown = JSON.parse(current);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error("expected `data` hash field to be a JSON object");
+      }
+      const obj = parsed as { [k: string]: unknown };
+      obj["lastHeartbeatAt"] = null;
+      obj["startedAt"] = null;
+      obj["status"] = "running";
+      await redis.hset(rawKey, "data", JSON.stringify(obj));
     }
 
     // With startedAt=null and lastHeartbeatAt=null the lastBeat guard returns false
@@ -805,93 +809,81 @@ describe.skipIf(!ctx.available)("BullMQJobQueue — branch coverage", () => {
     await redisConn.hset(rawKey, "data", JSON.stringify(parsed));
   }
 
-  it("dequeue throws QueueCorruptionError when next job has corrupt data", async () => {
+  // Each case drives the queue to the status the method requires, corrupts
+  // the stored data, and asserts the method surfaces QueueCorruptionError.
+  // `driveToRunning` — whether the job must be dequeued first so the method's
+  //   reachable parse path is the corrupt one (e.g. acknowledge/heartbeat).
+  // `timeoutMs` — overrides the default enqueue timeout; `findStalledJobs`
+  //   needs `1` so the stall check considers the job stalled if it parsed.
+  interface CorruptionCase {
+    readonly name: string;
+    readonly driveToRunning: boolean;
+    readonly timeoutMs?: number;
+    readonly invoke: (q: BullMQJobQueue, id: JobId) => Promise<unknown>;
+  }
+
+  const corruptionCases: readonly CorruptionCase[] = [
+    { name: "dequeue", driveToRunning: false, invoke: (q) => q.dequeue() },
+    { name: "acknowledge", driveToRunning: true, invoke: (q, id) => q.acknowledge(id, {}) },
+    { name: "fail", driveToRunning: true, invoke: (q, id) => q.fail(id, "boom") },
+    { name: "retry", driveToRunning: false, invoke: (q, id) => q.retry(id) },
+    { name: "cancel", driveToRunning: false, invoke: (q, id) => q.cancel(id) },
+    { name: "heartbeat", driveToRunning: true, invoke: (q, id) => q.heartbeat(id) },
+    {
+      name: "findStalledJobs",
+      driveToRunning: true,
+      timeoutMs: 1,
+      invoke: (q) => q.findStalledJobs(),
+    },
+  ];
+
+  it.each(corruptionCases)(
+    "$name throws QueueCorruptionError when stored data is corrupt",
+    async ({ driveToRunning, timeoutMs, invoke }) => {
+      const q = createQueue();
+      activeQueues.push(q);
+      if (redis === null) throw new Error("Valkey not available");
+
+      const enqueueOpts =
+        timeoutMs === undefined
+          ? { type: "sync-push" as const }
+          : { type: "sync-push" as const, timeoutMs };
+      const job = await q.enqueue(makeJobParams(enqueueOpts));
+      if (driveToRunning) await dequeueOrFail(q);
+      await corruptJobData(redis, q.name, job.id);
+
+      await expect(invoke(q, job.id)).rejects.toBeInstanceOf(QueueCorruptionError);
+    },
+  );
+
+  // ── findStalledJobs mixed-batch fail-closed (I2) ─────────────────────
+  //
+  // One corrupt active job aborts the ENTIRE sweep, not just that job's
+  // row. This is intentional — silently skipping corrupt records would
+  // hide stalled-detection gaps from operators. Documented explicitly so
+  // schedulers supervising this call don't assume partial success.
+
+  it("findStalledJobs aborts the whole sweep when one of several active jobs is corrupt", async () => {
     const q = createQueue();
     activeQueues.push(q);
     if (redis === null) throw new Error("Valkey not available");
 
-    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
-    await corruptJobData(redis, q.name, job.id);
+    const jobA = await q.enqueue(makeJobParams({ type: "sync-push", timeoutMs: 1 }));
+    const jobB = await q.enqueue(makeJobParams({ type: "sync-push", timeoutMs: 1 }));
+    const jobC = await q.enqueue(makeJobParams({ type: "sync-push", timeoutMs: 1 }));
 
-    await expect(q.dequeue()).rejects.toBeInstanceOf(QueueCorruptionError);
-  });
-
-  it("acknowledge throws QueueCorruptionError when stored data is corrupt", async () => {
-    const q = createQueue();
-    activeQueues.push(q);
-    if (redis === null) throw new Error("Valkey not available");
-
-    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
-    // Drive job to 'running' before corrupting so acknowledge's status check
-    // is reachable; then rewrite data so the parse step fails first.
     await dequeueOrFail(q);
-    await corruptJobData(redis, q.name, job.id);
-
-    await expect(q.acknowledge(job.id, {})).rejects.toBeInstanceOf(QueueCorruptionError);
-  });
-
-  it("fail throws QueueCorruptionError when stored data is corrupt", async () => {
-    const q = createQueue();
-    activeQueues.push(q);
-    if (redis === null) throw new Error("Valkey not available");
-
-    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
     await dequeueOrFail(q);
-    await corruptJobData(redis, q.name, job.id);
-
-    await expect(q.fail(job.id, "boom")).rejects.toBeInstanceOf(QueueCorruptionError);
-  });
-
-  it("retry throws QueueCorruptionError when BullMQ-store data is corrupt", async () => {
-    const q = createQueue();
-    activeQueues.push(q);
-    if (redis === null) throw new Error("Valkey not available");
-
-    // Produce a job with stored data corruption while still in BullMQ (not
-    // yet promoted to the cancelled store). retry() reads via queue.getJob
-    // and must surface QueueCorruptionError rather than a raw ZodError.
-    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
-    await corruptJobData(redis, q.name, job.id);
-
-    await expect(q.retry(job.id)).rejects.toBeInstanceOf(QueueCorruptionError);
-  });
-
-  it("cancel throws QueueCorruptionError when BullMQ-store data is corrupt", async () => {
-    const q = createQueue();
-    activeQueues.push(q);
-    if (redis === null) throw new Error("Valkey not available");
-
-    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
-    await corruptJobData(redis, q.name, job.id);
-
-    await expect(q.cancel(job.id)).rejects.toBeInstanceOf(QueueCorruptionError);
-  });
-
-  it("heartbeat throws QueueCorruptionError when stored data is corrupt", async () => {
-    const q = createQueue();
-    activeQueues.push(q);
-    if (redis === null) throw new Error("Valkey not available");
-
-    const job = await q.enqueue(makeJobParams({ type: "sync-push" }));
     await dequeueOrFail(q);
-    await corruptJobData(redis, q.name, job.id);
 
-    await expect(q.heartbeat(job.id)).rejects.toBeInstanceOf(QueueCorruptionError);
-  });
+    await corruptJobData(redis, q.name, jobB.id);
 
-  it("findStalledJobs throws QueueCorruptionError when an active job has corrupt data", async () => {
-    const q = createQueue();
-    activeQueues.push(q);
-    if (redis === null) throw new Error("Valkey not available");
-
-    // A job in BullMQ's "active" state with corrupt stored data must fail
-    // closed — findStalledJobs used to silently skip these, hiding potential
-    // stalled-detection gaps from operators.
-    const job = await q.enqueue(makeJobParams({ type: "sync-push", timeoutMs: 1 }));
-    await dequeueOrFail(q);
-    await corruptJobData(redis, q.name, job.id);
-
+    // Even though jobA and jobC parse cleanly and would be reported stalled,
+    // the first corrupt row short-circuits the sweep.
     await expect(q.findStalledJobs()).rejects.toBeInstanceOf(QueueCorruptionError);
+
+    void jobA;
+    void jobC;
   });
 
   it("findStalledJobs skips a job whose stored status differs from running", async () => {

--- a/packages/queue/src/adapters/bullmq/bullmq-job-queue.ts
+++ b/packages/queue/src/adapters/bullmq/bullmq-job-queue.ts
@@ -1,7 +1,6 @@
 import { brandId, extractErrorMessage, toUnixMillis } from "@pluralscape/types";
 import { createId, now } from "@pluralscape/types/runtime";
 import { Queue, Worker } from "bullmq";
-import { z } from "zod";
 
 import {
   IdempotencyConflictError,
@@ -10,7 +9,6 @@ import {
   QueueCorruptionError,
 } from "../../errors.js";
 import { fireHook } from "../../fire-hook.js";
-import { PayloadSchemaByType } from "../../payload-schemas.js";
 import { calculateBackoff, DEFAULT_RETRY_POLICY } from "../../policies/index.js";
 import {
   DEFAULT_TIMEOUT_MS,
@@ -20,7 +18,7 @@ import {
   SCAN_COUNT,
 } from "../../queue.constants.js";
 
-import { fromStoredData } from "./job-mapper.js";
+import { fromStoredData, StoredJobDataSchema } from "./job-mapper.js";
 
 import type { StoredJobData } from "./job-mapper.js";
 import type { JobEventHooks } from "../../event-hooks.js";
@@ -39,45 +37,17 @@ import type {
 import type { Job as BullMQJob } from "bullmq";
 import type IORedis from "ioredis";
 import type { RedisOptions } from "ioredis";
+import type { z } from "zod";
 
-const StoredJobDataSchema = z
-  .object({
-    systemId: z.string().nullable(),
-    type: z.string(),
-    payload: z.unknown(),
-    status: z.string(),
-    attempts: z.number(),
-    maxAttempts: z.number(),
-    nextRetryAt: z.number().nullable(),
-    error: z.string().nullable(),
-    result: z.unknown().nullable(),
-    createdAt: z.number(),
-    startedAt: z.number().nullable(),
-    completedAt: z.number().nullable(),
-    idempotencyKey: z.string().nullable(),
-    lastHeartbeatAt: z.number().nullable(),
-    timeoutMs: z.number(),
-    scheduledFor: z.number().nullable(),
-    priority: z.number(),
-  })
-  .superRefine((data, ctx) => {
-    // `data.type` is `string` at the deserialization boundary — look it up via
-    // `Object.hasOwn` + a narrowed access so TS treats the index result as
-    // possibly-undefined. Casting `data.type as JobType` here would tell TS
-    // the access is total and trip `no-unnecessary-condition` on the guard.
-    if (!Object.hasOwn(PayloadSchemaByType, data.type)) {
-      ctx.addIssue({ code: "custom", message: `Unknown job type: ${data.type}` });
-      return;
-    }
-    const schema = PayloadSchemaByType[data.type as JobType];
-    const r = schema.safeParse(data.payload);
-    if (!r.success) {
-      ctx.addIssue({
-        code: "custom",
-        message: `Payload mismatch for type ${data.type}: ${r.error.message}`,
-      });
-    }
-  });
+/**
+ * Render a Zod error as a compact, operator-readable summary: one
+ * `path: message` pair per issue, joined by "; ". Used as the `details`
+ * string passed to {@link QueueCorruptionError} so the top-level message
+ * surfaces the failing field without requiring callers to chase `cause`.
+ */
+function formatZodIssues(err: z.ZodError): string {
+  return err.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
+}
 
 function jobIdOf(job: BullMQJob): JobId {
   const id = job.id;
@@ -98,9 +68,11 @@ function jobIdOf(job: BullMQJob): JobId {
 function parseJobDataOrThrow(job: BullMQJob): StoredJobData {
   const result = StoredJobDataSchema.safeParse(job.data);
   if (!result.success) {
-    throw new QueueCorruptionError(jobIdOf(job), { cause: result.error });
+    throw new QueueCorruptionError(jobIdOf(job), formatZodIssues(result.error), {
+      cause: result.error,
+    });
   }
-  return result.data as StoredJobData;
+  return result.data;
 }
 
 /**
@@ -405,7 +377,7 @@ export class BullMQJobQueue implements JobQueue {
     const def = parseJobDataOrThrow(job);
 
     if (def.status !== "running") {
-      throw new InvalidJobTransitionError(jobId, def.status as JobStatus, "acknowledge");
+      throw new InvalidJobTransitionError(jobId, def.status, "acknowledge");
     }
 
     const currentTime = this.clock();
@@ -435,7 +407,7 @@ export class BullMQJobQueue implements JobQueue {
     const def = parseJobDataOrThrow(job);
 
     if (def.status !== "running") {
-      throw new InvalidJobTransitionError(jobId, def.status as JobStatus, "fail");
+      throw new InvalidJobTransitionError(jobId, def.status, "fail");
     }
 
     const newAttempts = def.attempts + 1;
@@ -483,9 +455,9 @@ export class BullMQJobQueue implements JobQueue {
     if (cancelledRaw !== null) {
       let parsed: StoredJobData;
       try {
-        parsed = StoredJobDataSchema.parse(JSON.parse(cancelledRaw)) as StoredJobData;
+        parsed = StoredJobDataSchema.parse(JSON.parse(cancelledRaw));
       } catch (err) {
-        throw new QueueCorruptionError(jobId, { cause: err });
+        throw new QueueCorruptionError(jobId, extractErrorMessage(err), { cause: err });
       }
       if (parsed.status !== "dead-letter") {
         throw new InvalidJobTransitionError(jobId, parsed.status, "retry");
@@ -508,7 +480,7 @@ export class BullMQJobQueue implements JobQueue {
 
     const def = parseJobDataOrThrow(job);
     if (def.status !== "dead-letter") {
-      throw new InvalidJobTransitionError(jobId, def.status as JobStatus, "retry");
+      throw new InvalidJobTransitionError(jobId, def.status, "retry");
     }
 
     const updated: StoredJobData = {
@@ -530,9 +502,9 @@ export class BullMQJobQueue implements JobQueue {
     if (cancelledRaw !== null) {
       let parsed: StoredJobData;
       try {
-        parsed = StoredJobDataSchema.parse(JSON.parse(cancelledRaw)) as StoredJobData;
+        parsed = StoredJobDataSchema.parse(JSON.parse(cancelledRaw));
       } catch (err) {
-        throw new QueueCorruptionError(jobId, { cause: err });
+        throw new QueueCorruptionError(jobId, extractErrorMessage(err), { cause: err });
       }
       if (parsed.status === "completed") {
         throw new InvalidJobTransitionError(jobId, "completed", "cancel");
@@ -567,7 +539,9 @@ export class BullMQJobQueue implements JobQueue {
     try {
       job = await this.queue.getJob(jobId);
     } catch (err) {
-      if (err instanceof SyntaxError) throw new QueueCorruptionError(jobId, { cause: err });
+      if (err instanceof SyntaxError) {
+        throw new QueueCorruptionError(jobId, extractErrorMessage(err), { cause: err });
+      }
       throw err;
     }
     if (job !== undefined) {
@@ -576,9 +550,11 @@ export class BullMQJobQueue implements JobQueue {
       // JobDefinition downstream.
       const parseResult = StoredJobDataSchema.safeParse(job.data);
       if (!parseResult.success) {
-        throw new QueueCorruptionError(jobId, { cause: parseResult.error });
+        throw new QueueCorruptionError(jobId, formatZodIssues(parseResult.error), {
+          cause: parseResult.error,
+        });
       }
-      return fromStoredData(jobIdOf(job), parseResult.data as StoredJobData);
+      return fromStoredData(jobIdOf(job), parseResult.data);
     }
 
     // Check cancelled store
@@ -586,9 +562,9 @@ export class BullMQJobQueue implements JobQueue {
     if (cancelledRaw !== null) {
       let parsed: StoredJobData;
       try {
-        parsed = StoredJobDataSchema.parse(JSON.parse(cancelledRaw)) as StoredJobData;
+        parsed = StoredJobDataSchema.parse(JSON.parse(cancelledRaw));
       } catch (err) {
-        throw new QueueCorruptionError(jobId, { cause: err });
+        throw new QueueCorruptionError(jobId, extractErrorMessage(err), { cause: err });
       }
       return fromStoredData(jobId, parsed);
     }
@@ -607,9 +583,11 @@ export class BullMQJobQueue implements JobQueue {
       // rather than silently yielding a malformed JobDefinition to callers.
       const parseResult = StoredJobDataSchema.safeParse(j.data);
       if (!parseResult.success) {
-        throw new QueueCorruptionError(jobIdOf(j), { cause: parseResult.error });
+        throw new QueueCorruptionError(jobIdOf(j), formatZodIssues(parseResult.error), {
+          cause: parseResult.error,
+        });
       }
-      return fromStoredData(jobIdOf(j), parseResult.data as StoredJobData);
+      return fromStoredData(jobIdOf(j), parseResult.data);
     });
 
     if (filter.status === undefined || filter.status === "cancelled") {
@@ -619,9 +597,7 @@ export class BullMQJobQueue implements JobQueue {
         if (raw !== null) {
           const id = brandId<JobId>(key.replace(`${this.prefix}:cancelled:`, ""));
           try {
-            allJobs.push(
-              fromStoredData(id, StoredJobDataSchema.parse(JSON.parse(raw)) as StoredJobData),
-            );
+            allJobs.push(fromStoredData(id, StoredJobDataSchema.parse(JSON.parse(raw))));
           } catch {
             this.logger.warn("Corrupt cancelled job data, skipping", { jobId: id });
           }
@@ -661,20 +637,30 @@ export class BullMQJobQueue implements JobQueue {
 
     const hbData = parseJobDataOrThrow(job);
     if (hbData.status !== "running") {
-      throw new InvalidJobTransitionError(jobId, hbData.status as JobStatus, "heartbeat");
+      throw new InvalidJobTransitionError(jobId, hbData.status, "heartbeat");
     }
 
     const updated: StoredJobData = { ...hbData, lastHeartbeatAt: this.clock() };
     await job.updateData(updated);
   }
 
+  /**
+   * Return every active job whose last heartbeat + timeout is in the past.
+   *
+   * **Fail-closed blast radius:** a single corrupt active job aborts the
+   * entire sweep with {@link QueueCorruptionError}. Schedulers calling this
+   * periodically MUST supervise that error — alert an operator, open a
+   * ticket, quarantine the bad key — rather than re-invoke blindly, since
+   * the corrupt record will keep tripping the guard until it is repaired
+   * or removed. The explicit trade-off vs. silent-skip is that a partial
+   * sweep can hide a real stall; here we prefer an obvious paged incident
+   * over a silent detection gap.
+   */
   async findStalledJobs(): Promise<readonly JobDefinition[]> {
     const currentTime = this.clock();
     const activeJobs = await this.queue.getJobs(["active"]);
 
     // Parse once per job, then reuse the validated shape in the map() pass.
-    // Fail-closed: a corrupt active job surfaces QueueCorruptionError rather
-    // than silently masking a stalled job detection gap.
     return activeJobs
       .map((job) => ({ job, data: parseJobDataOrThrow(job) }))
       .filter(({ data }) => {

--- a/packages/queue/src/adapters/bullmq/bullmq-job-queue.ts
+++ b/packages/queue/src/adapters/bullmq/bullmq-job-queue.ts
@@ -86,6 +86,24 @@ function jobIdOf(job: BullMQJob): JobId {
 }
 
 /**
+ * Validate a BullMQ job's `data` field against {@link StoredJobDataSchema} and
+ * return the parsed shape. Throws {@link QueueCorruptionError} on failure so
+ * callers surface a typed error rather than a raw ZodError leaking across the
+ * queue API boundary.
+ *
+ * Use this at every point where we deserialize `job.data` — silent casts let
+ * partial writes, schema drift, or manual Redis edits produce malformed
+ * JobDefinitions downstream, which violates the fail-closed contract.
+ */
+function parseJobDataOrThrow(job: BullMQJob): StoredJobData {
+  const result = StoredJobDataSchema.safeParse(job.data);
+  if (!result.success) {
+    throw new QueueCorruptionError(jobIdOf(job), { cause: result.error });
+  }
+  return result.data as StoredJobData;
+}
+
+/**
  * BullMQ-backed implementation of JobQueue.
  *
  * Uses a single BullMQ queue with our JobDefinition embedded in job data.
@@ -335,7 +353,7 @@ export class BullMQJobQueue implements JobQueue {
         const job = (await fetchWorker.getNextJob(this.token)) as BullMQJob | undefined;
         if (job === undefined) break;
 
-        const def = job.data as StoredJobData;
+        const def = parseJobDataOrThrow(job);
         // Check type filter
         if (types !== undefined && !types.includes(def.type)) {
           putBack.push(job);
@@ -384,7 +402,7 @@ export class BullMQJobQueue implements JobQueue {
 
   async acknowledge(jobId: JobId, result: { message?: string }): Promise<JobDefinition> {
     const job = await this.requireBullMQJob(jobId);
-    const def = job.data as StoredJobData;
+    const def = parseJobDataOrThrow(job);
 
     if (def.status !== "running") {
       throw new InvalidJobTransitionError(jobId, def.status as JobStatus, "acknowledge");
@@ -414,7 +432,7 @@ export class BullMQJobQueue implements JobQueue {
 
   async fail(jobId: JobId, error: string): Promise<JobDefinition> {
     const job = await this.requireBullMQJob(jobId);
-    const def = job.data as StoredJobData;
+    const def = parseJobDataOrThrow(job);
 
     if (def.status !== "running") {
       throw new InvalidJobTransitionError(jobId, def.status as JobStatus, "fail");
@@ -488,7 +506,7 @@ export class BullMQJobQueue implements JobQueue {
     const job = await this.queue.getJob(jobId);
     if (job === undefined) throw new JobNotFoundError(jobId);
 
-    const def = job.data as StoredJobData;
+    const def = parseJobDataOrThrow(job);
     if (def.status !== "dead-letter") {
       throw new InvalidJobTransitionError(jobId, def.status as JobStatus, "retry");
     }
@@ -527,7 +545,7 @@ export class BullMQJobQueue implements JobQueue {
     const job = await this.queue.getJob(jobId);
     if (job === undefined) throw new JobNotFoundError(jobId);
 
-    const def = job.data as StoredJobData;
+    const def = parseJobDataOrThrow(job);
     if (def.status === "completed") {
       throw new InvalidJobTransitionError(jobId, "completed", "cancel");
     }
@@ -641,7 +659,7 @@ export class BullMQJobQueue implements JobQueue {
     const job = await this.queue.getJob(jobId);
     if (job === undefined) throw new JobNotFoundError(jobId);
 
-    const hbData = job.data as StoredJobData;
+    const hbData = parseJobDataOrThrow(job);
     if (hbData.status !== "running") {
       throw new InvalidJobTransitionError(jobId, hbData.status as JobStatus, "heartbeat");
     }
@@ -654,15 +672,18 @@ export class BullMQJobQueue implements JobQueue {
     const currentTime = this.clock();
     const activeJobs = await this.queue.getJobs(["active"]);
 
+    // Parse once per job, then reuse the validated shape in the map() pass.
+    // Fail-closed: a corrupt active job surfaces QueueCorruptionError rather
+    // than silently masking a stalled job detection gap.
     return activeJobs
-      .filter((job) => {
-        const d = job.data as StoredJobData;
-        if (d.status !== "running") return false;
-        const lastBeat = d.lastHeartbeatAt ?? d.startedAt;
+      .map((job) => ({ job, data: parseJobDataOrThrow(job) }))
+      .filter(({ data }) => {
+        if (data.status !== "running") return false;
+        const lastBeat = data.lastHeartbeatAt ?? data.startedAt;
         if (lastBeat === null) return false;
-        return lastBeat + d.timeoutMs < currentTime;
+        return lastBeat + data.timeoutMs < currentTime;
       })
-      .map((j) => fromStoredData(jobIdOf(j), j.data as StoredJobData));
+      .map(({ job, data }) => fromStoredData(jobIdOf(job), data));
   }
 
   getRetryPolicy(type: JobType): RetryPolicy {

--- a/packages/queue/src/adapters/bullmq/bullmq-job-worker.ts
+++ b/packages/queue/src/adapters/bullmq/bullmq-job-worker.ts
@@ -2,10 +2,11 @@ import { brandId, extractErrorMessage } from "@pluralscape/types";
 import { now } from "@pluralscape/types/runtime";
 import { Worker } from "bullmq";
 
+import { QueueCorruptionError } from "../../errors.js";
 import { BASE_36 } from "../../queue.constants.js";
 import { BaseJobWorker } from "../base-job-worker.js";
 
-import { fromStoredData } from "./job-mapper.js";
+import { fromStoredData, StoredJobDataSchema } from "./job-mapper.js";
 
 import type { StoredJobData } from "./job-mapper.js";
 import type { HeartbeatHandle } from "../../heartbeat.js";
@@ -111,8 +112,34 @@ export class BullMQJobWorker extends BaseJobWorker {
     if (rawId === undefined) throw new Error("BullMQ job missing id");
     const jobId = brandId<JobId>(rawId);
 
-    // Update status to running
-    const currentData = bullmqJob.data as StoredJobData;
+    // Validate stored data once, at the worker's entry point into BullMQ's
+    // untyped `job.data`. Fail-closed: corrupt data here surfaces as a
+    // typed QueueCorruptionError via queue.fail, not a silent `as` cast that
+    // carries malformed state into handler code.
+    const parseResult = StoredJobDataSchema.safeParse(bullmqJob.data);
+    if (!parseResult.success) {
+      const details = parseResult.error.issues
+        .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+        .join("; ");
+      const corruption = new QueueCorruptionError(jobId, details, {
+        cause: parseResult.error,
+      });
+      this.logger.error("worker.corrupt-job-data", {
+        jobId,
+        error: extractErrorMessage(corruption),
+      });
+      try {
+        await this.queue.fail(jobId, extractErrorMessage(corruption));
+      } catch (failErr) {
+        this.logger.error("worker.fail-delegation-error", {
+          jobId,
+          error: extractErrorMessage(failErr),
+        });
+      }
+      return;
+    }
+    const currentData: StoredJobData = parseResult.data;
+
     const runningData: StoredJobData = {
       ...currentData,
       status: "running",
@@ -142,9 +169,13 @@ export class BullMQJobWorker extends BaseJobWorker {
 
     const heartbeatHandle: HeartbeatHandle = {
       heartbeat: async () => {
-        const data = bullmqJob.data as StoredJobData;
         try {
-          await bullmqJob.updateData({ ...data, lastHeartbeatAt: this.clock() });
+          // Reuse the validated `runningData` captured above — the job is
+          // locked by our worker token for the duration of processing, so
+          // no other writer can have mutated `bullmqJob.data` between
+          // heartbeats. Re-reading `bullmqJob.data` would bypass schema
+          // validation for no gain.
+          await bullmqJob.updateData({ ...runningData, lastHeartbeatAt: this.clock() });
         } catch (err) {
           const msg = `Heartbeat failed for job "${jobId}": ${extractErrorMessage(err)}`;
           this.logger.error("worker.heartbeat-update-failed", {

--- a/packages/queue/src/adapters/bullmq/job-mapper.ts
+++ b/packages/queue/src/adapters/bullmq/job-mapper.ts
@@ -1,13 +1,77 @@
-import { brandId, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
-
-import type {
-  JobDefinition,
-  JobId,
-  JobResult,
-  JobStatus,
-  JobType,
-  SystemId,
+import {
+  brandId,
+  JOB_STATUS_VALUES,
+  JOB_TYPE_VALUES,
+  toUnixMillis,
+  toUnixMillisOrNull,
 } from "@pluralscape/types";
+import { z } from "zod";
+
+import { PayloadSchemaByType } from "../../payload-schemas.js";
+
+import type { JobDefinition, JobId, JobStatus, JobType, SystemId } from "@pluralscape/types";
+
+/**
+ * Raw shape of a completed/failed result as persisted on-wire.
+ *
+ * Timestamps are plain numbers at the deserialization boundary — the
+ * `UnixMillis` brand is applied inside {@link fromStoredData}.
+ */
+export interface StoredJobResult {
+  readonly success: boolean;
+  readonly message: string | null;
+  readonly completedAt: number;
+}
+
+/**
+ * Schema for deserialized BullMQ `job.data`. Narrows `type` and `status` to
+ * their discriminated-union literals so the parsed value already satisfies
+ * {@link StoredJobData} without a trailing type assertion — the
+ * `superRefine` additionally enforces that `payload` matches the variant
+ * selected by `type`.
+ *
+ * Exported so every reader of `job.data` (queue adapter and worker alike)
+ * can share a single validator and fail-closed contract.
+ */
+export const StoredJobDataSchema = z
+  .object({
+    systemId: z.string().nullable(),
+    type: z.enum(JOB_TYPE_VALUES),
+    payload: z.record(z.string(), z.unknown()),
+    status: z.enum(JOB_STATUS_VALUES),
+    attempts: z.number(),
+    maxAttempts: z.number(),
+    nextRetryAt: z.number().nullable(),
+    error: z.string().nullable(),
+    // Raw on-wire shape: `completedAt` is a plain number at the
+    // deserialization boundary — it gets rebranded to `UnixMillis` inside
+    // `fromStoredData`.
+    result: z
+      .object({
+        success: z.boolean(),
+        message: z.string().nullable(),
+        completedAt: z.number(),
+      })
+      .nullable(),
+    createdAt: z.number(),
+    startedAt: z.number().nullable(),
+    completedAt: z.number().nullable(),
+    idempotencyKey: z.string().nullable(),
+    lastHeartbeatAt: z.number().nullable(),
+    timeoutMs: z.number(),
+    scheduledFor: z.number().nullable(),
+    priority: z.number(),
+  })
+  .superRefine((data, ctx) => {
+    const schema = PayloadSchemaByType[data.type];
+    const r = schema.safeParse(data.payload);
+    if (!r.success) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Payload mismatch for type ${data.type}: ${r.error.message}`,
+      });
+    }
+  });
 
 /**
  * The shape of data stored inside each BullMQ job.
@@ -22,7 +86,7 @@ export interface StoredJobData {
   maxAttempts: number;
   nextRetryAt: number | null;
   error: string | null;
-  result: JobResult | null;
+  result: StoredJobResult | null;
   createdAt: number;
   startedAt: number | null;
   completedAt: number | null;
@@ -52,7 +116,14 @@ export function fromStoredData(id: JobId, data: StoredJobData): JobDefinition {
     maxAttempts: data.maxAttempts,
     nextRetryAt: toUnixMillisOrNull(data.nextRetryAt ?? null),
     error: data.error ?? null,
-    result: data.result ?? null,
+    result:
+      data.result === null
+        ? null
+        : {
+            success: data.result.success,
+            message: data.result.message,
+            completedAt: toUnixMillis(data.result.completedAt),
+          },
     createdAt: toUnixMillis(data.createdAt),
     startedAt: toUnixMillisOrNull(data.startedAt ?? null),
     completedAt: toUnixMillisOrNull(data.completedAt ?? null),

--- a/packages/queue/src/adapters/sqlite/row-mapper.ts
+++ b/packages/queue/src/adapters/sqlite/row-mapper.ts
@@ -21,14 +21,16 @@ export function rowToJob(row: JobRow): JobDefinition {
   // dropped a type). Use `Object.hasOwn` to narrow the index access so the
   // subsequent safeParse is well-defined.
   if (!Object.hasOwn(PayloadSchemaByType, row.type)) {
-    throw new QueueCorruptionError(row.id, {
-      cause: new Error(`Unknown job type: ${row.type}`),
-    });
+    const cause = new Error(`Unknown job type: ${row.type}`);
+    throw new QueueCorruptionError(row.id, cause.message, { cause });
   }
   const schema = PayloadSchemaByType[row.type];
   const parsed = schema.safeParse(row.payload);
   if (!parsed.success) {
-    throw new QueueCorruptionError(row.id, { cause: parsed.error });
+    const details = parsed.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    throw new QueueCorruptionError(row.id, details, { cause: parsed.error });
   }
 
   return {

--- a/packages/queue/src/errors.ts
+++ b/packages/queue/src/errors.ts
@@ -75,13 +75,19 @@ export class DuplicateHandlerError extends Error {
  * Wraps the underlying parse error as `cause` so diagnostics are preserved
  * without leaking a bare `SyntaxError` / Zod `ZodError` across the queue API
  * boundary. Callers receive a typed, stable error they can branch on.
+ *
+ * Pass a `details` string to surface a compact, operator-readable summary in
+ * the top-level message — otherwise operators must chase `error.cause` for
+ * actionable context (path, field, reason). Keep details short; the full
+ * structured error stays on `cause`.
  */
 export class QueueCorruptionError extends Error {
   override readonly name = "QueueCorruptionError" as const;
   readonly jobId: JobId;
 
-  constructor(jobId: JobId, options?: ErrorOptions) {
-    super(`Corrupt stored data for job "${jobId}".`, options);
+  constructor(jobId: JobId, details?: string, options?: ErrorOptions) {
+    const base = `Corrupt stored data for job "${jobId}".`;
+    super(details === undefined || details.length === 0 ? base : `${base} ${details}`, options);
     this.jobId = jobId;
   }
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -433,6 +433,7 @@ export type {
   JobResult,
   JobDefinition,
 } from "./jobs.js";
+export { JOB_TYPE_VALUES, JOB_STATUS_VALUES } from "./jobs.js";
 
 // ── Blob ──────────────────────────────────────────────────────
 export type {

--- a/packages/types/src/jobs.ts
+++ b/packages/types/src/jobs.ts
@@ -18,31 +18,51 @@ export type EmailTemplateName =
   | "webhook-failure-digest"
   | "account-change-email";
 
+/**
+ * Runtime-visible enumeration of every supported job type.
+ *
+ * Expressed as a `const` tuple so it can double as a zod enum source at
+ * deserialization boundaries. Keep {@link JobType} derived from this tuple —
+ * a stray string literal in the type union but not in the tuple would silently
+ * slip past schema validation.
+ */
+export const JOB_TYPE_VALUES = [
+  "sync-push",
+  "sync-pull",
+  "blob-upload",
+  "blob-cleanup",
+  "export-generate",
+  "import-process",
+  "webhook-deliver",
+  "notification-send",
+  "analytics-compute",
+  "account-purge",
+  "bucket-key-rotation",
+  "report-generate",
+  "sync-queue-cleanup",
+  "audit-log-cleanup",
+  "partition-maintenance",
+  "sync-compaction",
+  "device-transfer-cleanup",
+  "check-in-generate",
+  "webhook-delivery-cleanup",
+  "email-send",
+] as const;
+
 /** The kind of background job. */
-export type JobType =
-  | "sync-push"
-  | "sync-pull"
-  | "blob-upload"
-  | "blob-cleanup"
-  | "export-generate"
-  | "import-process"
-  | "webhook-deliver"
-  | "notification-send"
-  | "analytics-compute"
-  | "account-purge"
-  | "bucket-key-rotation"
-  | "report-generate"
-  | "sync-queue-cleanup"
-  | "audit-log-cleanup"
-  | "partition-maintenance"
-  | "sync-compaction"
-  | "device-transfer-cleanup"
-  | "check-in-generate"
-  | "webhook-delivery-cleanup"
-  | "email-send";
+export type JobType = (typeof JOB_TYPE_VALUES)[number];
+
+/** Runtime-visible enumeration of every supported job status. */
+export const JOB_STATUS_VALUES = [
+  "pending",
+  "running",
+  "completed",
+  "cancelled",
+  "dead-letter",
+] as const;
 
 /** Current status of a background job. */
-export type JobStatus = "pending" | "running" | "completed" | "cancelled" | "dead-letter";
+export type JobStatus = (typeof JOB_STATUS_VALUES)[number];
 
 /** Backoff strategy for retry timing. */
 export type BackoffStrategy = "exponential" | "linear";


### PR DESCRIPTION
Implements the three high-priority audit findings from the 2026-04-20 audit for WT6 of the M9 Audit Remediation plan (epic `ps-v7el`).

## Beans

- **ps-74xz** fix(queue): validate BullMQ job.data with Zod in write paths
  Extracts a `parseJobDataOrThrow(job): StoredJobData` helper that runs `StoredJobDataSchema.safeParse` and throws `QueueCorruptionError` on failure. Replaces 7 bare `job.data as StoredJobData` casts in `dequeue`, `acknowledge`, `fail`, `retry`, `cancel`, `heartbeat`, and `findStalledJobs` so each write path fails closed when stored data disagrees with the discriminated schema. One integration test per method.

- **ps-ts6a** fix(import-pk): enforce HTTPS on PK API baseUrl
  Adds `assertBaseUrlIsSafe` and `assertTokenIsSane` guards to `createPkApiImportSource`, mirroring the `import-sp` pattern. Rejects non-HTTPS baseUrls for remote hosts (http:// only permitted for loopback) and empty/whitespace tokens. Prevents the PK token from leaving the device over cleartext or on a blank `Authorization` header.

- **ps-tfg2** fix(import-pk): handle numeric status in pk-error-classifier
  `pkapi.js` types `APIError.status` as string but copies it through from axios `response.status`, which is a number at runtime. The old classifier compared against string literals and used `.startsWith('5')`, so every numeric status fell through to fatal-recoverable. Normalises the status to `number | undefined` via a dedicated helper before comparison. 5xx detection now uses a numeric range. HTTP codes extracted to named constants.

## Test plan

- [x] `pnpm vitest run --project queue` / `queue-integration` — all passing
- [x] `pnpm vitest run --project import-pk` — 132 tests passing (was 112)
- [x] `pnpm test:unit` — 12616 passing, 1 skipped
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — zero warnings
- [ ] CI (`/verify`) — awaiting green tick before marking ready for review