### PR TITLE
docs: comprehensive refresh and M9 closeout

### DIFF
--- a/.beans/ps-h2gl--milestone-9-data-import-functionality.md
+++ b/.beans/ps-h2gl--milestone-9-data-import-functionality.md
@@ -1,11 +1,11 @@
 ---
 # ps-h2gl
 title: "Milestone 9: Data Import Functionality"
-status: in-progress
+status: completed
 type: milestone
 priority: normal
 created_at: 2026-03-31T23:10:26Z
-updated_at: 2026-04-16T06:49:43Z
+updated_at: 2026-04-21T05:42:19Z
 blocked_by:
   - ps-7j8n
 ---
@@ -39,3 +39,46 @@ Pulled data import forward from old M12 (Ancillary Features) as a standalone mil
 
 - ADR 033: PluralKit API client library selection
 - ADR 034: Import-core extraction
+
+## Summary of Changes
+
+Milestone 9 delivered the full data-import surface plus post-audit hardening:
+
+### Imports (ps-nrg4, ps-dvxb, ps-0w7l, ps-n0tq, ps-0enb, ps-hlq3, ps-86ya, ps-v7el)
+
+- Simply Plural import: file + API source modes, 15 collections, encrypted payload alignment, notes support.
+- PluralKit import: members, groups, fronting sessions, privacy-bucket synthesis, IPv6 loopback support.
+- Shared `packages/import-core` orchestration engine with checkpoint resume and pluggable Persister interface (ADR 034).
+- Mobile glue with 17 entity persisters and E2E infrastructure using deterministic seed scripts.
+- Mapped types routed through `@pluralscape/validation` schemas.
+
+### Zero-Knowledge compliance (ps-f5mh, crypto-w0fu, crypto-cpir)
+
+- Migrated all master-key operations to the client; server persists only encrypted master-key blobs and the auth-key hash.
+- Constant-time comparisons in crypto primitives; zero-key-material-after-use in rotation-worker.
+- NIST/RFC test vectors added for X25519, Ed25519, Argon2, BLAKE2b, XChaCha20-Poly1305.
+
+### Audit remediation (ps-ai5y, ps-g937, ps-9ujv, ps-up0u, ps-0enb, ps-tgk6, ps-tdj8; per-package epics api-v8zu, db-bry7, mobile-e3l7, sync-me6c)
+
+- Seven `chore(audit-m9)` PRs covering api, crypto, db, mobile, sync, queue+imports (#524, #525, #526, #529, #530, #531).
+- API: MIME validation, S3 size enforcement, session error codes, per-endpoint API-key scope enforcement.
+- DB: sync table RLS, friend connection RLS, device token hashing, partition sanitation.
+- Mobile: SQLite encryption, hooks ordering.
+- Sync: auth key binding, snapshot signatures, document authorization, materializer scoped queries.
+- Crypto: streaming improvements, CryptoError base class.
+
+### CI / Security / Deps
+
+- pnpm catalog adoption; Renovate batch updates; Terraform Google v7.
+- CodeQL v4 alignment; email ReDoS fix; HMAC-SHA256 API-key hashing (PR #395).
+- Coverage threshold raised to 89% across lines/functions/branches/statements.
+
+### Infra
+
+- GCP billing kill-switch Terraform module (PR #504).
+- OPFS wa-sqlite driver (mobile-shr0 phases 1-2, PRs #459, #460, #461).
+- Async `SqliteDriver` contract; parameterised queries in OPFS driver.
+
+### Documentation
+
+- Comprehensive docs refresh (tracking bean ps-w3j9) brought README, CHANGELOG, architecture, milestones, features, api-specification, database-schema, OpenAPI spec, tRPC guide, consumer guides, CONTRIBUTING, ADRs, and all 15 package READMEs into alignment with the shipped code.

--- a/.beans/ps-w3j9--comprehensive-docs-update-covering-post-m9-work.md
+++ b/.beans/ps-w3j9--comprehensive-docs-update-covering-post-m9-work.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-21T03:55:54Z
-updated_at: 2026-04-21T05:42:54Z
+updated_at: 2026-04-21T11:44:47Z
 ---
 
 Full sweep of repo docs to reflect 80 PRs merged since the last comprehensive docs update (PR #424 on 2026-04-14). Covers README, CHANGELOG, milestones, features, architecture, OpenAPI spec, db schema diagram, 15 package READMEs, trpc/REST consumer guides, and new CONTRIBUTORS.md. Marks Milestone 9 (ps-h2gl) completed at end.
@@ -79,7 +79,16 @@ Completed three-pass accuracy review (claim extraction → ground-truth check �
 
 1. **OpenAPI list-wrapper inconsistency**: 25+ list endpoints use varied response keys (items/members/groups/...) in OpenAPI while handlers return `data` via `buildPaginatedResult`. Needs spec-wide rename or server-side settlement + ADR.
 2. **SCOPE_INSUFFICIENT constant unused**: defined in `error-codes.ts` but no handler emits it; handlers use `FORBIDDEN`. Decide to emit the constant or drop it.
-3. **Orphan `apps/api/src/trpc/routers/i18n.ts`**: 6.7KB file not imported by root.ts (only `i18n-composer.ts` wired in). Dead code candidate.
+3. ~~Orphan `apps/api/src/trpc/routers/i18n.ts`~~ — INVALID. `i18n-composer.ts` imports `createI18nRouter` from `i18n.ts` and wires it into root.ts. Both files are live.
 4. **Missing `packages/logger/README.md`**: the package exists but has no README; was out of the 15-README scope.
 
 Milestone 9 (ps-h2gl) marked completed.
+
+## Follow-ups resolved (same branch)
+
+- **#1 OpenAPI list-wrapper rename** → commit `4a5ea65d`: 3 schemas + 38 inline renames across 23 path files, all list wrapper keys normalized to `data` to match `buildPaginatedResult`.
+- **#2 SCOPE_INSUFFICIENT emission** → commit `28566d45`: REST scope-gate middleware distinguishes FORBIDDEN (endpoint not registered) from SCOPE_INSUFFICIENT (scope mismatch). tRPC scope-gate keeps FORBIDDEN (code enum fixed). Docs updated.
+- **#3 Orphan i18n.ts** → INVALID; `i18n-composer.ts` imports `createI18nRouter` from `i18n.ts` and wires it into `root.ts`.
+- **#4 logger README** → commit `50126200`: new README for `@pluralscape/logger` covering mobile logger, default PII redaction, options, testing, design rationale.
+
+All four items verified: `openapi:check`, `openapi:lint`, `trpc:parity`, scope-gate tests (8/8 pass).

--- a/.beans/ps-w3j9--comprehensive-docs-update-covering-post-m9-work.md
+++ b/.beans/ps-w3j9--comprehensive-docs-update-covering-post-m9-work.md
@@ -1,0 +1,85 @@
+---
+# ps-w3j9
+title: Comprehensive docs update covering post-M9 work
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-21T03:55:54Z
+updated_at: 2026-04-21T05:42:54Z
+---
+
+Full sweep of repo docs to reflect 80 PRs merged since the last comprehensive docs update (PR #424 on 2026-04-14). Covers README, CHANGELOG, milestones, features, architecture, OpenAPI spec, db schema diagram, 15 package READMEs, trpc/REST consumer guides, and new CONTRIBUTORS.md. Marks Milestone 9 (ps-h2gl) completed at end.
+
+## Phase progress
+
+- [x] Phase 0: Evidence gathering (Task 0)
+- [x] Phase 1a: Architecture / milestones / features / api-spec (Tasks 1-4, Commit 1 = 8137aaf8)
+- [x] Phase 1b: README + CHANGELOG (Tasks 5-6, Commit 2 = 07bf8135)
+- [x] Phase 2a: Database schema (Task 7, Commit 3 = 62eaa883)
+- [x] Phase 2b: OpenAPI (Task 8, Commit 4 = c5adae53)
+
+**Deferred: OpenAPI list-wrapper inconsistency.** 25+ list endpoints use varied response keys (items/members/groups/sessions/...) in the OpenAPI spec while server handlers return `data` via `buildPaginatedResult`. Needs either spec-wide rename to `data` or an ADR settling on `items` and changing the server. Out of budget for this docs refresh — follow-up bean to be created at end.
+
+- [x] Phase 2c: Guides (Tasks 9-11, Commit 5 = 4b45b894)
+- [x] Phase 2d: CONTRIBUTING (Task 12, Commit 6 = 0cf3f9a3)
+- [x] Phase 2e: ADR accuracy (Task 13, Commit 7 = 5c8e955a)
+- [x] Phase 3a: Package READMEs batch 1 (Task 14, Commit 8 = 9a5656ad)
+- [x] Phase 3b: Package READMEs batch 2 (Task 15, Commit 9 = 80cd9f3f)
+- [x] Phase 3c: Package READMEs batch 3 (Task 16, Commit 10 = 11e3f336)
+- [x] Phase 4: Close beans (Task 17, Commit 11)
+- [ ] Phase 5: Pre-PR verification (Task 18)
+
+**Deferred: SCOPE_INSUFFICIENT constant vs handler behavior.** `SCOPE_INSUFFICIENT` is defined in `packages/types/src/api-constants/error-codes.ts` but no handler throws it — handlers use `FORBIDDEN` for scope denials. OpenAPI spec (Task 8) lists it in the ErrorResponse enum. Minor spec-vs-code divergence; follow-up bean to decide: emit `SCOPE_INSUFFICIENT` from scope-gate middleware, or remove from constants + OpenAPI enum.
+
+## Summary of Changes
+
+Completed three-pass accuracy review (claim extraction → ground-truth check → gap fill) across all user-facing documentation.
+
+### Root docs
+
+- README.md — refreshed REST op/domain counts (317/32), ADR count (37), added logger package, M9 paragraph.
+- CHANGELOG.md — new "2026-04-21 — Milestone 9 closeout" section with 6 thematic subsections (Imports, Zero-Knowledge, i18n, Audit Remediation, CI/Security/Deps, Infra).
+- CONTRIBUTING.md — post-M9 gates (openapi:check, trpc:parity), zero-knowledge rule, Crowdin workflow (ADR 036), beans workflow, pre-release code hygiene, coverage threshold 89%.
+
+### Planning docs
+
+- milestones.md — ADR count 34→37, M9 scope bullets verified.
+- features.md — REST 304→317, domains 31→32, router count 38 (orphan i18n.ts excluded), dual-source import framing, new i18n/OPFS/zero-knowledge/import-core bullets.
+- api-specification.md — no edits required (reviewed, all accurate).
+
+### Architecture and schema
+
+- docs/architecture.md — ADR 031/033/034/035/036/037 citations added; zero-knowledge master-key migration; OPFS/wa-sqlite; T2 algorithm XChaCha20-Poly1305 correction.
+- docs/database-schema.md — 62/68 tables PASS; fixed drift in accounts (auth_key_hash replaces password_hash; challenge columns), recovery_keys (recovery_key_hash), timer_configs (next_check_in_at), device_tokens (token_hash), import_jobs (checkpoint_state).
+
+### API references
+
+- docs/openapi/openapi.yaml + docs/openapi.yaml — 6 per-route fixes (auth envelope, duplicate-member defaults, fronting query params, import body enum, INVALID_STATE error, full api-key scope enum regen from ALL_API_KEY_SCOPES).
+- docs/trpc-guide.md — example signatures corrected (encryptedData vs plaintext); router table camelCase vs kebab-case; 3 missing routers added; scope-gate middleware note.
+
+### Consumer guides
+
+- docs/guides/api-consumer-guide.md — login salt endpoint POST /v1/auth/salt; FORBIDDEN (not SCOPE_INSUFFICIENT); rate-limit categories 17→19; new 8.6 Import Jobs section.
+- docs/guides/api-key-scopes.md — FORBIDDEN error code; scope count verified (68 = 21 domains × 3 + 1 + 4).
+- docs/guides/{mobile-developer,sync-protocol,webhook-signature-verification}.md — reviewed, all accurate.
+
+### ADR accuracy
+
+- ADR 006 — "Unified KDF Profile" → "Master-Key KDF Profile"; constants renamed per ADR 037.
+- ADR 036 — Native `gh pr merge --auto` flow (removed custom automerge workflow description); corrected MT engine coverage (es-419 has no MT engine).
+- ADRs 035, 037, 013 — verified accurate, no changes.
+
+### Package READMEs (15)
+
+- api-client, crypto, data, db, email (batch 1) — retry middleware, zero-knowledge framing, Argon2id profiles, transform table corrections, migration policy, ReDoS fix.
+- i18n, import-core, import-pk, import-sp, queue (batch 2) — OTA proxy, Persister interface, dual source modes, SP auth quirk, Valkey gate.
+- rotation-worker, storage, sync, types, validation (batch 3) — key zeroing, exact-size contract, async SqliteDriver, brandId, schema catalog.
+
+### Deferred follow-up items
+
+1. **OpenAPI list-wrapper inconsistency**: 25+ list endpoints use varied response keys (items/members/groups/...) in OpenAPI while handlers return `data` via `buildPaginatedResult`. Needs spec-wide rename or server-side settlement + ADR.
+2. **SCOPE_INSUFFICIENT constant unused**: defined in `error-codes.ts` but no handler emits it; handlers use `FORBIDDEN`. Decide to emit the constant or drop it.
+3. **Orphan `apps/api/src/trpc/routers/i18n.ts`**: 6.7KB file not imported by root.ts (only `i18n-composer.ts` wired in). Dead code candidate.
+4. **Missing `packages/logger/README.md`**: the package exists but has no README; was out of the 15-README scope.
+
+Milestone 9 (ps-h2gl) marked completed.

--- a/.beans/ps-w3j9--comprehensive-docs-update-covering-post-m9-work.md
+++ b/.beans/ps-w3j9--comprehensive-docs-update-covering-post-m9-work.md
@@ -27,7 +27,7 @@ Full sweep of repo docs to reflect 80 PRs merged since the last comprehensive do
 - [x] Phase 3b: Package READMEs batch 2 (Task 15, Commit 9 = 80cd9f3f)
 - [x] Phase 3c: Package READMEs batch 3 (Task 16, Commit 10 = 11e3f336)
 - [x] Phase 4: Close beans (Task 17, Commit 11)
-- [ ] Phase 5: Pre-PR verification (Task 18)
+- [x] Phase 5: Pre-PR verification (Task 18)
 
 **Deferred: SCOPE_INSUFFICIENT constant vs handler behavior.** `SCOPE_INSUFFICIENT` is defined in `packages/types/src/api-constants/error-codes.ts` but no handler throws it — handlers use `FORBIDDEN` for scope denials. OpenAPI spec (Task 8) lists it in the ErrorResponse enum. Minor spec-vs-code divergence; follow-up bean to decide: emit `SCOPE_INSUFFICIENT` from scope-gate middleware, or remove from constants + OpenAPI enum.
 
@@ -44,7 +44,7 @@ Completed three-pass accuracy review (claim extraction → ground-truth check �
 ### Planning docs
 
 - milestones.md — ADR count 34→37, M9 scope bullets verified.
-- features.md — REST 304→317, domains 31→32, router count 38 (orphan i18n.ts excluded), dual-source import framing, new i18n/OPFS/zero-knowledge/import-core bullets.
+- features.md — REST 304→317, domains 31→32, 38 top-level routers (i18n.ts is composed into i18nRouter via i18n-composer.ts), dual-source import framing, new i18n/OPFS/zero-knowledge/import-core bullets.
 - api-specification.md — no edits required (reviewed, all accurate).
 
 ### Architecture and schema
@@ -75,20 +75,15 @@ Completed three-pass accuracy review (claim extraction → ground-truth check �
 - i18n, import-core, import-pk, import-sp, queue (batch 2) — OTA proxy, Persister interface, dual source modes, SP auth quirk, Valkey gate.
 - rotation-worker, storage, sync, types, validation (batch 3) — key zeroing, exact-size contract, async SqliteDriver, brandId, schema catalog.
 
-### Deferred follow-up items
+### Follow-ups resolved (same branch)
 
-1. **OpenAPI list-wrapper inconsistency**: 25+ list endpoints use varied response keys (items/members/groups/...) in OpenAPI while handlers return `data` via `buildPaginatedResult`. Needs spec-wide rename or server-side settlement + ADR.
-2. **SCOPE_INSUFFICIENT constant unused**: defined in `error-codes.ts` but no handler emits it; handlers use `FORBIDDEN`. Decide to emit the constant or drop it.
-3. ~~Orphan `apps/api/src/trpc/routers/i18n.ts`~~ — INVALID. `i18n-composer.ts` imports `createI18nRouter` from `i18n.ts` and wires it into root.ts. Both files are live.
-4. **Missing `packages/logger/README.md`**: the package exists but has no README; was out of the 15-README scope.
+All four items originally deferred were resolved before opening the PR:
 
-Milestone 9 (ps-h2gl) marked completed.
-
-## Follow-ups resolved (same branch)
-
-- **#1 OpenAPI list-wrapper rename** → commit `4a5ea65d`: 3 schemas + 38 inline renames across 23 path files, all list wrapper keys normalized to `data` to match `buildPaginatedResult`.
-- **#2 SCOPE_INSUFFICIENT emission** → commit `28566d45`: REST scope-gate middleware distinguishes FORBIDDEN (endpoint not registered) from SCOPE_INSUFFICIENT (scope mismatch). tRPC scope-gate keeps FORBIDDEN (code enum fixed). Docs updated.
-- **#3 Orphan i18n.ts** → INVALID; `i18n-composer.ts` imports `createI18nRouter` from `i18n.ts` and wires it into `root.ts`.
-- **#4 logger README** → commit `50126200`: new README for `@pluralscape/logger` covering mobile logger, default PII redaction, options, testing, design rationale.
+1. **OpenAPI list-wrapper rename** → commit `4a5ea65d`: 3 schemas + 38 inline renames across 23 path files, all list wrapper keys normalized to `data` to match `buildPaginatedResult`.
+2. **SCOPE_INSUFFICIENT emission** → commit `28566d45`: REST scope-gate middleware distinguishes `FORBIDDEN` (endpoint not registered) from `SCOPE_INSUFFICIENT` (scope mismatch). tRPC scope-gate keeps `FORBIDDEN` (code enum fixed). Docs updated.
+3. **Orphan `apps/api/src/trpc/routers/i18n.ts`** → INVALID; `i18n-composer.ts` imports `createI18nRouter` from `i18n.ts` and wires it into `root.ts`. Both files are live.
+4. **Missing `packages/logger/README.md`** → commit `50126200`: new README for `@pluralscape/logger` covering mobile logger, default PII redaction, options, testing, design rationale.
 
 All four items verified: `openapi:check`, `openapi:lint`, `trpc:parity`, scope-gate tests (8/8 pass).
+
+Milestone 9 (ps-h2gl) marked completed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), using milestone headers instead of version numbers during pre-production development.
 
+## 2026-04-21 — Milestone 9 closeout
+
+### Imports
+
+- Simply Plural import — file and API source modes covering 15 collections with encrypted payload alignment, notes support, and checkpoint-based resume.
+- PluralKit import — member, group, fronting session, and group membership mapping from PK JSON exports, with zero-duration session correction.
+- Import mapped types now flow through shared Zod validation schemas for both SP and PK, eliminating hand-rolled type assertions at trust boundaries.
+- Import security hardening — bounded input parsing, deduplication guarantees, and expanded coverage across real-data edge cases.
+- Queue + import worker audit fixes — tightened job payload validation, safer failure handling, and reduced retry amplification.
+
+### Zero-Knowledge
+
+- Server-side master key operations fully migrated to client, restoring the zero-knowledge server guarantee for account-level key material.
+- Crypto primitives covered by NIST/RFC test vectors across XChaCha20-Poly1305, X25519, Argon2id, and BLAKE2b paths.
+- Constant-time comparison helpers, stricter type guards, and a unified crypto error base class close out the hardening audit.
+- Rotation worker now zeroes key material after use, removing residual plaintext from long-lived worker buffers.
+- Streaming improvements in `packages/crypto` reduce peak memory for large encrypted blob operations.
+
+### i18n / Localization
+
+- Crowdin integration shipped with 12 locales, daily sync workflow, and OTA proxy serving bundles to mobile clients.
+- Automation polish — glossary, pre-translation, and auto-merge on bot PRs reduce translator round-trip time.
+- Full-IETF Crowdin codes mapped to short app locale directories, with `es-419` routed to human-translate only.
+- Locale-parity test reads `languages_mapping` from the nested file entry, catching config drift before release.
+- Crowdin config pipeline hardened — `pipefail` enforcement, author_not_bot rename, and resilient source/context upload.
+- Email templates and i18n defaults aligned so transactional messages respect the recipient's locale.
+
+### Audit Remediation
+
+- `apps/api` hardening — MIME validation, S3 upload size enforcement, session error codes, central scope registry with fail-closed API key enforcement, and Zod validation on deserialized Redis/JSON payloads.
+- `packages/db` RLS hardening across sync, friend-connection, and device-token tables, plus partition sanitation and device-token hashing.
+- `packages/sync` auth key binding, snapshot signature verification, and per-document authorization on CRDT operations.
+- `apps/mobile` SQLite encryption path, hook-ordering fixes, and expanded data-layer support for scoped API keys.
+- Performance — batch reorder queries, materializer query scoping, and base64 encode/decode switched from O(n) string concat to Buffer.
+- Integration coverage added for 15 tRPC routers and E2E specs for analytics and fronting-reports, closing the coverage gap on previously untested services.
+- Branded IDs applied consistently in structure-entity and webhook services, with privacy bucket encrypted fields audited end-to-end.
+
+### CI / Security / Deps
+
+- CodeQL v4 alignment and round-2 triage, including ReDoS fix in the email package and an API-key hashing alert resolution.
+- `hono` bumped to v4.12.14 and `dompurify` pinned to >=3.4.0 to clear upstream advisories.
+- `zod` upgraded to v4 across the monorepo, with Renovate batches consolidating TanStack Query, AWS SDK, BullMQ, Expo, and typescript-eslint updates.
+- pnpm catalog adopted to deduplicate workspace dependency declarations and stabilize lockfile churn.
+- Crowdin GitHub App auto-merge and `setup-pnpm` composite action reduce CI maintenance overhead.
+- `follow-redirects` overridden to >=1.16.0 to mitigate GHSA-r4q5-vmmm-2653.
+
+### Infra
+
+- GCP billing kill-switch Terraform module gives operators a one-knob cost circuit-breaker for the hosted environment.
+- Terraform `google` provider upgraded to v7, unlocking newer resource schemas.
+- OPFS web worker SQLite driver landed (mobile-shr0 phase 2), enabling encrypted local storage on modern browsers.
+- `SqliteDriver` contract is now fully async across sync and mobile, aligning native and web drivers behind one interface.
+- Parameterized queries implemented in the OPFS wa-sqlite driver, closing a SQL-injection footgun on the web path.
+- React Native bumped to 0.85.1 and the Expo monorepo updated in lockstep to keep mobile on the supported SDK line.
+
 ## Milestone 9: Data Import
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,23 @@ We welcome contributions from everyone. This project is community-driven by desi
 - Update documentation if behavior changes
 - List any deferred work in the "Deferred Items" section of the PR template
 
+### Required pre-PR gates
+
+Every PR must pass these checks locally before it is opened; CI enforces them as well:
+
+- `pnpm format` — Prettier formatting
+- `pnpm lint` — ESLint with zero warnings (`--max-warnings 0`)
+- `pnpm typecheck` — TypeScript strict type-checking
+- `pnpm test` — unit + integration suites
+- `pnpm openapi:check` — REST spec reconciler; the checked-in `docs/openapi.yaml` must match generated output
+- `pnpm trpc:parity` — REST route / tRPC procedure parity (see [Adding API Endpoints](#adding-api-endpoints))
+
+The `/verify` command runs the full suite (format, lint, typecheck, unit, integration, e2e) in one shot.
+
+### Pre-release code hygiene
+
+Pluralscape is pre-production. Remove deprecated code outright — no backwards-compatible aliases, re-exports, or `@deprecated` shims. Delete old symbols in the same PR that introduces the replacement.
+
 ## Commit Conventions
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):
@@ -34,6 +51,18 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `style`, `perf`, `ci`
 ## Architecture Decisions
 
 Major technical decisions are documented as ADRs in `docs/adr/`. If your contribution involves a significant architectural choice, please write an ADR using the template at `docs/adr/000-template.md`.
+
+### Zero-knowledge rule
+
+The server must never perform master-key operations or handle raw user-secret material. All envelope encryption, bucket key derivation, and recovery-package assembly happen client-side. See [ADR 013 — API Auth & Encryption](docs/adr/013-api-auth-encryption.md) and the master-key migration in PR #439 for the authoritative boundary. PRs that route master-key material through the server will be rejected.
+
+## Work Tracking (Beans)
+
+Work items are tracked as **beans** (a CLI issue tracker) with files committed under `.beans/` alongside the code they describe. Full conventions live in [docs/work-tracking.md](docs/work-tracking.md).
+
+- Before committing, mark the bean as completed and add a `## Summary of Changes` section describing what shipped.
+- Include the bean file in the **same commit** as the code change so history stays self-contained.
+- Use the existing prefixes (`ps-`, `api-`, `mobile-`, `db-`, `crypto-`, `sync-`, `types-`, `client-`, `infra-`). Epics are containers — break them into `feature` / `task` / `bug` children.
 
 ## Development Methodology — TDD
 
@@ -163,11 +192,11 @@ Test coverage is enforced in CI. The thresholds below are minimums — aim highe
 
 | Test Type   | Coverage Target              | Tool       | What It Covers                                     |
 | ----------- | ---------------------------- | ---------- | -------------------------------------------------- |
-| Unit        | 85% lines/functions/branches | Vitest     | Pure functions, utilities, domain logic            |
-| Integration | 85% lines/functions/branches | Vitest     | API routes, database queries, cross-module flows   |
+| Unit        | 89% lines/functions/branches | Vitest     | Pure functions, utilities, domain logic            |
+| Integration | 89% lines/functions/branches | Vitest     | API routes, database queries, cross-module flows   |
 | E2E         | Critical paths               | Playwright | User-facing flows: auth, fronting, switching, sync |
 
-- **Unit + Integration** (85% combined): Lines, functions, branches, and statements are all measured. Type-only files and barrel/index files are excluded from coverage. Measured across the combined unit + integration run.
+- **Unit + Integration** (89% combined): Lines, functions, branches, and statements are all measured. Type-only files and barrel/index files are excluded from coverage. Measured across the combined unit + integration run.
 - **E2E tests**: No line-coverage metric — instead, all critical user journeys must have corresponding tests. Tracked via a test matrix in the test plan.
 
 Coverage is checked in CI on every PR. PRs that drop coverage below thresholds will not merge.
@@ -181,7 +210,7 @@ Coverage is checked in CI on every PR. PRs that drop coverage below thresholds w
 
 ## Translations
 
-Pluralscape uses [Crowdin](https://crowdin.com) for translation management. The project qualifies for the free open-source tier.
+Pluralscape uses [Crowdin](https://crowdin.com) for translation management. The project qualifies for the free open-source tier. The automation design is authoritative in [ADR 036 — Crowdin automation](docs/adr/036-crowdin-automation.md); operational runbook lives in [docs/i18n/crowdin-operations.md](docs/i18n/crowdin-operations.md).
 
 ### How translations flow
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pluralscape helps plural systems (DID, OSDD, and beyond) manage identity trackin
 
 **Active development — Milestones 0-9 complete, Milestone 10 (UI/UX Design) next.**
 
-Milestones 0-7 built the full backend: data layer, API, sync, fronting, communication, privacy, and data portability. The REST API covers 304 operations across 31 route domains ([OpenAPI spec](docs/openapi/openapi.yaml)), with a type-safe tRPC layer mirroring the full surface for the Expo mobile client ([ADR 032](docs/adr/032-trpc-parity-enforcement.md)).
+Milestones 0-7 built the full backend: data layer, API, sync, fronting, communication, privacy, and data portability. The REST API covers 317 operations across 32 route domains ([OpenAPI spec](docs/openapi/openapi.yaml)), with a type-safe tRPC layer mirroring the full surface for the Expo mobile client ([ADR 032](docs/adr/032-trpc-parity-enforcement.md)).
 
 Milestone 8 delivered the complete client foundation: Expo app shell with auth-gated routing, a 14-provider initialization tree (platform detection, auth state machine, encryption, sync), offline-first local data layer (SQLite + FTS5 search), 50+ domain data hooks via factory pattern (`useOfflineFirstQuery`/`useOfflineFirstInfiniteQuery`), web platform adapter (OPFS/IndexedDB), and CRDT sync coverage for all entity types.
 
@@ -64,6 +64,7 @@ packages/
   api-client/      tRPC + TanStack Query client bindings
   email/           Transactional email — Resend + SMTP adapters, templates
   i18n/            Internationalization — locale formatting, nomenclature
+  logger/          Structured logger with PII redaction (mobile + shared adapters)
   queue/           Background job queue — SQLite-backed with retry/DLQ
   rotation-worker/ Key rotation worker — processes bucket key rotation chunks
   storage/         Blob storage — S3 + filesystem adapters, quota management
@@ -85,7 +86,7 @@ ui-design/
 docs/
   openapi/         OpenAPI 3.1 spec (multi-file source, Redocly CLI)
   openapi.yaml     Bundled single-file OpenAPI spec (generated)
-  adr/             Architecture Decision Records (34 accepted)
+  adr/             Architecture Decision Records (37 accepted)
   audits/          Codebase audit reports
   planning/        Specifications, milestones, feature planning
   future-features/ Unscheduled feature design documents
@@ -105,7 +106,7 @@ docs/
 | Media        | S3-compatible (MinIO for self-hosted)           | [ADR 009](docs/adr/009-blob-media-storage.md) |
 | Job Queue    | BullMQ (Valkey) / SQLite (self-hosted fallback) | [ADR 010](docs/adr/010-background-jobs.md)    |
 
-All dependencies verified AGPL-3.0 compatible — see [license audit](docs/audits/001-license-compatibility.md). Architecture decisions documented in [34 ADRs](docs/adr/).
+All dependencies verified AGPL-3.0 compatible — see [license audit](docs/audits/001-license-compatibility.md). Architecture decisions documented in [37 ADRs](docs/adr/).
 
 ## Key Libraries
 
@@ -205,7 +206,7 @@ Domain prefixes: `ps-`, `api-`, `mobile-`, `db-`, `crypto-`, `sync-`, `types-`, 
 
 ## Architecture Decision Records
 
-Major technical decisions are documented as ADRs in [`docs/adr/`](docs/adr/). 34 accepted ADRs cover the full stack from licensing through import engine architecture. See the [ADR template](docs/adr/000-template.md) for the format.
+Major technical decisions are documented as ADRs in [`docs/adr/`](docs/adr/). 37 accepted ADRs cover the full stack from licensing through import engine architecture. See the [ADR template](docs/adr/000-template.md) for the format.
 
 ## License
 

--- a/apps/api/src/__tests__/middleware/scope.integration.test.ts
+++ b/apps/api/src/__tests__/middleware/scope.integration.test.ts
@@ -67,7 +67,7 @@ describe("scope gate integration", () => {
     const res = await app.request("/systems/sys_123/members", { method: "POST" });
     expect(res.status).toBe(403);
     const body = (await res.json()) as { error?: { code?: string; message?: string } };
-    expect(body.error?.code).toBe("FORBIDDEN");
+    expect(body.error?.code).toBe("SCOPE_INSUFFICIENT");
     expect(body.error?.message).toContain("write:members");
   });
 

--- a/apps/api/src/middleware/scope-gate.ts
+++ b/apps/api/src/middleware/scope-gate.ts
@@ -26,8 +26,10 @@ function getRoutePattern(c: Context): string | null {
  *
  * - Session auth: always passes through.
  * - API key auth: looks up the matched route pattern in SCOPE_REGISTRY.rest.
- *   - Entry found: checks hasScope(auth, entry.scope).
- *   - Entry missing: rejects with 403 (fail-closed).
+ *   - No route pattern or entry missing: 403 `FORBIDDEN` (fail-closed — endpoint
+ *     is not available for API key access).
+ *   - Entry found but `hasScope(auth, entry.scope)` is false: 403
+ *     `SCOPE_INSUFFICIENT` with a message naming the required scope.
  */
 export function scopeGateMiddleware(): MiddlewareHandler<AuthEnv> {
   return async (c, next) => {

--- a/apps/api/src/middleware/scope-gate.ts
+++ b/apps/api/src/middleware/scope-gate.ts
@@ -57,7 +57,7 @@ export function scopeGateMiddleware(): MiddlewareHandler<AuthEnv> {
     if (!hasScope(auth, entry.scope)) {
       throw new ApiHttpError(
         HTTP_FORBIDDEN,
-        "FORBIDDEN",
+        "SCOPE_INSUFFICIENT",
         `Insufficient scope: requires ${entry.scope}`,
       );
     }

--- a/docs/adr/006-encryption.md
+++ b/docs/adr/006-encryption.md
@@ -119,15 +119,16 @@ Rationale:
 
 Note: although keypairs are deterministically derivable from the master key, they are also stored server-side as encrypted blobs (`encryptedSigningPrivateKey`, `encryptedEncryptionPrivateKey`). This allows future support for non-deterministic or rotated keypairs without a protocol break.
 
-### Addendum: Unified KDF Profile
+### Addendum: Master-Key KDF Profile
 
-All Argon2id password-to-key derivations use a single profile:
+Password-to-key derivations for account-lifetime secrets use the
+`ARGON2ID_PROFILE_MASTER_KEY` profile:
 
 - Memory: 64 MiB (`memlimit = 67108864`)
 - Iterations: 4 (`opslimit = 4`)
 - Output: 64 bytes (split into `auth_key` || `password_key`)
 
-A single KDF call produces both keys. The profile is stored in `packages/crypto/src/crypto.constants.ts`.
+A single KDF call produces both keys. The profile is stored in `packages/crypto/src/crypto.constants.ts`. Short-lived derivations (device-transfer) use a separate `ARGON2ID_PROFILE_TRANSFER` profile; see ADR 037 for the per-context rationale.
 
 ### License
 

--- a/docs/adr/036-crowdin-automation.md
+++ b/docs/adr/036-crowdin-automation.md
@@ -22,19 +22,21 @@ We adopt a machine-translation pipeline with four components:
 
 1. **Config-as-code**: `scripts/crowdin-glossary.json` is the source of truth for glossary terms. A `crowdin-config` GitHub Actions workflow applies changes to Crowdin via its API on every push to `main` touching glossary or setup files. Crowdin project state is derived; the repo is canonical.
 
-2. **Dual MT engines**: DeepL Free for the 10 languages it supports (de, es, fr, it, ja, ko, nl, pt-BR, ru, zh-Hans); Google Cloud Translation for the two it does not (ar, es-419). Both engines run with glossary enforcement.
+2. **Dual MT engines**: DeepL Free for the 10 languages it supports (de, es-ES, fr, it, ja, ko, nl, pt-BR, ru, zh-CN); Google Cloud Translation for Arabic. Latin American Spanish (es-419) has no MT engine — DeepL does not support it, and Google's Crowdin integration rejects it (HTTP 400 "Languages [es-419] are not supported by Mt Engine"); `es-419` is included in the TM pass but left for human translation on the MT pass. Both engines run with glossary enforcement.
 
 3. **Automatic pre-translation**: After the sync workflow uploads English sources to Crowdin, it runs `scripts/crowdin-pretranslate.ts` to kick off a TM + MT pre-translation job. New strings typically arrive pre-translated within a few minutes of the daily sync; the workflow allows up to 10 minutes per pre-translate pass before failing.
 
-4. **Auto-merge for translation-only PRs**: A `crowdin-automerge` workflow evaluates an 8-step guard chain (author, branch, label, path allowlist, no deletions, reviews, CI status, required-check allowlist) and squash-merges eligible PRs. `apps/mobile/locales/en/**` is explicitly excluded from the allowlist so a mixed-content PR is always rejected. The required-check allowlist rejects a PR as `ci_missing` when any configured required check never posts, guarding against a "zero checks = green" misinterpretation.
+4. **Auto-merge for translation-only PRs**: The `crowdin-sync` workflow enables GitHub's native auto-merge on the daily translation PR via `gh pr merge --auto --squash --delete-branch`. Safety is enforced by branch protection on `main` (required status checks must pass) plus a GitHub ruleset on `chore/crowdin-translations` that restricts pushes to the Pluralscape Crowdin Bot GitHub App — only Crowdin-originated commits reach the branch, and a failing check blocks the merge. The earlier custom `crowdin-automerge` workflow and its multi-step guard chain were replaced by this native flow in PR #476.
 
 Export policy: all translations (not just approved) are exported from Crowdin, since there are no human approvers. Manual edits in the Crowdin UI automatically supersede MT in Crowdin's translation priority ranking.
 
 Crowdin pre-translates new strings in two passes: (1) translation memory for all
 12 target languages, reusing prior translations across the project; (2) machine
 translation for anything TM did not fill — DeepL for 10 languages it supports,
-Google Translate for Arabic and Latin American Spanish. All results are
-auto-approved as the shipping translation during the transitional phase.
+Google Translate for Arabic. Latin American Spanish (es-419) has no supported
+MT engine and is skipped on the MT pass, staying at whatever TM provided until
+a human translator edits it. All MT results are auto-approved as the shipping
+translation during the transitional phase.
 
 ## Transitional posture
 
@@ -80,13 +82,12 @@ downloads, and a separate ADR will document the gated workflow.
 
 ## Rollout plan
 
-Auto-merge ships gated behind repo variable `CROWDIN_AUTOMERGE_DRY_RUN`,
-defaulting to `true`. In dry-run mode the workflow logs its merge decision and
-posts the comment it _would_ have posted, but does not call `gh pr merge`.
-After at least one week of dry-run decisions on real Crowdin PRs with no
-false-positive "would-merge" outcomes, a maintainer flips the repo variable to
-`false` via the GitHub Actions variables UI. Flipping back is a single UI
-change with no code revert required.
+Auto-merge was initially gated behind a custom `crowdin-automerge` workflow
+with a dry-run repo variable. That workflow and its guard chain were removed
+in PR #476 in favour of GitHub's native auto-merge, with safety provided by
+required status checks on `main` and the App-scoped ruleset on
+`chore/crowdin-translations`. A maintainer can disable the flow on any given
+PR by clicking "Disable auto-merge" in the GitHub UI.
 
 ## References
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,8 @@ Community terminology is used throughout: "system" (not patient), "member" (not 
         (primary DB)    (cache/pub-sub) (blob storage)
 ```
 
+On iOS and Android the client uses `expo-sqlite` with SQLCipher. On web, the client substitutes OPFS-backed `wa-sqlite` (with an IndexedDB fallback for browsers that lack OPFS), preserving the same SQLite-shaped adapter interfaces — see [adr/031-web-storage-backend.md](adr/031-web-storage-backend.md).
+
 ### Self-Hosted Deployment
 
 ```
@@ -80,7 +82,7 @@ Tooling packages (`eslint-config`, `prettier-config`, `tsconfig`, `test-utils`) 
             │               │                              │
             ▼               ▼                              ▼
         ┌──────┐     ┌────────────┐                ┌────────────┐
-        │crypto│     │ validation │                │    i18n    │
+        │crypto│     │ validation │                │    i18n    │  (types)
         └──┬───┘     └─────┬──────┘                └────────────┘
            │               │
       ┌────┴────┐      ┌────┘
@@ -107,12 +109,16 @@ Tooling packages (`eslint-config`, `prettier-config`, `tsconfig`, `test-utils`) 
   │ email │  (no @pluralscape deps)
   └───────┘
 
+  ┌────────┐
+  │ logger │  (types)
+  └────────┘
+
   ┌────────────┐
   │ api-client │  (depends on @pluralscape/api for router types)
   └────────────┘
 
   ┌──────┐
-  │ data │  (api-client + crypto + sync + types)
+  │ data │  (api-client + crypto + types)
   └──────┘
 
   ┌─────────────┐
@@ -122,25 +128,27 @@ Tooling packages (`eslint-config`, `prettier-config`, `tsconfig`, `test-utils`) 
     │         │
     ▼         ▼
 ┌───────────┐  ┌───────────┐
-│ import-sp │  │ import-pk │  (import-core + types + validation)
+│ import-sp │  │ import-pk │  (import-core + types + validation; import-pk also depends on data)
 └───────────┘  └───────────┘
 ```
 
+`packages/import-core` is the shared orchestration engine (dependency-ordered walks, checkpoint-based resumption, error classification, bounded warning buffers, `Persister` boundary) behind both SP and PK imports — see [adr/034-import-core-extraction.md](adr/034-import-core-extraction.md).
+
 ### Classification
 
-| Category    | Packages                                                      |
-| ----------- | ------------------------------------------------------------- |
-| Server-only | `db`, `queue`, `rotation-worker`, `email`                     |
-| Client-only | `api-client`, `data`, `import-core`, `import-sp`, `import-pk` |
-| Shared      | `types`, `crypto`, `sync`, `validation`, `i18n`, `storage`    |
+| Category    | Packages                                                                |
+| ----------- | ----------------------------------------------------------------------- |
+| Server-only | `db`, `queue`, `rotation-worker`, `email`                               |
+| Client-only | `api-client`, `data`, `import-core`, `import-sp`, `import-pk`, `logger` |
+| Shared      | `types`, `crypto`, `sync`, `validation`, `i18n`, `storage`              |
 
 ### App Consumers
 
-| App            | Packages consumed                                                                                |
-| -------------- | ------------------------------------------------------------------------------------------------ |
-| `apps/api`     | `crypto`, `db`, `email`, `queue`, `storage`, `sync`, `types`, `validation`                       |
-| `apps/mobile`  | `api-client`, `crypto`, `data`, `i18n`, `import-core`, `import-sp`, `import-pk`, `sync`, `types` |
-| `apps/api-e2e` | `api` (for router types), `crypto`, `sync`, `types`                                              |
+| App            | Packages consumed                                                              |
+| -------------- | ------------------------------------------------------------------------------ |
+| `apps/api`     | `crypto`, `db`, `email`, `queue`, `storage`, `sync`, `types`, `validation`     |
+| `apps/mobile`  | `api-client`, `crypto`, `data`, `i18n`, `import-sp`, `logger`, `sync`, `types` |
+| `apps/api-e2e` | `api` (for router types), `crypto`, `sync`, `types`                            |
 
 ---
 
@@ -204,11 +212,11 @@ Offline queue  ──▶  CRDT merge (conflict resolution)
 
 ### Encryption Boundaries
 
-| Tier                  | Scope                                                  | Algorithm                                       | Key holder                                       |
-| --------------------- | ------------------------------------------------------ | ----------------------------------------------- | ------------------------------------------------ |
-| T1 — User content     | Member profiles, journal entries, front logs, messages | XChaCha20-Poly1305 (libsodium)                  | Client only; server sees ciphertext              |
-| T2 — Operational data | Email addresses, webhook URLs                          | AES-256-GCM (BLAKE2b hash preserved for lookup) | Server; encrypted at rest, decrypted transiently |
-| T3 — Infrastructure   | Push tokens, session metadata                          | Plaintext (TLS in transit)                      | Server; no application-level encryption          |
+| Tier                  | Scope                                                  | Algorithm                                              | Key holder                                       |
+| --------------------- | ------------------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------ |
+| T1 — User content     | Member profiles, journal entries, front logs, messages | XChaCha20-Poly1305 (libsodium)                         | Client only; server sees ciphertext              |
+| T2 — Operational data | Email addresses, webhook URLs                          | XChaCha20-Poly1305 (BLAKE2b hash preserved for lookup) | Server; encrypted at rest, decrypted transiently |
+| T3 — Infrastructure   | Push tokens, session metadata                          | Plaintext (TLS in transit)                             | Server; no application-level encryption          |
 
 Per-bucket symmetric keys are derived client-side. The server never holds T1 key material.
 
@@ -216,25 +224,30 @@ Per-bucket symmetric keys are derived client-side. The server never holds T1 key
 
 ## 4. Key Architecture Decisions
 
-| Pattern             | Decision                                                      | ADR                                                                              |
-| ------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| License             | AGPL-3.0 — copyleft to protect community data                 | [adr/001-agpl-3-license.md](adr/001-agpl-3-license.md)                           |
-| Frontend framework  | React Native via Expo — single codebase for iOS, Android, Web | [adr/002-frontend-framework.md](adr/002-frontend-framework.md)                   |
-| API framework       | Hono on Bun — fast, edge-compatible, supports Bun native APIs | [adr/003-api-framework.md](adr/003-api-framework.md)                             |
-| Database            | PostgreSQL (hosted) + SQLite/SQLCipher (client + self-hosted) | [adr/004-database.md](adr/004-database.md)                                       |
-| Offline sync        | CRDT-based encrypted sync; server relays opaque ciphertext    | [adr/005-offline-sync.md](adr/005-offline-sync.md)                               |
-| Encryption          | libsodium — XChaCha20-Poly1305, X25519, Argon2id              | [adr/006-encryption.md](adr/006-encryption.md)                                   |
-| Real-time           | WebSocket + SSE via tRPC subscriptions                        | [adr/007-realtime.md](adr/007-realtime.md)                                       |
-| Runtime             | Bun — faster cold start, native SQLite, built-in test runner  | [adr/008-runtime.md](adr/008-runtime.md)                                         |
-| Blob storage        | S3-compatible (MinIO self-hosted); pre-signed URLs            | [adr/009-blob-media-storage.md](adr/009-blob-media-storage.md)                   |
-| Background jobs     | BullMQ-compatible queue on Valkey                             | [adr/010-background-jobs.md](adr/010-background-jobs.md)                         |
-| Key recovery        | Recovery code derivation via Argon2id, sharded backup         | [adr/011-key-recovery.md](adr/011-key-recovery.md)                               |
-| Self-hosted tiers   | Minimal (single binary) vs Full (Docker Compose)              | [adr/012-self-hosted-tiers.md](adr/012-self-hosted-tiers.md)                     |
-| Encryption boundary | T1/T2/T3 classification; fail-closed on unmapped data         | [adr/018-encryption-at-rest-boundary.md](adr/018-encryption-at-rest-boundary.md) |
-| RLS denormalization | system_id/account_id columns on every table for RLS           | [adr/020-rls-denormalization.md](adr/020-rls-denormalization.md)                 |
-| Email encryption    | Server-side AES-256-GCM; BLAKE2b hash for lookup              | [adr/029-server-side-encrypted-email.md](adr/029-server-side-encrypted-email.md) |
-| Web storage backend | OPFS+wa-sqlite preferred, IndexedDB fallback; auto-detected   | [adr/031-web-storage-backend.md](adr/031-web-storage-backend.md)                 |
-| tRPC parity         | `pnpm trpc:parity` enforces REST+tRPC coverage on every PR    | [adr/032-trpc-parity-enforcement.md](adr/032-trpc-parity-enforcement.md)         |
+| Pattern             | Decision                                                                                           | ADR                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| License             | AGPL-3.0 — copyleft to protect community data                                                      | [adr/001-agpl-3-license.md](adr/001-agpl-3-license.md)                             |
+| Frontend framework  | React Native via Expo — single codebase for iOS, Android, Web                                      | [adr/002-frontend-framework.md](adr/002-frontend-framework.md)                     |
+| API framework       | Hono on Bun — fast, edge-compatible, supports Bun native APIs                                      | [adr/003-api-framework.md](adr/003-api-framework.md)                               |
+| Database            | PostgreSQL (hosted) + SQLite/SQLCipher (client + self-hosted)                                      | [adr/004-database.md](adr/004-database.md)                                         |
+| Offline sync        | CRDT-based encrypted sync; server relays opaque ciphertext                                         | [adr/005-offline-sync.md](adr/005-offline-sync.md)                                 |
+| Encryption          | libsodium — XChaCha20-Poly1305, X25519, Argon2id                                                   | [adr/006-encryption.md](adr/006-encryption.md)                                     |
+| Real-time           | WebSocket + SSE via tRPC subscriptions                                                             | [adr/007-realtime.md](adr/007-realtime.md)                                         |
+| Runtime             | Bun — faster cold start, native SQLite, built-in test runner                                       | [adr/008-runtime.md](adr/008-runtime.md)                                           |
+| Blob storage        | S3-compatible (MinIO self-hosted); pre-signed URLs                                                 | [adr/009-blob-media-storage.md](adr/009-blob-media-storage.md)                     |
+| Background jobs     | BullMQ-compatible queue on Valkey                                                                  | [adr/010-background-jobs.md](adr/010-background-jobs.md)                           |
+| Key recovery        | Recovery code derivation via Argon2id, sharded backup                                              | [adr/011-key-recovery.md](adr/011-key-recovery.md)                                 |
+| Self-hosted tiers   | Minimal (single binary) vs Full (Docker Compose)                                                   | [adr/012-self-hosted-tiers.md](adr/012-self-hosted-tiers.md)                       |
+| Encryption boundary | T1/T2/T3 classification; fail-closed on unmapped data                                              | [adr/018-encryption-at-rest-boundary.md](adr/018-encryption-at-rest-boundary.md)   |
+| RLS denormalization | system_id/account_id columns on every table for RLS                                                | [adr/020-rls-denormalization.md](adr/020-rls-denormalization.md)                   |
+| Email encryption    | Server-side XChaCha20-Poly1305 (AEAD); BLAKE2b hash for lookup                                     | [adr/029-server-side-encrypted-email.md](adr/029-server-side-encrypted-email.md)   |
+| Web storage backend | OPFS+wa-sqlite preferred, IndexedDB fallback; auto-detected                                        | [adr/031-web-storage-backend.md](adr/031-web-storage-backend.md)                   |
+| tRPC parity         | `pnpm trpc:parity` enforces REST+tRPC coverage on every PR                                         | [adr/032-trpc-parity-enforcement.md](adr/032-trpc-parity-enforcement.md)           |
+| PluralKit client    | Adopt `pkapi.js` (BSD-2-Clause) for PK API v2 with built-in rate limiting                          | [adr/033-pluralkit-api-client-library.md](adr/033-pluralkit-api-client-library.md) |
+| Import core         | Shared orchestration engine behind SP and PK import engines                                        | [adr/034-import-core-extraction.md](adr/034-import-core-extraction.md)             |
+| i18n OTA delivery   | `i18next-chained-backend` (bundled + HTTP), API proxies Crowdin with 24h TTL                       | [adr/035-i18n-ota-delivery.md](adr/035-i18n-ota-delivery.md)                       |
+| Crowdin automation  | Config-as-code glossary, DeepL+Google MT, TM+MT pre-translate, auto-merge for translation-only PRs | [adr/036-crowdin-automation.md](adr/036-crowdin-automation.md)                     |
+| Argon2id profiles   | Context-specific profiles (`TRANSFER`, `MASTER_KEY`) replacing the unified parameter set           | [adr/037-argon2id-context-profiles.md](adr/037-argon2id-context-profiles.md)       |
 
 ---
 
@@ -242,9 +255,9 @@ Per-bucket symmetric keys are derived client-side. The server never holds T1 key
 
 ### Zero-Knowledge Server
 
-The server stores only T1 ciphertext. It cannot read member profiles, journal entries, front logs, or messages. Raw passwords and master keys never reach the server.
+The server stores only T1 ciphertext. It cannot read member profiles, journal entries, front logs, or messages. Raw passwords and master keys never reach the server. All master-key derivation, unwrap, rewrap, and recovery operations execute on the client; the server persists only the encrypted master-key blobs and the auth-key hash.
 
-Authentication uses a split key derivation protocol (ADR 006): a single Argon2id pass over the password produces an `auth_key` (sent to the server, stored as a BLAKE2B hash) and a `password_key` (client-only, used to unwrap the master key). The server verifies a hash of the auth key — it cannot derive the password key or the master key from what it stores.
+Authentication uses a split key derivation protocol (ADR 006): a single Argon2id pass over the password produces an `auth_key` (sent to the server, stored as a BLAKE2B hash) and a `password_key` (client-only, used to unwrap the master key). The server verifies a hash of the auth key — it cannot derive the password key or the master key from what it stores. Argon2id runs against context-specific profiles (`TRANSFER`, `MASTER_KEY`) rather than a single unified parameter set — see [adr/037-argon2id-context-profiles.md](adr/037-argon2id-context-profiles.md).
 
 Per-bucket symmetric keys are generated client-side and exchanged between devices via encrypted key bundles (X25519 ECDH). Key rotation is lazy: triggered on device removal or compromise, not on every write.
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -27,9 +27,11 @@ erDiagram
         varchar email_hash
         varchar email_salt
         binary encrypted_email "server-side key (ADR 029), nullable"
-        varchar password_hash
+        binary auth_key_hash
         varchar kdf_salt
-        binary encrypted_master_key "two-layer KEK/DEK, nullable"
+        binary encrypted_master_key "two-layer KEK/DEK"
+        binary challenge_nonce "nullable, cleared after two-phase register commit"
+        timestamp challenge_expires_at "nullable, paired with challenge_nonce"
         boolean audit_log_ip_tracking "default false"
     }
 
@@ -55,6 +57,7 @@ erDiagram
         varchar id PK
         varchar account_id FK
         binary encrypted_master_key
+        binary recovery_key_hash "nullable, BLAKE2b of raw recovery key"
         timestamp revoked_at
     }
 
@@ -456,6 +459,7 @@ erDiagram
         boolean waking_hours_only "nullable"
         varchar waking_start "nullable, HH:MM:SS"
         varchar waking_end "nullable, HH:MM:SS"
+        timestamp next_check_in_at "nullable, driven by scheduling worker"
         blob encrypted_data "T1"
     }
 
@@ -851,7 +855,7 @@ erDiagram
         varchar account_id FK
         varchar system_id FK
         varchar platform
-        varchar token
+        varchar token_hash "unique per (token_hash, platform)"
         timestamp last_active_at "nullable"
         timestamp revoked_at
     }
@@ -905,11 +909,12 @@ erDiagram
         varchar source
         varchar status
         integer progress_percent
-        jsonb error_log
+        jsonb error_log "nullable, bounded length"
+        jsonb checkpoint_state "nullable, resumption state"
         integer warning_count
-        integer chunks_total
+        integer chunks_total "nullable"
         integer chunks_completed
-        timestamp completed_at
+        timestamp completed_at "nullable"
     }
 
     import_entity_refs {

--- a/docs/guides/api-consumer-guide.md
+++ b/docs/guides/api-consumer-guide.md
@@ -660,7 +660,8 @@ The full set of error codes is defined in `@pluralscape/types` (`API_ERROR_CODES
 | `LOGIN_THROTTLED`      | 429    | Too many failed login attempts for this account                                    |
 | `ALREADY_ARCHIVED`     | 409    | Entity is already archived                                                         |
 | `NOT_ARCHIVED`         | 409    | Cannot restore an entity that is not archived                                      |
-| `FORBIDDEN`            | 403    | API key lacks the required scope (message: `Insufficient scope: requires <scope>`) |
+| `SCOPE_INSUFFICIENT`   | 403    | API key lacks the required scope (message: `Insufficient scope: requires <scope>`) |
+| `FORBIDDEN`            | 403    | Endpoint not registered for API key access, or other authorization failure         |
 | `BUCKET_ACCESS_DENIED` | 403    | Friend does not have access to this privacy bucket                                 |
 | `QUOTA_EXCEEDED`       | 413    | Storage quota exceeded                                                             |
 | `PRECONDITION_FAILED`  | 412    | ETag mismatch or other precondition                                                |
@@ -1465,7 +1466,7 @@ POST   /v1/systems/:systemId/api-keys/:apiKeyId/revoke    Revoke key
 
 The `token` field is only returned in the create response -- store it securely. It cannot be retrieved again.
 
-**Scope enforcement:** a global middleware resolves each request against the central scope registry. If the route is not registered for API key access, or the key lacks the required scope, the server returns `403` with error code `FORBIDDEN` and a message of the form `Insufficient scope: requires <scope>`. Session-authenticated requests bypass the registry. API key management endpoints require the `full` scope to prevent privilege escalation.
+**Scope enforcement:** a global middleware resolves each request against the central scope registry. Session-authenticated requests bypass the registry. If the key lacks the required scope, the server returns `403` with error code `SCOPE_INSUFFICIENT` and a message of the form `Insufficient scope: requires <scope>`. If the route is not registered for API key access at all, the server returns `403` with error code `FORBIDDEN`. API key management endpoints require the `full` scope to prevent privilege escalation.
 
 ---
 

--- a/docs/guides/api-consumer-guide.md
+++ b/docs/guides/api-consumer-guide.md
@@ -17,6 +17,7 @@
    - [8.3 Privacy Buckets](#83-privacy-buckets)
    - [8.4 Friend Network](#84-friend-network)
    - [8.5 Push Notifications](#85-push-notifications)
+   - [8.6 Import Jobs](#86-import-jobs)
 9. [API Keys](#9-api-keys)
    - [9.1 Key Types](#91-key-types)
    - [9.2 Scopes](#92-scopes)
@@ -169,7 +170,7 @@ POST /v1/auth/login
 }
 ```
 
-The client derives the `authKey` from the user's password via Argon2id using the stored account `kdfSalt` (obtained from the account lookup on the client side via `GET /v1/auth/account-salt/:email`), splits the 64-byte derivation, and sends only the auth key portion.
+The client derives the `authKey` from the user's password via Argon2id using the stored account `kdfSalt` (obtained by posting the email to `POST /v1/auth/salt` with body `{ "email": "..." }`), splits the 64-byte derivation, and sends only the auth key portion.
 
 **Response (200 OK):**
 
@@ -649,23 +650,23 @@ In production, 5xx errors have their `message` masked to `"Internal Server Error
 
 The full set of error codes is defined in `@pluralscape/types` (`API_ERROR_CODES`). Key domain-specific codes:
 
-| Code                   | Status | When                                                                  |
-| ---------------------- | ------ | --------------------------------------------------------------------- |
-| `HAS_DEPENDENTS`       | 409    | Delete blocked because entity has dependent records                   |
-| `IDEMPOTENCY_CONFLICT` | 409    | A request with the same idempotency key is already in flight          |
-| `ROTATION_IN_PROGRESS` | 409    | Bucket key rotation prevents the operation                            |
-| `KEY_VERSION_STALE`    | 409    | Write rejected because key version is outdated (re-encrypt and retry) |
-| `SESSION_EXPIRED`      | 401    | Session exceeded its absolute TTL or idle timeout                     |
-| `LOGIN_THROTTLED`      | 429    | Too many failed login attempts for this account                       |
-| `ALREADY_ARCHIVED`     | 409    | Entity is already archived                                            |
-| `NOT_ARCHIVED`         | 409    | Cannot restore an entity that is not archived                         |
-| `SCOPE_INSUFFICIENT`   | 403    | API key lacks the required scope                                      |
-| `BUCKET_ACCESS_DENIED` | 403    | Friend does not have access to this privacy bucket                    |
-| `QUOTA_EXCEEDED`       | 413    | Storage quota exceeded                                                |
-| `PRECONDITION_FAILED`  | 412    | ETag mismatch or other precondition                                   |
-| `INVALID_CURSOR`       | 400    | Pagination cursor malformed or expired                                |
-| `CYCLE_DETECTED`       | 409    | Hierarchical operation would create a cycle                           |
-| `MAX_DEPTH_EXCEEDED`   | 409    | Hierarchy depth limit exceeded                                        |
+| Code                   | Status | When                                                                               |
+| ---------------------- | ------ | ---------------------------------------------------------------------------------- |
+| `HAS_DEPENDENTS`       | 409    | Delete blocked because entity has dependent records                                |
+| `IDEMPOTENCY_CONFLICT` | 409    | A request with the same idempotency key is already in flight                       |
+| `ROTATION_IN_PROGRESS` | 409    | Bucket key rotation prevents the operation                                         |
+| `KEY_VERSION_STALE`    | 409    | Write rejected because key version is outdated (re-encrypt and retry)              |
+| `SESSION_EXPIRED`      | 401    | Session exceeded its absolute TTL or idle timeout                                  |
+| `LOGIN_THROTTLED`      | 429    | Too many failed login attempts for this account                                    |
+| `ALREADY_ARCHIVED`     | 409    | Entity is already archived                                                         |
+| `NOT_ARCHIVED`         | 409    | Cannot restore an entity that is not archived                                      |
+| `FORBIDDEN`            | 403    | API key lacks the required scope (message: `Insufficient scope: requires <scope>`) |
+| `BUCKET_ACCESS_DENIED` | 403    | Friend does not have access to this privacy bucket                                 |
+| `QUOTA_EXCEEDED`       | 413    | Storage quota exceeded                                                             |
+| `PRECONDITION_FAILED`  | 412    | ETag mismatch or other precondition                                                |
+| `INVALID_CURSOR`       | 400    | Pagination cursor malformed or expired                                             |
+| `CYCLE_DETECTED`       | 409    | Hierarchical operation would create a cycle                                        |
+| `MAX_DEPTH_EXCEEDED`   | 409    | Hierarchy depth limit exceeded                                                     |
 
 ### 4.4 Idempotency
 
@@ -716,7 +717,7 @@ X-RateLimit-Reset: 1711843260
 
 When the limit is exceeded, the server returns `429` with an additional `Retry-After` header (seconds until the window resets).
 
-**Rate limit categories:** There are 17 categories ranging from `authHeavy` (5 req/min for login, register, password reset) to `readDefault` (60 req/min for standard reads). Sensitive operations use stricter limits (`accountPurge`: 1/day, `dataExport`: 2/hour). See [`docs/api-limits.md`](../api-limits.md#rate-limits) for the complete table with all current values.
+**Rate limit categories:** There are 19 categories ranging from `authHeavy` (5 req/min for login, register, password reset) to `readDefault` (60 req/min for standard reads). Sensitive operations use stricter limits (`accountPurge`: 1/day, `dataExport`/`dataImport`: 2/hour). See [`docs/api-limits.md`](../api-limits.md#rate-limits) for the complete table with all current values.
 
 Values are defined in `@pluralscape/types` (`RATE_LIMITS`).
 
@@ -1388,6 +1389,29 @@ Each config has `enabled` (master toggle) and `pushEnabled` (push-specific toggl
 
 **Trigger flow:** when a fronting session is created, the API dispatches switch alert jobs to the queue. The push worker picks up the job, resolves eligible friends (based on notification preferences and bucket visibility), and delivers the push notification. This is entirely server-side -- the client only needs to register tokens and configure preferences.
 
+### 8.6 Import Jobs
+
+Import jobs drive bulk data import from other plural-tracking systems (Simply Plural, PluralKit) or a previous Pluralscape export. Jobs are system-scoped and follow a status lifecycle rather than the standard archive/restore pattern.
+
+**Endpoints:**
+
+| Method  | Path                        | Purpose                                                                                                        |
+| ------- | --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `POST`  | `/import-jobs`              | Create a job (uploads source payload, enters `pending`). `write` rate limit, idempotent via `Idempotency-Key`. |
+| `GET`   | `/import-jobs`              | List jobs (paginated; filter by `status` and `source`). `readDefault` rate limit.                              |
+| `GET`   | `/import-jobs/:importJobId` | Get a single job, including progress counters and summary.                                                     |
+| `PATCH` | `/import-jobs/:importJobId` | Update a job (typically to cancel a `pending` job or acknowledge `completed`). `write` rate limit.             |
+
+**Status lifecycle:** `pending → validating → importing → completed` (happy path) or `pending|validating|importing → failed` (terminal). Statuses are a closed enum — see `IMPORT_JOB_STATUSES` in `@pluralscape/types`.
+
+**Sources:** `simply-plural`, `pluralkit`, `pluralscape` — see `IMPORT_SOURCES`. PluralKit and Simply Plural imports consume the vendor export JSON; Pluralscape imports consume the output of the data-export flow.
+
+**Scopes:** all import-job endpoints require the `read:system` (GET) or `write:system` (POST/PATCH) scope when called with an API key.
+
+**Rate limiting:** job creation and update use the `write` category. List/get use `readDefault`. Sustained import throughput is also governed by the `dataImport` category (2/hour) applied at the service layer.
+
+**Result envelope:** create/get/update return `{ data: ImportJob }`; list returns the standard paginated shape (`{ data, nextCursor, hasMore, totalCount }`).
+
 ---
 
 ## 9. API Keys
@@ -1441,7 +1465,7 @@ POST   /v1/systems/:systemId/api-keys/:apiKeyId/revoke    Revoke key
 
 The `token` field is only returned in the create response -- store it securely. It cannot be retrieved again.
 
-**Scope enforcement:** every endpoint checks the requesting key's scopes. If the key lacks the required scope, the server returns `403` with error code `SCOPE_INSUFFICIENT`. API key management endpoints require the `full` scope to prevent privilege escalation.
+**Scope enforcement:** a global middleware resolves each request against the central scope registry. If the route is not registered for API key access, or the key lacks the required scope, the server returns `403` with error code `FORBIDDEN` and a message of the form `Insufficient scope: requires <scope>`. Session-authenticated requests bypass the registry. API key management endpoints require the `full` scope to prevent privilege escalation.
 
 ---
 

--- a/docs/guides/api-key-scopes.md
+++ b/docs/guides/api-key-scopes.md
@@ -68,7 +68,7 @@ When an endpoint requires a scope, the server checks in this order:
 3. For each tier at or above the required tier (write, delete):
    - Check if the key has the aggregate scope for that tier (`write-all`, `delete-all`)
    - Check if the key has the per-entity scope for that tier (`write:members`, `delete:members`)
-4. If none match — denied (403 `FORBIDDEN` with message `Insufficient scope: requires <scope>`)
+4. If none match — denied (403 `SCOPE_INSUFFICIENT` with message `Insufficient scope: requires <scope>`). If the endpoint is not registered for API key access at all, the response is 403 `FORBIDDEN` instead.
 
 ## Scope Count
 

--- a/docs/guides/api-key-scopes.md
+++ b/docs/guides/api-key-scopes.md
@@ -68,7 +68,7 @@ When an endpoint requires a scope, the server checks in this order:
 3. For each tier at or above the required tier (write, delete):
    - Check if the key has the aggregate scope for that tier (`write-all`, `delete-all`)
    - Check if the key has the per-entity scope for that tier (`write:members`, `delete:members`)
-4. If none match — denied (403 `SCOPE_INSUFFICIENT`)
+4. If none match — denied (403 `FORBIDDEN` with message `Insufficient scope: requires <scope>`)
 
 ## Scope Count
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1720,9 +1720,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - systems
+                      - data
                     properties:
-                      systems:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/SystemProfile"
@@ -1939,9 +1939,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/SnapshotResponse"
@@ -2370,9 +2370,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - members
+                      - data
                     properties:
-                      members:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/MemberResponse"
@@ -2631,9 +2631,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - memberships
+                      - data
                     properties:
-                      memberships:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/GroupMembership"
@@ -2896,9 +2896,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - groups
+                      - data
                     properties:
-                      groups:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/GroupResponse"
@@ -3251,9 +3251,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - members
+                      - data
                     properties:
-                      members:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/GroupMembership"
@@ -3353,9 +3353,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - customFronts
+                      - data
                     properties:
-                      customFronts:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/CustomFrontResponse"
@@ -3820,9 +3820,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - fields
+                      - data
                     properties:
-                      fields:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/FieldDefinitionResponse"
@@ -4170,9 +4170,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - relationships
+                      - data
                     properties:
-                      relationships:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/RelationshipResponse"
@@ -4410,9 +4410,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - entityTypes
+                      - data
                     properties:
-                      entityTypes:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/StructureEntityTypeResponse"
@@ -4627,9 +4627,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - entities
+                      - data
                     properties:
-                      entities:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/StructureEntityResponse"
@@ -4849,9 +4849,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - links
+                      - data
                     properties:
-                      links:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/StructureEntityLinkResponse"
@@ -4986,9 +4986,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - memberLinks
+                      - data
                     properties:
-                      memberLinks:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/StructureEntityMemberLinkResponse"
@@ -5086,9 +5086,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - associations
+                      - data
                     properties:
-                      associations:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/StructureEntityAssociationResponse"
@@ -5185,9 +5185,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - events
+                      - data
                     properties:
-                      events:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/LifecycleEventResponse"
@@ -5352,9 +5352,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - regions
+                      - data
                     properties:
-                      regions:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/RegionResponse"
@@ -5566,9 +5566,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - entities
+                      - data
                     properties:
-                      entities:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/EntityResponse"
@@ -5836,9 +5836,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - blobs
+                      - data
                     properties:
-                      blobs:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/BlobResponse"
@@ -6046,9 +6046,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/BucketResponse"
@@ -6955,9 +6955,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/FrontingSessionResponse"
@@ -7289,9 +7289,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/FrontingCommentResponse"
@@ -7941,9 +7941,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/WebhookConfigResponse"
@@ -8266,9 +8266,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/WebhookDeliveryResponse"
@@ -8368,9 +8368,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/ApiKeyResponse"
@@ -8530,9 +8530,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/ChannelResponse"
@@ -8808,9 +8808,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/MessageResponse"
@@ -9141,9 +9141,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/BoardMessageResponse"
@@ -9513,9 +9513,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/NoteResponse"
@@ -9775,9 +9775,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/PollResponse"
@@ -10009,9 +10009,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/PollVoteResponse"
@@ -10304,9 +10304,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/AcknowledgementResponse"
@@ -10553,9 +10553,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/TimerConfigResponse"
@@ -10782,9 +10782,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/CheckInRecordResponse"
@@ -11171,9 +11171,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/ImportJobResponse"
@@ -11371,9 +11371,9 @@ paths:
                 allOf:
                   - type: object
                     required:
-                      - items
+                      - data
                     properties:
-                      items:
+                      data:
                         type: array
                         items:
                           $ref: "#/components/schemas/ImportEntityRefResponse"
@@ -12173,10 +12173,10 @@ components:
     SessionListResponse:
       type: object
       required:
-        - sessions
+        - data
         - hasMore
       properties:
-        sessions:
+        data:
           type: array
           items:
             $ref: "#/components/schemas/SessionInfo"
@@ -12363,10 +12363,10 @@ components:
     AuditLogResponse:
       type: object
       required:
-        - events
+        - data
         - hasMore
       properties:
-        events:
+        data:
           type: array
           items:
             $ref: "#/components/schemas/AuditLogEntry"
@@ -16187,13 +16187,13 @@ components:
     BucketExportPageResponse:
       type: object
       required:
-        - items
+        - data
         - nextCursor
         - hasMore
         - totalCount
         - etag
       properties:
-        items:
+        data:
           type: array
           items:
             $ref: "#/components/schemas/BucketExportEntity"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4040,19 +4040,17 @@ paths:
                   - data
                 properties:
                   data:
-                    type: object
-                    required:
-                      - items
-                    properties:
-                      items:
-                        type: array
-                        items:
-                          type: object
-                          required:
-                            - bucketId
-                          properties:
-                            bucketId:
-                              type: string
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - fieldDefinitionId
+                        - bucketId
+                      properties:
+                        fieldDefinitionId:
+                          type: string
+                        bucketId:
+                          type: string
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "404":
@@ -11124,9 +11122,9 @@ paths:
               schema:
                 type: object
                 required:
-                  - items
+                  - data
                 properties:
-                  items:
+                  data:
                     type: array
                     items:
                       $ref: "#/components/schemas/HierarchyNode"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -773,7 +773,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/account_PinRequest"
+              $ref: "#/components/schemas/PinRequest-2"
       responses:
         "204":
           $ref: "#/components/responses/NoContent"
@@ -802,7 +802,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/account_PinRequest"
+              $ref: "#/components/schemas/PinRequest-2"
       responses:
         "204":
           $ref: "#/components/responses/NoContent"
@@ -833,7 +833,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/account_PinRequest"
+              $ref: "#/components/schemas/PinRequest-2"
       responses:
         "200":
           description: PIN verified
@@ -6918,6 +6918,18 @@ paths:
             type: integer
             format: int64
           description: Filter sessions starting at or before this Unix timestamp (ms)
+        - name: endFrom
+          in: query
+          schema:
+            type: integer
+            format: int64
+          description: Filter sessions ending at or after this Unix timestamp (ms)
+        - name: endUntil
+          in: query
+          schema:
+            type: integer
+            format: int64
+          description: Filter sessions ending at or before this Unix timestamp (ms)
         - name: activeOnly
           in: query
           schema:
@@ -11650,6 +11662,31 @@ paths:
                     $ref: "#/components/schemas/I18nNamespace"
         "304":
           description: Not modified
+        "404":
+          description: Translation not found for the given locale/namespace
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - NAMESPACE_NOT_FOUND
+                      message:
+                        type: string
+              example:
+                error:
+                  code: NAMESPACE_NOT_FOUND
+                  message: Translation not found
         "429":
           $ref: "#/components/responses/RateLimited"
         "502":
@@ -11731,6 +11768,7 @@ components:
                 - BUCKET_ACCESS_DENIED
                 - NOT_FOUND
                 - CONFLICT
+                - INVALID_STATE
                 - HAS_DEPENDENTS
                 - ROTATION_IN_PROGRESS
                 - FRIEND_CODE_EXPIRED
@@ -12186,12 +12224,8 @@ components:
         data:
           type: object
           required:
-            - success
             - revokedCount
           properties:
-            success:
-              type: boolean
-              const: true
             revokedCount:
               type: integer
               description: Number of sessions revoked
@@ -12573,9 +12607,6 @@ components:
       type: object
       required:
         - encryptedData
-        - copyPhotos
-        - copyFields
-        - copyMemberships
       properties:
         encryptedData:
           type: string
@@ -12585,12 +12616,15 @@ components:
           description: T1-encrypted PlaintextMember for the new duplicate (see ./plaintext.yaml#/PlaintextMember)
         copyPhotos:
           type: boolean
+          default: false
           description: Whether to copy the source member's photos to the duplicate
         copyFields:
           type: boolean
+          default: false
           description: Whether to copy the source member's custom field values to the duplicate
         copyMemberships:
           type: boolean
+          default: false
           description: Whether to copy the source member's group memberships to the duplicate
     CreateMemberPhotoRequest:
       type: object
@@ -16045,7 +16079,7 @@ components:
         notes:
           type: string
           nullable: true
-    account_PinRequest:
+    PinRequest-2:
       type: object
       required:
         - pin
@@ -16420,22 +16454,81 @@ components:
       type: string
       enum:
         - read:members
-        - write:members
         - read:fronting
-        - write:fronting
         - read:groups
-        - write:groups
         - read:system
-        - write:system
+        - read:structure
+        - read:reports
         - read:webhooks
-        - write:webhooks
-        - read:audit-log
         - read:blobs
-        - write:blobs
         - read:notifications
+        - read:acknowledgements
+        - read:channels
+        - read:messages
+        - read:notes
+        - read:polls
+        - read:relationships
+        - read:innerworld
+        - read:fields
+        - read:check-ins
+        - read:lifecycle-events
+        - read:timers
+        - read:buckets
+        - write:members
+        - write:fronting
+        - write:groups
+        - write:system
+        - write:structure
+        - write:reports
+        - write:webhooks
+        - write:blobs
         - write:notifications
+        - write:acknowledgements
+        - write:channels
+        - write:messages
+        - write:notes
+        - write:polls
+        - write:relationships
+        - write:innerworld
+        - write:fields
+        - write:check-ins
+        - write:lifecycle-events
+        - write:timers
+        - write:buckets
+        - delete:members
+        - delete:fronting
+        - delete:groups
+        - delete:system
+        - delete:structure
+        - delete:reports
+        - delete:webhooks
+        - delete:blobs
+        - delete:notifications
+        - delete:acknowledgements
+        - delete:channels
+        - delete:messages
+        - delete:notes
+        - delete:polls
+        - delete:relationships
+        - delete:innerworld
+        - delete:fields
+        - delete:check-ins
+        - delete:lifecycle-events
+        - delete:timers
+        - delete:buckets
+        - read:audit-log
+        - read-all
+        - write-all
+        - delete-all
         - full
-      description: Permission scope granted to this API key
+      description: |
+        Permission scope granted to an API key. Scopes follow the
+        `<tier>:<domain>` pattern plus a small set of special values.
+
+        - Tiers: `read` (list/get), `write` (create/update), `delete` (destroy).
+        - Aggregates: `read-all`, `write-all`, `delete-all` grant the tier across every domain.
+        - `read:audit-log` is the only audit-log scope (read-only by design).
+        - `full` grants unrestricted access including audit-log and api-key management endpoints.
     ApiKeyResponse:
       description: |
         An API key. The plaintext `token` is only returned on creation and
@@ -17364,7 +17457,7 @@ components:
           type: object
           additionalProperties:
             type: boolean
-          description: Map of ImportEntityType → whether to import. At least one must be true.
+          description: Map of ImportCollectionType → whether to import. At least one must be true.
         avatarMode:
           $ref: "#/components/schemas/ImportAvatarMode"
     UpdateImportJobBody:

--- a/docs/openapi/paths/acknowledgements.yaml
+++ b/docs/openapi/paths/acknowledgements.yaml
@@ -37,9 +37,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/acknowledgements.yaml#/AcknowledgementResponse"

--- a/docs/openapi/paths/api-keys.yaml
+++ b/docs/openapi/paths/api-keys.yaml
@@ -28,9 +28,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/api-keys.yaml#/ApiKeyResponse"

--- a/docs/openapi/paths/blobs.yaml
+++ b/docs/openapi/paths/blobs.yaml
@@ -23,9 +23,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [blobs]
+                  required: [data]
                   properties:
-                    blobs:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/blobs.yaml#/BlobResponse"

--- a/docs/openapi/paths/board-messages.yaml
+++ b/docs/openapi/paths/board-messages.yaml
@@ -37,9 +37,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/board-messages.yaml#/BoardMessageResponse"

--- a/docs/openapi/paths/buckets.yaml
+++ b/docs/openapi/paths/buckets.yaml
@@ -29,9 +29,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/buckets.yaml#/BucketResponse"

--- a/docs/openapi/paths/channels.yaml
+++ b/docs/openapi/paths/channels.yaml
@@ -43,9 +43,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/channels.yaml#/ChannelResponse"

--- a/docs/openapi/paths/check-in-records.yaml
+++ b/docs/openapi/paths/check-in-records.yaml
@@ -39,9 +39,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/timers.yaml#/CheckInRecordResponse"

--- a/docs/openapi/paths/custom-fronts.yaml
+++ b/docs/openapi/paths/custom-fronts.yaml
@@ -23,9 +23,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [customFronts]
+                  required: [data]
                   properties:
-                    customFronts:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/custom-fronts.yaml#/CustomFrontResponse"

--- a/docs/openapi/paths/fields.yaml
+++ b/docs/openapi/paths/fields.yaml
@@ -234,17 +234,15 @@
               required: [data]
               properties:
                 data:
-                  type: object
-                  required: [items]
-                  properties:
-                    items:
-                      type: array
-                      items:
-                        type: object
-                        required: [bucketId]
-                        properties:
-                          bucketId:
-                            type: string
+                  type: array
+                  items:
+                    type: object
+                    required: [fieldDefinitionId, bucketId]
+                    properties:
+                      fieldDefinitionId:
+                        type: string
+                      bucketId:
+                        type: string
       "401":
         $ref: "../openapi.yaml#/components/responses/Unauthenticated"
       "404":

--- a/docs/openapi/paths/fields.yaml
+++ b/docs/openapi/paths/fields.yaml
@@ -18,9 +18,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [fields]
+                  required: [data]
                   properties:
-                    fields:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/fields.yaml#/FieldDefinitionResponse"

--- a/docs/openapi/paths/fronting-sessions.yaml
+++ b/docs/openapi/paths/fronting-sessions.yaml
@@ -42,6 +42,18 @@
           type: integer
           format: int64
         description: Filter sessions starting at or before this Unix timestamp (ms)
+      - name: endFrom
+        in: query
+        schema:
+          type: integer
+          format: int64
+        description: Filter sessions ending at or after this Unix timestamp (ms)
+      - name: endUntil
+        in: query
+        schema:
+          type: integer
+          format: int64
+        description: Filter sessions ending at or before this Unix timestamp (ms)
       - name: activeOnly
         in: query
         schema:

--- a/docs/openapi/paths/fronting-sessions.yaml
+++ b/docs/openapi/paths/fronting-sessions.yaml
@@ -74,9 +74,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/fronting.yaml#/FrontingSessionResponse"
@@ -402,9 +402,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/fronting.yaml#/FrontingCommentResponse"

--- a/docs/openapi/paths/groups.yaml
+++ b/docs/openapi/paths/groups.yaml
@@ -22,9 +22,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [groups]
+                  required: [data]
                   properties:
-                    groups:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/groups.yaml#/GroupResponse"
@@ -373,9 +373,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [members]
+                  required: [data]
                   properties:
-                    members:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/groups.yaml#/GroupMembership"

--- a/docs/openapi/paths/import-entity-refs.yaml
+++ b/docs/openapi/paths/import-entity-refs.yaml
@@ -37,9 +37,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/import-export.yaml#/ImportEntityRefResponse"

--- a/docs/openapi/paths/import-jobs.yaml
+++ b/docs/openapi/paths/import-jobs.yaml
@@ -31,9 +31,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/import-export.yaml#/ImportJobResponse"

--- a/docs/openapi/paths/innerworld.yaml
+++ b/docs/openapi/paths/innerworld.yaml
@@ -18,9 +18,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [regions]
+                  required: [data]
                   properties:
-                    regions:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/innerworld.yaml#/RegionResponse"
@@ -228,9 +228,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [entities]
+                  required: [data]
                   properties:
-                    entities:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/innerworld.yaml#/EntityResponse"

--- a/docs/openapi/paths/lifecycle-events.yaml
+++ b/docs/openapi/paths/lifecycle-events.yaml
@@ -25,9 +25,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [events]
+                  required: [data]
                   properties:
-                    events:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/lifecycle-events.yaml#/LifecycleEventResponse"

--- a/docs/openapi/paths/members.yaml
+++ b/docs/openapi/paths/members.yaml
@@ -23,9 +23,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [members]
+                  required: [data]
                   properties:
-                    members:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/members.yaml#/MemberResponse"
@@ -280,9 +280,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [memberships]
+                  required: [data]
                   properties:
-                    memberships:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/groups.yaml#/GroupMembership"

--- a/docs/openapi/paths/messages.yaml
+++ b/docs/openapi/paths/messages.yaml
@@ -53,9 +53,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/messages.yaml#/MessageResponse"

--- a/docs/openapi/paths/notes.yaml
+++ b/docs/openapi/paths/notes.yaml
@@ -50,9 +50,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/notes.yaml#/NoteResponse"

--- a/docs/openapi/paths/polls.yaml
+++ b/docs/openapi/paths/polls.yaml
@@ -37,9 +37,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/polls.yaml#/PollResponse"
@@ -265,9 +265,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/polls.yaml#/PollVoteResponse"

--- a/docs/openapi/paths/relationships.yaml
+++ b/docs/openapi/paths/relationships.yaml
@@ -22,9 +22,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [relationships]
+                  required: [data]
                   properties:
-                    relationships:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/relationships.yaml#/RelationshipResponse"

--- a/docs/openapi/paths/structure-entities.yaml
+++ b/docs/openapi/paths/structure-entities.yaml
@@ -23,9 +23,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [entities]
+                  required: [data]
                   properties:
-                    entities:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/structures.yaml#/StructureEntityResponse"
@@ -281,9 +281,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [links]
+                  required: [data]
                   properties:
-                    links:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/structures.yaml#/StructureEntityLinkResponse"
@@ -415,9 +415,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [memberLinks]
+                  required: [data]
                   properties:
-                    memberLinks:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/structures.yaml#/StructureEntityMemberLinkResponse"
@@ -513,9 +513,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [associations]
+                  required: [data]
                   properties:
-                    associations:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/structures.yaml#/StructureEntityAssociationResponse"

--- a/docs/openapi/paths/structure-entities.yaml
+++ b/docs/openapi/paths/structure-entities.yaml
@@ -182,9 +182,9 @@
           application/json:
             schema:
               type: object
-              required: [items]
+              required: [data]
               properties:
-                items:
+                data:
                   type: array
                   items:
                     $ref: "../schemas/structures.yaml#/HierarchyNode"

--- a/docs/openapi/paths/structure-entity-types.yaml
+++ b/docs/openapi/paths/structure-entity-types.yaml
@@ -18,9 +18,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [entityTypes]
+                  required: [data]
                   properties:
-                    entityTypes:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/structures.yaml#/StructureEntityTypeResponse"

--- a/docs/openapi/paths/systems.yaml
+++ b/docs/openapi/paths/systems.yaml
@@ -20,9 +20,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [systems]
+                  required: [data]
                   properties:
-                    systems:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/systems.yaml#/SystemProfile"
@@ -235,9 +235,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/systems.yaml#/SnapshotResponse"

--- a/docs/openapi/paths/timer-configs.yaml
+++ b/docs/openapi/paths/timer-configs.yaml
@@ -27,9 +27,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/timers.yaml#/TimerConfigResponse"

--- a/docs/openapi/paths/webhook-configs.yaml
+++ b/docs/openapi/paths/webhook-configs.yaml
@@ -28,9 +28,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/webhooks.yaml#/WebhookConfigResponse"

--- a/docs/openapi/paths/webhook-deliveries.yaml
+++ b/docs/openapi/paths/webhook-deliveries.yaml
@@ -38,9 +38,9 @@
             schema:
               allOf:
                 - type: object
-                  required: [items]
+                  required: [data]
                   properties:
-                    items:
+                    data:
                       type: array
                       items:
                         $ref: "../schemas/webhooks.yaml#/WebhookDeliveryResponse"

--- a/docs/openapi/schemas/account.yaml
+++ b/docs/openapi/schemas/account.yaml
@@ -120,9 +120,9 @@ AuditLogEntry:
 
 AuditLogResponse:
   type: object
-  required: [events, hasMore]
+  required: [data, hasMore]
   properties:
-    events:
+    data:
       type: array
       items:
         $ref: "#/AuditLogEntry"

--- a/docs/openapi/schemas/api-keys.yaml
+++ b/docs/openapi/schemas/api-keys.yaml
@@ -8,23 +8,86 @@ ApiKeyType:
 ApiKeyScope:
   type: string
   enum:
+    # Per-domain read scopes
     - "read:members"
-    - "write:members"
     - "read:fronting"
-    - "write:fronting"
     - "read:groups"
-    - "write:groups"
     - "read:system"
-    - "write:system"
+    - "read:structure"
+    - "read:reports"
     - "read:webhooks"
-    - "write:webhooks"
-    - "read:audit-log"
     - "read:blobs"
-    - "write:blobs"
     - "read:notifications"
+    - "read:acknowledgements"
+    - "read:channels"
+    - "read:messages"
+    - "read:notes"
+    - "read:polls"
+    - "read:relationships"
+    - "read:innerworld"
+    - "read:fields"
+    - "read:check-ins"
+    - "read:lifecycle-events"
+    - "read:timers"
+    - "read:buckets"
+    # Per-domain write scopes
+    - "write:members"
+    - "write:fronting"
+    - "write:groups"
+    - "write:system"
+    - "write:structure"
+    - "write:reports"
+    - "write:webhooks"
+    - "write:blobs"
     - "write:notifications"
+    - "write:acknowledgements"
+    - "write:channels"
+    - "write:messages"
+    - "write:notes"
+    - "write:polls"
+    - "write:relationships"
+    - "write:innerworld"
+    - "write:fields"
+    - "write:check-ins"
+    - "write:lifecycle-events"
+    - "write:timers"
+    - "write:buckets"
+    # Per-domain delete scopes
+    - "delete:members"
+    - "delete:fronting"
+    - "delete:groups"
+    - "delete:system"
+    - "delete:structure"
+    - "delete:reports"
+    - "delete:webhooks"
+    - "delete:blobs"
+    - "delete:notifications"
+    - "delete:acknowledgements"
+    - "delete:channels"
+    - "delete:messages"
+    - "delete:notes"
+    - "delete:polls"
+    - "delete:relationships"
+    - "delete:innerworld"
+    - "delete:fields"
+    - "delete:check-ins"
+    - "delete:lifecycle-events"
+    - "delete:timers"
+    - "delete:buckets"
+    # Special scopes
+    - "read:audit-log"
+    - "read-all"
+    - "write-all"
+    - "delete-all"
     - "full"
-  description: Permission scope granted to this API key
+  description: |
+    Permission scope granted to an API key. Scopes follow the
+    `<tier>:<domain>` pattern plus a small set of special values.
+
+    - Tiers: `read` (list/get), `write` (create/update), `delete` (destroy).
+    - Aggregates: `read-all`, `write-all`, `delete-all` grant the tier across every domain.
+    - `read:audit-log` is the only audit-log scope (read-only by design).
+    - `full` grants unrestricted access including audit-log and api-key management endpoints.
 
 ApiKeyResponse:
   description: |

--- a/docs/openapi/schemas/auth.yaml
+++ b/docs/openapi/schemas/auth.yaml
@@ -333,11 +333,8 @@ RevokeAllResponse:
   properties:
     data:
       type: object
-      required: [success, revokedCount]
+      required: [revokedCount]
       properties:
-        success:
-          type: boolean
-          const: true
         revokedCount:
           type: integer
           description: Number of sessions revoked

--- a/docs/openapi/schemas/auth.yaml
+++ b/docs/openapi/schemas/auth.yaml
@@ -274,9 +274,9 @@ SessionInfo:
 
 SessionListResponse:
   type: object
-  required: [sessions, hasMore]
+  required: [data, hasMore]
   properties:
-    sessions:
+    data:
       type: array
       items:
         $ref: "#/SessionInfo"

--- a/docs/openapi/schemas/bucket-export.yaml
+++ b/docs/openapi/schemas/bucket-export.yaml
@@ -54,9 +54,9 @@ BucketExportEntity:
 
 BucketExportPageResponse:
   type: object
-  required: [items, nextCursor, hasMore, totalCount, etag]
+  required: [data, nextCursor, hasMore, totalCount, etag]
   properties:
-    items:
+    data:
       type: array
       items:
         $ref: "#/BucketExportEntity"

--- a/docs/openapi/schemas/common.yaml
+++ b/docs/openapi/schemas/common.yaml
@@ -20,6 +20,7 @@ ErrorResponse:
             - BUCKET_ACCESS_DENIED
             - NOT_FOUND
             - CONFLICT
+            - INVALID_STATE
             - HAS_DEPENDENTS
             - ROTATION_IN_PROGRESS
             - FRIEND_CODE_EXPIRED

--- a/docs/openapi/schemas/import-export.yaml
+++ b/docs/openapi/schemas/import-export.yaml
@@ -210,7 +210,7 @@ CreateImportJobBody:
       type: object
       additionalProperties:
         type: boolean
-      description: Map of ImportEntityType → whether to import. At least one must be true.
+      description: Map of ImportCollectionType → whether to import. At least one must be true.
     avatarMode:
       $ref: "#/ImportAvatarMode"
 

--- a/docs/openapi/schemas/members.yaml
+++ b/docs/openapi/schemas/members.yaml
@@ -30,7 +30,7 @@ UpdateMemberRequest:
 
 DuplicateMemberRequest:
   type: object
-  required: [encryptedData, copyPhotos, copyFields, copyMemberships]
+  required: [encryptedData]
   properties:
     encryptedData:
       type: string
@@ -40,10 +40,13 @@ DuplicateMemberRequest:
       description: "T1-encrypted PlaintextMember for the new duplicate (see ./plaintext.yaml#/PlaintextMember)"
     copyPhotos:
       type: boolean
+      default: false
       description: Whether to copy the source member's photos to the duplicate
     copyFields:
       type: boolean
+      default: false
       description: Whether to copy the source member's custom field values to the duplicate
     copyMemberships:
       type: boolean
+      default: false
       description: Whether to copy the source member's group memberships to the duplicate

--- a/docs/planning/features.md
+++ b/docs/planning/features.md
@@ -179,7 +179,7 @@ Full-text search across all entity types, powered by local SQLite FTS5. Search r
   - Key creation UI uses plain language, visual scope indicators, and confirmation prompts for high-access keys
   - OpenAPI 3.1 specification with automated reconciliation script and CI drift check
 - **tRPC internal API** — end-to-end type-safe API layer for the Expo mobile client (ADR 032) [complete]
-  - 39 routers mirroring the full REST surface; same service layer, same validation, same rate limits
+  - 38 routers mirroring the full REST surface; same service layer, same validation, same rate limits
   - `@pluralscape/api-client` package with TanStack Query integration, React provider, and typed hooks
   - CI-enforced parity script verifying 1:1 REST ↔ tRPC coverage
   - [tRPC consumer guide](../trpc-guide.md) and [API consumer guide](../guides/api-consumer-guide.md)

--- a/docs/planning/features.md
+++ b/docs/planning/features.md
@@ -170,7 +170,7 @@ Full-text search across all entity types, powered by local SQLite FTS5. Search r
 
 ## 9. API and Integrations
 
-- **Public REST API** — 31 route domains, 304 operations (ADR 003) [API complete, client pending]
+- **Public REST API** — 32 route domains, 317 operations (ADR 003) [API complete, client pending]
   - API uses canonical terms (`member`, `system`, `fronting`, `switch`) regardless of per-system nomenclature settings
   - Hybrid auth model with two key types (ADR 013):
     - **Metadata keys** — access tier 3 plaintext data only (timestamps, events, connection status). No crypto needed. For simple integrations like Discord bots.
@@ -179,7 +179,7 @@ Full-text search across all entity types, powered by local SQLite FTS5. Search r
   - Key creation UI uses plain language, visual scope indicators, and confirmation prompts for high-access keys
   - OpenAPI 3.1 specification with automated reconciliation script and CI drift check
 - **tRPC internal API** — end-to-end type-safe API layer for the Expo mobile client (ADR 032) [complete]
-  - 35 routers mirroring the full REST surface; same service layer, same validation, same rate limits
+  - 39 routers mirroring the full REST surface; same service layer, same validation, same rate limits
   - `@pluralscape/api-client` package with TanStack Query integration, React provider, and typed hooks
   - CI-enforced parity script verifying 1:1 REST ↔ tRPC coverage
   - [tRPC consumer guide](../trpc-guide.md) and [API consumer guide](../guides/api-consumer-guide.md)
@@ -192,9 +192,9 @@ Full-text search across all entity types, powered by local SQLite FTS5. Search r
   - Optional: encrypted tier 1/2 payloads for webhook endpoints with an assigned crypto key
 - **Email notifications** — system-level email delivery for account events (password changes, friend requests, etc.); managed via notification configuration API
 - **Device transfer** — encrypted device-to-device key transfer for multi-device key recovery (ADR 011) [API complete, client pending]
-- **PluralKit bridge** — bidirectional sync via PK token; runs client-side (requires app to be open) since the server cannot decrypt data
+- **PluralKit bridge** — bidirectional sync via PK token; runs client-side (requires app to be open) since the server cannot decrypt data. Built on the same `pkapi.js` client library used by PK import (ADR 033).
 - **Rate limiting** — per-category rate limits (read, write, auth, sensitive) with Valkey-backed distributed store; applied to both REST and tRPC
-- **API documentation** — OpenAPI 3.1 specification (304 operations), API consumer guide, tRPC consumer guide
+- **API documentation** — OpenAPI 3.1 specification (317 operations), API consumer guide, tRPC consumer guide
 - **Integration guides** — step-by-step guides for common languages (Python, JavaScript/TypeScript, Go, Rust, C#) covering authentication, metadata endpoints, and encrypted data decryption
 - **Client SDKs** (future) — official libraries for common languages that handle authentication and libsodium decryption, so third-party developers don't need to implement the crypto stack themselves. See [future feature doc](../future-features/003-client-sdks.md) for detailed design.
 
@@ -202,8 +202,10 @@ Full-text search across all entity types, powered by local SQLite FTS5. Search r
 
 All report generation is client-side (the server cannot read encrypted data).
 
-- **Simply Plural import** — parse SP JSON export (raw MongoDB dump, no schema version): members, fronting history, custom fields, groups, notes, chat messages (decrypted), board messages, polls, timers, privacy buckets, friend data. Avatars imported separately (ZIP with 7-day expiry). IDs are MongoDB ObjectIds; timestamps are epoch milliseconds. Import runs client-side with progress indicator; large imports are chunked to avoid OOM on low-spec devices.
-- **PluralKit import** — parse PK JSON export (schema version 2): members, switches, groups. Uses 5-char human-readable IDs; timestamps are ISO 8601. Note: PK has no custom fields, notes, polls, chat, timers, or privacy buckets.
+All import engines share the orchestration layer in `@pluralscape/import-core` — dependency-ordered collection walks, checkpoint-based resume, error classification, and the `Persister` boundary (ADR 034).
+
+- **Simply Plural import** — two source modes: JSON file (raw MongoDB export, no schema version) or live SP API (`ApiSource`) using the user's SP token. Covers members, fronting history, custom fields, groups, notes, chat messages, board messages, polls, timers, privacy buckets, and friend data. Avatars imported separately (ZIP with 7-day expiry). IDs are MongoDB ObjectIds; timestamps are epoch milliseconds. Import runs client-side with progress indicator; large imports are chunked to avoid OOM on low-spec devices.
+- **PluralKit import** — two source modes: JSON file (schema version 2) or live PK API via the `pkapi.js` client library (ADR 033), which handles PK's per-scope rate limits and `retry_after` backoff. Covers members, switches, and groups. Uses 5-char human-readable IDs; timestamps are ISO 8601. Note: PK has no custom fields, notes, polls, chat, timers, or privacy buckets.
 - **Encrypted blob storage** — upload and download URLs for client-encrypted media via the blobs API; blob confirmation and lifecycle management [API complete, client pending]
 - **JSON/CSV export** — all user data, single-click
 - **Member report** — generated based on a chosen privacy bucket; includes all member data visible within that bucket, formatted for readability even with hundreds of members (HTML or PDF, potentially many pages)
@@ -212,11 +214,13 @@ All report generation is client-side (the server cannot read encrypted data).
 
 ## 11. Internationalization (i18n)
 
-- All UI strings externalized from day one
-- Translation framework integrated into build pipeline
-- RTL language support
+- All UI strings externalized from day one (i18next + `@pluralscape/i18n`)
+- 12 target locales shipping today: ar, de, en, es, es-419, fr, it, ja, ko, nl, pt-BR, ru, zh-Hans (English is the source)
+- Baseline translations bundled per app build via Metro code-splitting (only the active locale parses at runtime)
+- **OTA delivery** via `/v1/i18n/:locale/:namespace` proxy on the Pluralscape API, backed by Crowdin Distribution CDN with 24h Valkey TTL and ETag-gated 304s. Mobile uses `i18next-chained-backend` (bundled → OTA) with AsyncStorage cache; stale/failed fetches fall back to the bundled baseline. End-user IPs never reach Crowdin. (ADR 035)
+- **Crowdin automation pipeline** (ADR 036): config-as-code glossary, dual MT engines (DeepL for 10 languages, Google Cloud Translation for ar and es-419), automatic TM + MT pre-translation on source upload, and guard-chained auto-merge for translation-only PRs. MT output is the shipping translation during the transitional phase; human edits in the Crowdin UI supersede MT on the next daily sync.
+- RTL language support (Arabic today)
 - Date/time/number localization
-- Community translations via Crowdin
 
 ## 12. Configurable Nomenclature
 
@@ -264,6 +268,7 @@ Data is categorized into three tiers based on sensitivity and server visibility:
 - libsodium: XChaCha20-Poly1305 (symmetric), X25519 (key exchange), Argon2id (key derivation) — ADR 006
 - Per-bucket symmetric keys for privacy bucket sharing
 - Client-side encryption/decryption for all tier 1 and tier 2 data
+- **Zero-knowledge master key** — all master-key operations (derivation from password, unwrap of per-bucket keys, recovery-key flows) run exclusively on the client. The server never receives the master key or any long-lived key material; it stores only verifier hashes, wrapped blobs, and public key material. Argon2id runs on-device with context-specific profiles (ADR 037).
 
 ### Key recovery (ADR 011)
 
@@ -286,6 +291,10 @@ Data is categorized into three tiers based on sensitivity and server visibility:
 - Sync protocol co-designed with database schema (not retrofitted)
 - Visual sync indicator (spinning icon during transfer)
 - Queue-based offline writes persisted and replayed on reconnect
+- **Web storage backend** (ADR 031) — tiered with automatic capability detection:
+  - **OPFS + wa-sqlite** (preferred) — WebAssembly SQLite backed by the Origin Private File System, runs in a dedicated Web Worker, reuses the same `SqliteDriver` and adapter layer as mobile
+  - **IndexedDB fallback** — same `SyncStorageAdapter` / `OfflineQueueAdapter` interfaces for browsers without OPFS support
+  - Auth token storage is independent of the CRDT backend so sessions survive refresh on every supported browser
 
 ## 16. Media Storage
 

--- a/docs/planning/milestones.md
+++ b/docs/planning/milestones.md
@@ -285,4 +285,4 @@ These features are tracked but may be deferred past initial launch. Each has a d
 
 For system topology, package dependencies, data flow, encryption boundaries, and the development sequence rationale, see the [Architecture Overview](../architecture.md).
 
-34 accepted ADRs are documented in [`docs/adr/`](../adr/).
+37 accepted ADRs are documented in [`docs/adr/`](../adr/).

--- a/docs/trpc-guide.md
+++ b/docs/trpc-guide.md
@@ -19,65 +19,72 @@ import { trpc } from "@pluralscape/api-client/trpc";
 ### Usage with React Query hooks
 
 ```ts
-// Query
-const { data, isLoading } = trpc.member.list.useQuery({ systemId });
+// Query — the active system is resolved from session context, not input
+const { data, isLoading } = trpc.member.list.useQuery({ includeArchived: false });
 
-// Mutation
+// Mutation — member payloads are end-to-end encrypted; pass the sealed blob
 const createMember = trpc.member.create.useMutation();
-createMember.mutate({ systemId, name: "Iris", pronouns: "she/her" });
+createMember.mutate({ encryptedData });
 
 // Invalidate after mutation
 const utils = trpc.useUtils();
-await utils.member.list.invalidate({ systemId });
+await utils.member.list.invalidate();
 ```
 
 React Query handles deduplication and retry. Do not add manual idempotency keys to tRPC calls.
 
 ### Available routers
 
-| Router                | Domain                                    |
-| --------------------- | ----------------------------------------- |
-| `account`             | Account management and deletion           |
-| `acknowledgement`     | Acknowledgement records                   |
-| `analytics`           | System usage analytics                    |
-| `api-key`             | API key issuance and revocation           |
-| `auth`                | Authentication (login, register, session) |
-| `blob`                | Binary asset upload and retrieval         |
-| `board-message`       | Message board posts                       |
-| `bucket`              | Privacy buckets                           |
-| `channel`             | Communication channels                    |
-| `check-in-record`     | Check-in entries                          |
-| `custom-front`        | Custom front states (e.g. "Dissociated")  |
-| `device-token`        | Push notification tokens                  |
-| `field`               | Custom fields                             |
-| `friend-code`         | Friend code generation and redemption     |
-| `friend`              | Friend relationships                      |
-| `fronting-comment`    | Comments on fronting sessions             |
-| `fronting-report`     | Fronting history reports                  |
-| `fronting-session`    | Active and past fronting sessions         |
-| `group`               | Member groups                             |
-| `innerworld`          | Innerworld locations and map data         |
-| `lifecycle-event`     | Member lifecycle events                   |
-| `member-photo`        | Member profile photos                     |
-| `member`              | System members (headmates)                |
-| `message`             | Direct messages                           |
-| `note`                | Notes and journal entries                 |
-| `notification-config` | Notification preferences                  |
-| `poll`                | Polls                                     |
-| `relationship`        | Member-to-member relationships            |
-| `snapshot`            | System snapshots for sync                 |
-| `structure`           | System structure metadata                 |
-| `system-settings`     | System-level settings                     |
-| `system`              | System (account) profile                  |
-| `timer-config`        | Timers                                    |
-| `webhook-config`      | Webhook configuration                     |
-| `webhook-delivery`    | Webhook delivery log                      |
+Router keys match the object composed in `apps/api/src/trpc/root.ts` — use them as-written on the client (`trpc.frontingSession.list.useQuery(...)`).
+
+| Router               | Domain                                    |
+| -------------------- | ----------------------------------------- |
+| `account`            | Account management and deletion           |
+| `acknowledgement`    | Acknowledgement records                   |
+| `analytics`          | System usage analytics                    |
+| `apiKey`             | API key issuance and revocation           |
+| `auth`               | Authentication (login, register, session) |
+| `blob`               | Binary asset upload and retrieval         |
+| `boardMessage`       | Message board posts                       |
+| `bucket`             | Privacy buckets                           |
+| `channel`            | Communication channels                    |
+| `checkInRecord`      | Check-in entries                          |
+| `customFront`        | Custom front states (e.g. "Dissociated")  |
+| `deviceToken`        | Push notification tokens                  |
+| `field`              | Custom fields                             |
+| `friend`             | Friend relationships                      |
+| `friendCode`         | Friend code generation and redemption     |
+| `frontingComment`    | Comments on fronting sessions             |
+| `frontingReport`     | Fronting history reports                  |
+| `frontingSession`    | Active and past fronting sessions         |
+| `group`              | Member groups                             |
+| `i18n`               | Localization manifest and namespace fetch |
+| `importEntityRef`    | Import entity cross-references            |
+| `importJob`          | Import job orchestration and status       |
+| `innerworld`         | Innerworld locations and map data         |
+| `lifecycleEvent`     | Member lifecycle events                   |
+| `member`             | System members (headmates)                |
+| `memberPhoto`        | Member profile photos                     |
+| `message`            | Direct messages                           |
+| `note`               | Notes and journal entries                 |
+| `notificationConfig` | Notification preferences                  |
+| `poll`               | Polls                                     |
+| `relationship`       | Member-to-member relationships            |
+| `snapshot`           | System snapshots for sync                 |
+| `structure`          | System structure metadata                 |
+| `system`             | System (account) profile                  |
+| `systemSettings`     | System-level settings                     |
+| `timerConfig`        | Timers                                    |
+| `webhookConfig`      | Webhook configuration                     |
+| `webhookDelivery`    | Webhook delivery log                      |
 
 ### Auth levels
 
 - **Public** — no session required (e.g. `auth.login`, `auth.register`)
 - **Protected** — valid session required
 - **System-scoped** — session must belong to the system that owns the resource; enforced by middleware on every mutating procedure
+
+API key requests additionally pass through the fail-closed scope gate (`scopeGateMiddleware`), which looks up each procedure path in the shared `SCOPE_REGISTRY.trpc`. Procedures with no registry entry are rejected with `FORBIDDEN` — the same registry powers REST per-endpoint scope enforcement.
 
 ---
 

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -63,6 +63,12 @@ const { data, error } = await client.GET("/api/v1/systems/{systemId}/members", {
 The `getToken` callback may be synchronous or async and return `string | null`. When
 `null` is returned, the `Authorization` header is omitted entirely.
 
+The REST client installs an `onResponse` middleware that transparently retries a single time
+on `429 Too Many Requests`. The middleware reads the `Retry-After` response header (seconds,
+per RFC 9110), falls back to a 1 s delay when the header is absent or non-numeric, and tags
+the retry with an `X-Retry-Count` header so it cannot loop. If the retry fetch throws, the
+original `429` response is returned unchanged.
+
 ### tRPC client (mobile app)
 
 Set up the tRPC provider once at the app root:
@@ -148,5 +154,8 @@ Unit tests only — no integration variant exists for this package.
 pnpm vitest run --project api-client
 ```
 
-Tests cover `createApiClient` construction, `Authorization` header attachment when a token is
-present, and omission of the header when `getToken` returns `null`.
+Tests cover `createApiClient` construction, `Authorization` header attachment for both
+synchronous and `Promise`-returning `getToken` callbacks, omission of the header when
+`getToken` returns `null`, and the `429` retry middleware (single-retry guarantee,
+`Retry-After` seconds parsing, default-delay fallback, non-`429` pass-through, and original
+response preservation when the retry fetch throws).

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -4,11 +4,11 @@ Client-side encryption layer for Pluralscape — libsodium primitives, key hiera
 
 ## Overview
 
-Pluralscape enforces zero-knowledge encryption: the server never sees plaintext user data. This package implements the full client-side cryptographic stack using [libsodium](https://libsodium.org/) (XChaCha20-Poly1305 for symmetric encryption, X25519 for asymmetric, Ed25519 for signing, Argon2id for key derivation). All encryption and decryption happens on the device before any data leaves or arrives from the server.
+Pluralscape enforces zero-knowledge encryption: the server never sees plaintext user data, and it never sees master-key material in any form. Every master-key operation — password-derived KEK derivation, master-key wrap/unwrap, rewrap on password change, and recovery-key rewrap — runs on the device. The server stores only an opaque ciphertext blob (`encrypted_master_key`) plus a BLAKE2b hash of the auth half of the split derivation. This package implements the full client-side cryptographic stack using [libsodium](https://libsodium.org/) (XChaCha20-Poly1305 for symmetric encryption, X25519 for asymmetric, Ed25519 for signing, Argon2id for key derivation). All encryption and decryption happens on the device before any data leaves or arrives from the server.
 
-Data is encrypted at one of three tiers based on its sensitivity and sharing requirements. **T1** (zero-knowledge) encrypts with a sub-key derived from the system master key — only the account owner can decrypt. **T2** (per-bucket) encrypts with a per-Privacy-Bucket symmetric key distributed asymmetrically to authorized friends — enabling selective sharing without the server ever seeing the bucket key. **T3** is a typed passthrough for non-sensitive metadata fields that remain in plaintext. See [ADR 006](../../docs/adr/006-encryption.md) for the full encryption architecture.
+Data is encrypted at one of three tiers based on its sensitivity and sharing requirements. **T1** (zero-knowledge) encrypts with a sub-key derived from the system master key — only the account owner can decrypt. **T2** (per-bucket) encrypts with a per-Privacy-Bucket symmetric key distributed asymmetrically to authorized friends — enabling selective sharing without the server ever seeing the bucket key. **T3** is a typed passthrough for non-sensitive metadata fields that remain in plaintext. See [ADR 006](../../docs/adr/006-encryption.md) for the full encryption architecture, including the _Master-Key KDF Profile_ addendum.
 
-The key hierarchy flows from a user password through Argon2id to a 256-bit master key, then to identity keypairs (X25519 + Ed25519, independently derived via BLAKE2B KDF) and per-bucket symmetric keys. Key recovery uses a generated recovery phrase that re-encrypts the master key independently of the password. Device transfer uses a QR-scanned ephemeral key to securely bootstrap a new device without a server round-trip. See [ADR 011](../../docs/adr/011-key-recovery.md) and [ADR 014](../../docs/adr/014-lazy-key-rotation.md) for recovery and rotation details.
+The key hierarchy flows from a user password through Argon2id to a 64-byte split derivation — bytes `[0..31]` become the `authKey` (hashed server-side for login, never stored raw) and bytes `[32..63]` become the `passwordKey` (a KEK that wraps the 256-bit random master key on-device). The master key in turn feeds BLAKE2B KDF sub-keys for identity keypairs (X25519 + Ed25519), per-bucket symmetric keys, and the sync-encryption key. Argon2id runs under per-context profiles (`ARGON2ID_PROFILE_MASTER_KEY` for login/PIN, `ARGON2ID_PROFILE_TRANSFER` for device-transfer code stretching) so each workload gets parameters matched to its threat model — see [ADR 037](../../docs/adr/037-argon2id-context-profiles.md). Key recovery uses a generated recovery phrase that rewraps the master key independently of the password. Device transfer uses a QR-scanned ephemeral key to securely bootstrap a new device without a server round-trip. See [ADR 011](../../docs/adr/011-key-recovery.md) and [ADR 014](../../docs/adr/014-lazy-key-rotation.md) for recovery and rotation details.
 
 ## Key Exports
 
@@ -16,9 +16,11 @@ The key hierarchy flows from a user password through Argon2id to a 256-bit maste
 
 **Sodium lifecycle** — `initSodium`, `configureSodium`, `getSodium`, `isReady`
 
-**Key derivation** — `generateSalt`, `derivePasswordKey`, `generateMasterKey`, `wrapMasterKey`, `unwrapMasterKey`, `deriveSyncEncryptionKey`
+**Master key** — `generateSalt`, `generateMasterKey`, `wrapMasterKey`, `unwrapMasterKey`, `deriveSyncEncryptionKey`
 
-**Symmetric encryption** — `encrypt`, `decrypt`, `encryptJSON`, `decryptJSON`, `encryptStream`, `decryptStream`
+**Split-key auth** — `deriveAuthAndPasswordKeys`, `hashAuthKey`, `verifyAuthKey`, `hashRecoveryKey`, `verifyRecoveryKey`, `generateChallengeNonce`, `signChallenge`, `verifyChallenge`
+
+**Symmetric encryption** — `encrypt`, `decrypt`, `encryptJSON`, `decryptJSON`, `encryptStream`, `encryptStreamAsync`, `decryptStream`, `toAsyncIterable`
 
 **Tier helpers** — `encryptTier1`, `decryptTier1`, `encryptTier1Batch`, `decryptTier1Batch`, `encryptTier2`, `decryptTier2`, `encryptTier2Batch`, `decryptTier2Batch`, `wrapTier3`
 
@@ -28,25 +30,27 @@ The key hierarchy flows from a user password through Argon2id to a 256-bit maste
 
 **Key grants** — `createKeyGrant`, `createKeyGrants`, `decryptKeyGrant`
 
-**Recovery and transfer** — `generateRecoveryKey`, `recoverMasterKey`, `isValidRecoveryKeyFormat`, `toRecoveryKeyDisplay`, `serializeRecoveryBackup`, `deserializeRecoveryBackup`, `resetPasswordViaRecoveryKey`, `regenerateRecoveryKey`, `generateTransferCode`, `deriveTransferKey`, `encryptForTransfer`, `decryptFromTransfer`, `encodeQRPayload`, `decodeQRPayload`
+**Recovery and transfer** — `generateRecoveryKey`, `recoverMasterKey`, `isValidRecoveryKeyFormat`, `toRecoveryKeyDisplay`, `serializeRecoveryBackup`, `deserializeRecoveryBackup`, `withMasterKeyFromReset`, `withPasswordResetResult`, `regenerateRecoveryKey`, `generateTransferCode`, `isValidTransferCode`, `deriveTransferKey`, `encryptForTransfer`, `decryptFromTransfer`, `encodeQRPayload`, `decodeQRPayload`, `TRANSFER_TIMEOUT_MS`
 
 **Signing** — `sign`, `verify`, `signThenEncrypt`, `decryptThenVerify`
 
 **Safety numbers** — `computeSafetyNumber`
 
-**Password / PIN** — `hashPassword`, `verifyPassword`, `hashPin`, `verifyPin`
+**PIN** — `hashPin`, `verifyPin`, `MIN_PIN_LENGTH`
 
 **Key storage** — `createWebKeyStorage`
 
 **Key lifecycle** — `MobileKeyLifecycleManager`, `SECURITY_PRESETS`
 
-**Validation** — `assertAeadKey`, `assertAeadNonce`, `assertBufferLength`, `assertPwhashSalt`, `assertSignature`, `assertSignPublicKey`
+**Validation** — `assertAeadKey`, `assertAeadNonce`, `assertAuthKey`, `assertAuthKeyHash`, `assertBufferLength`, `assertChallengeNonce`, `assertEncryptedBlob`, `assertPwhashSalt`, `assertRecoveryKeyHash`, `assertSignature`, `assertSignPublicKey`
 
 **Hex encoding** — `toHex`, `fromHex`
 
 **Blob codec** — `serializeEncryptedBlob`, `deserializeEncryptedBlob`
 
-**Errors** — `DecryptionFailedError`, `KeysLockedError`, `SignatureVerificationError`, `CryptoNotReadyError`, `InvalidInputError`, `BiometricFailedError`, `AlreadyInitializedError`, `InvalidStateTransitionError`, `KeyStorageFailedError`, `UnsupportedOperationError`
+**Argon2id profiles** — `ARGON2ID_PROFILE_MASTER_KEY`, `ARGON2ID_PROFILE_TRANSFER` (see [ADR 037](../../docs/adr/037-argon2id-context-profiles.md))
+
+**Errors** — `CryptoError` (base), `DecryptionFailedError`, `KeysLockedError`, `SignatureVerificationError`, `CryptoNotReadyError`, `InvalidInputError`, `BiometricFailedError`, `AlreadyInitializedError`, `InvalidStateTransitionError`, `KeyStorageFailedError`, `UnsupportedOperationError`
 
 ### Sub-entry points
 
@@ -115,4 +119,4 @@ pnpm vitest run --project crypto
 pnpm vitest run --project crypto-integration
 ```
 
-Unit tests cover individual cryptographic operations (key derivation, encrypt/decrypt, signing, validation). Integration tests exercise the full key lifecycle, recovery flows, and device transfer protocol against real sodium operations.
+Unit tests cover individual cryptographic operations (key derivation, encrypt/decrypt, signing, validation). Integration tests exercise the full key lifecycle, recovery flows, and device transfer protocol against real sodium operations. The suite also pins each primitive to its standard via known-answer tests — see `src/__tests__/test-vectors.test.ts` for X25519 (RFC 7748), Ed25519 (RFC 8032), Argon2 (RFC 9106), BLAKE2b (RFC 7693), and NIST/IETF vectors for XChaCha20-Poly1305 — so an accidental algorithm or parameter swap fails the suite rather than silently round-tripping.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -38,21 +38,36 @@ import { createCrdtQueryBridge } from "@pluralscape/data";
 
 ### Crypto transforms (per domain)
 
-All transform modules are re-exported from the root entry and also available as granular sub-path imports (e.g. `@pluralscape/data/transforms/member`).
+Every transform module is available as a granular sub-path import (e.g. `@pluralscape/data/transforms/member` — see the `exports` field in `package.json` for the full list). A commonly used subset is also re-exported from the root entry for convenience; transforms not in the root re-export table below must be imported via their sub-path.
 
-| Domain        | Transforms                                                                                                             |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| System        | `decryptSystemSettings`, `encryptSystemSettingsUpdate`, `decryptNomenclature`, `encryptNomenclatureUpdate`             |
-| Members       | `decryptMember`, `decryptMemberPage`, `encryptMemberInput`, `encryptMemberUpdate`                                      |
-| Fronting      | `decryptFrontingSession`, `encryptFrontingSessionInput`, `decryptFrontingComment`, `decryptFrontingReport`, ...        |
-| Custom fronts | `decryptCustomFront`, `encryptCustomFrontInput`, `encryptCustomFrontUpdate`                                            |
-| Custom fields | `decryptFieldDefinition`, `decryptFieldValue`, `encryptFieldValueInput`, ...                                           |
-| Communication | `decryptChannel`, `decryptMessage`, `decryptBoardMessage`, `decryptPoll`, `decryptNote`, `decryptAcknowledgement`, ... |
-| Innerworld    | `decryptInner­worldEntity`, `decryptInner­worldRegion`, `decryptInner­worldCanvas`                                     |
-| Relationships | `decryptRelationship`                                                                                                  |
-| Social        | `decryptFriendConnection`, `decryptFriendCode`, `decryptFriendDashboard`, `decryptPrivacyBucket`                       |
-| Notifications | `decryptNotificationConfig`, `decryptDeviceToken`                                                                      |
-| Blobs         | `decodeAndDecryptT1`, `encryptAndEncodeT1`, `encryptInput`, `encryptUpdate`                                            |
+**Re-exported from `@pluralscape/data`:**
+
+| Domain        | Transforms                                                                                                                                                                                                 |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| System        | `decryptSystemSettings`, `encryptSystemSettingsUpdate`, `decryptNomenclature`, `encryptNomenclatureUpdate`                                                                                                 |
+| Members       | `decryptMember`, `decryptMemberPage`, `encryptMemberInput`, `encryptMemberUpdate`                                                                                                                          |
+| Groups        | `decryptGroup`, `decryptGroupPage`, `encryptGroupInput`, `encryptGroupUpdate`                                                                                                                              |
+| Custom fronts | `decryptCustomFront`, `decryptCustomFrontPage`, `encryptCustomFrontInput`, `encryptCustomFrontUpdate`                                                                                                      |
+| Custom fields | `decryptFieldDefinition`, `decryptFieldDefinitionPage`, `encryptFieldDefinitionInput`, `decryptFieldValue`, `decryptFieldValueList`, `encryptFieldValueInput`                                              |
+| Fronting      | `decryptFrontingSession{,Page}`, `encryptFrontingSessionInput/Update`, `decryptFrontingComment{,Page}`, `encryptFrontingCommentInput/Update`, `decryptFrontingReport{,Page}`, `encryptFrontingReportInput` |
+| Timers        | `decryptTimerConfig{,Page}`, `encryptTimerConfigInput/Update`, `decryptCheckInRecord{,Page}`                                                                                                               |
+| Communication | `decryptChannel`, `decryptMessage`, `decryptBoardMessage`, `decryptPoll`, `decryptPollVote`, `decryptNote`, `decryptAcknowledgement` (each with `*Page` + matching encrypt helpers)                        |
+| Privacy       | `decryptPrivacyBucket`, `decryptPrivacyBucketPage`, `encryptBucketInput`, `encryptBucketUpdate`                                                                                                            |
+| Blobs         | `decodeAndDecryptT1`, `encryptAndEncodeT1`, `encryptInput`, `encryptUpdate`                                                                                                                                |
+
+**Sub-path only** (import from `@pluralscape/data/transforms/<name>`):
+
+| Domain         | Module                                                                                                                                                                        |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Structure      | `structure-entity`, `structure-entity-type`                                                                                                                                   |
+| Relationships  | `relationship`                                                                                                                                                                |
+| Innerworld     | `innerworld-entity`, `innerworld-region`, `innerworld-canvas`                                                                                                                 |
+| Lifecycle      | `lifecycle-event`, `snapshot`                                                                                                                                                 |
+| Social         | `friend-connection`, `friend-code`, `friend-dashboard`                                                                                                                        |
+| Notifications  | `notification-config`, `device-token`                                                                                                                                         |
+| Shared helpers | `decode-blob` (exports `decodeAndDecryptT2`, `encryptAndEncodeT2`, `extractT2BucketId`, `assertObjectBlob`, `assertStringField`, `assertArrayField`, `base64urlToUint8Array`) |
+
+Every `decrypt*` function validates that the decrypted blob matches the expected field shape (not just `name`): missing or wrong-typed fields throw synchronously so ciphertext corruption, key mismatch, or server tampering surfaces as an error rather than silent data loss. Encrypt/decrypt pairs round-trip — e.g. `encryptBucketInput` followed by `decryptPrivacyBucket` reproduces the original plaintext. Base64 encode/decode inside `decode-blob.ts` is backed by Node's `Buffer` API for linear-time conversion.
 
 ## Usage
 
@@ -123,4 +138,4 @@ The test suite covers:
 - `createAppQueryClient` — verifies the configured default options (stale time, GC time, retry counts).
 - `createRestQueryFactory` — covers successful decrypted and plain fetches, missing master key, and API error propagation.
 - `createCrdtQueryBridge` — verifies that `documentQueryOptions` projects snapshots correctly and throws when the document is not loaded.
-- Crypto transforms are exercised indirectly through the factory tests; each transform module is individually importable for targeted testing.
+- Every transform module has a dedicated spec under `src/transforms/__tests__/` that exercises the encrypt → decrypt round-trip, the archived/non-archived branches, pagination, and the field assertions (missing fields, wrong types, non-object blobs).

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -16,10 +16,18 @@ entry point (`@pluralscape/db`) exports the client factory, dialect and deployme
 detection utilities, RLS helpers, shared query helpers, enumeration constants, and view
 types that are dialect-agnostic.
 
-Row-Level Security (RLS) is enforced on the PostgreSQL dialect. Every table is protected
-by tenant-scoped policies keyed on `system_id` and `account_id`. The RLS migration is
-generated from the schema and must be regenerated whenever the schema changes (see
-[Migrations](#migrations)).
+Row-Level Security (RLS) is enforced on the PostgreSQL dialect. Every tenant table is
+protected by policies keyed on `system_id`, `account_id`, or both — including sync
+tables (`sync_docs`, `sync_events`, `sync_cursors`) and bidirectional friend
+connections. The RLS migration is generated from `RLS_TABLE_POLICIES` in
+`src/rls/policies.ts` and must be regenerated whenever tables are added, removed, or
+change scope (see [Migrations](#migrations)).
+
+Several high-volume tables use PostgreSQL range partitioning by timestamp —
+`fronting_sessions` (by `start_time`), `messages` (by `timestamp`), and `audit_log`
+(by `timestamp`). Partition creation and detachment are handled by the helpers in
+`src/queries/partition-maintenance.ts` (`pgEnsureFuturePartitions`,
+`pgDetachOldPartitions`); only `audit_log` partitions may be detached destructively.
 
 ## Key Exports
 
@@ -112,6 +120,13 @@ const rows = await db.drizzle.select().from(members).where(eq(members.systemId, 
 
 Migration files live in `migrations/pg/` and `migrations/sqlite/`.
 
+**Pre-release migration policy:** Pluralscape is pre-production, so generated migration
+files are regularly nuked and regenerated from scratch. The Drizzle schema files under
+`src/schema/pg/` and `src/schema/sqlite/` are the single source of truth for table
+shape — never treat a migration file as authoritative. Changes to column names,
+constraints, or indexes land in the schema files first; migrations are then regenerated
+to reflect them.
+
 Generate the Drizzle schema migration after schema changes:
 
 ```bash
@@ -133,6 +148,12 @@ pnpm --filter @pluralscape/db exec tsx scripts/generate-rls-migration.ts \
 The RLS migration must always be `0001_rls_all_tables.sql` (after the `0000` Drizzle
 schema migration). Update the filename reference in
 `src/__tests__/rls-migrations.integration.test.ts` if the migration file changes.
+
+To apply RLS to a live PostgreSQL database (for example from a deploy script), use:
+
+```bash
+pnpm --filter @pluralscape/db db:apply-rls
+```
 
 ## Testing
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -15,12 +15,15 @@ optional connection pooling. `StubEmailAdapter` is a no-op suitable as a product
 when no provider is configured. `InMemoryEmailAdapter` (available via the `./testing` entry
 point) captures sent messages in memory for test assertions.
 
-The `./templates` entry point provides five typed security notification templates:
-`recovery-key-regenerated`, `new-device-login`, `password-changed`, `two-factor-changed`, and
-`webhook-failure-digest`. Each template is rendered to `{ subject, html, text }` via
-`renderTemplate`, keeping HTML generation separate from delivery.
+The `./templates` entry point provides six typed security notification templates:
+`recovery-key-regenerated`, `new-device-login`, `password-changed`, `two-factor-changed`,
+`webhook-failure-digest`, and `account-change-email`. Each template is rendered to
+`{ subject, html, text }` via `renderTemplate`, keeping HTML generation separate from delivery.
 
-Design rationale: ADR 029 (Server-Side Encrypted Email), ADR 030 (Email Provider Selection).
+This package is transport-only. Email addresses themselves are encrypted at rest on the server
+via XChaCha20-Poly1305 with a server-held symmetric key; decryption and address resolution live
+in the API (`resolveAccountEmail`), not here. See ADR 029 (Server-Side Encrypted Email) and
+ADR 030 (Email Provider Selection) for design rationale.
 
 ## Key Exports
 
@@ -34,12 +37,17 @@ Design rationale: ADR 029 (Server-Side Encrypted Email), ADR 030 (Email Provider
 | `StubEmailAdapter`        | class     | No-op adapter, safe as a production fallback                           |
 | `EmailDeliveryError`      | class     | Provider rejected the message                                          |
 | `EmailConfigurationError` | class     | Adapter is misconfigured (bad API key, SMTP connection failure)        |
-| `EmailRateLimitError`     | class     | Provider rate-limited the request                                      |
-| `InvalidRecipientError`   | class     | Recipient address rejected by the provider                             |
+| `EmailRateLimitError`     | class     | Provider rate-limited the request (carries `retryAfterSeconds`)        |
+| `EmailValidationError`    | class     | Send params failed local validation (carries `field`, `actual`, `max`) |
+| `InvalidRecipientError`   | class     | Recipient, `from`, or `replyTo` address rejected                       |
 | `DEFAULT_FROM_ADDRESS`    | const     | Default sender address                                                 |
 | `MAX_RECIPIENTS`          | const     | Maximum recipients per send                                            |
 | `MAX_SUBJECT_LENGTH`      | const     | Maximum subject line length                                            |
 | `validateSendParams`      | function  | Throws on invalid params before hitting the provider                   |
+
+`validateSendParams` checks recipient count, subject length, and the shape of optional `from`
+and `replyTo` addresses. The address check is implemented as a linear scan (not a regex) to
+avoid polynomial-time backtracking on adversarial inputs (CodeQL `js/polynomial-redos`).
 
 ### Resend adapter (`@pluralscape/email/resend`)
 
@@ -72,6 +80,7 @@ Factory methods: `SmtpEmailAdapter.create(config, fromAddress?)`, `SmtpEmailAdap
 | `PasswordChangedVars`        | interface | `{ timestamp }`                                                         |
 | `TwoFactorChangedVars`       | interface | `{ timestamp, action }`                                                 |
 | `WebhookFailureDigestVars`   | interface | `{ webhookUrl, failureCount, lastError, timeRangeStart, timeRangeEnd }` |
+| `AccountChangeEmailVars`     | interface | `{ oldEmail, newEmail, timestamp, ipAddress? }`                         |
 
 ### Testing helpers (`@pluralscape/email/testing`)
 

--- a/packages/email/src/templates/index.ts
+++ b/packages/email/src/templates/index.ts
@@ -10,4 +10,5 @@ export type {
   PasswordChangedVars,
   TwoFactorChangedVars,
   WebhookFailureDigestVars,
+  AccountChangeEmailVars,
 } from "./types.js";

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -19,7 +19,14 @@ user-preferred word in the right grammatical form.
 
 RTL layout is supported via `getTextDirection` / `isRtl`, which map a locale tag to `"ltr"` or
 `"rtl"`. RTL locales are declared in `RTL_LOCALES`. Supported locales are declared in
-`SUPPORTED_LOCALES`; additional locales are added there alongside translation resource bundles.
+`SUPPORTED_LOCALES` (re-exported from `@pluralscape/types`, the single source of truth); additional
+locales are added there alongside translation resource bundles.
+
+Pluralscape ships 13 locales: `en`, `es`, `es-419`, `fr`, `de`, `it`, `pt-BR`, `ru`, `nl`,
+`zh-Hans`, `ja`, `ko`, and `ar`. English is the source language; the other 12 are translated via
+Crowdin and delivered over-the-air. Arabic is the only RTL locale currently shipped — `he`, `fa`,
+and `ur` remain in `RTL_LOCALES` so device-detected fallbacks render correctly even though they are
+not translated yet.
 
 ## Key Exports
 
@@ -28,8 +35,11 @@ RTL layout is supported via `getTextDirection` / `isRtl`, which map a locale tag
 | Export                         | Description                                                         |
 | ------------------------------ | ------------------------------------------------------------------- |
 | `createI18nInstance(options?)` | Creates an uninitialized i18next instance with Pluralscape defaults |
-| `CreateI18nOptions`            | `{ missingKeyMode: "warn" \| "throw", logger? }`                    |
+| `CreateI18nOptions`            | `{ missingKeyMode: "warn" \| "throw", logger?, backend? }`          |
 | `createMissingKeyHandler`      | Builds the missing-key callback used internally by the instance     |
+
+The optional `backend` plugin is registered on the instance before initialization — the mobile app
+passes its chained OTA→cache→bundled backend here (see "Runtime loading" below).
 
 ### Constants
 
@@ -178,16 +188,63 @@ pnpm vitest run --project i18n
 
 ## Runtime loading (mobile)
 
-See [ADR 035](../../docs/adr/035-i18n-ota-delivery.md) for the OTA delivery
-architecture. The chained-backend resolution order — fresh OTA cache →
-OTA network → stale OTA cache → bundled baseline — is documented both
-there and in-code at `apps/mobile/src/i18n/chained-backend.ts`
-(`resolveNamespace`).
+Translations reach the app through three layers — bundled baseline, cached OTA, and live OTA —
+composed behind a single i18next backend.
+
+### Crowdin OTA proxy
+
+The API exposes a read-only proxy in front of the Crowdin distribution CDN (see
+[ADR 035](../../docs/adr/035-i18n-ota-delivery.md) and
+[ADR 036](../../docs/adr/036-crowdin-automation.md)):
+
+- `GET /v1/i18n/manifest` — current distribution manifest (`I18nManifest`).
+- `GET /v1/i18n/:locale/:namespace` — one namespace of translations for a locale.
+
+Both responses are cached in Valkey with `I18N_CACHE_TTL_MS` (24 hours). Namespace responses carry
+a strong `ETag` derived from the translations body plus `Cache-Control: public, max-age=0,
+must-revalidate`; requests with a matching `If-None-Match` short-circuit to `304 Not Modified`
+(RFC 7232 §4.1) with no body. Upstream 404 surfaces as `NAMESPACE_NOT_FOUND` (404); timeout,
+malformed response, or other upstream failure surfaces as `UPSTREAM_UNAVAILABLE` (502). The
+route rate-limits under the `i18nFetch` category. Locale and namespace URL segments are validated
+against the shared `LocaleSchema` / `NamespaceSchema` to block path traversal into the Crowdin CDN.
+
+### Chained backend
+
+The mobile app's i18next backend at `apps/mobile/src/i18n/chained-backend.ts` resolves each
+`(locale, namespace)` in this order (`resolveNamespace`):
+
+1. **Fresh OTA cache** — AsyncStorage entry within TTL.
+2. **OTA network** — request the proxy with `If-None-Match`; `304` refreshes `fetchedAt`, `200`
+   rewrites the cache entry with the new etag and body.
+3. **Stale OTA cache** — on network failure, serve the previous entry regardless of TTL.
+4. **Bundled baseline** — `loadBundled()` from `apps/mobile/locales/index.ts`.
+
+### Bundled baseline and Metro code-splitting
+
+`apps/mobile/locales/index.ts` loads each namespace via a dynamic `import()` with a literal-prefix
+template (`./${locale}/${namespace}.json`). Metro code-splits the JSON into per-chunk bundles so
+only the active locale's namespaces are parsed at runtime. `BUNDLED_NAMESPACES` is intentionally a
+subset of `NAMESPACES` — the core user-facing set (`common`, `auth`, `fronting`, `members`,
+`settings`) — keeping the shipped binary small while still giving every locale an offline-first
+fallback.
+
+### Crowdin integration
+
+`crowdin.yml` configures the daily sync workflow. Two non-obvious details:
+
+- `languages_mapping.locale` keys are **Crowdin language IDs**, not locale values. Without the
+  mapping, the default `%locale%` expansion writes to directories like `ar-SA/` or `de-DE/` that
+  the loader does not read. The mapping normalises every target onto the short-code directory
+  layout under `apps/mobile/locales/`.
+- `.context.json` sidecars alongside source files are excluded — they feed the
+  `crowdin-upload-context` step and must not be ingested as source strings.
 
 ## Adding a new locale
 
-1. Add the locale tag to `SUPPORTED_LOCALES` in `i18n.constants.ts`.
-2. Add the locale to `BUNDLED_LOCALES` in `apps/mobile/locales/index.ts`.
+1. Add the locale tag to `SUPPORTED_LOCALES` in `packages/types/src/i18n.ts` (the canonical
+   declaration — `packages/i18n/src/i18n.constants.ts` re-exports it).
+2. Add the locale to `BUNDLED_LOCALES` in `apps/mobile/locales/index.ts` (a test asserts the two
+   lists stay in sync).
 3. Generate baseline translations via the local subagent (invoke `/translate-locale <locale>`).
-4. Update `crowdin.yml` language mapping if Crowdin's locale tag differs.
+4. Update `crowdin.yml` `languages_mapping` if Crowdin's language ID differs from the short code.
 5. Verify with `pnpm vitest run --project i18n` and `pnpm vitest run --project mobile`.

--- a/packages/import-core/README.md
+++ b/packages/import-core/README.md
@@ -18,68 +18,95 @@ interface Persister {
 }
 ```
 
-- `upsertEntity` must be idempotent keyed on `(entityType, sourceEntityId)`. Return `action: "skipped"` for content-identical re-upserts.
-- `recordError` must never throw.
-- `flush` is called at chunk boundaries for checkpoint persistence.
+- `upsertEntity` MUST be idempotent keyed on `(entityType, sourceEntityId)`. Content-identical re-upserts SHOULD return `action: "skipped"` so engine progress counters report no-op work accurately.
+- `upsertEntity` returns `{ action, pluralscapeEntityId }` where `action` is `"created" | "updated" | "skipped"`.
+- `recordError` MUST NOT throw — error recording must always succeed.
+- `flush` is called at chunk boundaries (every `CHECKPOINT_CHUNK_SIZE` documents) and at each collection boundary; implementations should commit any buffered writes before resolving.
 
-`PersistableEntity` is a discriminated union — narrow on `entityType` to access the strongly-typed `payload` without casts.
+`PersistableEntity` carries an `entityType: ImportCollectionType` discriminator, `sourceEntityId`, `source: ImportSourceFormat`, and a payload typed as `unknown`. Source-specific packages narrow the payload via their own discriminated unions.
 
-### `ImportSource`
+### `ImportDataSource`
 
 ```ts
 interface ImportDataSource {
-  listCollections(): Promise<string[]>;
-  iterate(collection: string): AsyncIterable<unknown>;
+  readonly mode: SourceMode; // "api" | "file" | "fake"
+  iterate(collection: string): AsyncIterable<SourceEvent>;
+  listCollections(): Promise<readonly string[]>;
   close(): Promise<void>;
-  supplyParentIds?(): Promise<Map<string, string[]>>;
+  supplyParentIds?(parentCollection: string, sourceIds: readonly string[]): void;
 }
 ```
 
-Each import engine provides its own source factories (file, API, fake).
+Sources yield `SourceEvent`s tagged either `"doc"` (a raw document the engine validates and maps) or `"drop"` (a document the source knowingly rejected before producing it — recorded by the engine as a non-fatal `invalid-source-document` error). Transport and parse failures throw and are fatal. Iteration order must be stable across calls so the engine's resume cursor remains meaningful.
+
+`supplyParentIds` is an optional hook the engine invokes after finishing a parent collection, passing the source IDs persisted from that collection to any dependent collection that needs them.
 
 ### Checkpoint and resume
 
-Imports are resumable via `ImportCheckpointState`. The engine records progress at chunk boundaries (`CHECKPOINT_CHUNK_SIZE = 50` documents). On resume, collections already completed are skipped and the in-progress collection resumes from the last checkpointed source entity ID.
+Imports are resumable via `ImportCheckpointState`, persisted on the `import_jobs.checkpoint_state` column (JSONB). Checkpoint state is keyed by `ImportCollectionType` (e.g., `"member"`), not source-specific collection names. The engine persists progress every `CHECKPOINT_CHUNK_SIZE = 50` documents and at each collection boundary, invoking `persister.flush()` then the caller's `onProgress(state)` callback.
+
+On resume, the engine:
+
+1. Skips collections in `completedCollections`.
+2. Finds the current collection in `dependencyOrder` via `collectionToEntityType`.
+3. Advances through its iterator discarding events until it sees `currentCollectionLastSourceId`, then continues mapping from the next event.
+4. If the cutoff ID is never seen (the source dropped that document between runs), the engine aborts with a fatal `ResumeCutoffNotFoundError` rather than silently skipping the remainder — operators must restart the import deliberately.
 
 ### Entity reference tracking
 
-`import_entity_refs` (in `@pluralscape/db`) maps `(source, sourceEntityType, sourceEntityId)` to `pluralscapeEntityId`. This enables dedup across re-imports and cross-source entity resolution.
+`import_entity_refs` (in `@pluralscape/db`) maps `(account_id, system_id, source, source_entity_type, source_entity_id)` to `pluralscape_entity_id`. This enables dedup across re-imports and cross-source entity resolution, and is how a real persister computes whether an upsert is `created`, `updated`, or `skipped`.
 
 ### Error classification
 
 ```ts
-classifyError(thrown: unknown, ctx: ClassifyContext): ImportError
-isFatalError(error: ImportError): boolean
+type ErrorClassifier = (thrown: unknown, ctx: ClassifyContext) => ImportError;
+
+classifyErrorDefault(thrown, ctx): ImportError;
+isFatalError(error: ImportError): boolean;
 ```
 
-Errors are classified as fatal (abort import) or non-fatal (record and continue). Fatal errors may be recoverable (resume from checkpoint after user action) or non-recoverable (restart required).
+Callers can inject their own `ErrorClassifier` via `RunImportEngineArgs.classifyError`; otherwise the engine uses `classifyErrorDefault`:
+
+- `ResumeCutoffNotFoundError` → `fatal: true, recoverable: true` (restart required, but checkpoint is preserved).
+- `SyntaxError` (parse failure) → `fatal: true, recoverable: false`.
+- Anything else → `fatal: false` (record as non-fatal `ImportError` and continue).
+
+Errors thrown by the source's iterator are always treated as fatal — there is no way to continue iterating after the generator has thrown.
+
+### Mapper dispatch
+
+Each collection is wired to either a `SingleMapperEntry` (document-at-a-time) or a `BatchMapperEntry` (all documents for the collection supplied as one array, enabling cross-document analysis such as converting PK switches into fronting sessions). Mappers return a tagged `MapperResult`: `mapped | skipped | failed`.
 
 ---
 
-## Testing
+## Testing helpers
 
-`InMemoryPersister` is provided for unit and integration tests. It accumulates entities in memory and exposes a snapshot for assertions:
+The `@pluralscape/import-core/testing` subpath exports:
+
+- `createInMemoryPersister(options?)` — returns `{ persister, snapshot }`. Stores upserts keyed by `(entityType, sourceEntityId)`, hashes payloads so content-identical re-upserts return `action: "skipped"`, and produces deterministic `pluralscapeEntityId`s (SHA-256 prefix of the key) so fixture assertions can pin IDs. Accepts `throwOn` specs to inject per-entity failures for error-path tests.
+- `createFakeImportSource(data, options?)` — an in-memory `ImportDataSource` for engine tests.
 
 ```ts
-import { InMemoryPersister } from "@pluralscape/import-core/testing";
+import { createInMemoryPersister } from "@pluralscape/import-core/testing";
 
-const persister = new InMemoryPersister();
-// ... run import ...
-const snapshot = persister.snapshot();
-snapshot.entitiesByType("member"); // PersistableEntity[]
+const { persister, snapshot } = createInMemoryPersister();
+// ... run engine ...
+const { entitiesByType, errors, flushCount } = snapshot();
+entitiesByType("member"); // readonly StoredEntity[]
 ```
 
 ---
 
 ## Dependencies
 
-- `@pluralscape/types` — `ImportCollectionType`, `ImportError`, `ImportCheckpointState`, branded IDs
+- `@pluralscape/types` — `ImportCollectionType`, `ImportEntityType`, `ImportError`, `ImportFailureKind`, `ImportCheckpointState`, `ImportSourceFormat`, `ImportAvatarMode`, branded IDs.
 
 ---
 
 ## See also
 
-- [ADR 034](../../docs/adr/034-import-core-extraction.md) — extraction rationale
-- `packages/import-sp` — Simply Plural import engine
-- `packages/import-pk` — PluralKit import engine
-- `packages/db` — `import_jobs`, `import_entity_refs` schema
+- [ADR 034](../../docs/adr/034-import-core-extraction.md) — extraction rationale.
+- `packages/import-sp` — Simply Plural import engine (sources, mappers, fixtures).
+- `packages/import-pk` — PluralKit import engine.
+- `apps/mobile/src/features/import-sp/persister/` — mobile-side `Persister` implementations.
+- `packages/db` — `import_jobs` (with `checkpoint_state` JSONB column) and `import_entity_refs` schema.

--- a/packages/import-pk/README.md
+++ b/packages/import-pk/README.md
@@ -1,35 +1,128 @@
 # @pluralscape/import-pk
 
-PluralKit import engine — maps PluralKit JSON exports to Pluralscape entities.
+PluralKit import engine — maps PluralKit data to Pluralscape entities.
 
-Parses PluralKit's export format, maps members, groups, group membership, and
-fronting sessions (switches) to Pluralscape entities, and drives a resumable
+Accepts two source modes — a PluralKit JSON export file or the live PK REST API
+(via `pkapi.js`) — validates each document with Zod, maps members, groups,
+group membership, fronting sessions (derived from switches), and a synthesised
+privacy bucket to Pluralscape entities, and drives a resumable, checkpoint-based
 import via the shared `Persister` interface from `@pluralscape/import-core`.
 
-This package is **mobile-compatible** — no Node streams, no `fs`, no React.
+---
+
+## Public surface
+
+```ts
+import {
+  runPkImport,
+  createPkFileImportSource,
+  createPkApiImportSource,
+  PK_DEPENDENCY_ORDER,
+  PK_MAPPER_DISPATCH,
+  pkCollectionToEntityType,
+} from "@pluralscape/import-pk";
+```
+
+### `runPkImport(args): Promise<ImportRunResult>`
+
+Thin wrapper around `runImportEngine` from `@pluralscape/import-core`. Walks
+`PK_DEPENDENCY_ORDER`, dispatches each document through `PK_MAPPER_DISPATCH`,
+persists via the injected `Persister`, and calls `onProgress` at every
+checkpoint boundary.
+
+### Source factories
+
+| Factory                    | Use case                                    |
+| -------------------------- | ------------------------------------------- |
+| `createPkFileImportSource` | PK JSON export file (Node `fs`, whole-file) |
+| `createPkApiImportSource`  | Live PK REST API via `pkapi.js`             |
+
+Both factories return an `ImportDataSource`. The API source wraps `pkapi.js`
+and converts its class-based Member / Group / Switch shapes into plain objects
+matching the export schema, so a single set of validators and mappers covers
+both modes.
+
+The file source uses `node:fs` (whole-file `readFileSync` bounded by
+`MAX_IMPORT_FILE_BYTES` from `@pluralscape/import-core`). Mobile callers should
+use the API source; the file source is Node-only.
+
+### API source guards
+
+The API source enforces two boundary checks before any request reaches the
+wire:
+
+- **Token sanity** — empty or whitespace-only tokens are rejected before they
+  can be sent as a blank `Authorization` header.
+- **HTTPS-or-loopback** — when `baseUrl` is supplied, `http://` is refused
+  except for loopback hosts (`localhost`, `127.0.0.1`, `::1`). IPv6 literal
+  brackets are stripped before the host check so `http://[::1]:…` is
+  recognised as loopback. When `baseUrl` is omitted, `pkapi.js` uses its
+  built-in `https://api.pluralkit.me` default.
 
 ---
 
 ## Collections mapped
 
-| PK Export Field    | Pluralscape Entity | Notes                                      |
-| ------------------ | ------------------ | ------------------------------------------ |
-| `members`          | member             | Name, pronouns, description, color, avatar |
-| `groups`           | group              | Name, description, color                   |
-| `members[].groups` | group-membership   | Derived from member-to-group references    |
-| `switches`         | fronting-session   | Zero-duration sessions bumped by 1ms       |
+| PK Source          | Pluralscape Entity | Notes                                               |
+| ------------------ | ------------------ | --------------------------------------------------- |
+| `members`          | member             | Name, pronouns, description, color, avatar          |
+| `groups`           | group              | Name, description, color                            |
+| `members[].groups` | group-membership   | Derived from member-to-group references             |
+| `switches`         | fronting-session   | Diffed into per-member sessions; see below          |
+| synthetic scan     | privacy-bucket     | One "PK Private" bucket synthesised from PK privacy |
+
+`PK_DEPENDENCY_ORDER` is `member → group → switch → privacy-bucket`.
+
+### Switch-to-session diff
+
+PK records snapshots of who is fronting at a timestamp. The switch mapper
+sorts switches, tracks active fronters, and emits a completed session for each
+member when they drop out of the current snapshot. Members still fronting at
+the end of the stream become open sessions (`endTime = null`).
 
 ### Zero-duration session handling
 
-PluralKit allows switches with identical start and end timestamps (zero-duration).
-Pluralscape requires `endTime > startTime`, so the mapper bumps `endTime` by 1ms
-for any zero-duration session.
+PluralKit allows consecutive switches with identical timestamps
+(zero-duration). Pluralscape requires `endTime > startTime`, so the mapper
+bumps `endTime` by 1 ms whenever `endTime === startTime`. Without this every
+such session would be rejected by the API's ordering constraint.
+
+### Privacy bucket synthesis
+
+PK has per-field privacy flags on members; Pluralscape has tagged privacy
+buckets. The `privacy-bucket` batch mapper scans collected member privacy data
+and synthesises a single "PK Private" bucket when any member has at least one
+private field. Both source modes feed it: the file source reads
+`payload.members[].privacy`, and the API source collects privacy data during
+member iteration and yields a synthetic `privacy-scan` document for the
+`privacy-bucket` pass.
+
+---
+
+## Error classification
+
+`classifyPkError` wraps `pkapi.js`'s `APIError` with HTTP-status-aware
+classification before falling back to `classifyErrorDefault`:
+
+| Status          | Fatal | Recoverable | Meaning                             |
+| --------------- | ----- | ----------- | ----------------------------------- |
+| 401 / 403       | Yes   | No          | Auth failure; retry cannot succeed  |
+| 404             | No    | —           | May resolve as prerequisites finish |
+| 429             | No    | —           | Rate-limit; retry with backoff      |
+| 5xx             | No    | —           | Transient server-side failure       |
+| Other / missing | Yes   | Yes         | Surfaced without retry-looping      |
+
+`APIError.status` is typed as `string` by `pkapi.js` but arrives at runtime as
+a number, a stringified number, or the literal `"???"`. The classifier
+normalises it to `number | undefined` up-front so every branch compares a
+single shape.
 
 ---
 
 ## E2E test setup
 
-PK import E2E tests run against a real PluralKit API instance with seeded test data.
+PK import E2E tests run against a real PluralKit API instance with seeded test
+data.
 
 ### Prerequisites
 
@@ -71,6 +164,7 @@ verified against its manifest entry.
 ## See also
 
 - [ADR 033](../../docs/adr/033-pluralkit-api-client-library.md) — PK API client library selection
+- [ADR 034](../../docs/adr/034-import-core-extraction.md) — import-core extraction rationale
 - `packages/import-core` — shared orchestration engine
 - `packages/import-sp` — Simply Plural import (sibling engine)
 - `scripts/pk-seed` — PK test data seeder

--- a/packages/import-sp/README.md
+++ b/packages/import-sp/README.md
@@ -49,6 +49,17 @@ const result = await runImport({
 All factories return an `ImportDataSource` implementing `iterate(collection)`,
 `listCollections()`, `close()`, and optionally `supplyParentIds()`.
 
+### SP API auth quirk
+
+Simply Plural's API authenticates with the raw API key sent as the
+`Authorization` header value — no `Bearer ` prefix. The api-source issues
+`Authorization: <token>` directly. Using the `Bearer` scheme will get a 401
+rejection.
+
+The api-source also refuses to send a token to a non-HTTPS `baseUrl` unless
+the host is loopback (`localhost`, `127.0.0.1`, `::1`) — last-line protection
+against leaking the token over cleartext.
+
 ---
 
 ## Collection coverage
@@ -151,6 +162,31 @@ the import twice produces identical results — the persister decides `created` 
 
 ---
 
+## Type safety and validation
+
+Mapped entity payloads are strongly typed from `@pluralscape/validation` request
+schemas (e.g. `CreateMemberBodySchema`, `CreateGroupBodySchema`). Mapper return
+types are derived with `z.infer<typeof Schema>` so the Pluralscape side of the
+mapping stays aligned with the public API contract — a schema break is a
+TypeScript break. SP input documents are validated per-document with Zod before
+mapping.
+
+---
+
+## Security bounds
+
+- Per-request timeout: `SP_API_REQUEST_TIMEOUT_MS = 30_000` ms.
+- Retries: `SP_API_MAX_RETRIES = 5` with exponential backoff capped at
+  `SP_API_BACKOFF_MAX_MS = 16_000` ms.
+- Maximum API response body: `SP_API_MAX_RESPONSE_BYTES = 50 MiB`.
+- Maximum file export size: `MAX_IMPORT_FILE_BYTES` (re-exported from
+  `@pluralscape/import-core`).
+- Warning buffer capped at `MAX_WARNING_BUFFER_SIZE` to prevent unbounded
+  growth on pathological inputs.
+- HTTPS enforcement on `createApiImportSource.baseUrl` (loopback exception).
+
+---
+
 ## Fail-closed behavior
 
 - Unknown SP fields are surfaced as `dropped-collection` or `unknown-field`
@@ -225,7 +261,11 @@ source .env.sp-test && SP_TEST_LIVE_API=true pnpm vitest run --project import-sp
 ### Architecture note
 
 This package was originally self-contained. The shared orchestration layer
-(Persister, checkpoint, error classification) was extracted into
-`@pluralscape/import-core` ([ADR 034](../../docs/adr/034-import-core-extraction.md))
-when the PluralKit import engine was built, to avoid duplicating the import
-infrastructure.
+(checkpoint state, advance deltas, warning buffers, file-size and chunk
+constants) was extracted into `@pluralscape/import-core`
+([ADR 034](../../docs/adr/034-import-core-extraction.md)) when the PluralKit
+import engine was built, to avoid duplicating the import infrastructure.
+The SP engine re-exports shared constants from import-core and imports
+`advanceWithinCollection`, `completeCollection`, `emptyCheckpointState`, and
+related checkpoint helpers from it; SP-specific concerns (source factories,
+mappers, dependency order, error classes) stay in this package.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,90 @@
+# `@pluralscape/logger`
+
+Runtime-scoped logger factories for Pluralscape clients. Provides the shared `Logger` contract from `@pluralscape/types` plus concrete implementations per runtime.
+
+Currently ships the mobile (React Native / Expo / Hermes) logger. The API runtime (Bun/Node) has its own logger at `apps/api/src/lib/logger.ts`; a web sibling will land alongside the web app.
+
+## Overview
+
+`Logger` is the structured-logging contract used across the app. It exposes `info`, `warn`, and `error` methods that accept a message and an optional JSON-serializable payload. This package produces runtime-specific implementations of that contract.
+
+Every logger factory in this package applies **PII redaction** by default. Callers can supply a custom redactor or opt out with `null` after manually sanitizing values. The default redactor walks the payload recursively, masking values under PII-adjacent keys, and breaks cycles with a `WeakSet` guard so self-referential payloads never crash the call site.
+
+## Key Exports
+
+### Root (`@pluralscape/logger`)
+
+| Export                | Kind     | Purpose                                                    |
+| --------------------- | -------- | ---------------------------------------------------------- |
+| `Logger`              | type     | Re-exported from `@pluralscape/types`; the shared contract |
+| `createMobileLogger`  | function | Factory for React Native / Expo (console-backed)           |
+| `MobileLoggerOptions` | type     | Options bag for `createMobileLogger`                       |
+| `MobileLoggerPayload` | type     | `Record<string, unknown>` — structured payload shape       |
+
+### Mobile entry (`@pluralscape/logger/mobile`)
+
+Same exports as the root; kept as a distinct subpath so platform-specific bundlers can split runtime-specific code.
+
+| Export                | Kind     | Purpose                                                               |
+| --------------------- | -------- | --------------------------------------------------------------------- |
+| `createMobileLogger`  | function | Factory returning a `Logger` that writes through `globalThis.console` |
+| `defaultRedact`       | function | Recursive PII masking — used as the default payload transform         |
+| `DEFAULT_REDACT_KEYS` | const    | Case-insensitive substrings that trigger redaction                    |
+
+## Mobile logger
+
+```ts
+import { createMobileLogger } from "@pluralscape/logger/mobile";
+
+const log = createMobileLogger();
+
+log.info("sync started", { queueSize: 12 });
+log.warn("retrying request", { attempt: 2, url: "/v1/members" });
+log.error("upload failed", { error: err.message, apiKey: "sk_..." });
+// → console.error('upload failed {"error":"network","apiKey":"[redacted]"}')
+```
+
+### Options
+
+```ts
+createMobileLogger({
+  // Custom redactor (fully replaces the default)
+  redact: (payload) => ({ ...payload, extra: "masked" }),
+});
+
+createMobileLogger({
+  // Explicit opt-out — payload passes through untouched
+  redact: null,
+});
+
+createMobileLogger({
+  // Swap the console target (useful in tests)
+  console: capturedCalls,
+});
+```
+
+### Default redaction keys
+
+Case-insensitive substring matches against any key in the payload trigger replacement with `"[redacted]"`:
+
+```
+password, passwordHash, token, accessToken, refreshToken, apiKey,
+authorization, secret, privateKey, recoveryKey, email, pepper
+```
+
+The walk is recursive and handles arrays, nested objects, and cycles (substituted as `"[cycle]"`). Values that fail `JSON.stringify` fall through to `"[unserializable]"`.
+
+## Testing
+
+Unit tests in `src/__tests__/` cover:
+
+- `defaultRedact` — key matching (exact, substring, case-insensitive), nested objects, arrays, cycles.
+- `createMobileLogger` — message passthrough, payload redaction, custom redactor override, `redact: null` opt-out, console target swap, unserializable payload handling.
+
+Run via `pnpm vitest run --project logger`.
+
+## Design rationale
+
+The mobile logger intentionally wraps `console.{info,warn,error}` rather than a third-party logging framework: React Native's log pipeline (Metro, `react-native log-ios|log-android`, Hermes trace tooling) reads `console` output directly, and payloads serialize as JSON suffixes so they remain grep-friendly in captured logs.
+
+PII redaction is enforced by default so developers cannot accidentally ship identifying data into device logs or crash reports. Opting out requires an explicit `redact: null` — matching the Pluralscape principle that privacy boundaries default to maximum restriction.

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -22,6 +22,13 @@ through the observability layer. Job payloads carry only IDs and encrypted refer
 plaintext user data. See [ADR 010](../../docs/adr/010-background-jobs.md) for the full decision
 record.
 
+Deserialized payloads are validated at every trust boundary. Both adapters parse stored job data
+through Zod schemas in `PayloadSchemaByType` (per job type) — BullMQ via `StoredJobDataSchema`'s
+`superRefine` when reading `job.data`, SQLite via `rowToJob` when hydrating from the job row. A
+mismatched `(type, payload)` pair raises `QueueCorruptionError` rather than propagating a
+silently-malformed `JobDefinition`. A compile-time conformance check keeps the schemas aligned
+with `JobPayloadMap` so new job types cannot be added without a matching schema.
+
 ## Key Exports
 
 ### Root (`@pluralscape/queue`)
@@ -45,11 +52,13 @@ record.
 - `InvalidJobTransitionError` — illegal state transition (e.g., completing a buried job)
 - `JobNotFoundError` — job ID not found when acknowledging or burying
 - `NoHandlersRegisteredError` — worker started with no handlers
+- `QueueCorruptionError` — stored job data failed payload-schema validation at the deserialization boundary
 - `WorkerAlreadyRunningError` — `start()` called on an already-running worker
 
-**Types**
+**Types and schemas**
 
 - `JobEnqueueParams`, `JobFilter`, `IdempotencyCheckResult`
+- `PayloadSchemaByType` — per-`JobType` Zod schemas used by adapters to validate deserialized payloads
 
 **Constants (exported from root)**
 
@@ -68,7 +77,7 @@ record.
 | `/policies`      | `calculateBackoff`, `DEFAULT_RETRY_POLICY`, `DEFAULT_RETRY_POLICIES`, `applyDefaultPolicies`                                                                                                                                                  |
 | `/dlq`           | `DLQManager`, `DLQFilter`                                                                                                                                                                                                                     |
 | `/observability` | `ObservableJobQueue`, `ObservableJobWorker`, `QueueHealthService`, `QueueHealthSummary`, `InMemoryJobMetrics`, `AggregateMetrics`, `JobMetrics`, `JobTypeMetrics`, `StalledJobSweeper`, `StalledSweeperOptions`, `checkAlerts`, `AlertConfig` |
-| `/testing`       | `InMemoryJobQueue`, `InMemoryJobWorker`, `runJobQueueContract`, `runJobWorkerContract`, `makeJobParams`, `testSystemId`, `delay`, `dequeueOrFail`                                                                                             |
+| `/testing`       | `InMemoryJobQueue`, `InMemoryJobWorker`, `runJobQueueContract`, `runJobWorkerContract`, `makeJobParams`, `testSystemId`, `delay`, `dequeueOrFail`, `ensureValkey`, `ValkeyTestContext`                                                        |
 
 ## Usage
 
@@ -108,15 +117,33 @@ For the SQLite backend, replace `BullMQJobQueue`/`BullMQJobWorker` with `SqliteJ
 
 For tests, use `InMemoryJobQueue` and `InMemoryJobWorker` from `@pluralscape/queue/testing`, or run adapter contract suites against a custom implementation with `runJobQueueContract` and `runJobWorkerContract`.
 
+## Retry policies
+
+`DEFAULT_RETRY_POLICIES` covers every `JobType` at compile time. Every entry uses exponential
+backoff with a 20% jitter fraction unless noted:
+
+- Low-latency jobs (`sync-push`, `sync-pull`, `sync-compaction`) — 3 retries, 1s base, 2x multiplier, 30s cap
+- User-visible work (`export-generate`, `import-process`, `report-generate`) — 3 retries, 1s base, 4x multiplier, 60s cap
+- Blob uploads — 3 retries, 2s base, 4x multiplier, 60s cap
+- Notifications (`notification-send`) — 3 retries, 5s base, linear (multiplier 1), 30s cap
+- Email (`email-send`), device transfer cleanup, check-in generation — 3 retries, 5–10s base, 2x, 60s cap
+- Webhook delivery — 5 retries, 30s base, 4x multiplier, 2h cap (matches downstream SLAs)
+- Heavy maintenance (`analytics-compute`, `bucket-key-rotation`, `partition-maintenance`, `audit-log-cleanup`, `webhook-delivery-cleanup`, `blob-cleanup`, `sync-queue-cleanup`) — 2 retries, 5min base, 5x multiplier, 30min cap
+- `account-purge` — 3 retries, 60s base, 5x multiplier, 30min cap
+
+`DEFAULT_RETRY_POLICY` is the fallback when no per-type policy is configured. `applyDefaultPolicies`
+fills in any missing entry on an enqueue-parameter object.
+
 ## Dependencies
 
-| Package              | Role                                                   |
-| -------------------- | ------------------------------------------------------ |
-| `bullmq`             | BullMQ queue and worker (hosted/full self-hosted tier) |
-| `ioredis`            | Valkey/Redis client used by BullMQ                     |
-| `drizzle-orm`        | SQLite job table queries                               |
-| `@pluralscape/db`    | Shared database instance and schema                    |
-| `@pluralscape/types` | Shared domain types                                    |
+| Package              | Role                                                    |
+| -------------------- | ------------------------------------------------------- |
+| `bullmq`             | BullMQ queue and worker (hosted/full self-hosted tier)  |
+| `ioredis`            | Valkey/Redis client used by BullMQ                      |
+| `drizzle-orm`        | SQLite job table queries                                |
+| `zod`                | Payload-schema validation at deserialization boundaries |
+| `@pluralscape/db`    | Shared database instance and schema                     |
+| `@pluralscape/types` | Shared domain types                                     |
 
 ## Testing
 
@@ -126,11 +153,16 @@ Unit tests (no external services):
 pnpm vitest run --project queue
 ```
 
-Integration tests (requires a running Valkey instance):
+Integration tests (requires Valkey — provisioned automatically when Docker is available):
 
 ```bash
 pnpm vitest run --project queue-integration
 ```
+
+Integration suites call `ensureValkey()` from `/testing`, which first tries `localhost:6379`
+and, on failure, starts a `valkey/valkey:8-alpine` container named `pluralscape-valkey-test`
+on `TEST_VALKEY_PORT` (default `10944`). When neither direct connection nor Docker is available
+the suite reports `available: false` and skips rather than hanging.
 
 Both adapters are covered by the shared contract suites in `/testing`. Integration tests exercise
 the BullMQ adapter against a real Valkey connection, DLQ promotion, stalled-job sweeping, and

--- a/packages/rotation-worker/README.md
+++ b/packages/rotation-worker/README.md
@@ -6,9 +6,16 @@ Client-side incremental re-encryption worker for privacy bucket key rotation.
 
 When a friend is removed from a privacy bucket, Pluralscape immediately revokes their API access and generates a new bucket key. All data previously encrypted under the old key must then be re-encrypted under the new key. This package implements that re-encryption process on the client, following the lazy rotation protocol specified in [ADR 014](../../docs/adr/014-lazy-key-rotation.md).
 
-Re-encryption proceeds in chunks. The worker claims a batch of items from the server-side rotation ledger, fetches each entity blob, decrypts it with the old key, re-encrypts it with the new key, uploads the result, and reports completion. The server never sees key material. Multiple devices owned by the same system can work concurrently — each claims independent chunks, and stale claims are automatically reclaimed after five minutes.
+Re-encryption proceeds in chunks. The worker claims a batch of items from the server-side rotation ledger, fetches each entity blob, decrypts it with the old key, re-encrypts it with the new key, uploads the result, and reports completion. The server never sees key material. Multiple devices owned by the same system can work concurrently — each claims independent chunks, and stale claims are automatically reclaimed after five minutes (`KEY_ROTATION.staleClaimTimeoutMs`).
 
 The worker is resumable across sessions. If the device goes offline mid-rotation, progress is preserved in the server ledger. On the next session the worker picks up from where it left off. A 404 response on the rotation resource (rotation deleted or cancelled) causes the worker to stop gracefully. Per-item 404 (entity deleted) and 409 (version conflict from a concurrent newer write) are treated as successful completion of that item.
+
+### Zero key material after use
+
+Key bytes are wiped as soon as they are no longer needed, so plaintext never lingers in memory beyond the re-encryption that required it:
+
+- **Plaintext** returned by `decryptWithDualKey` is zeroed with `sodium.memzero` in a `finally` block around the re-encrypt + upload step, so it is cleared even if `encrypt` or the upload throws.
+- **Old and new bucket keys** are zeroed in the worker's outer `finally` block when `start()` settles — whether the rotation completed, failed, aborted, or threw. The worker requires a `RotationSodium` adapter (exposing `memzero`) on its config so the caller can inject the platform's libsodium binding.
 
 ## Key Exports
 
@@ -58,24 +65,34 @@ function processChunk(
 
 ### Types
 
-| Type                        | Description                                                                                     |
-| --------------------------- | ----------------------------------------------------------------------------------------------- |
-| `RotationWorkerConfig`      | Worker configuration: bucket ID, rotation ID, old/new keys and versions, chunk size, API client |
-| `RotationApiClient`         | Interface the app must implement to connect the worker to its HTTP layer                        |
-| `RotationProgressCallback`  | `(rotation: BucketKeyRotation) => void` — called after each chunk completes                     |
-| `VersionedEncryptedPayload` | Encrypted blob with its `keyVersion` metadata                                                   |
-| `CompletionItem`            | Per-item result (`completed` or `failed`) reported back to the server                           |
-| `ItemProcessResult`         | Internal per-item result carrying the original `BucketRotationItem`                             |
+| Type                        | Description                                                                                                     |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `RotationWorkerConfig`      | Worker configuration: bucket ID, rotation ID, old/new keys and versions, chunk size, API client, sodium adapter |
+| `RotationApiClient`         | Interface the app must implement to connect the worker to its HTTP layer                                        |
+| `RotationSodium`            | Minimal `{ memzero(buf) }` adapter — wraps the platform's libsodium binding for key zeroing                     |
+| `RotationProgressCallback`  | `(rotation: BucketKeyRotation) => void` — called after each chunk completes                                     |
+| `VersionedEncryptedPayload` | Encrypted blob with its `keyVersion` metadata                                                                   |
+| `CompletionItem`            | Per-item result (`completed` or `failed`) reported back to the server                                           |
+| `ItemProcessResult`         | Internal per-item result carrying the original `BucketRotationItem`                                             |
 
 ## Usage
 
 ```ts
 import { RotationWorker } from "@pluralscape/rotation-worker";
-import type { RotationApiClient, RotationWorkerConfig } from "@pluralscape/rotation-worker";
+import type {
+  RotationApiClient,
+  RotationSodium,
+  RotationWorkerConfig,
+} from "@pluralscape/rotation-worker";
 
 // Implement RotationApiClient using your app's HTTP layer
 const apiClient: RotationApiClient = {
   /* ... */
+};
+
+// Provide the platform's libsodium binding for key zeroing
+const sodium: RotationSodium = {
+  memzero: (buf) => platformSodium.memzero(buf),
 };
 
 const config: RotationWorkerConfig = {
@@ -86,6 +103,7 @@ const config: RotationWorkerConfig = {
   oldKeyVersion: 1,
   newKey: fetchedNewKey,
   newKeyVersion: 2,
+  sodium,
   chunkSize: 50, // optional, defaults to KEY_ROTATION.defaultChunkSize
 };
 
@@ -117,4 +135,4 @@ Unit tests only (no integration variant — the worker is a pure client-side sta
 pnpm vitest run --project rotation-worker
 ```
 
-Tests cover: full rotation loop (single and multi-chunk), early exit when chunk is empty or rotation transitions to `completed`/`failed`, graceful stop via `abort`, 404 on the rotation resource, per-item retry with exponential backoff, per-item 404 and 409 short-circuit, dual-key selection by version, unknown key version rejection, and abort mid-chunk.
+Tests cover: full rotation loop (single and multi-chunk), early exit when chunk is empty or rotation transitions to `completed`/`failed`, graceful stop via `abort`, 404 on the rotation resource, per-item retry with exponential backoff, per-item 404 and 409 short-circuit, dual-key selection by version, unknown key version rejection, abort mid-chunk, plaintext zeroing around re-encrypt/upload (including failure paths), and old/new key zeroing on both success and error exits from `start()`.

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -49,7 +49,7 @@ import { S3BlobStorageAdapter } from "@pluralscape/storage/s3";
 import type { S3AdapterConfig } from "@pluralscape/storage/s3";
 ```
 
-Works against AWS S3, Cloudflare R2, Backblaze B2, or MinIO. Supports presigned upload and download URLs.
+Works against AWS S3, Cloudflare R2, Backblaze B2, or MinIO. Supports presigned upload and download URLs, configurable `maxSizeBytes` enforcement (throws `BlobTooLargeError` on over-sized `upload()`), and write-once semantics via `If-None-Match: *` baked into both direct PUTs and presigned URLs. Presigned uploads sign `content-length`, `content-type`, and `if-none-match` into the signature so clients cannot override them at upload time — this is required for MinIO and some S3-compatible backends that do not auto-sign those headers.
 
 ### `/filesystem` — Local filesystem adapter
 
@@ -57,7 +57,7 @@ Works against AWS S3, Cloudflare R2, Backblaze B2, or MinIO. Supports presigned 
 import { FilesystemBlobStorageAdapter } from "@pluralscape/storage/filesystem";
 ```
 
-Minimal self-hosted fallback. Stores blobs in a configurable directory. Does not support presigned URLs (`supportsPresignedUrls` is `false`); the API server proxies uploads and downloads directly.
+Minimal self-hosted fallback. Stores blobs in a configurable directory with atomic temp-file + link writes and optional `maxSizeBytes` enforcement. Does not support presigned URLs (`supportsPresignedUrls` is `false`); the API server proxies uploads and downloads directly. Accepts an optional `logger` for structured observability (e.g. sidecar parse failures).
 
 ### `/quota` — Quota and cleanup utilities
 
@@ -68,10 +68,11 @@ import {
   OrphanBlobDetector,
   BlobCleanupHandler,
   DEFAULT_QUOTA_BYTES,
+  DEFAULT_GRACE_PERIOD_MS,
 } from "@pluralscape/storage/quota";
 ```
 
-`BlobQuotaService` checks and records per-system usage before writes. `OrphanBlobDetector` identifies blobs whose metadata records have been deleted (with a configurable grace period). `BlobCleanupHandler` drives the archival and removal job.
+`BlobQuotaService` exposes `getUsage`, `checkQuota`, `assertQuota`, and `reserveQuota` for per-system enforcement before writes. `reserveQuota` is the advisory-lock integration point — it is equivalent to `assertQuota` today and is subject to TOCTOU races until the API layer wraps reserve + upload in a serializable transaction with `pg_advisory_xact_lock`. `OrphanBlobDetector` identifies blobs whose metadata records have been deleted (with a configurable grace period, 24 h by default). `BlobCleanupHandler` drives the archival and removal job; per-key failures are isolated and reported in `CleanupResult.failedKeys` without aborting the run.
 
 ## Usage
 
@@ -89,7 +90,11 @@ const adapter = new S3BlobStorageAdapter({
 
 const storageKey = generateStorageKey(systemId, blobId);
 
-// Generate a presigned URL for the client to upload directly
+// Generate a presigned URL for the client to upload directly.
+// `sizeBytes` MUST be the exact on-the-wire body length — i.e. the
+// ciphertext length, never the plaintext size. The value is signed into
+// the request as a `Content-Length` constraint; a mismatch at upload
+// time yields HTTP 403 `SignatureDoesNotMatch` from S3.
 const result = await adapter.generatePresignedUploadUrl({
   storageKey,
   mimeType: "image/webp",

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -6,9 +6,13 @@ Encrypted offline-first CRDT sync over a zero-knowledge relay using Automerge.
 
 `@pluralscape/sync` implements the sync layer for Pluralscape's offline-first architecture. Local SQLite is the source of truth; this package is responsible for merging local changes with remote ones and propagating them through an encrypted relay. The server is a dumb relay — it stores and forwards opaque ciphertext and never reads or merges document contents.
 
-CRDT documents are managed with [Automerge](https://automerge.org/). Each logical entity (system core, fronting sessions, journal, etc.) maps to a dedicated Automerge document. Changes are encrypted client-side using per-document symmetric keys from `@pluralscape/crypto` before submission. The relay stores envelopes; clients decrypt and apply them locally.
+CRDT documents are managed with [Automerge](https://automerge.org/). Each logical entity (system core, fronting, chat, journal, notes, privacy config, bucket projections) maps to a dedicated Automerge document. The full entity coverage — including webhook configs and friend connections — lives in `ENTITY_CRDT_STRATEGIES`. Changes are encrypted client-side using per-document symmetric keys from `@pluralscape/crypto` before submission. The relay stores envelopes; clients decrypt and apply them locally.
+
+Every envelope (change and snapshot) is Ed25519-signed by the author and the signature is verified before decryption. The envelope's `authorPublicKey` is mixed into the AEAD additional data, cryptographically binding the advertised public key to the ciphertext — swapping the public key after the fact produces `KeyBindingMismatchError` on decrypt. Snapshot envelopes additionally commit to a big-endian `snapshotVersion` to prevent cross-version replay. Document access is authorised via the document key resolver, which maps document IDs to bucket keys and refuses unknown buckets with `BucketKeyNotFoundError`.
 
 Conflict resolution happens entirely on-device: Automerge provides last-writer-wins semantics per field for concurrent edits. Post-merge validation runs after each merge to detect application-level inconsistencies (e.g., overlapping fronting sessions) and surfaces them as `ConflictNotification` events rather than silently discarding data. Documents that exceed size or time thresholds are split or compacted automatically.
+
+Incoming changes are materialised into SQLite through per-document materializers. Each merge carries a `dirtyEntityTypes` hint so only entity types whose CRDT fields actually changed are queried and diffed — clean types issue zero SQL. Hot-path entity writes emit `materialized:entity` events for downstream query invalidation.
 
 ## Key Exports
 
@@ -30,6 +34,7 @@ All imports below are from `@pluralscape/sync` unless noted.
 **Encryption**
 
 - `encryptChange` / `decryptChange`, `encryptSnapshot` / `decryptSnapshot`, `verifyEnvelopeSignature`
+- `SignatureVerificationError`, `KeyBindingMismatchError`, `EncryptionKeyMismatchError` — distinguish signature forgery, author-key binding mismatch, and benign key-desync decrypt failures
 
 **Conflict resolution**
 
@@ -52,12 +57,12 @@ All imports below are from `@pluralscape/sync` unless noted.
 
 **Sub-entry points**
 
-| Import path                      | Contents                                                                                                                                                      |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@pluralscape/sync/adapters`     | `SqliteStorageAdapter`, `WsNetworkAdapter`, `SqliteOfflineQueueAdapter`, `createWsClientAdapter`, `createBunSqliteDriver`, adapter interfaces                 |
-| `@pluralscape/sync/schemas`      | Automerge document schema types (`CrdtSystem`, `CrdtMember`, `CrdtFrontingSession`, `SystemCoreDocument`, `FrontingDocument`, etc.)                           |
-| `@pluralscape/sync/protocol`     | Full protocol message taxonomy (`ClientMessage`, `ServerMessage`, `AuthenticateRequest`, `ManifestResponse`, `DocumentUpdate`, `SYNC_PROTOCOL_VERSION`, etc.) |
-| `@pluralscape/sync/materializer` | Entity registry, base materializer, `diffEntities`, `applyDiff`, `generateAllDdl`, `createMaterializer`, `registerMaterializer`                               |
+| Import path                      | Contents                                                                                                                                                                                                 |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@pluralscape/sync/adapters`     | `SqliteStorageAdapter`, `WsNetworkAdapter`, `SqliteOfflineQueueAdapter`, `createWsClientAdapter`, `createBunSqliteDriver`, `runAsyncTransaction`, adapter interfaces (`SqliteDriver`, `SqliteStatement`) |
+| `@pluralscape/sync/schemas`      | Automerge document schema types (`CrdtSystem`, `CrdtMember`, `CrdtFrontingSession`, `SystemCoreDocument`, `FrontingDocument`, etc.)                                                                      |
+| `@pluralscape/sync/protocol`     | Full protocol message taxonomy (`ClientMessage`, `ServerMessage`, `AuthenticateRequest`, `ManifestResponse`, `DocumentUpdate`, `SYNC_PROTOCOL_VERSION`, etc.)                                            |
+| `@pluralscape/sync/materializer` | Entity registry, base materializer, `diffEntities`, `applyDiff`, `generateAllDdl`, `createMaterializer`, `registerMaterializer`                                                                          |
 
 ## Usage
 
@@ -101,6 +106,14 @@ const envelope = await encryptChange(change, {
 
 // envelope is an EncryptedChangeEnvelope — safe to relay to the server
 ```
+
+## SQLite drivers
+
+The `SqliteDriver` contract is fully async — every `run` / `all` / `get` / `exec` / `transaction` / `close` returns a `Promise`. Sync-native backends (`bun:sqlite`, `expo-sqlite`, `better-sqlite3-multiple-ciphers`) wrap their synchronous calls with `Promise.resolve`; the overhead is one microtask per call. This contract is required so the web build can talk to an OPFS-backed wa-sqlite driver over `postMessage`, where every call is inherently async.
+
+This package ships `createBunSqliteDriver` (bun:sqlite) and `runAsyncTransaction` (shared `BEGIN`/`COMMIT`/`ROLLBACK` helper with `AggregateError` for rollback-on-rollback). The expo-sqlite driver and the OPFS web-worker driver live in `apps/mobile/src/platform/drivers/` alongside the platform detection that chooses between them.
+
+Nested transactions are rejected synchronously at the driver level — callers must guard their own re-entry.
 
 ## Dependencies
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -38,36 +38,52 @@ See [ADR-006](../../docs/adr/006-encryption.md) for the encryption boundary rati
 - `HexColor`, `SlugHash`, `ChecksumHex`, `StorageKey` — branded scalar types
 - `ID_PREFIXES` — runtime map of entity type to string prefix (e.g. `"sys_"`, `"mbr_"`)
 - `EntityType` — discriminated union of all entity type strings
+- `brandId<B>(value)` (`brand-utils.ts`) — zero-cost cast from a plain string to a branded ID,
+  centralizing the `as XxxId` pattern so branding changes have a single update point
+- `assertBrandedTargetId()`, `InvalidBrandedIdError` (`assert-branded.ts`) — runtime validation
+  that an unknown string matches the expected branded-ID prefix
 
 ### Domain Types by Feature
 
-| Module                 | Types                                                                                                                                      |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `identity.ts`          | `System`, `Member`, `MemberPhoto`, `Tag`, `SaturationLevel`, `CreateMemberBody`, `UpdateMemberBody`                                        |
-| `fronting.ts`          | `ActiveFrontingSession`, `CompletedFrontingSession`, `FrontingSession`, `CustomFront`, `CoFrontState`, `OuttriggerSentiment`               |
-| `privacy.ts`           | `PrivacyBucket`, `BucketVisibilityScope`, `KeyGrant`, `FriendConnection`, `FriendCode`, `BucketAccessCheck`                                |
-| `structure.ts`         | `SystemStructureEntity`, `SystemStructureEntityType`, `Relationship`, `SystemProfile`, `ArchitectureType`                                  |
-| `groups.ts`            | `Group`, `GroupMembership`, `GroupTree`, `GroupMoveOperation`                                                                              |
-| `encryption.ts`        | `Server*` / `Client*` pairs for every encrypted entity, `Encrypted`, `BucketEncrypted`, `ServerSafe`, `DecryptFn`, `EncryptFn`             |
-| `auth.ts`              | `Account`, `AuthKey`, `Session`, `RecoveryKey`, `DeviceTransferRequest`, `LoginCredentials`                                                |
-| `communication.ts`     | `Channel`, `ChatMessage`, `BoardMessage`, `Note`, `Poll`, `PollVote`, `AcknowledgementRequest`                                             |
-| `journal.ts`           | `JournalEntry`, `WikiPage`, `JournalBlock` (paragraph, heading, list, quote, code, image, divider, member/entity link), `FrontingSnapshot` |
-| `lifecycle.ts`         | `LifecycleEvent`, `SplitEvent`, `FusionEvent`, `DiscoveryEvent`, `ArchivalEvent`, and 8 additional event types                             |
-| `custom-fields.ts`     | `FieldDefinition`, `FieldValue`, `FieldType`, `FieldBucketVisibility`                                                                      |
-| `analytics.ts`         | `FrontingAnalytics`, `CoFrontingAnalytics`, `ChartData`, `DateRangeFilter`, `DateRangePreset`                                              |
-| `innerworld.ts`        | `InnerWorldCanvas`, `InnerWorldEntity`, `InnerWorldRegion`                                                                                 |
-| `sync.ts`              | `SyncDocument`, `SyncState`, `SyncIndicator`, `SyncDocumentType`                                                                           |
-| `import-export.ts`     | `ImportJob`, `ImportEntityRef`, `ImportCheckpointState`, `ExportRequest`, `PKImport*`, `AccountPurgeRequest`                               |
-| `pk-bridge.ts`         | `PKBridgeConfig`, `PKEntityMapping`, `PKSyncState`, `PKSyncError`                                                                          |
-| `webhooks.ts`          | `WebhookConfig`, `WebhookDelivery`, `WebhookEventPayloadMap`                                                                               |
-| `notifications.ts`     | `DeviceToken`, `NotificationConfig`, `FriendNotificationPreference`                                                                        |
-| `realtime.ts`          | `WebSocketEvent`, `SSEEvent`, `RealtimeSubscription`, `WebSocketConnectionState`                                                           |
-| `settings.ts`          | `SystemSettings`, `AppLockConfig`, `SyncPreferences`, `PrivacyDefaults`                                                                    |
-| `nomenclature.ts`      | `NomenclatureSettings`, `TermCategory`, `TermPreset`                                                                                       |
-| `littles-safe-mode.ts` | `LittlesSafeModeConfig`, `SafeModeUIFlags`, `SafeModeContentItem`                                                                          |
-| `snapshot.ts`          | `SystemSnapshot` and per-entity snapshot subtypes                                                                                          |
-| `key-rotation.ts`      | `BucketKeyRotation`, `BucketRotationItem`, `RotationState`                                                                                 |
-| `audit-log.ts`         | `AuditLogEntry`, `AuditEventType`, `AuditActor`                                                                                            |
+| Module                   | Types                                                                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `identity.ts`            | `System`, `Member`, `MemberPhoto`, `Tag`, `SaturationLevel`, `CreateMemberBody`, `UpdateMemberBody`                                        |
+| `fronting.ts`            | `ActiveFrontingSession`, `CompletedFrontingSession`, `FrontingSession`, `CustomFront`, `CoFrontState`, `OuttriggerSentiment`               |
+| `privacy.ts`             | `PrivacyBucket`, `BucketVisibilityScope`, `KeyGrant`, `FriendConnection`, `FriendCode`, `BucketAccessCheck`                                |
+| `structure.ts`           | `SystemStructureEntity`, `SystemStructureEntityType`, `Relationship`, `SystemProfile`, `ArchitectureType`                                  |
+| `groups.ts`              | `Group`, `GroupMembership`, `GroupTree`, `GroupMoveOperation`                                                                              |
+| `encryption.ts`          | `Server*` / `Client*` pairs for every encrypted entity, `Encrypted`, `BucketEncrypted`, `ServerSafe`, `DecryptFn`, `EncryptFn`             |
+| `auth.ts`                | `Account`, `AuthKey`, `Session`, `RecoveryKey`, `DeviceTransferRequest`, `LoginCredentials`                                                |
+| `communication.ts`       | `Channel`, `ChatMessage`, `BoardMessage`, `Note`, `Poll`, `PollVote`, `AcknowledgementRequest`                                             |
+| `journal.ts`             | `JournalEntry`, `WikiPage`, `JournalBlock` (paragraph, heading, list, quote, code, image, divider, member/entity link), `FrontingSnapshot` |
+| `lifecycle.ts`           | `LifecycleEvent`, `SplitEvent`, `FusionEvent`, `DiscoveryEvent`, `ArchivalEvent`, and 8 additional event types                             |
+| `custom-fields.ts`       | `FieldDefinition`, `FieldValue`, `FieldType`, `FieldBucketVisibility`                                                                      |
+| `analytics.ts`           | `FrontingAnalytics`, `CoFrontingAnalytics`, `ChartData`, `DateRangeFilter`, `DateRangePreset`                                              |
+| `innerworld.ts`          | `InnerWorldCanvas`, `InnerWorldEntity`, `InnerWorldRegion`                                                                                 |
+| `sync.ts`                | `SyncDocument`, `SyncState`, `SyncIndicator`, `SyncDocumentType`                                                                           |
+| `import-export.ts`       | `ImportJob`, `ImportEntityRef`, `ImportCheckpointState`, `ExportRequest`, `PKImport*`, `AccountPurgeRequest`                               |
+| `pk-bridge.ts`           | `PKBridgeConfig`, `PKEntityMapping`, `PKSyncState`, `PKSyncError`                                                                          |
+| `webhooks.ts`            | `WebhookConfig`, `WebhookDelivery`, `WebhookEventPayloadMap`                                                                               |
+| `notifications.ts`       | `DeviceToken`, `NotificationConfig`, `FriendNotificationPreference`                                                                        |
+| `realtime.ts`            | `WebSocketEvent`, `SSEEvent`, `RealtimeSubscription`, `WebSocketConnectionState`                                                           |
+| `settings.ts`            | `SystemSettings`, `AppLockConfig`, `SyncPreferences`, `PrivacyDefaults`                                                                    |
+| `nomenclature.ts`        | `NomenclatureSettings`, `TermCategory`, `TermPreset`                                                                                       |
+| `littles-safe-mode.ts`   | `LittlesSafeModeConfig`, `SafeModeUIFlags`, `SafeModeContentItem`                                                                          |
+| `snapshot.ts`            | `SystemSnapshot` and per-entity snapshot subtypes                                                                                          |
+| `key-rotation.ts`        | `BucketKeyRotation`, `BucketRotationItem`, `RotationState`                                                                                 |
+| `audit-log.ts`           | `AuditLogEntry`, `AuditEventType`, `AuditActor`, `SetupStepName`                                                                           |
+| `api-keys.ts`            | `ApiKey`, `ApiKeyWithSecret`, `ApiKeyScope`, `ApiKeyToken`, `MetadataApiKey`, `CryptoApiKey`, `API_KEY_TOKEN_PREFIX`                       |
+| `scope-domains.ts`       | `ScopeDomain`, `ScopeTier`, `RequiredScope`, `SCOPE_DOMAINS`, `ALL_API_KEY_SCOPES`                                                         |
+| `jobs.ts`                | `JobType`, `JobStatus`, `JobPayloadMap`, `JobPayload`, `JobDefinition`, `RetryPolicy`, `BackoffStrategy`, `JOB_TYPE_VALUES`                |
+| `blob.ts`                | `BlobMetadata`, `BlobUploadRequest`, `BlobDownloadRef`, `EncryptionTier`, `BlobPurpose`                                                    |
+| `timer.ts`               | `TimerConfig`, `CheckInRecord`, `CheckInRecordStatus`                                                                                      |
+| `reports.ts`             | `ReportType`, `ReportConfig`, `ReportData`, `BucketExportManifestEntry`, `BucketExportPageResponse`, `REPORT_TYPES`                        |
+| `search.ts`              | `SearchIndex`, `SearchQuery`, `SearchResult`, `SearchableEntityType`                                                                       |
+| `friend-dashboard.ts`    | `FriendDashboardResponse`, `FriendAccessContext`, `FriendDashboardSyncResponse`                                                            |
+| `friend-export.ts`       | `FriendExportEntity`, `FriendExportManifestResponse`, `FriendExportPageResponse`, `FRIEND_EXPORT_ENTITY_TYPES`                             |
+| `subscription-events.ts` | `EntityChangeEvent`, `MessageChangeEvent`, `BoardMessageChangeEvent`, `PollChangeEvent`, `AcknowledgementChangeEvent`                      |
+| `crypto-keys.ts`         | `KdfMasterKey`                                                                                                                             |
+| `i18n.ts` / `i18n/`      | `Locale`, `TranslationMap`, `LocaleConfig`, `SUPPORTED_LOCALES`, `I18nManifest`, `I18nNamespaceWithEtag`, `Etag`, `asEtag`                 |
 
 ### Shared Utilities
 
@@ -79,6 +95,7 @@ See [ADR-006](../../docs/adr/006-encryption.md) for the encryption boundary rati
 - `server-safe.ts` — `ServerSafe<T>`, `serverSafe()` branding function
 - `checksum.ts` — `toChecksumHex()`
 - `logger.ts` — `Logger` interface (structural, no concrete implementation)
+- `runtime.ts` — `createId()`, `now()`, `toISO()`, `extractErrorMessage()`
 
 ## Usage
 
@@ -86,15 +103,15 @@ Importing domain types across packages:
 
 ```typescript
 import type { Member, MemberId, FrontingSession } from "@pluralscape/types";
-import { ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
 
 // IDs are nominally typed — MemberId is not assignable from a plain string
 function getFrontingSession(memberId: MemberId): FrontingSession {
   /* ... */
 }
 
-// createId enforces the prefix contract at runtime
-const memberId = createId(ID_PREFIXES.member) as MemberId;
+// createId enforces the prefix contract at runtime; brandId centralizes the cast
+const memberId = brandId<MemberId>(createId(ID_PREFIXES.member));
 ```
 
 Using the server/client encryption boundary:
@@ -129,4 +146,7 @@ pnpm vitest run --project types
 Tests are co-located in `src/__tests__/` with one file per source module. Coverage focuses on
 runtime utilities (`createId`, `now`, `toISO`, `toUnixMillis`, timestamp conversions, checksum
 encoding), discriminated union type guards, and constants. Pure type exports are validated by the
-TypeScript compiler via `pnpm typecheck` rather than runtime assertions.
+TypeScript compiler via `pnpm typecheck`, supplemented by compile-time assertions with Vitest's
+`expectTypeOf`. For entities with matching Zod schemas in `@pluralscape/validation`, contract
+tests pair `expectTypeOf` checks with runtime `safeParse` assertions so drift between the type
+and schema sides is caught immediately.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -6,15 +6,17 @@ Shared Zod v4 schemas for all API request boundaries across the Pluralscape mono
 
 `@pluralscape/validation` provides hand-written Zod schemas for every REST and tRPC request boundary in the API. Both the Hono REST routes (`apps/api/`) and tRPC procedure inputs import from this package, guaranteeing that the two transports enforce identical validation rules at runtime.
 
+All schemas import from `zod/v4` — the Zod v4 subpath. The catalog version is pinned to `^4.3.6`.
+
 TypeScript types remain the source of truth — defined in `@pluralscape/types`, never inferred from schemas. The `packages/validation` schemas are written by hand and verified against those types via contract tests that run `expectTypeOf` (compile-time alignment) and `safeParse` (runtime shape). This approach is documented in [ADR 023](../../docs/adr/023-zod-type-alignment.md).
 
-Scope is intentionally limited to boundary types: API request bodies, job payloads, webhook inputs, and query parameters. Internal domain types that never cross a trust boundary do not have schemas here.
+Scope is intentionally limited to trust-boundary types: API request bodies, query parameters, import job payloads, webhook inputs, and import-mapper output shapes. Internal domain types that never cross a trust boundary do not have schemas here. Adapter-local boundary schemas (e.g. BullMQ's `StoredJobDataSchema`) live in their own package; this one is the canonical home for schemas that cross the API surface.
 
 ## Key Exports
 
 ### Auth and account
 
-- `RegistrationInputSchema`, `LoginCredentialsSchema`
+- `RegistrationInitiateSchema`, `RegistrationCommitSchema`, `LoginSchema`, `SaltFetchSchema`
 - `ChangeEmailSchema`, `ChangePasswordSchema`
 - `RegenerateRecoveryKeySchema`, `PasswordResetViaRecoveryKeySchema`
 - `UpdateAccountSettingsSchema`, `DeleteAccountBodySchema`
@@ -49,11 +51,11 @@ Scope is intentionally limited to boundary types: API request bodies, job payloa
 - `CreateNoteBodySchema`, `UpdateNoteBodySchema`, `NoteQuerySchema`
 - `CreatePollBodySchema`, `UpdatePollBodySchema`, `CastVoteBodySchema`, `UpdatePollVoteBodySchema`, `PollQuerySchema`, `PollVoteQuerySchema`
 - `CreateAcknowledgementBodySchema`, `ConfirmAcknowledgementBodySchema`, `AcknowledgementQuerySchema`
-- `CreateTimerConfigBodySchema`, `UpdateTimerConfigBodySchema`, `CreateCheckInRecordBodySchema`, `RespondCheckInRecordBodySchema`
+- `CreateTimerConfigBodySchema`, `UpdateTimerConfigBodySchema`, `TimerConfigQuerySchema`, `CreateCheckInRecordBodySchema`, `RespondCheckInRecordBodySchema`, `CheckInRecordQuerySchema`
 
 ### Privacy and friends
 
-- `CreateBucketBodySchema`, `UpdateBucketBodySchema`, `TagContentBodySchema`, `BucketContentTagQuerySchema`, `SetFieldBucketVisibilityBodySchema`
+- `CreateBucketBodySchema`, `UpdateBucketBodySchema`, `BucketQuerySchema`, `TagContentBodySchema`, `BucketContentTagQuerySchema`, `SetFieldBucketVisibilityBodySchema`
 - `RedeemFriendCodeBodySchema`, `UpdateFriendVisibilityBodySchema`, `AssignBucketBodySchema`, `FriendConnectionQuerySchema`, `FriendCodeQuerySchema`
 - `FriendExportQuerySchema`, `ListReceivedKeyGrantsQuerySchema`
 
@@ -63,8 +65,9 @@ Scope is intentionally limited to boundary types: API request bodies, job payloa
 - `CreateStructureEntityBodySchema`, `UpdateStructureEntityBodySchema`
 - `CreateStructureEntityLinkBodySchema`, `UpdateStructureEntityLinkBodySchema`
 - `CreateStructureEntityMemberLinkBodySchema`, `CreateStructureEntityAssociationBodySchema`
+- `StructureEntityLinkQuerySchema`, `StructureEntityMemberLinkQuerySchema`, `StructureEntityAssociationQuerySchema`
 - `CreateRelationshipBodySchema`, `UpdateRelationshipBodySchema`, `RELATIONSHIP_TYPES`
-- `CreateLifecycleEventBodySchema`, `UpdateLifecycleEventBodySchema`, `LIFECYCLE_EVENT_TYPES`, `validateLifecycleMetadata`
+- `CreateLifecycleEventBodySchema`, `UpdateLifecycleEventBodySchema`, `LIFECYCLE_EVENT_TYPES`, `validateLifecycleMetadata`, `PlaintextMetadata` (type)
 - `CreateRegionBodySchema`, `UpdateRegionBodySchema`, `CreateEntityBodySchema`, `UpdateEntityBodySchema`, `UpdateCanvasBodySchema`
 
 ### Infrastructure
@@ -74,9 +77,18 @@ Scope is intentionally limited to boundary types: API request bodies, job payloa
 - `InitiateRotationBodySchema`, `ClaimChunkBodySchema`, `CompleteChunkBodySchema`
 - `CreateWebhookConfigBodySchema`, `UpdateWebhookConfigBodySchema`, `RotateWebhookSecretBodySchema`, `WebhookConfigQuerySchema`, `WebhookDeliveryQuerySchema`
 - `RegisterDeviceTokenBodySchema`, `UpdateDeviceTokenBodySchema`, `UpdateNotificationConfigBodySchema`, `UpdateFriendNotificationPreferenceBodySchema`
-- `CreateUploadUrlBodySchema`, `ConfirmUploadBodySchema`
+- `CreateUploadUrlBodySchema`, `ConfirmUploadBodySchema`, `ALLOWED_MIME_TYPES`
 - `GenerateReportBodySchema`, `BucketExportQuerySchema`
 - `CreateFieldDefinitionBodySchema`, `UpdateFieldDefinitionBodySchema`, `SetFieldValueBodySchema`, `UpdateFieldValueBodySchema`
+
+### Imports
+
+Trust-boundary schemas shared between the API and the import packages (`@pluralscape/import-sp`, `@pluralscape/import-pk`). The importers derive their `Mapped*` output types via `z.infer<typeof CreateMemberBodySchema>` so mapper output cannot drift from the shape the API accepts.
+
+- `CreateImportJobBodySchema`, `UpdateImportJobBodySchema`, `ImportJobQuerySchema`
+- `ImportErrorSchema`, `ImportCheckpointStateSchema`
+- `ImportEntityRefQuerySchema`, `ImportEntityRefLookupBatchBodySchema`, `ImportEntityRefUpsertBatchBodySchema`
+- `ImportEntityRefLookupBatchBody`, `ImportEntityRefUpsertBatchBody` (types)
 
 ### Utilities and constants
 
@@ -85,7 +97,7 @@ Scope is intentionally limited to boundary types: API request bodies, job payloa
 - `booleanQueryParam`, `optionalBooleanQueryParam` — coerce string query params to booleans
 - `IncludeArchivedQuerySchema`, `InnerWorldEntityQuerySchema`, `LifecycleEventQuerySchema`, `RelationshipQuerySchema` and related query schemas
 - `parseTimeToMinutes` — parse human-readable time strings to integer minutes
-- Constants: `AUTH_MIN_PASSWORD_LENGTH`, `MAX_ENCRYPTED_DATA_SIZE`, `MAX_ENCRYPTED_MEMBER_DATA_SIZE`, `MAX_REORDER_OPERATIONS`, `WEBHOOK_EVENT_TYPE_VALUES`, `MAX_ANALYTICS_CUSTOM_RANGE_MS`, `DEVICE_TOKEN_PLATFORM_VALUES`, and more — see `validation.constants.ts`
+- Constants: `AUTH_MIN_PASSWORD_LENGTH`, `MAX_ENCRYPTED_DATA_SIZE`, `MAX_ENCRYPTED_SYSTEM_DATA_SIZE`, `MAX_ENCRYPTED_MEMBER_DATA_SIZE`, `MAX_ENCRYPTED_PHOTO_DATA_SIZE`, `MAX_ENCRYPTED_FIELD_DATA_SIZE`, `MAX_ENCRYPTED_FIELD_VALUE_SIZE`, `MAX_REORDER_OPERATIONS`, `MAX_ANALYTICS_CUSTOM_RANGE_MS`, `MAX_DEVICE_TOKEN_LENGTH`, `MAX_REPORT_TITLE_LENGTH`, `BUCKET_EXPORT_DEFAULT_LIMIT`, `BUCKET_EXPORT_MAX_LIMIT`, `IMPORT_ENTITY_REF_BATCH_MAX`, `WEBHOOK_EVENT_TYPE_VALUES`, `DEVICE_TOKEN_PLATFORM_VALUES`, `FRIEND_NOTIFICATION_EVENT_TYPE_VALUES` — see `validation.constants.ts`
 
 ## Usage
 
@@ -95,8 +107,9 @@ Import schemas directly from the package. Both REST handlers and tRPC procedure 
 import {
   CreateMemberBodySchema,
   CreateFrontingSessionBodySchema,
-  LoginCredentialsSchema,
+  LoginSchema,
 } from "@pluralscape/validation";
+import type { z } from "zod/v4";
 
 // tRPC procedure input
 export const createMember = protectedProcedure
@@ -113,16 +126,18 @@ app.post("/members", async (c) => {
   // parsed.data is fully typed
 });
 
-// Infer request body type
-type LoginCredentials = z.infer<typeof LoginCredentialsSchema>;
+// Infer request body type at a trust boundary
+type LoginBody = z.infer<typeof LoginSchema>;
 ```
+
+The importers re-use the same schemas as the API. For example, `@pluralscape/import-sp` defines `MappedMember` as `Omit<z.infer<typeof CreateMemberBodySchema>, "encryptedData"> & { ... }`, so mapper output is statically pinned to the shape the API already validates.
 
 ## Dependencies
 
-| Package                          | Role                                                                 |
-| -------------------------------- | -------------------------------------------------------------------- |
-| `zod` (`^4.3.6`)                 | Runtime schema parsing and type inference                            |
-| `@pluralscape/types` (workspace) | Canonical TypeScript types; schemas are verified to align with these |
+| Package                          | Role                                                                       |
+| -------------------------------- | -------------------------------------------------------------------------- |
+| `zod` (catalog, `^4.3.6`)        | Runtime schema parsing and type inference — imported via the `zod/v4` path |
+| `@pluralscape/types` (workspace) | Canonical TypeScript types; schemas are verified to align with these       |
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Comprehensive documentation refresh aligning every user-facing doc with the current code, plus four targeted follow-ups surfaced during the accuracy review. Closes Milestone 9 (`ps-h2gl`). Tracking bean: `ps-w3j9`.

## Scope

- **Root docs:** `README.md`, `CHANGELOG.md` (new "2026-04-21 — Milestone 9 closeout" section, 6 thematic subsections), `CONTRIBUTING.md` (post-M9 gates, zero-knowledge rule, Crowdin workflow, beans workflow, pre-release code hygiene).
- **Planning docs:** `milestones.md`, `features.md`, `api-specification.md`.
- **Architecture & schema:** `architecture.md` (ADRs 031/033/034/035/036/037), `database-schema.md` (ERD verified against Drizzle definitions; 5 tables had real column drift).
- **API references:** `openapi/openapi.yaml` (6 per-route fixes in Commit 4, then 3+38 list-wrapper renames to `data` in the follow-up), `trpc-guide.md` (example signatures corrected; router table camelCase).
- **Consumer guides:** `api-consumer-guide.md`, `api-key-scopes.md`, `mobile-developer-guide.md`, `sync-protocol.md`, `webhook-signature-verification.md`.
- **ADR accuracy:** touch-ups on ADR 006 (Master-Key KDF Profile addendum rename) and ADR 036 (native auto-merge workflow, correct MT coverage). ADRs 035, 037, 013 verified accurate.
- **Package READMEs:** all 15 existing READMEs refreshed, plus a new `packages/logger/README.md`.

## Follow-ups resolved on this branch

1. **OpenAPI list-wrapper inconsistency.** 25+ list endpoints used varied response keys (`items`, `members`, `groups`, ...) while server handlers emit `{ data, ... }` via `buildPaginatedResult`. Normalized to `data` across 3 schemas and 38 path-inline occurrences.
2. **`SCOPE_INSUFFICIENT` vs handler behavior.** REST `scope-gate` now emits `SCOPE_INSUFFICIENT` for scope-insufficient rejections while keeping `FORBIDDEN` for the "endpoint not registered for API key access" case. tRPC keeps `FORBIDDEN` because the `TRPCError` code enum is fixed.
3. **Orphan `apps/api/src/trpc/routers/i18n.ts`** — invalid finding. `i18n-composer.ts` imports `createI18nRouter` from `i18n.ts` and wires it into `root.ts`.
4. **Missing `packages/logger/README.md`** — new README added (mobile logger, PII redaction, testing, design rationale).

## Verification

- `pnpm format` — exit 0
- `pnpm lint` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm openapi:check` — exit 0 (317 routes = 317 operations)
- `pnpm openapi:lint` — exit 0
- `pnpm trpc:parity` — exit 0
- `pnpm test:coverage` — exit 0 (95.14 / 89.41 / 94.74 / 95.83; 15795 tests pass)
- Targeted scope-gate tests — 8/8 pass with SCOPE_INSUFFICIENT / FORBIDDEN distinction

## Commits

16 per-domain commits on `chore/docs-and-beans-updates`, roughly one commit per logical cluster (architecture/planning batched, README/CHANGELOG together, each guide-batch, each package-README-batch, each follow-up separate).

## Test plan

- [ ] CI passes on this branch.
- [ ] Spot-check CHANGELOG M9 closeout section for accuracy.
- [ ] Spot-check OpenAPI list-wrapper rename against a couple of client consumers (generated `api-types.ts` regenerates in CI).
- [ ] Confirm `ps-h2gl` bean status is `completed`.