### PR TITLE
chore(audit-m9): apps/mobile security and perf fixes

### DIFF
--- a/.beans/mobile-76ql--scope-searchindex-updated-invalidation-instead-of.md
+++ b/.beans/mobile-76ql--scope-searchindex-updated-invalidation-instead-of.md
@@ -1,12 +1,20 @@
 ---
 # mobile-76ql
 title: Scope search:index-updated invalidation instead of nuking all
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-04-20T09:22:51Z
-updated_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T19:00:04Z
 parent: mobile-e3l7
 ---
 
 Finding [PERF-2] from audit 2026-04-20. apps/mobile/src/data/query-invalidator.ts:31. Every materialized document fires search:index-updated, nuking all ['search', ...] entries regardless of scope. Fix: scope invalidation by entity type or search query text.
+
+## Summary of Changes
+
+Scoped the search:index-updated invalidation by the event's `scope` (`self` | `friend`) in apps/mobile/src/data/query-invalidator.ts. Previously every search index update blanket-invalidated all `["search", …]` queries regardless of scope; now a predicate matches the third key slot (scope) against the event scope so a self-scope materialization no longer purges friend search caches (and vice versa).
+
+Keys lacking the scope slot (e.g., a bare `["search"]` entry) fall through the predicate and stay cached.
+
+Tests: replaced the two scope-agnostic assertions with three cases covering predicate shape, per-scope match/reject behavior, and the friend-scope ↔ self-scope isolation invariant.

--- a/.beans/mobile-79vz--narrow-materializeddocument-invalidation-to-affect.md
+++ b/.beans/mobile-79vz--narrow-materializeddocument-invalidation-to-affect.md
@@ -1,12 +1,21 @@
 ---
 # mobile-79vz
 title: Narrow materialized:document invalidation to affected keys
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-04-20T09:22:51Z
-updated_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T18:58:55Z
 parent: mobile-e3l7
 ---
 
 Finding [PERF-1] from audit 2026-04-20. apps/mobile/src/data/query-invalidator.ts:22. invalidateQueries({ queryKey: [tableName] }) marks every cached query stale on every sync document event. Cascades in high-frequency scenarios. Fix: narrow invalidation when document type maps 1:1 to entity ID, similar to per-entity path at line 28.
+
+## Summary of Changes
+
+Narrowed the materialized:document invalidation path in apps/mobile/src/data/query-invalidator.ts to distinguish hot-path from non-hot-path entity types:
+
+- Hot-path entity types (fronting, chat, reactions, …) also emit per-entity materialized:entity events that already precisely invalidate detail queries (`[tableName, entityId]`). The document event now invalidates only list-shaped queries (`[tableName, "list", …]`) via a predicate that matches the `"list"` discriminator, leaving individual detail caches to the entity path.
+- Non-hot-path entity types never emit materialized:entity events, so the document event preserves the broad `[tableName]` invalidation for them (correctness fallback).
+
+Added unit tests asserting: non-hot-path documents fire without a predicate; hot-path documents fire with a predicate that accepts `[tableName, "list", …]` keys and rejects `[tableName, entityId]` detail keys on the same table.

--- a/.beans/mobile-c01j--production-appjson-hardcodes-httplocalhost3000-api.md
+++ b/.beans/mobile-c01j--production-appjson-hardcodes-httplocalhost3000-api.md
@@ -1,12 +1,25 @@
 ---
 # mobile-c01j
 title: Production app.json hardcodes http://localhost:3000 apiBaseUrl
-status: todo
+status: completed
 type: bug
 priority: critical
 created_at: 2026-04-20T09:21:02Z
-updated_at: 2026-04-20T09:21:02Z
+updated_at: 2026-04-20T18:47:46Z
 parent: mobile-e3l7
 ---
 
 Finding [CRIT-1] from audit 2026-04-20. apps/mobile/app.json:23. Prod build without override communicates over plaintext HTTP, bypassing ws:// guard (WS-only check). Fix: remove apiBaseUrl from app.json; require eas.json/env-specific config injection.
+
+## Summary of Changes
+
+Removed hardcoded http://localhost:3000 from apps/mobile/app.json. Production and preview apiBaseUrl values now ship via eas.json per-profile extras (production: https://api.pluralscape.app, preview: https://api-preview.pluralscape.app). Development profile keeps http://localhost:3000 for the local emulator.
+
+apps/mobile/src/config.ts now requires an apiBaseUrl value and throws on:
+
+- missing or non-string values
+- http:// in a non-dev build (production/preview)
+- http:// in a dev build for a non-loopback host
+- unsupported schemes
+
+Added apps/mobile/.env.example documenting the eas.json injection path and added a unit test covering every branch of the loader.

--- a/.beans/mobile-e3l7--audit-remediation-appsmobile-2026-04-20.md
+++ b/.beans/mobile-e3l7--audit-remediation-appsmobile-2026-04-20.md
@@ -1,12 +1,22 @@
 ---
 # mobile-e3l7
 title: "Audit remediation: apps/mobile (2026-04-20)"
-status: in-progress
+status: completed
 type: epic
 priority: critical
 created_at: 2026-04-20T09:20:30Z
-updated_at: 2026-04-20T18:43:29Z
+updated_at: 2026-04-20T19:01:36Z
 parent: ps-h2gl
 ---
 
 Remediation from comprehensive audit 2026-04-20. 1 Critical (plaintext HTTP fallback) + 4 High. See docs/local-audits/comprehensive-audit-2026-04-20/mobile.md. Tracking: ps-g937.
+
+## Summary of Changes
+
+Landed all 5 high-priority findings from the apps/mobile audit:
+
+- mobile-c01j (CRIT): removed hardcoded http://localhost:3000 from app.json. Per-profile apiBaseUrl now ships via eas.json extras (dev/preview/production). Loader throws on missing values and rejects http:// in non-dev builds or on non-loopback hosts.
+- mobile-scko: SP token SecureStore operations now pass WHEN_UNLOCKED_THIS_DEVICE_ONLY for parity across read/write/delete, blocking iCloud sync and keeping the token unreadable while the device is locked.
+- mobile-h89l: hoisted AsyncStorageI18nCache and createChainedBackend out of the locale-keyed useMemo into module-scope singletons.
+- mobile-79vz: document-level invalidation narrows hot-path tables to list-shaped queries via a predicate, preserving broad invalidation for non-hot-path tables.
+- mobile-76ql: search:index-updated invalidation now predicate-matches by scope so self-scope events do not purge friend search caches (and vice versa).

--- a/.beans/mobile-e3l7--audit-remediation-appsmobile-2026-04-20.md
+++ b/.beans/mobile-e3l7--audit-remediation-appsmobile-2026-04-20.md
@@ -1,11 +1,11 @@
 ---
 # mobile-e3l7
 title: "Audit remediation: apps/mobile (2026-04-20)"
-status: todo
+status: in-progress
 type: epic
 priority: critical
 created_at: 2026-04-20T09:20:30Z
-updated_at: 2026-04-20T09:20:30Z
+updated_at: 2026-04-20T18:43:29Z
 parent: ps-h2gl
 ---
 

--- a/.beans/mobile-h89l--hoist-i18nconfig-singletons-out-of-usememo.md
+++ b/.beans/mobile-h89l--hoist-i18nconfig-singletons-out-of-usememo.md
@@ -1,12 +1,18 @@
 ---
 # mobile-h89l
 title: Hoist i18nConfig singletons out of useMemo
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-04-20T09:22:51Z
-updated_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T18:52:19Z
 parent: mobile-e3l7
 ---
 
 Finding [PERF-3] from audit 2026-04-20. apps/mobile/app/\_layout.tsx:199-212. AsyncStorageI18nCache and createChainedBackend re-created on every locale change. Stateless singletons. Fix: module-level const or ref.
+
+## Summary of Changes
+
+Hoisted the AsyncStorageI18nCache and createChainedBackend constructions out of the locale-keyed useMemo in apps/mobile/app/\_layout.tsx into module-scope constants. They are stateless singletons (the cache closes over AsyncStorage + I18N_CACHE_TTL_MS; the backend closes over apiBaseUrl + loadBundled + the cache) and never needed to re-initialise on locale changes. The i18nConfig useMemo now just swaps the locale and reuses the hoisted backend.
+
+Updated app/**tests**/\_layout.test.tsx to use vi.hoisted for the mocked createChainedBackend stub, since the module-scope call now runs during import rather than during render.

--- a/.beans/mobile-scko--set-keychainaccessible-on-sp-token-securestore.md
+++ b/.beans/mobile-scko--set-keychainaccessible-on-sp-token-securestore.md
@@ -1,12 +1,22 @@
 ---
 # mobile-scko
 title: Set keychainAccessible on SP token SecureStore
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-20T09:22:51Z
-updated_at: 2026-04-20T09:22:51Z
+updated_at: 2026-04-20T18:50:37Z
 parent: mobile-e3l7
 ---
 
 Finding [HIGH-1] from audit 2026-04-20. apps/mobile/src/features/import-sp/sp-token-storage.ts:34-37. SecureStore.setItemAsync with no options inherits AFTER_FIRST_UNLOCK — readable while device locked and may be included in iCloud/Google encrypted backups. Fix: add { keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY }.
+
+## Summary of Changes
+
+Set keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY on every SecureStore call in apps/mobile/src/features/import-sp/sp-token-storage.ts (setItemAsync, getItemAsync on get()/hasToken(), and deleteItemAsync). The SP token is no longer readable while the device is locked and is excluded from iCloud Keychain sync and cross-device encrypted-backup restores.
+
+Hardened options are applied for parity across read/write/delete calls even though iOS binds the accessibility class at write time — keeps intent obvious and guards against future platform changes that might expose per-call overrides.
+
+Tests: added four keychainAccessible assertion cases to sp-token-storage.test.ts (one per SecureStore method). Extended the shared expo-secure-store mock with per-method option capture so the assertions observe the options actually passed. Added the keychain-accessibility constants to the inline mock in import.hooks.test.tsx.
+
+Scope note: expo-secure-token-store.ts (auth session token) already sets WHEN_UNLOCKED_THIS_DEVICE_ONLY; no other SecureStore secret needed an update in this bean.

--- a/.beans/ps-n2dd--pr-529-audit-follow-up-fixes.md
+++ b/.beans/ps-n2dd--pr-529-audit-follow-up-fixes.md
@@ -1,11 +1,44 @@
 ---
 # ps-n2dd
 title: "PR #529 audit follow-up fixes"
-status: in-progress
+status: completed
 type: task
 priority: high
 created_at: 2026-04-20T20:39:16Z
-updated_at: 2026-04-20T20:39:16Z
+updated_at: 2026-04-20T21:00:03Z
 ---
 
 Fix two critical regressions in query-invalidator plus \_layout error boundary, config URL parsing, expo-constants types, and test mock cleanup. See PR #529 review.
+
+## Summary of Changes
+
+Five commits on `chore/audit-m9-mobile-followup` (branched from `origin/chore/audit-m9-mobile`):
+
+1. **fix(mobile): match search invalidation against query-scope vocabulary** — Event scope (`"self"|"friend"`) and query scope (`"self"|"friends"|"all"`) are different unions. The previous predicate equality check never matched the default `"all"` query scope, leaving every default search stale. Replaced with a `queryScopesToInvalidate` mapping.
+
+2. **fix(mobile): fall back to broad invalidation for compound detail keys** — `messages` is hotPath but `useMessage` keys details as `[table, channelId, messageId]`. Hot-path narrowing skipped them, and entity events couldn't prefix-match either. Added `compoundDetailKey` flag to `EntityTableDef`, set on the `message` row; invalidator falls back to broad table invalidation when set.
+
+3. **fix(mobile): guard module-init errors with try/catch in \_layout** — Hoisted `createChainedBackend` called `getApiBaseUrl()` at module import. A throw there preempted React mount. Wrapped in try/catch; RootLayout surfaces the failure via the existing ErrorScreen boundary.
+
+4. **refactor(mobile): parse URL for scheme dispatch in config.ts** — Replaced fragile `startsWith("https://")/startsWith("http://")` chain with `new URL(...).protocol` switch. Catches `"HTTPS://..."` (case), `"http:example.com"` (malformed), `"http://[::1]:3000"` (IPv6 loopback). `getWsUrl` is now a pure scheme transform — `getApiBaseUrl` is the single validation choke point.
+
+5. **chore(mobile): drop redundant lastOptions map in secure-store test mock** — The keyed `lastOptions` map duplicated what `lastOptionsByMethod` already captured. Removed both map and `__lastOptions` accessor; migrated the one caller.
+
+**NOT actioned** from the plan:
+
+- **Suggestion 2 (expo-constants extras type augmentation)** — Upstream `{ [k: string]: any }` index signature in `@expo/config-types` wins the intersection, so module augmentation cannot actually narrow the type. Kept the original `const configured: unknown = ...` annotation (strictly widens `any` to `unknown`, forces the existing `typeof` guard — strictly MORE type-safe than dropping the cast).
+- **Suggestion 4 (eas.json preview DNS)** — out-of-code infra verification, noted in PR body.
+- **Follow-up bean: reshape `useMessage` key to `[table, messageId]`** — deferred per plan.
+
+## Verification
+
+- `pnpm typecheck` — clean across 21 packages
+- `pnpm lint` — clean across 17 packages
+- `pnpm vitest run --project mobile` — 1354/1354 pass
+- `pnpm vitest run --project sync` — 912/912 pass
+
+New test counts:
+
+- `query-invalidator.test.ts`: +5 tests (3 scope cases, 2 compoundDetailKey cases)
+- `_layout.test.tsx`: +2 tests (module-init error, backend hoisting invariant)
+- `config.test.ts`: +3 tests (case-insensitive https, malformed `http:example.com`, IPv6 loopback)

--- a/.beans/ps-n2dd--pr-529-audit-follow-up-fixes.md
+++ b/.beans/ps-n2dd--pr-529-audit-follow-up-fixes.md
@@ -1,0 +1,11 @@
+---
+# ps-n2dd
+title: "PR #529 audit follow-up fixes"
+status: in-progress
+type: task
+priority: high
+created_at: 2026-04-20T20:39:16Z
+updated_at: 2026-04-20T20:39:16Z
+---
+
+Fix two critical regressions in query-invalidator plus \_layout error boundary, config URL parsing, expo-constants types, and test mock cleanup. See PR #529 review.

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,8 @@
+# Pluralscape mobile client configuration.
+#
+# The apiBaseUrl is injected at build time via eas.json per-profile extras.
+# See eas.json for the dev / preview / production values.
+#
+# Production and preview builds must use https://; development builds may
+# use http:// but only for loopback hosts (localhost, 127.0.0.1, ::1).
+# Any other combination is rejected at runtime by src/config.ts.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -18,9 +18,6 @@
     "web": {
       "bundler": "metro",
       "output": "single"
-    },
-    "extra": {
-      "apiBaseUrl": "http://localhost:3000"
     }
   }
 }

--- a/apps/mobile/app/__tests__/_layout.test.tsx
+++ b/apps/mobile/app/__tests__/_layout.test.tsx
@@ -48,7 +48,7 @@ vi.mock("expo-router", () => ({
 }));
 
 vi.mock("expo-constants", () => ({
-  default: { expoConfig: { extra: { apiBaseUrl: "http://test:3000" } } },
+  default: { expoConfig: { extra: { apiBaseUrl: "https://test.example.com" } } },
 }));
 
 vi.mock("@microsoft/fetch-event-source", () => ({

--- a/apps/mobile/app/__tests__/_layout.test.tsx
+++ b/apps/mobile/app/__tests__/_layout.test.tsx
@@ -59,7 +59,15 @@ const mockDetectPlatform = vi.fn<() => Promise<PlatformContext>>();
 const mockCreateTokenStore = vi.fn<() => Promise<TokenStore>>();
 const mockDetectLocale = vi.fn<(locales: string[]) => string>().mockReturnValue("en");
 const mockApplyLayoutDirection = vi.fn<(locale: string) => void>();
-const mockCreateChainedBackend = vi.fn(() => ({ type: "backend" as const, read: vi.fn() }));
+
+// `_layout.tsx` hoists createChainedBackend/AsyncStorageI18nCache construction
+// to module scope, so the i18n mock factory has to return a real function
+// the moment the layout module is imported. `vi.hoisted` gives us a stub
+// that exists before any `vi.mock` factory runs.
+const { mockCreateChainedBackend } = vi.hoisted(() => ({
+  mockCreateChainedBackend: vi.fn(() => ({ type: "backend" as const, read: vi.fn() })),
+}));
+
 const mockLoadBundledNamespace = vi.fn(
   (locale: string, namespace: string): Promise<Readonly<Record<string, string>>> => {
     void locale;

--- a/apps/mobile/app/__tests__/_layout.test.tsx
+++ b/apps/mobile/app/__tests__/_layout.test.tsx
@@ -332,6 +332,51 @@ describe("RootLayout — error state", () => {
     expect(queryByTestId("redirect")).toBeNull();
   });
 
+  it("renders error screen when module-scope i18n construction throws", async () => {
+    // `getApiBaseUrl()` throws when eas.json extras are missing (e.g. web
+    // dev without the right profile, or CI without expo-constants config).
+    // Simulate that by making the hoisted `createChainedBackend` stub
+    // throw, then reimport the layout so its module-scope try/catch runs.
+    vi.resetModules();
+    mockCreateChainedBackend.mockImplementationOnce(() => {
+      throw new Error("apiBaseUrl is not configured. Set it via eas.json per-profile extras.");
+    });
+
+    const freshModule = await import("../_layout.js");
+    const FreshRootLayout = freshModule.default;
+
+    const { findByRole, queryByRole } = render(<FreshRootLayout />);
+    const retryBtn = await findByRole("button", { name: "Retry initialization" });
+    expect(retryBtn.tagName).toBe("BUTTON");
+    // Clicking the retry button must NOT crash — module-scope failure is
+    // non-recoverable, but the screen must not throw on interaction.
+    retryBtn.click();
+    expect(queryByRole("button", { name: "Retry initialization" })).not.toBeNull();
+  });
+
+  it("constructs the i18n backend exactly once across locale rerenders", async () => {
+    mockDetectPlatform.mockResolvedValue(makePlatformContext());
+    mockCreateTokenStore.mockResolvedValue(makeTokenStore());
+    // Flip detectLocale across renders so the locale state actually changes
+    // after initial mount. The backend factory is hoisted to module scope
+    // and must not run again for any of those transitions.
+    mockDetectLocale.mockReturnValueOnce("en");
+    mockDetectLocale.mockReturnValueOnce("fr");
+    mockDetectLocale.mockReturnValueOnce("es");
+
+    const initialCalls = mockCreateChainedBackend.mock.calls.length;
+
+    const { findByTestId, rerender } = render(<RootLayout />);
+    await findByTestId("redirect");
+    rerender(<RootLayout />);
+    rerender(<RootLayout />);
+
+    // Exactly one additional invocation beyond any previous test's toll,
+    // corresponding to this file's module import + RootLayout tree.
+    // (Module scope runs once; rerenders reuse the same singleton.)
+    expect(mockCreateChainedBackend.mock.calls.length - initialCalls).toBeLessThanOrEqual(1);
+  });
+
   it("renders error screen when token store creation rejects", async () => {
     mockDetectPlatform.mockResolvedValue(makePlatformContext());
     mockCreateTokenStore.mockRejectedValue(new Error("token store boom"));

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -40,12 +40,31 @@ import type { ReactNode } from "react";
 // so they are hoisted to module scope. Previously they were re-allocated on
 // every locale transition via a useMemo keyed on `locale`, which broke
 // reference equality for downstream consumers and churned garbage.
-const i18nCache = new AsyncStorageI18nCache(AsyncStorage, I18N_CACHE_TTL_MS);
-const i18nBackend = createChainedBackend({
-  apiBaseUrl: getApiBaseUrl(),
-  loadBundled: loadBundledNamespace,
-  cache: i18nCache,
-});
+//
+// `getApiBaseUrl()` throws if eas.json extras are misconfigured (missing or
+// non-https outside a dev build). Without a try/catch the throw runs during
+// module import — before React mounts — and the user sees an unstyled
+// redbox / white screen instead of the `ErrorScreen` boundary. Capture the
+// failure so `RootLayout` can render `ErrorScreen` on the first paint.
+type I18nBackendType = ReturnType<typeof createChainedBackend>;
+
+function noop(): void {
+  // Module-scope i18n failure is non-recoverable at runtime — see the
+  // ErrorScreen branch in RootLayout.
+}
+
+let i18nBackend: I18nBackendType | null = null;
+let i18nInitError: Error | null = null;
+try {
+  const i18nCache = new AsyncStorageI18nCache(AsyncStorage, I18N_CACHE_TTL_MS);
+  i18nBackend = createChainedBackend({
+    apiBaseUrl: getApiBaseUrl(),
+    loadBundled: loadBundledNamespace,
+    cache: i18nCache,
+  });
+} catch (err) {
+  i18nInitError = err instanceof Error ? err : new Error(String(err));
+}
 
 const styles = StyleSheet.create({
   centered: {
@@ -209,13 +228,16 @@ export default function RootLayout(): React.JSX.Element {
   const connectionManagerRef = useRef<ConnectionManager | null>(null);
   connectionManagerRef.current ??= new ConnectionManager(connectionConfig);
 
-  const i18nConfig = useMemo<I18nConfig>(
-    () => ({
-      locale,
-      fallbackLocale: DEFAULT_LOCALE,
-      resources: {},
-      backend: i18nBackend,
-    }),
+  const i18nConfig = useMemo<I18nConfig | null>(
+    () =>
+      i18nBackend === null
+        ? null
+        : {
+            locale,
+            fallbackLocale: DEFAULT_LOCALE,
+            resources: {},
+            backend: i18nBackend,
+          },
     [locale],
   );
 
@@ -257,11 +279,19 @@ export default function RootLayout(): React.JSX.Element {
     return tokenStore.getToken();
   }, [tokenStore]);
 
+  if (i18nInitError !== null) {
+    // Module-scope i18n construction failed (typically `getApiBaseUrl()`
+    // throwing on a misconfigured build). There is nothing to retry at
+    // runtime — retrying would re-run a module-scope singleton that has
+    // already thrown — so surface the error with a no-op retry handler.
+    return <ErrorScreen error={i18nInitError} onRetry={noop} />;
+  }
+
   if (initError !== null) {
     return <ErrorScreen error={initError} onRetry={initPlatform} />;
   }
 
-  if (platform === null || tokenStore === null) {
+  if (platform === null || tokenStore === null || i18nConfig === null) {
     return <LoadingSpinner />;
   }
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -34,6 +34,19 @@ import type { PlatformContext } from "../src/platform/index.js";
 import type { I18nConfig } from "@pluralscape/i18n";
 import type { ReactNode } from "react";
 
+// `AsyncStorageI18nCache` is stateless beyond the (storage, ttl) pair it is
+// constructed with, and `createChainedBackend` closes over the API base URL
+// plus a stateless cache/loader. Both are invariant across locale changes,
+// so they are hoisted to module scope. Previously they were re-allocated on
+// every locale transition via a useMemo keyed on `locale`, which broke
+// reference equality for downstream consumers and churned garbage.
+const i18nCache = new AsyncStorageI18nCache(AsyncStorage, I18N_CACHE_TTL_MS);
+const i18nBackend = createChainedBackend({
+  apiBaseUrl: getApiBaseUrl(),
+  loadBundled: loadBundledNamespace,
+  cache: i18nCache,
+});
+
 const styles = StyleSheet.create({
   centered: {
     flex: 1,
@@ -196,20 +209,15 @@ export default function RootLayout(): React.JSX.Element {
   const connectionManagerRef = useRef<ConnectionManager | null>(null);
   connectionManagerRef.current ??= new ConnectionManager(connectionConfig);
 
-  const i18nConfig = useMemo<I18nConfig>(() => {
-    const cache = new AsyncStorageI18nCache(AsyncStorage, I18N_CACHE_TTL_MS);
-    const backend = createChainedBackend({
-      apiBaseUrl: getApiBaseUrl(),
-      loadBundled: loadBundledNamespace,
-      cache,
-    });
-    return {
+  const i18nConfig = useMemo<I18nConfig>(
+    () => ({
       locale,
       fallbackLocale: DEFAULT_LOCALE,
       resources: {},
-      backend,
-    };
-  }, [locale]);
+      backend: i18nBackend,
+    }),
+    [locale],
+  );
 
   const initPlatform = useCallback(() => {
     setInitError(null);

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,30 @@
+{
+  "cli": {
+    "version": ">= 14.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "extra": {
+        "apiBaseUrl": "http://localhost:3000"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "extra": {
+        "apiBaseUrl": "https://api-preview.pluralscape.app"
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "extra": {
+        "apiBaseUrl": "https://api.pluralscape.app"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/apps/mobile/src/__tests__/config.test.ts
+++ b/apps/mobile/src/__tests__/config.test.ts
@@ -94,6 +94,29 @@ describe("getApiBaseUrl", () => {
     constants.__setConfig({ extra: { apiBaseUrl: "ftp://example.com" } });
     expect(() => getApiBaseUrl()).toThrow(/unsupported scheme/);
   });
+
+  it("accepts https:// case-insensitively (URL normalizes the scheme)", () => {
+    // `new URL(...)` lower-cases the scheme, so "HTTPS://..." is safe to
+    // accept. A `startsWith("https://")` check would reject it outright —
+    // URL-parse dispatch catches the intent.
+    constants.__setConfig({ extra: { apiBaseUrl: "HTTPS://api.example.com" } });
+    expect(getApiBaseUrl()).toBe("HTTPS://api.example.com");
+  });
+
+  it("rejects http:example.com (missing // authority) as a malformed URL", () => {
+    // `"http:example.com"` parses as `{ protocol: "http:", pathname: "example.com" }`
+    // with empty host — a startsWith chain would have waved it through as
+    // "starts with http:". URL-parse gates on protocol + empty hostname.
+    setDev(true);
+    constants.__setConfig({ extra: { apiBaseUrl: "http:example.com" } });
+    expect(() => getApiBaseUrl()).toThrow(/non-loopback host in a dev build/);
+  });
+
+  it("permits http://[::1] in a dev build (IPv6 loopback)", () => {
+    setDev(true);
+    constants.__setConfig({ extra: { apiBaseUrl: "http://[::1]:3000" } });
+    expect(getApiBaseUrl()).toBe("http://[::1]:3000");
+  });
 });
 
 describe("getWsUrl", () => {

--- a/apps/mobile/src/__tests__/config.test.ts
+++ b/apps/mobile/src/__tests__/config.test.ts
@@ -8,58 +8,107 @@ import { getApiBaseUrl, getWsUrl } from "../config";
 // resolves to our mock. Import helpers directly.
 import * as constants from "./expo-constants-mock";
 
+// React Native's runtime exposes `__DEV__` as a global; vitest (Node) does
+// not. Each test opts in by toggling this flag on globalThis so we can
+// exercise dev-only and non-dev branches deterministically.
+interface GlobalWithDev {
+  __DEV__: boolean;
+}
+
+function setDev(value: boolean): void {
+  (globalThis as Partial<GlobalWithDev>).__DEV__ = value;
+}
+
+function clearDev(): void {
+  delete (globalThis as Partial<GlobalWithDev>).__DEV__;
+}
+
 describe("getApiBaseUrl", () => {
   beforeEach(() => {
     constants.__reset();
+    clearDev();
   });
 
   afterEach(() => {
     constants.__reset();
+    clearDev();
   });
 
-  it("returns configured apiBaseUrl when present in extra", () => {
+  it("returns configured apiBaseUrl when it is an https URL", () => {
     constants.__setConfig({
       extra: { apiBaseUrl: "https://api.pluralscape.org" },
     });
     expect(getApiBaseUrl()).toBe("https://api.pluralscape.org");
   });
 
-  it("falls back to DEV_API_BASE_URL when apiBaseUrl is an empty string", () => {
+  it("returns configured http://localhost URL when running in a dev build", () => {
+    setDev(true);
+    constants.__setConfig({ extra: { apiBaseUrl: "http://localhost:3000" } });
+    expect(getApiBaseUrl()).toBe("http://localhost:3000");
+  });
+
+  it("permits http://127.0.0.1 in a dev build", () => {
+    setDev(true);
+    constants.__setConfig({ extra: { apiBaseUrl: "http://127.0.0.1:4000" } });
+    expect(getApiBaseUrl()).toBe("http://127.0.0.1:4000");
+  });
+
+  it("throws when apiBaseUrl is an empty string", () => {
     constants.__setConfig({ extra: { apiBaseUrl: "" } });
-    expect(getApiBaseUrl()).toBe("http://localhost:3000");
+    expect(() => getApiBaseUrl()).toThrow(/apiBaseUrl is not configured/);
   });
 
-  it("falls back to DEV_API_BASE_URL when apiBaseUrl is not a string", () => {
+  it("throws when apiBaseUrl is not a string", () => {
     constants.__setConfig({ extra: { apiBaseUrl: 42 } });
-    expect(getApiBaseUrl()).toBe("http://localhost:3000");
+    expect(() => getApiBaseUrl()).toThrow(/apiBaseUrl is not configured/);
   });
 
-  it("falls back to DEV_API_BASE_URL when apiBaseUrl is missing from extra", () => {
+  it("throws when apiBaseUrl is missing from extra", () => {
     constants.__setConfig({ extra: {} });
-    expect(getApiBaseUrl()).toBe("http://localhost:3000");
+    expect(() => getApiBaseUrl()).toThrow(/apiBaseUrl is not configured/);
   });
 
-  it("falls back to DEV_API_BASE_URL when extra is undefined", () => {
+  it("throws when extra is undefined", () => {
     constants.__setConfig({ extra: undefined });
-    expect(getApiBaseUrl()).toBe("http://localhost:3000");
+    expect(() => getApiBaseUrl()).toThrow(/apiBaseUrl is not configured/);
   });
 
-  it("falls back to DEV_API_BASE_URL when expoConfig is null", () => {
+  it("throws when expoConfig is null", () => {
     constants.__setConfig(null);
-    expect(getApiBaseUrl()).toBe("http://localhost:3000");
+    expect(() => getApiBaseUrl()).toThrow(/apiBaseUrl is not configured/);
+  });
+
+  it("throws when apiBaseUrl uses http:// in a non-dev build", () => {
+    setDev(false);
+    constants.__setConfig({ extra: { apiBaseUrl: "http://localhost:3000" } });
+    expect(() => getApiBaseUrl()).toThrow(/non-development build/);
+  });
+
+  it("throws when apiBaseUrl uses http:// in a dev build pointing at a non-loopback host", () => {
+    setDev(true);
+    constants.__setConfig({ extra: { apiBaseUrl: "http://api.pluralscape.app" } });
+    expect(() => getApiBaseUrl()).toThrow(/non-loopback host in a dev build/);
+  });
+
+  it("throws when apiBaseUrl has an unsupported scheme", () => {
+    constants.__setConfig({ extra: { apiBaseUrl: "ftp://example.com" } });
+    expect(() => getApiBaseUrl()).toThrow(/unsupported scheme/);
   });
 });
 
 describe("getWsUrl", () => {
   beforeEach(() => {
     constants.__reset();
+    clearDev();
   });
 
   afterEach(() => {
     constants.__reset();
+    clearDev();
   });
 
-  it("converts http base URL to ws and appends /sync", () => {
+  it("converts http loopback base URL to ws in a dev build", () => {
+    setDev(true);
     constants.__setConfig({
       extra: { apiBaseUrl: "http://localhost:3000" },
     });
@@ -73,27 +122,25 @@ describe("getWsUrl", () => {
     expect(getWsUrl()).toBe("wss://api.example.com/sync");
   });
 
-  it("uses dev fallback ws URL when no config present", () => {
-    expect(getWsUrl()).toBe("ws://localhost:3000/sync");
+  it("throws when no config is present (apiBaseUrl required)", () => {
+    expect(() => getWsUrl()).toThrow(/apiBaseUrl is not configured/);
   });
 
-  it("permits plaintext ws:// for 127.0.0.1", () => {
+  it("permits plaintext ws:// for 127.0.0.1 in a dev build", () => {
+    setDev(true);
     constants.__setConfig({ extra: { apiBaseUrl: "http://127.0.0.1:4000" } });
     expect(getWsUrl()).toBe("ws://127.0.0.1:4000/sync");
   });
 
-  it("permits plaintext ws:// for IPv6 loopback", () => {
+  it("permits plaintext ws:// for IPv6 loopback in a dev build", () => {
+    setDev(true);
     constants.__setConfig({ extra: { apiBaseUrl: "http://[::1]:3000" } });
     expect(getWsUrl()).toBe("ws://[::1]:3000/sync");
   });
 
-  it("throws when apiBaseUrl is http:// pointing at a non-loopback host", () => {
+  it("rejects apiBaseUrl http://non-loopback before WS derivation in non-dev builds", () => {
+    setDev(false);
     constants.__setConfig({ extra: { apiBaseUrl: "http://api.pluralscape.app" } });
-    expect(() => getWsUrl()).toThrow(/plaintext WebSocket to a non-loopback host/);
-  });
-
-  it("throws when apiBaseUrl is a malformed http URL", () => {
-    constants.__setConfig({ extra: { apiBaseUrl: "http://" } });
-    expect(() => getWsUrl()).toThrow(/plaintext WebSocket to a non-loopback host/);
+    expect(() => getWsUrl()).toThrow(/non-development build/);
   });
 });

--- a/apps/mobile/src/__tests__/expo-secure-store-mock.ts
+++ b/apps/mobile/src/__tests__/expo-secure-store-mock.ts
@@ -10,14 +10,17 @@ interface SecureStoreOptions {
   readonly authenticationPrompt?: string;
 }
 
+type SecureStoreMethod = "getItemAsync" | "setItemAsync" | "deleteItemAsync";
+
 const store = new Map<string, string>();
 const lastOptions = new Map<string, SecureStoreOptions | undefined>();
+const lastOptionsByMethod = new Map<string, SecureStoreOptions | undefined>();
 let throwOnNextOp: { method: string; error: Error } | null = null;
 
 // Mock the real expo-secure-store KeychainAccessibilityConstant values (strings,
-// not numbers). Production code in this repo does not currently pass options to
-// SecureStore.setItemAsync, but typing these as strings matches the real API so
-// future options-passing code won't fail at runtime against a number-typed mock.
+// not numbers). Production code in this repo passes these to options
+// parameters; typing them as strings matches the real API so options-passing
+// code exercises the same shapes the device sees.
 export const WHEN_UNLOCKED = "AccessibleWhenUnlocked" as const;
 export const WHEN_UNLOCKED_THIS_DEVICE_ONLY = "AccessibleWhenUnlockedThisDeviceOnly" as const;
 export const AFTER_FIRST_UNLOCK = "AccessibleAfterFirstUnlock" as const;
@@ -32,8 +35,13 @@ function maybeThrow(method: string): void {
   }
 }
 
-export function getItemAsync(key: string): Promise<string | null> {
+function byMethodKey(method: SecureStoreMethod, key: string): string {
+  return `${method}:${key}`;
+}
+
+export function getItemAsync(key: string, options?: SecureStoreOptions): Promise<string | null> {
   maybeThrow("getItemAsync");
+  lastOptionsByMethod.set(byMethodKey("getItemAsync", key), options);
   return Promise.resolve(store.has(key) ? (store.get(key) ?? null) : null);
 }
 
@@ -45,11 +53,13 @@ export function setItemAsync(
   maybeThrow("setItemAsync");
   store.set(key, value);
   lastOptions.set(key, options);
+  lastOptionsByMethod.set(byMethodKey("setItemAsync", key), options);
   return Promise.resolve();
 }
 
-export function deleteItemAsync(key: string): Promise<void> {
+export function deleteItemAsync(key: string, options?: SecureStoreOptions): Promise<void> {
   maybeThrow("deleteItemAsync");
+  lastOptionsByMethod.set(byMethodKey("deleteItemAsync", key), options);
   store.delete(key);
   return Promise.resolve();
 }
@@ -62,6 +72,7 @@ export function isAvailableAsync(): Promise<boolean> {
 export function __reset(): void {
   store.clear();
   lastOptions.clear();
+  lastOptionsByMethod.clear();
   throwOnNextOp = null;
 }
 
@@ -69,10 +80,14 @@ export function __lastOptions(key: string): SecureStoreOptions | undefined {
   return lastOptions.get(key);
 }
 
-export function __throwOnNext(
-  method: "getItemAsync" | "setItemAsync" | "deleteItemAsync",
-  error: Error,
-): void {
+export function __lastOptionsForMethod(
+  method: SecureStoreMethod,
+  key: string,
+): SecureStoreOptions | undefined {
+  return lastOptionsByMethod.get(byMethodKey(method, key));
+}
+
+export function __throwOnNext(method: SecureStoreMethod, error: Error): void {
   throwOnNextOp = { method, error };
 }
 

--- a/apps/mobile/src/__tests__/expo-secure-store-mock.ts
+++ b/apps/mobile/src/__tests__/expo-secure-store-mock.ts
@@ -13,7 +13,6 @@ interface SecureStoreOptions {
 type SecureStoreMethod = "getItemAsync" | "setItemAsync" | "deleteItemAsync";
 
 const store = new Map<string, string>();
-const lastOptions = new Map<string, SecureStoreOptions | undefined>();
 const lastOptionsByMethod = new Map<string, SecureStoreOptions | undefined>();
 let throwOnNextOp: { method: string; error: Error } | null = null;
 
@@ -52,7 +51,6 @@ export function setItemAsync(
 ): Promise<void> {
   maybeThrow("setItemAsync");
   store.set(key, value);
-  lastOptions.set(key, options);
   lastOptionsByMethod.set(byMethodKey("setItemAsync", key), options);
   return Promise.resolve();
 }
@@ -71,13 +69,8 @@ export function isAvailableAsync(): Promise<boolean> {
 // Test helpers — not part of the real expo-secure-store API.
 export function __reset(): void {
   store.clear();
-  lastOptions.clear();
   lastOptionsByMethod.clear();
   throwOnNextOp = null;
-}
-
-export function __lastOptions(key: string): SecureStoreOptions | undefined {
-  return lastOptions.get(key);
 }
 
 export function __lastOptionsForMethod(

--- a/apps/mobile/src/auth/__tests__/expo-secure-token-store.test.ts
+++ b/apps/mobile/src/auth/__tests__/expo-secure-token-store.test.ts
@@ -65,7 +65,7 @@ describe("expo-secure-token-store", () => {
     it("persists with WHEN_UNLOCKED_THIS_DEVICE_ONLY so the token does not travel in device backups", async () => {
       const store = createExpoSecureTokenStore();
       await store.setToken("accessibility-check");
-      const opts = secureStore.__lastOptions("pluralscape_session_token");
+      const opts = secureStore.__lastOptionsForMethod("setItemAsync", "pluralscape_session_token");
       expect(opts?.keychainAccessible).toBe(secureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY);
     });
 

--- a/apps/mobile/src/config.ts
+++ b/apps/mobile/src/config.ts
@@ -8,15 +8,6 @@ import Constants from "expo-constants";
  */
 const PLAINTEXT_ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
-function isPlaintextHostAllowed(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return PLAINTEXT_ALLOWED_HOSTS.has(parsed.hostname);
-  } catch {
-    return false;
-  }
-}
-
 /**
  * True in development builds (Metro, dev client). React Native exposes
  * `__DEV__` as a global; we tolerate its absence here so the config module
@@ -28,20 +19,13 @@ function isDevBuild(): boolean {
 }
 
 export function getWsUrl(): string {
+  // `getApiBaseUrl()` is the single choke point for scheme validation, so
+  // `base` is guaranteed to be https://… or an http://loopback URL here.
+  // A plain `/^http/ → ws/` regex therefore cannot produce a plaintext
+  // `ws://` to a non-loopback host.
   const base = getApiBaseUrl();
   const wsBase = base.replace(/^http(s?)/, "ws$1");
-  const wsUrl = `${wsBase}/sync`;
-  // Reject plaintext `ws://` on non-loopback hosts. In production builds the
-  // API URL is baked in at build time via eas.json extras — catching a bad
-  // apiBaseUrl here turns a silent downgrade into a visible failure before
-  // any session token is sent.
-  if (wsUrl.startsWith("ws://") && !isPlaintextHostAllowed(wsUrl)) {
-    throw new Error(
-      `Refusing to open a plaintext WebSocket to a non-loopback host: ${wsUrl}. ` +
-        `Configure apiBaseUrl to use https:// (which maps to wss://).`,
-    );
-  }
-  return wsUrl;
+  return `${wsBase}/sync`;
 }
 
 /**
@@ -55,12 +39,15 @@ export function getWsUrl(): string {
  * Throws a descriptive error if:
  *   - the value is missing (app.json/eas.json misconfiguration)
  *   - the value is not a non-empty string
- *   - the scheme is `http://` outside a dev build
- *   - the scheme is `http://` in a dev build but the host is not loopback
+ *   - the value is not a parseable URL
+ *   - the scheme is `http:` outside a dev build
+ *   - the scheme is `http:` in a dev build but the host is not loopback
+ *   - the scheme is anything other than `http:` / `https:`
  */
 export function getApiBaseUrl(): string {
-  const extra: Record<string, unknown> | undefined = Constants.expoConfig?.extra;
-  const configured: unknown = extra?.apiBaseUrl;
+  // `extra` is typed as `{ [k: string]: any }` by @expo/config-types, so an
+  // explicit `unknown` annotation is required to force narrowing before use.
+  const configured: unknown = Constants.expoConfig?.extra?.apiBaseUrl;
 
   if (typeof configured !== "string" || configured.length === 0) {
     throw new Error(
@@ -69,27 +56,38 @@ export function getApiBaseUrl(): string {
     );
   }
 
-  if (configured.startsWith("https://")) {
-    return configured;
+  // Parsing up-front normalizes scheme casing (`HTTPS://…` → `https:`) and
+  // rejects malformed inputs like `http:example.com` (missing `//`) before
+  // any `startsWith` check could wave them through.
+  let parsed: URL;
+  try {
+    parsed = new URL(configured);
+  } catch {
+    throw new Error(
+      `apiBaseUrl is not a valid URL: ${configured}. Expected https:// (or http:// for a dev-build loopback).`,
+    );
   }
 
-  if (configured.startsWith("http://")) {
-    if (!isDevBuild()) {
+  switch (parsed.protocol) {
+    case "https:":
+      return configured;
+    case "http:":
+      if (!isDevBuild()) {
+        throw new Error(
+          `Refusing plaintext apiBaseUrl (${configured}) in a non-development build. ` +
+            `Production and preview must use https://.`,
+        );
+      }
+      if (!PLAINTEXT_ALLOWED_HOSTS.has(parsed.hostname)) {
+        throw new Error(
+          `Refusing plaintext apiBaseUrl (${configured}) for a non-loopback host in a dev build. ` +
+            `Use https:// or point at localhost/127.0.0.1/::1.`,
+        );
+      }
+      return configured;
+    default:
       throw new Error(
-        `Refusing plaintext apiBaseUrl (${configured}) in a non-development build. ` +
-          `Production and preview must use https://.`,
+        `apiBaseUrl has an unsupported scheme: ${parsed.protocol}. Expected https:// (or http:// for a dev-build loopback).`,
       );
-    }
-    if (!isPlaintextHostAllowed(configured)) {
-      throw new Error(
-        `Refusing plaintext apiBaseUrl (${configured}) for a non-loopback host in a dev build. ` +
-          `Use https:// or point at localhost/127.0.0.1/::1.`,
-      );
-    }
-    return configured;
   }
-
-  throw new Error(
-    `apiBaseUrl has an unsupported scheme: ${configured}. Expected https:// (or http:// for a dev-build loopback).`,
-  );
 }

--- a/apps/mobile/src/config.ts
+++ b/apps/mobile/src/config.ts
@@ -1,21 +1,30 @@
 import Constants from "expo-constants";
 
-const DEV_API_BASE_URL = "http://localhost:3000";
-
 /**
- * Hostnames permitted to use plaintext `ws://`. Anything else must use TLS
- * (`wss://`) — a misconfigured production build that downgraded to `ws://`
- * would otherwise expose session tokens and sync payloads on the wire.
+ * Hostnames permitted to use plaintext `http://` / `ws://`. Anything else
+ * must use TLS (`https://` / `wss://`) — a misconfigured production build
+ * that downgraded to `http://` would otherwise expose session tokens and
+ * sync payloads on the wire.
  */
-const PLAINTEXT_WS_ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+const PLAINTEXT_ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 function isPlaintextHostAllowed(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return PLAINTEXT_WS_ALLOWED_HOSTS.has(parsed.hostname);
+    return PLAINTEXT_ALLOWED_HOSTS.has(parsed.hostname);
   } catch {
     return false;
   }
+}
+
+/**
+ * True in development builds (Metro, dev client). React Native exposes
+ * `__DEV__` as a global; we tolerate its absence here so the config module
+ * is safe to import in any host (including vitest).
+ */
+function isDevBuild(): boolean {
+  const dev = (globalThis as { __DEV__?: unknown }).__DEV__;
+  return dev === true;
 }
 
 export function getWsUrl(): string {
@@ -23,7 +32,7 @@ export function getWsUrl(): string {
   const wsBase = base.replace(/^http(s?)/, "ws$1");
   const wsUrl = `${wsBase}/sync`;
   // Reject plaintext `ws://` on non-loopback hosts. In production builds the
-  // API URL is baked in at build time via app.config — catching a bad
+  // API URL is baked in at build time via eas.json extras — catching a bad
   // apiBaseUrl here turns a silent downgrade into a visible failure before
   // any session token is sent.
   if (wsUrl.startsWith("ws://") && !isPlaintextHostAllowed(wsUrl)) {
@@ -35,11 +44,52 @@ export function getWsUrl(): string {
   return wsUrl;
 }
 
+/**
+ * Reads `apiBaseUrl` from Expo config extras. The value is injected at build
+ * time via `eas.json` per-profile extras (dev / preview / production); there
+ * is no source-tree default. Production and preview builds must use
+ * `https://`. Development builds may use `http://` but only for loopback
+ * hosts (localhost, 127.0.0.1, ::1) so a misconfigured dev environment
+ * cannot silently downgrade real traffic.
+ *
+ * Throws a descriptive error if:
+ *   - the value is missing (app.json/eas.json misconfiguration)
+ *   - the value is not a non-empty string
+ *   - the scheme is `http://` outside a dev build
+ *   - the scheme is `http://` in a dev build but the host is not loopback
+ */
 export function getApiBaseUrl(): string {
   const extra: Record<string, unknown> | undefined = Constants.expoConfig?.extra;
   const configured: unknown = extra?.apiBaseUrl;
-  if (typeof configured === "string" && configured.length > 0) {
+
+  if (typeof configured !== "string" || configured.length === 0) {
+    throw new Error(
+      "apiBaseUrl is not configured. Set it via eas.json per-profile extras " +
+        '(e.g., `{ "build": { "production": { "extra": { "apiBaseUrl": "https://api.pluralscape.app" } } } }`).',
+    );
+  }
+
+  if (configured.startsWith("https://")) {
     return configured;
   }
-  return DEV_API_BASE_URL;
+
+  if (configured.startsWith("http://")) {
+    if (!isDevBuild()) {
+      throw new Error(
+        `Refusing plaintext apiBaseUrl (${configured}) in a non-development build. ` +
+          `Production and preview must use https://.`,
+      );
+    }
+    if (!isPlaintextHostAllowed(configured)) {
+      throw new Error(
+        `Refusing plaintext apiBaseUrl (${configured}) for a non-loopback host in a dev build. ` +
+          `Use https:// or point at localhost/127.0.0.1/::1.`,
+      );
+    }
+    return configured;
+  }
+
+  throw new Error(
+    `apiBaseUrl has an unsupported scheme: ${configured}. Expected https:// (or http:// for a dev-build loopback).`,
+  );
 }

--- a/apps/mobile/src/data/__tests__/query-invalidator.test.ts
+++ b/apps/mobile/src/data/__tests__/query-invalidator.test.ts
@@ -195,7 +195,7 @@ describe("createQueryInvalidator", () => {
   });
 
   describe("search:index-updated", () => {
-    it("invalidates the search query key", () => {
+    it("invalidates the search key with a scope-filtering predicate", () => {
       createQueryInvalidator(eventBus, queryClient);
 
       eventBus.emit("search:index-updated", {
@@ -203,10 +203,32 @@ describe("createQueryInvalidator", () => {
         scope: "self",
       });
 
-      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["search"] });
+      expect(invalidateQueries).toHaveBeenCalledTimes(1);
+      const filters = filterAt(invalidateQueries, 0);
+      expect(filters.queryKey).toEqual(["search"]);
+      expect(hasPredicate(filters)).toBe(true);
     });
 
-    it("invalidates search regardless of scope", () => {
+    it("predicate matches only queries with matching scope", () => {
+      createQueryInvalidator(eventBus, queryClient);
+
+      eventBus.emit("search:index-updated", {
+        type: "search:index-updated",
+        scope: "self",
+      });
+
+      const predicate = requirePredicate(filterAt(invalidateQueries, 0));
+
+      // Matching scope → invalidated.
+      expect(predicate({ queryKey: ["search", "hello", "self"] })).toBe(true);
+      expect(predicate({ queryKey: ["search", "", "self"] })).toBe(true);
+      // Other scope → preserved.
+      expect(predicate({ queryKey: ["search", "hello", "friend"] })).toBe(false);
+      // Key shape without scope slot → preserved.
+      expect(predicate({ queryKey: ["search"] })).toBe(false);
+    });
+
+    it("a friend-scope event does not invalidate self-scope queries", () => {
       createQueryInvalidator(eventBus, queryClient);
 
       eventBus.emit("search:index-updated", {
@@ -215,7 +237,10 @@ describe("createQueryInvalidator", () => {
         documentType: "system-core",
       });
 
-      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["search"] });
+      const predicate = requirePredicate(filterAt(invalidateQueries, 0));
+
+      expect(predicate({ queryKey: ["search", "q", "friend"] })).toBe(true);
+      expect(predicate({ queryKey: ["search", "q", "self"] })).toBe(false);
     });
   });
 

--- a/apps/mobile/src/data/__tests__/query-invalidator.test.ts
+++ b/apps/mobile/src/data/__tests__/query-invalidator.test.ts
@@ -1,12 +1,33 @@
 import { createEventBus } from "@pluralscape/sync";
 import { QueryClient } from "@tanstack/react-query";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { createQueryInvalidator } from "../query-invalidator.js";
 
 import type { DataLayerEventMap, EventBus } from "@pluralscape/sync";
+import type { InvalidateQueryFilters, QueryKey } from "@tanstack/react-query";
 
 // ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Narrow stand-in for `QueryClient.invalidateQueries`. The bridge under
+ * test only ever calls the overload `(filters?) => Promise<void>`, so we
+ * type the mock with that signature and re-bind the client method to it.
+ */
+type InvalidateFn = (filters?: InvalidateQueryFilters) => Promise<void>;
+
+/** Predicate callback shape used inside the filter under test. */
+type QueryForPredicate = { readonly queryKey: QueryKey };
+type FilterPredicate = (query: QueryForPredicate) => boolean;
+
+/** Strongly-typed view of a filter that carries a predicate. */
+interface FilterWithPredicate extends InvalidateQueryFilters {
+  readonly predicate: FilterPredicate;
+}
+
+function hasPredicate(filters: InvalidateQueryFilters): filters is FilterWithPredicate {
+  return typeof filters.predicate === "function";
+}
 
 function makeEventBus(): EventBus<DataLayerEventMap> {
   return createEventBus<DataLayerEventMap>();
@@ -16,17 +37,48 @@ function makeQueryClient(): QueryClient {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
+function createInvalidateSpy(): Mock<InvalidateFn> {
+  return vi.fn<InvalidateFn>(() => Promise.resolve());
+}
+
+/**
+ * Rebinds `queryClient.invalidateQueries` to the spy so every call routes
+ * through a typed mock. This bypasses the overload soup of `vi.spyOn` while
+ * keeping strict typing (no `any`, no double-cast).
+ */
+function installInvalidateSpy(queryClient: QueryClient, spy: Mock<InvalidateFn>): void {
+  Object.defineProperty(queryClient, "invalidateQueries", {
+    configurable: true,
+    writable: true,
+    value: spy,
+  });
+}
+
+function filterAt(spy: Mock<InvalidateFn>, callIndex: number): InvalidateQueryFilters {
+  const call = spy.mock.calls[callIndex];
+  if (call === undefined) throw new Error(`no invalidate call at index ${String(callIndex)}`);
+  const [filters] = call;
+  if (filters === undefined) throw new Error(`call ${String(callIndex)} had no filter argument`);
+  return filters;
+}
+
+function requirePredicate(filters: InvalidateQueryFilters): FilterPredicate {
+  if (!hasPredicate(filters)) throw new Error("expected filters.predicate to be defined");
+  return filters.predicate;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────
 
 describe("createQueryInvalidator", () => {
   let eventBus: EventBus<DataLayerEventMap>;
   let queryClient: QueryClient;
-  let invalidateQueries: ReturnType<typeof vi.spyOn>;
+  let invalidateQueries: Mock<InvalidateFn>;
 
   beforeEach(() => {
     eventBus = makeEventBus();
     queryClient = makeQueryClient();
-    invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    invalidateQueries = createInvalidateSpy();
+    installInvalidateSpy(queryClient, invalidateQueries);
   });
 
   it("returns a cleanup function", () => {
@@ -34,23 +86,49 @@ describe("createQueryInvalidator", () => {
     expect(typeof cleanup).toBe("function");
   });
 
-  describe("materialized:document", () => {
-    it("invalidates all entity table keys for a document type", () => {
+  describe("materialized:document (non-hotPath tables — broad fallback)", () => {
+    it("invalidates the full table key for non-hotPath entity types", () => {
       createQueryInvalidator(eventBus, queryClient);
 
+      // `system-core` contains member/group/system/buckets — all hotPath: false.
       eventBus.emit("materialized:document", {
         type: "materialized:document",
         documentType: "system-core",
       });
 
-      // system-core entities include member → "members", group → "groups",
-      // system → "system", among others. Each gets a table-level invalidation.
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["members"] });
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["groups"] });
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["system"] });
+
+      // None of the non-hotPath calls carry a predicate (broad fallback).
+      for (const [i] of invalidateQueries.mock.calls.entries()) {
+        const filters = filterAt(invalidateQueries, i);
+        expect(filters.predicate).toBeUndefined();
+      }
+    });
+  });
+
+  describe("materialized:document (hotPath tables — narrowed to lists)", () => {
+    it("narrows invalidation to list-style queries for hotPath entity types", () => {
+      createQueryInvalidator(eventBus, queryClient);
+
+      // `fronting` document: every entity type is hotPath: true
+      // (fronting-session, fronting-comment, fronting-message, ...).
+      eventBus.emit("materialized:document", {
+        type: "materialized:document",
+        documentType: "fronting",
+      });
+
+      expect(invalidateQueries).toHaveBeenCalled();
+
+      // Every hotPath call carries the list-only predicate.
+      for (const [i] of invalidateQueries.mock.calls.entries()) {
+        const filters = filterAt(invalidateQueries, i);
+        expect(hasPredicate(filters)).toBe(true);
+      }
     });
 
-    it("does not invalidate with entity-level key on document event", () => {
+    it("predicate matches list queries and rejects detail queries on the same table", () => {
       createQueryInvalidator(eventBus, queryClient);
 
       eventBus.emit("materialized:document", {
@@ -58,12 +136,27 @@ describe("createQueryInvalidator", () => {
         documentType: "fronting",
       });
 
-      // All calls should be table-level only (single-element queryKey arrays)
-      expect(invalidateQueries).toHaveBeenCalled();
-      for (const call of invalidateQueries.mock.calls) {
-        const arg = call[0] as { queryKey: unknown[] };
-        expect(arg.queryKey).toHaveLength(1);
-      }
+      // Find the call for `fronting_sessions` — fronting-session is hotPath.
+      const sessionsIndex = invalidateQueries.mock.calls.findIndex((call) => {
+        const [filters] = call;
+        if (filters === undefined) return false;
+        const key = filters.queryKey;
+        return Array.isArray(key) && key[0] === "fronting_sessions";
+      });
+      expect(sessionsIndex).toBeGreaterThanOrEqual(0);
+
+      const predicate = requirePredicate(filterAt(invalidateQueries, sessionsIndex));
+
+      // The predicate is AND-composed with the `queryKey` prefix filter by
+      // React Query — it only runs for queries whose key starts with
+      // `[tableName]`. It therefore only needs to distinguish list queries
+      // from detail queries within the table.
+      //
+      // List query → matches.
+      expect(predicate({ queryKey: ["fronting_sessions", "list"] })).toBe(true);
+      expect(predicate({ queryKey: ["fronting_sessions", "list", true, "member-1"] })).toBe(true);
+      // Detail query → does NOT match (entity events cover these).
+      expect(predicate({ queryKey: ["fronting_sessions", "fs-1"] })).toBe(false);
     });
   });
 

--- a/apps/mobile/src/data/__tests__/query-invalidator.test.ts
+++ b/apps/mobile/src/data/__tests__/query-invalidator.test.ts
@@ -209,7 +209,7 @@ describe("createQueryInvalidator", () => {
       expect(hasPredicate(filters)).toBe(true);
     });
 
-    it("predicate matches only queries with matching scope", () => {
+    it("self-scope event invalidates self and all query scopes (not friends)", () => {
       createQueryInvalidator(eventBus, queryClient);
 
       eventBus.emit("search:index-updated", {
@@ -219,16 +219,18 @@ describe("createQueryInvalidator", () => {
 
       const predicate = requirePredicate(filterAt(invalidateQueries, 0));
 
-      // Matching scope → invalidated.
+      // The UI-side scope union is "self" | "friends" | "all" (see
+      // use-search.ts). A "self"-scope event corresponds to own-data
+      // materialization, which must invalidate both the "self"-only view
+      // and the default "all" view, but not a friends-only view.
       expect(predicate({ queryKey: ["search", "hello", "self"] })).toBe(true);
-      expect(predicate({ queryKey: ["search", "", "self"] })).toBe(true);
-      // Other scope → preserved.
-      expect(predicate({ queryKey: ["search", "hello", "friend"] })).toBe(false);
+      expect(predicate({ queryKey: ["search", "hello", "all"] })).toBe(true);
+      expect(predicate({ queryKey: ["search", "hello", "friends"] })).toBe(false);
       // Key shape without scope slot → preserved.
       expect(predicate({ queryKey: ["search"] })).toBe(false);
     });
 
-    it("a friend-scope event does not invalidate self-scope queries", () => {
+    it("friend-scope event invalidates friends and all query scopes (not self)", () => {
       createQueryInvalidator(eventBus, queryClient);
 
       eventBus.emit("search:index-updated", {
@@ -239,8 +241,24 @@ describe("createQueryInvalidator", () => {
 
       const predicate = requirePredicate(filterAt(invalidateQueries, 0));
 
-      expect(predicate({ queryKey: ["search", "q", "friend"] })).toBe(true);
+      expect(predicate({ queryKey: ["search", "q", "friends"] })).toBe(true);
+      expect(predicate({ queryKey: ["search", "q", "all"] })).toBe(true);
       expect(predicate({ queryKey: ["search", "q", "self"] })).toBe(false);
+    });
+
+    it("preserves queries whose scope slot is not a recognized string value", () => {
+      createQueryInvalidator(eventBus, queryClient);
+
+      eventBus.emit("search:index-updated", {
+        type: "search:index-updated",
+        scope: "self",
+      });
+
+      const predicate = requirePredicate(filterAt(invalidateQueries, 0));
+
+      expect(predicate({ queryKey: ["search", "q", "bogus"] })).toBe(false);
+      expect(predicate({ queryKey: ["search", "q", 42] })).toBe(false);
+      expect(predicate({ queryKey: ["search", "q", undefined] })).toBe(false);
     });
   });
 

--- a/apps/mobile/src/data/__tests__/query-invalidator.test.ts
+++ b/apps/mobile/src/data/__tests__/query-invalidator.test.ts
@@ -112,8 +112,8 @@ describe("createQueryInvalidator", () => {
     it("narrows invalidation to list-style queries for hotPath entity types", () => {
       createQueryInvalidator(eventBus, queryClient);
 
-      // `fronting` document: every entity type is hotPath: true
-      // (fronting-session, fronting-comment, fronting-message, ...).
+      // `fronting` document: fronting-session, fronting-comment,
+      // check-in-record — all hotPath: true, all simple detail keys.
       eventBus.emit("materialized:document", {
         type: "materialized:document",
         documentType: "fronting",
@@ -126,6 +126,55 @@ describe("createQueryInvalidator", () => {
         const filters = filterAt(invalidateQueries, i);
         expect(hasPredicate(filters)).toBe(true);
       }
+    });
+
+    it("falls back to broad invalidation for compoundDetailKey entity types", () => {
+      createQueryInvalidator(eventBus, queryClient);
+
+      // `chat` document contains `message`, which is hotPath AND carries
+      // `compoundDetailKey: true` because `useMessage` keys details as
+      // `["messages", channelId, messageId]`. Narrowing to `"list"` would
+      // leave those details stale, so the invalidator must fall back to a
+      // broad `{ queryKey: ["messages"] }` call with no predicate.
+      eventBus.emit("materialized:document", {
+        type: "materialized:document",
+        documentType: "chat",
+      });
+
+      const messagesCallIndex = invalidateQueries.mock.calls.findIndex((call) => {
+        const [filters] = call;
+        if (filters === undefined) return false;
+        const key = filters.queryKey;
+        return Array.isArray(key) && key[0] === "messages";
+      });
+      expect(messagesCallIndex).toBeGreaterThanOrEqual(0);
+
+      const filters = filterAt(invalidateQueries, messagesCallIndex);
+      expect(filters.predicate).toBeUndefined();
+      expect(filters.queryKey).toEqual(["messages"]);
+    });
+
+    it("still narrows to lists for hotPath entity types with simple detail keys (regression)", () => {
+      createQueryInvalidator(eventBus, queryClient);
+
+      // `fronting-session` is hotPath and has NO compoundDetailKey flag —
+      // the narrowing optimization should still apply to it so detail
+      // refetches remain cheap.
+      eventBus.emit("materialized:document", {
+        type: "materialized:document",
+        documentType: "fronting",
+      });
+
+      const sessionsCallIndex = invalidateQueries.mock.calls.findIndex((call) => {
+        const [filters] = call;
+        if (filters === undefined) return false;
+        const key = filters.queryKey;
+        return Array.isArray(key) && key[0] === "fronting_sessions";
+      });
+      expect(sessionsCallIndex).toBeGreaterThanOrEqual(0);
+
+      const filters = filterAt(invalidateQueries, sessionsCallIndex);
+      expect(hasPredicate(filters)).toBe(true);
     });
 
     it("predicate matches list queries and rejects detail queries on the same table", () => {

--- a/apps/mobile/src/data/query-invalidator.ts
+++ b/apps/mobile/src/data/query-invalidator.ts
@@ -1,7 +1,19 @@
 import { getEntityTypesForDocument, getTableDef } from "@pluralscape/sync/materializer";
 
 import type { DataLayerEventMap, EventBus } from "@pluralscape/sync";
-import type { QueryClient } from "@tanstack/react-query";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+
+/**
+ * Index into a React Query key at which list-style queries carry the
+ * `"list"` discriminator. See `src/hooks/use-*.ts` — all list hooks shape
+ * keys as `[tableName, "list", ...]` and detail hooks shape keys as
+ * `[tableName, entityId]`.
+ */
+const LIST_DISCRIMINATOR_INDEX = 1;
+
+function isListQuery(queryKey: QueryKey): boolean {
+  return queryKey[LIST_DISCRIMINATOR_INDEX] === "list";
+}
 
 /**
  * Bridges the sync/materialization event bus to React Query invalidations.
@@ -18,8 +30,23 @@ export function createQueryInvalidator(
   const unsubDocument = eventBus.on("materialized:document", (event) => {
     const entityTypes = getEntityTypesForDocument(event.documentType);
     for (const entityType of entityTypes) {
-      const { tableName } = getTableDef(entityType);
-      void queryClient.invalidateQueries({ queryKey: [tableName] });
+      const tableDef = getTableDef(entityType);
+      // Narrowing: for hot-path entity types, per-entity `materialized:entity`
+      // events (see `unsubEntity` below) already precisely invalidate detail
+      // queries (`[tableName, entityId]`). The document-level event only
+      // needs to cover list queries (`[tableName, "list", ...]`).
+      //
+      // For non-hot-path entity types no entity-level events fire, so the
+      // document event must broadly invalidate `[tableName]` to keep both
+      // list and detail queries in sync.
+      if (tableDef.hotPath) {
+        void queryClient.invalidateQueries({
+          queryKey: [tableDef.tableName],
+          predicate: (query) => isListQuery(query.queryKey),
+        });
+      } else {
+        void queryClient.invalidateQueries({ queryKey: [tableDef.tableName] });
+      }
     }
   });
 

--- a/apps/mobile/src/data/query-invalidator.ts
+++ b/apps/mobile/src/data/query-invalidator.ts
@@ -1,6 +1,10 @@
 import { getEntityTypesForDocument, getTableDef } from "@pluralscape/sync/materializer";
 
-import type { DataLayerEventMap, EventBus } from "@pluralscape/sync";
+import type {
+  DataLayerEventMap,
+  EventBus,
+  SearchScope as EventSearchScope,
+} from "@pluralscape/sync";
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
 
 /**
@@ -12,11 +16,32 @@ import type { QueryClient, QueryKey } from "@tanstack/react-query";
 const LIST_DISCRIMINATOR_INDEX = 1;
 
 /**
- * Index into a search query key at which the scope (`"self" | "friend"`)
- * appears. Search keys are shaped `["search", debouncedQuery, scope]`
- * (see `src/hooks/use-search.ts`).
+ * Index into a search query key at which the scope
+ * (`"self" | "friends" | "all"`) appears. Search keys are shaped
+ * `["search", debouncedQuery, scope]` (see `src/hooks/use-search.ts`).
  */
 const SEARCH_SCOPE_INDEX = 2;
+
+/**
+ * Maps an event's search scope (the data source that materialized) to the
+ * set of UI-side query scopes that must be invalidated.
+ *
+ * Event scope union: `"self" | "friend"` (see `@pluralscape/sync` event map).
+ * Query scope union: `"self" | "friends" | "all"` (see `use-search.ts`).
+ *
+ * A self-materialization invalidates both `"self"`-only and `"all"`-scope
+ * searches; a friend-materialization invalidates both `"friends"`-only and
+ * `"all"`-scope searches. The `"all"` default is critical — it's what
+ * `useSearch()` uses when no scope is passed explicitly.
+ */
+function queryScopesToInvalidate(scope: EventSearchScope): ReadonlySet<string> {
+  switch (scope) {
+    case "self":
+      return new Set(["self", "all"]);
+    case "friend":
+      return new Set(["friends", "all"]);
+  }
+}
 
 function isListQuery(queryKey: QueryKey): boolean {
   return queryKey[LIST_DISCRIMINATOR_INDEX] === "list";
@@ -63,15 +88,20 @@ export function createQueryInvalidator(
   });
 
   const unsubSearch = eventBus.on("search:index-updated", (event) => {
-    // Search queries are keyed `["search", debouncedQuery, scope]` (see
-    // `use-search.ts`). Scope the invalidation so a `self` materialization
-    // does not purge friend search caches (and vice versa). Queries that
-    // lack a scope slot (e.g., a bare `["search"]` entry) fall through
-    // the predicate and stay cached.
-    const { scope } = event;
+    // Search queries are keyed `["search", debouncedQuery, scope]` where the
+    // UI-side scope union is `"self" | "friends" | "all"` (see
+    // `use-search.ts`). The event's scope is the data-source that
+    // materialized (`"self" | "friend"`). Map through
+    // `queryScopesToInvalidate` so an "all"-scope default search is not
+    // left stale after either kind of event. Queries without a string
+    // scope slot fall through and stay cached.
+    const targetScopes = queryScopesToInvalidate(event.scope);
     void queryClient.invalidateQueries({
       queryKey: ["search"],
-      predicate: (query) => query.queryKey[SEARCH_SCOPE_INDEX] === scope,
+      predicate: (query) => {
+        const scopeSlot = query.queryKey[SEARCH_SCOPE_INDEX];
+        return typeof scopeSlot === "string" && targetScopes.has(scopeSlot);
+      },
     });
   });
 

--- a/apps/mobile/src/data/query-invalidator.ts
+++ b/apps/mobile/src/data/query-invalidator.ts
@@ -63,15 +63,20 @@ export function createQueryInvalidator(
     const entityTypes = getEntityTypesForDocument(event.documentType);
     for (const entityType of entityTypes) {
       const tableDef = getTableDef(entityType);
-      // Narrowing: for hot-path entity types, per-entity `materialized:entity`
-      // events (see `unsubEntity` below) already precisely invalidate detail
-      // queries (`[tableName, entityId]`). The document-level event only
-      // needs to cover list queries (`[tableName, "list", ...]`).
+      // Narrowing: for hot-path entity types whose detail keys are shaped
+      // `[tableName, entityId]`, per-entity `materialized:entity` events
+      // (see `unsubEntity` below) already precisely invalidate those detail
+      // queries. The document-level event only needs to cover list queries
+      // (`[tableName, "list", ...]`).
       //
-      // For non-hot-path entity types no entity-level events fire, so the
-      // document event must broadly invalidate `[tableName]` to keep both
-      // list and detail queries in sync.
-      if (tableDef.hotPath) {
+      // For non-hot-path entity types no entity-level events fire, and for
+      // hot-path entity types with compound detail keys (e.g., `messages`
+      // uses `[tableName, channelId, entityId]`) the list-only predicate
+      // would skip details that the entity-event prefix match also misses.
+      // In both cases the document event must broadly invalidate
+      // `[tableName]` so details stay fresh.
+      const canNarrowToLists = tableDef.hotPath && tableDef.compoundDetailKey !== true;
+      if (canNarrowToLists) {
         void queryClient.invalidateQueries({
           queryKey: [tableDef.tableName],
           predicate: (query) => isListQuery(query.queryKey),

--- a/apps/mobile/src/data/query-invalidator.ts
+++ b/apps/mobile/src/data/query-invalidator.ts
@@ -11,6 +11,13 @@ import type { QueryClient, QueryKey } from "@tanstack/react-query";
  */
 const LIST_DISCRIMINATOR_INDEX = 1;
 
+/**
+ * Index into a search query key at which the scope (`"self" | "friend"`)
+ * appears. Search keys are shaped `["search", debouncedQuery, scope]`
+ * (see `src/hooks/use-search.ts`).
+ */
+const SEARCH_SCOPE_INDEX = 2;
+
 function isListQuery(queryKey: QueryKey): boolean {
   return queryKey[LIST_DISCRIMINATOR_INDEX] === "list";
 }
@@ -55,8 +62,17 @@ export function createQueryInvalidator(
     void queryClient.invalidateQueries({ queryKey: [tableName, event.entityId] });
   });
 
-  const unsubSearch = eventBus.on("search:index-updated", () => {
-    void queryClient.invalidateQueries({ queryKey: ["search"] });
+  const unsubSearch = eventBus.on("search:index-updated", (event) => {
+    // Search queries are keyed `["search", debouncedQuery, scope]` (see
+    // `use-search.ts`). Scope the invalidation so a `self` materialization
+    // does not purge friend search caches (and vice versa). Queries that
+    // lack a scope slot (e.g., a bare `["search"]` entry) fall through
+    // the predicate and stay cached.
+    const { scope } = event;
+    void queryClient.invalidateQueries({
+      queryKey: ["search"],
+      predicate: (query) => query.queryKey[SEARCH_SCOPE_INDEX] === scope,
+    });
   });
 
   return () => {

--- a/apps/mobile/src/features/import-sp/__tests__/import.hooks.test.tsx
+++ b/apps/mobile/src/features/import-sp/__tests__/import.hooks.test.tsx
@@ -98,6 +98,13 @@ vi.mock("@pluralscape/api-client/trpc", async () => {
 vi.mock("expo-secure-store", () => {
   const store = new Map<string, string>();
   return {
+    // Expose the keychain-accessibility constants that sp-token-storage.ts
+    // reads at module load; omitting them causes a ReferenceError when the
+    // hooks are exercised against this inline mock.
+    WHEN_UNLOCKED: "AccessibleWhenUnlocked" as const,
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "AccessibleWhenUnlockedThisDeviceOnly" as const,
+    AFTER_FIRST_UNLOCK: "AccessibleAfterFirstUnlock" as const,
+    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: "AccessibleAfterFirstUnlockThisDeviceOnly" as const,
     getItemAsync: (key: string) => Promise.resolve(store.get(key) ?? null),
     setItemAsync: (key: string, value: string) => {
       store.set(key, value);

--- a/apps/mobile/src/features/import-sp/__tests__/sp-token-storage.test.ts
+++ b/apps/mobile/src/features/import-sp/__tests__/sp-token-storage.test.ts
@@ -9,11 +9,45 @@ import type { SystemId } from "@pluralscape/types";
 const SYSTEM_A = brandId<SystemId>("sys_aaaaaaaaaaaaaaaaaaaaaaaaa");
 const SYSTEM_B = brandId<SystemId>("sys_bbbbbbbbbbbbbbbbbbbbbbbbb");
 
+function tokenKey(systemId: SystemId): string {
+  return `pluralscape_sp_token_${systemId}`;
+}
+
 afterEach(() => {
   secureStore.__reset();
 });
 
 describe("sp-token-storage", () => {
+  describe("keychainAccessible", () => {
+    it("passes WHEN_UNLOCKED_THIS_DEVICE_ONLY to setItemAsync", async () => {
+      const storage = createSpTokenStorage();
+      await storage.set(SYSTEM_A, "stored-value");
+      const options = secureStore.__lastOptionsForMethod("setItemAsync", tokenKey(SYSTEM_A));
+      expect(options?.keychainAccessible).toBe(secureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY);
+    });
+
+    it("passes WHEN_UNLOCKED_THIS_DEVICE_ONLY to getItemAsync on get()", async () => {
+      const storage = createSpTokenStorage();
+      await storage.get(SYSTEM_A);
+      const options = secureStore.__lastOptionsForMethod("getItemAsync", tokenKey(SYSTEM_A));
+      expect(options?.keychainAccessible).toBe(secureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY);
+    });
+
+    it("passes WHEN_UNLOCKED_THIS_DEVICE_ONLY to getItemAsync on hasToken()", async () => {
+      const storage = createSpTokenStorage();
+      await storage.hasToken(SYSTEM_A);
+      const options = secureStore.__lastOptionsForMethod("getItemAsync", tokenKey(SYSTEM_A));
+      expect(options?.keychainAccessible).toBe(secureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY);
+    });
+
+    it("passes WHEN_UNLOCKED_THIS_DEVICE_ONLY to deleteItemAsync", async () => {
+      const storage = createSpTokenStorage();
+      await storage.clear(SYSTEM_A);
+      const options = secureStore.__lastOptionsForMethod("deleteItemAsync", tokenKey(SYSTEM_A));
+      expect(options?.keychainAccessible).toBe(secureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY);
+    });
+  });
+
   describe("get", () => {
     it("returns null when no token has been stored", async () => {
       const storage = createSpTokenStorage();

--- a/apps/mobile/src/features/import-sp/sp-token-storage.ts
+++ b/apps/mobile/src/features/import-sp/sp-token-storage.ts
@@ -24,23 +24,41 @@ function keyFor(systemId: SystemId): string {
   return `${SP_TOKEN_KEY_PREFIX}${systemId}`;
 }
 
+/**
+ * Hardened SecureStore options applied to every SP token operation.
+ *
+ * `WHEN_UNLOCKED_THIS_DEVICE_ONLY` ensures that:
+ *   - the token is unreadable while the device is locked
+ *   - the Keychain / EncryptedSharedPreferences entry is excluded from
+ *     iCloud Keychain sync and encrypted-backup restores on a different
+ *     physical device (no migration off-device)
+ *
+ * Applied to read, write, and delete calls for parity: SecureStore binds
+ * the accessibility class at write time, but passing the same options on
+ * reads/deletes keeps intent obvious and avoids accidental downgrades if
+ * the underlying platform ever exposes per-call overrides.
+ */
+const SP_TOKEN_SECURE_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+};
+
 /** Creates an SP token storage backed by Expo SecureStore. */
 export function createSpTokenStorage(): SpTokenStorage {
   return {
     async get(systemId: SystemId): Promise<string | null> {
-      return SecureStore.getItemAsync(keyFor(systemId));
+      return SecureStore.getItemAsync(keyFor(systemId), SP_TOKEN_SECURE_STORE_OPTIONS);
     },
 
     async set(systemId: SystemId, token: string): Promise<void> {
-      await SecureStore.setItemAsync(keyFor(systemId), token);
+      await SecureStore.setItemAsync(keyFor(systemId), token, SP_TOKEN_SECURE_STORE_OPTIONS);
     },
 
     async clear(systemId: SystemId): Promise<void> {
-      await SecureStore.deleteItemAsync(keyFor(systemId));
+      await SecureStore.deleteItemAsync(keyFor(systemId), SP_TOKEN_SECURE_STORE_OPTIONS);
     },
 
     async hasToken(systemId: SystemId): Promise<boolean> {
-      const value = await SecureStore.getItemAsync(keyFor(systemId));
+      const value = await SecureStore.getItemAsync(keyFor(systemId), SP_TOKEN_SECURE_STORE_OPTIONS);
       return value !== null;
     },
   };

--- a/packages/sync/src/materializer/entity-registry.ts
+++ b/packages/sync/src/materializer/entity-registry.ts
@@ -23,6 +23,20 @@ export interface EntityTableDef {
    * When false, document-level invalidation is emitted instead.
    */
   readonly hotPath: boolean;
+  /**
+   * When true, the React Query detail key for this entity type is NOT
+   * shaped `[tableName, entityId]` — it embeds additional scoping slots
+   * (e.g., `messages` uses `[tableName, channelId, entityId]`). Hot-path
+   * document-level invalidation normally narrows to list queries only
+   * (detail queries get covered by entity-level events whose key is
+   * `[tableName, entityId]`). For compound detail keys that prefix
+   * shortcut misses the detail, so the invalidator must fall back to
+   * broad `[tableName]` invalidation on document events even when
+   * `hotPath` is true.
+   *
+   * Consumed by the mobile query invalidator. Defaults to `false`.
+   */
+  readonly compoundDetailKey?: boolean;
 }
 
 // ── Shared column helpers ────────────────────────────────────────────
@@ -534,6 +548,14 @@ export const ENTITY_TABLE_REGISTRY: Record<SyncedEntityType, EntityTableDef> = {
     ],
     ftsColumns: ["content"],
     hotPath: true,
+    // `useMessage` keys details as `["messages", channelId, messageId]`
+    // (see apps/mobile/src/hooks/use-messages.ts). The hot-path narrowing
+    // optimization assumes detail keys are `[tableName, entityId]` and
+    // relies on per-entity events to cover them, but that shape doesn't
+    // prefix-match this compound key. Opt out of narrowing so document
+    // events broadly invalidate the `messages` table and keep details
+    // fresh.
+    compoundDetailKey: true,
   },
 
   "board-message": {


### PR DESCRIPTION
## Summary
- mobile-c01j (CRIT): remove plaintext apiBaseUrl from app.json; inject per-profile via eas.json extras; loader requires apiBaseUrl and rejects http:// outside dev-loopback
- mobile-scko: lock SP token SecureStore calls to WHEN_UNLOCKED_THIS_DEVICE_ONLY (read, write, delete parity)
- mobile-h89l: hoist AsyncStorageI18nCache + createChainedBackend singletons out of the locale-keyed useMemo into module scope
- mobile-79vz: narrow materialized:document invalidation to list-shaped queries for hot-path tables (entity events cover details); broad fallback for non-hot-path
- mobile-76ql: scope search:index-updated invalidation by event scope (self / friend) so unrelated search caches are preserved

## Audit Epic
Closes mobile-e3l7. Related: ps-g937, M9 (ps-h2gl).

## Test Plan
- [x] pnpm typecheck
- [x] pnpm lint --max-warnings 0
- [x] pnpm vitest --project mobile (1346 tests pass)
- [ ] /verify