### PR TITLE
feat(types): types-tef0 — PlaintextX OpenAPI parity + Member pilot SoT consolidation

### DIFF
--- a/.beans/types-ltel--types-single-source-of-truth.md
+++ b/.beans/types-ltel--types-single-source-of-truth.md
@@ -5,7 +5,7 @@ status: in-progress
 type: epic
 priority: normal
 created_at: 2026-04-21T13:54:18Z
-updated_at: 2026-04-22T23:05:34Z
+updated_at: 2026-04-23T06:14:53Z
 parent: ps-cd6x
 ---
 
@@ -57,3 +57,26 @@ Pilot landed. Member and AuditLogEntry through the parity stack:
 - Manifest completeness gate prevents silent entity drop-off (pilot-scope: Member + AuditLogEntry).
 
 Fleet (Phase 2) next: ~23 remaining Server/Client entity pairs across 6 domain clusters. See follow-up plan for rollout. Follow-up beans: `db-drq1` (Drizzle helper branding), `types-tef0` (OpenAPI enc/dec boundary).
+
+## Plan 2 fleet preconditions (documented by types-tef0)
+
+Each per-entity fleet PR must include these substeps in addition to renaming the Server<X>:
+
+**Types package** (`packages/types/src/entities/<x>.ts`):
+
+1. Rename `Server<X>` → `<X>ServerMetadata`; move declaration from `encryption-primitives.ts` to the entity file.
+2. Refactor as `<X>ServerMetadata = Omit<<X>, <X>EncryptedFields> & { encryptedData: EncryptedBlob }` (consumes the `<X>EncryptedFields` union already in place from types-tef0). Note Member also required omitting `"archived"` due to literal-type mismatch — check each entity for similar.
+3. Add `<X>Wire = Serialize<<X>>`.
+4. Delete old `Server<X>` / `Client<X>` declarations from `encryption-primitives.ts`.
+
+**Parity test** (`scripts/openapi-wire-parity.type-test.ts`): 5. **Do NOT add per-entity encrypted-wire (`<X>Response`) parity** — architecturally impossible. OpenAPI models `encryptedData` as opaque `string`, domain models it as structured `EncryptedBlob`. The shared `EncryptedEntity` envelope parity already covers the wire-shape tripwire.
+
+**Data package** (`packages/data/src/transforms/<x>.ts`): 6. Rename hand-written `<X>EncryptedFields` interface → `<X>EncryptedInput = Pick<<X>, <X>EncryptedFields>` (consumes types-package keys-union). 7. Delete local `AssertXFieldsSubset` type (redundant — `Pick` enforces the constraint). 8. Delete hand-written `assertXEncryptedFields` runtime validator. 9. Update `encryptXInput(data: <X>EncryptedInput, masterKey)` signature.
+
+**Validation package** (`packages/validation/src/<x>.ts`): 10. Add `<X>EncryptedInputSchema` Zod schema (every field of `<X>EncryptedInput`; nested types from shared `plaintext-shared.ts`). 11. Add Zod parity test: `Equal<z.infer<typeof <X>EncryptedInputSchema>, Pick<<X>, <X>EncryptedFields>>` (assert against `Pick` directly to avoid data → validation cycle). 12. Replace `assertXEncryptedFields` call sites (typically inside `decryptX`) with `<X>EncryptedInputSchema.parse()`.
+
+**Consumer packages**: 13. `packages/import-sp/src/mappers/<x>.mapper.ts` + `packages/import-pk/src/mappers/<x>.mapper.ts`: rename imports `<X>EncryptedFields` → `<X>EncryptedInput`.
+
+**Sot manifest** — already done by types-tef0 (all 20 entries include `encryptedFields`). Fleet only needs to upgrade the partial entries (`{ domain, encryptedFields }`) to full entries (`{ domain, server, wire, encryptedFields }`) as it lands `<X>ServerMetadata` and `<X>Wire`.
+
+Pilot (Member) landed in types-tef0 as a reference implementation. The 18 non-pilot entities + Nomenclature are fleet scope.

--- a/.beans/types-ltel--types-single-source-of-truth.md
+++ b/.beans/types-ltel--types-single-source-of-truth.md
@@ -5,7 +5,7 @@ status: in-progress
 type: epic
 priority: normal
 created_at: 2026-04-21T13:54:18Z
-updated_at: 2026-04-23T06:14:53Z
+updated_at: 2026-04-23T06:55:26Z
 parent: ps-cd6x
 ---
 
@@ -69,7 +69,22 @@ Each per-entity fleet PR must include these substeps in addition to renaming the
 3. Add `<X>Wire = Serialize<<X>>`.
 4. Delete old `Server<X>` / `Client<X>` declarations from `encryption-primitives.ts`.
 
-**Parity test** (`scripts/openapi-wire-parity.type-test.ts`): 5. **Do NOT add per-entity encrypted-wire (`<X>Response`) parity** — architecturally impossible. OpenAPI models `encryptedData` as opaque `string`, domain models it as structured `EncryptedBlob`. The shared `EncryptedEntity` envelope parity already covers the wire-shape tripwire.
+**Parity test** (`scripts/openapi-wire-parity.type-test.ts`): 5. Add split-form encrypted-wire parity for the entity:
+
+```ts
+type <X>ResponseOpenApi = components["schemas"]["<X>Response"];
+
+expectTypeOf<
+  Equal<
+    Omit<<X>ResponseOpenApi, "encryptedData">,
+    Omit<Serialize<<X>ServerMetadata>, "encryptedData">
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<<X>ResponseOpenApi["encryptedData"]>().toEqualTypeOf<string>();
+```
+
+The Omit excludes the one structurally-impossible field (`encryptedData` is opaque `string` on wire but structured `EncryptedBlob` in domain). All plaintext columns (ids, timestamps, version, archived flags, and per-entity denormalized plaintext additions like `FrontingSessionResponse.structureEntityId`) are asserted.
 
 **Data package** (`packages/data/src/transforms/<x>.ts`): 6. Rename hand-written `<X>EncryptedFields` interface → `<X>EncryptedInput = Pick<<X>, <X>EncryptedFields>` (consumes types-package keys-union). 7. Delete local `AssertXFieldsSubset` type (redundant — `Pick` enforces the constraint). 8. Delete hand-written `assertXEncryptedFields` runtime validator. 9. Update `encryptXInput(data: <X>EncryptedInput, masterKey)` signature.
 

--- a/.beans/types-ltel--types-single-source-of-truth.md
+++ b/.beans/types-ltel--types-single-source-of-truth.md
@@ -5,7 +5,7 @@ status: in-progress
 type: epic
 priority: normal
 created_at: 2026-04-21T13:54:18Z
-updated_at: 2026-04-23T06:55:26Z
+updated_at: 2026-04-23T07:03:00Z
 parent: ps-cd6x
 ---
 
@@ -69,7 +69,33 @@ Each per-entity fleet PR must include these substeps in addition to renaming the
 3. Add `<X>Wire = Serialize<<X>>`.
 4. Delete old `Server<X>` / `Client<X>` declarations from `encryption-primitives.ts`.
 
-**Parity test** (`scripts/openapi-wire-parity.type-test.ts`): 5. Add split-form encrypted-wire parity for the entity:
+**Drizzle schema parity** (`packages/db/src/__tests__/type-parity/<x>.type.test.ts`): 5. Create a new parity test file asserting the Drizzle row shape structurally matches `<X>ServerMetadata`:
+
+```ts
+import { describe, expectTypeOf, it } from "vitest";
+import { <tableName> } from "../../schema/pg/<table-file>.js";
+import type { StripBrands } from "./__helpers__.js";
+import type { Equal, <X>ServerMetadata } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("<X> Drizzle parity", () => {
+  it("row has the same property keys as <X>ServerMetadata", () => {
+    type Row = InferSelectModel<typeof <tableName>>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof <X>ServerMetadata>();
+  });
+
+  it("row equals <X>ServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof <tableName>>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<<X>ServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});
+```
+
+Uses the existing `StripBrands<T>` wrapper because shared column helpers (`timestamps()`, `versioned()`, `archivable()`) return unbranded columns. `db-drq1` tracks lifting brands into the helpers so the wrapper can be removed and brand-level drift becomes caught too.
+
+**Parity test** (`scripts/openapi-wire-parity.type-test.ts`): 6. Add split-form encrypted-wire parity for the entity:
 
 ```ts
 type <X>ResponseOpenApi = components["schemas"]["<X>Response"];
@@ -86,11 +112,11 @@ expectTypeOf<<X>ResponseOpenApi["encryptedData"]>().toEqualTypeOf<string>();
 
 The Omit excludes the one structurally-impossible field (`encryptedData` is opaque `string` on wire but structured `EncryptedBlob` in domain). All plaintext columns (ids, timestamps, version, archived flags, and per-entity denormalized plaintext additions like `FrontingSessionResponse.structureEntityId`) are asserted.
 
-**Data package** (`packages/data/src/transforms/<x>.ts`): 6. Rename hand-written `<X>EncryptedFields` interface → `<X>EncryptedInput = Pick<<X>, <X>EncryptedFields>` (consumes types-package keys-union). 7. Delete local `AssertXFieldsSubset` type (redundant — `Pick` enforces the constraint). 8. Delete hand-written `assertXEncryptedFields` runtime validator. 9. Update `encryptXInput(data: <X>EncryptedInput, masterKey)` signature.
+**Data package** (`packages/data/src/transforms/<x>.ts`): 7. Rename hand-written `<X>EncryptedFields` interface → `<X>EncryptedInput = Pick<<X>, <X>EncryptedFields>` (consumes types-package keys-union). 8. Delete local `AssertXFieldsSubset` type (redundant — `Pick` enforces the constraint). 9. Delete hand-written `assertXEncryptedFields` runtime validator. 10. Update `encryptXInput(data: <X>EncryptedInput, masterKey)` signature.
 
-**Validation package** (`packages/validation/src/<x>.ts`): 10. Add `<X>EncryptedInputSchema` Zod schema (every field of `<X>EncryptedInput`; nested types from shared `plaintext-shared.ts`). 11. Add Zod parity test: `Equal<z.infer<typeof <X>EncryptedInputSchema>, Pick<<X>, <X>EncryptedFields>>` (assert against `Pick` directly to avoid data → validation cycle). 12. Replace `assertXEncryptedFields` call sites (typically inside `decryptX`) with `<X>EncryptedInputSchema.parse()`.
+**Validation package** (`packages/validation/src/<x>.ts`): 11. Add `<X>EncryptedInputSchema` Zod schema (every field of `<X>EncryptedInput`; nested types from shared `plaintext-shared.ts`). 12. Add Zod parity test: `Equal<z.infer<typeof <X>EncryptedInputSchema>, Pick<<X>, <X>EncryptedFields>>` (assert against `Pick` directly to avoid data → validation cycle). 13. Replace `assertXEncryptedFields` call sites (typically inside `decryptX`) with `<X>EncryptedInputSchema.parse()`.
 
-**Consumer packages**: 13. `packages/import-sp/src/mappers/<x>.mapper.ts` + `packages/import-pk/src/mappers/<x>.mapper.ts`: rename imports `<X>EncryptedFields` → `<X>EncryptedInput`.
+**Consumer packages**: 14. `packages/import-sp/src/mappers/<x>.mapper.ts` + `packages/import-pk/src/mappers/<x>.mapper.ts`: rename imports `<X>EncryptedFields` → `<X>EncryptedInput`.
 
 **Sot manifest** — already done by types-tef0 (all 20 entries include `encryptedFields`). Fleet only needs to upgrade the partial entries (`{ domain, encryptedFields }`) to full entries (`{ domain, server, wire, encryptedFields }`) as it lands `<X>ServerMetadata` and `<X>Wire`.
 

--- a/.beans/types-tef0--openapi-wire-parity-for-member-and-auditlogentry-r.md
+++ b/.beans/types-tef0--openapi-wire-parity-for-member-and-auditlogentry-r.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-22T22:58:41Z
-updated_at: 2026-04-23T06:55:44Z
+updated_at: 2026-04-23T07:03:10Z
 parent: types-ltel
 ---
 
@@ -124,3 +124,7 @@ Blocked-by `types-reorg` (per-entity file consolidation). Once every entity has 
 
 - 13-step checklist appended to `types-ltel` parent bean. Each fleet per-entity PR must follow.
 - Fleet step #5 now mandates split-form per-entity plaintext-column parity (`Omit<..., "encryptedData">` equality + `encryptedData extends string`). The `encryptedData` field itself is the only structurally-impossible piece; all plaintext columns are fully asserted per-entity.
+
+### Follow-up fix
+
+Noticed during review that the Plan 2 fleet checklist on `types-ltel` was missing the `db` package Drizzle parity step. Added as step 5 of the checklist — fleet now creates a per-entity Drizzle parity test file (`packages/db/src/__tests__/type-parity/<x>.type.test.ts`) asserting `Equal<StripBrands<InferSelectModel<typeof <table>>>, StripBrands<<X>ServerMetadata>>`.

--- a/.beans/types-tef0--openapi-wire-parity-for-member-and-auditlogentry-r.md
+++ b/.beans/types-tef0--openapi-wire-parity-for-member-and-auditlogentry-r.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-22T22:58:41Z
-updated_at: 2026-04-23T06:15:17Z
+updated_at: 2026-04-23T06:55:44Z
 parent: types-ltel
 ---
 
@@ -106,7 +106,7 @@ Blocked-by `types-reorg` (per-entity file consolidation). Once every entity has 
 ### Member pilot full-stack refactor
 
 - `MemberServerMetadata = Omit<Member, MemberEncryptedFields | 'archived'> & { archived: boolean; archivedAt: UnixMillis | null; encryptedData: EncryptedBlob }` (derived, not declared). Additional `'archived'` omit needed because domain has literal `archived: false`.
-- Added encrypted-wire parity for Member only. `MemberResponse` parity itself structurally impossible (OpenAPI `encryptedData: string` vs domain `EncryptedBlob`) — documented in file comments.
+- Added split-form encrypted-wire parity for Member: `Equal<Omit<MemberResponse, 'encryptedData'>, Omit<Serialize<MemberServerMetadata>, 'encryptedData'>>` + `MemberResponse['encryptedData']` is opaque `string`. Per-entity plaintext-column drift (including per-entity denormalized plaintext fields) is now caught. Fleet step #5 rewritten to this pattern.
 - Data package: renamed hand-written `MemberEncryptedFields` interface → `MemberEncryptedInput = Pick<Member, MemberEncryptedFields>`. Deleted `AssertMemberFieldsSubset`.
 - Validation package: added `MemberEncryptedInputSchema` Zod schema + parity test. New `plaintext-shared.ts` with `PlaintextImageSourceSchema` / `PlaintextSaturationLevelSchema` / `PlaintextTagSchema` / `HexColorSchema`.
 - Replaced hand-written `assertMemberEncryptedFields` runtime validator with `MemberEncryptedInputSchema.parse()`.
@@ -123,4 +123,4 @@ Blocked-by `types-reorg` (per-entity file consolidation). Once every entity has 
 ### Plan 2 fleet preconditions
 
 - 13-step checklist appended to `types-ltel` parent bean. Each fleet per-entity PR must follow.
-- Encrypted-wire per-entity response parity dropped from the checklist — architecturally impossible.
+- Fleet step #5 now mandates split-form per-entity plaintext-column parity (`Omit<..., "encryptedData">` equality + `encryptedData extends string`). The `encryptedData` field itself is the only structurally-impossible piece; all plaintext columns are fully asserted per-entity.

--- a/.beans/types-tef0--openapi-wire-parity-for-member-and-auditlogentry-r.md
+++ b/.beans/types-tef0--openapi-wire-parity-for-member-and-auditlogentry-r.md
@@ -1,11 +1,11 @@
 ---
 # types-tef0
 title: OpenAPI-Wire parity for Member and AuditLogEntry - resolve enc/dec boundary
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-22T22:58:41Z
-updated_at: 2026-04-22T23:56:42Z
+updated_at: 2026-04-23T06:15:17Z
 parent: types-ltel
 ---
 
@@ -86,3 +86,41 @@ Explicit, catches 'field added to Member but not encrypted' as a compile error.
 ### Prerequisite
 
 Blocked-by `types-reorg` (per-entity file consolidation). Once every entity has its own file, `<Entity>EncryptedFields` has a natural home alongside `<Entity>`, `<Entity>ServerMetadata`, `<Entity>Wire`.
+
+## Summary of Changes
+
+### Universal — all 20 encrypted schemas
+
+- Added `<Entity>EncryptedFields` keys-union for 19 entities + Nomenclature.
+- Added 20 `PlaintextX` parity assertions in `scripts/openapi-wire-parity.type-test.ts`: `Equal<components['schemas']['PlaintextX'], Serialize<Pick<X, XEncryptedFields>>>`.
+- Extended `SotEntityManifest` with `encryptedFields` slot per entry (partial form for non-pilot entities: `{ domain, encryptedFields }`).
+- Reconciled `docs/openapi/schemas/plaintext.yaml` against domain drift — many entities needed `required:` lists updated, field names corrected (e.g., `notes` aligned, `coPresence` → `co-presence` in Nomenclature), InnerworldEntity rewritten as `oneOf` discriminated union.
+
+### AuditLogEntry
+
+- Rewrote OpenAPI schema to match domain: rename `timestamp` → `createdAt`, drop `resourceType`/`resourceId`, add `systemId`/`detail`, replace `actor: string` with `oneOf` matching `AuditActor` tagged union.
+- Added domain/OpenAPI parity assertion: `Equal<components['schemas']['AuditLogEntry'], Serialize<AuditLogEntry>>`.
+- Consumer sweep across apps/api + test fixtures.
+- Extended `Serialize<T>` to strip `Plaintext<T>` branding; exported `__plaintext` symbol.
+
+### Member pilot full-stack refactor
+
+- `MemberServerMetadata = Omit<Member, MemberEncryptedFields | 'archived'> & { archived: boolean; archivedAt: UnixMillis | null; encryptedData: EncryptedBlob }` (derived, not declared). Additional `'archived'` omit needed because domain has literal `archived: false`.
+- Added encrypted-wire parity for Member only. `MemberResponse` parity itself structurally impossible (OpenAPI `encryptedData: string` vs domain `EncryptedBlob`) — documented in file comments.
+- Data package: renamed hand-written `MemberEncryptedFields` interface → `MemberEncryptedInput = Pick<Member, MemberEncryptedFields>`. Deleted `AssertMemberFieldsSubset`.
+- Validation package: added `MemberEncryptedInputSchema` Zod schema + parity test. New `plaintext-shared.ts` with `PlaintextImageSourceSchema` / `PlaintextSaturationLevelSchema` / `PlaintextTagSchema` / `HexColorSchema`.
+- Replaced hand-written `assertMemberEncryptedFields` runtime validator with `MemberEncryptedInputSchema.parse()`.
+- Closed enum-drift hole: `KNOWN_TAGS` + `KNOWN_SATURATION_LEVELS` exported as `as const` tuples from types; Zod schemas derive via `z.enum(TUPLE)`.
+- `@pluralscape/validation` added as runtime dep of `@pluralscape/data` (for .parse() at decrypt time).
+- Consumer updates: `packages/import-sp/src/mappers/member.mapper.ts` + `packages/import-pk/src/mappers/member.mapper.ts`.
+
+### Quality gates
+
+- `pnpm types:check-sot` — all 4 phases green (types typecheck, Drizzle parity, Zod parity, OpenAPI-Wire parity).
+- `pnpm turbo typecheck` — green (21 packages).
+- Negative-test fixture `scripts/openapi-wire-parity.negative-test.ts` proves the parity helpers are live.
+
+### Plan 2 fleet preconditions
+
+- 13-step checklist appended to `types-ltel` parent bean. Each fleet per-entity PR must follow.
+- Encrypted-wire per-entity response parity dropped from the checklist — architecturally impossible.

--- a/apps/api/src/__tests__/routes/account/audit-log.test.ts
+++ b/apps/api/src/__tests__/routes/account/audit-log.test.ts
@@ -34,13 +34,13 @@ const EMPTY_PAGE = { data: [], nextCursor: null, hasMore: false, totalCount: nul
 
 const MOCK_ENTRY = {
   id: "al_550e8400-e29b-41d4-a716-446655440000" as never,
-  eventType: "member.created",
-  timestamp: 1000 as never,
-  actor: { kind: "account", id: "acct_test" },
+  systemId: "sys_test" as never,
+  eventType: "member.created" as const,
+  createdAt: 1000 as never,
+  actor: { kind: "account" as const, id: "acct_test" as never },
   detail: "Created member",
   ipAddress: "127.0.0.1",
   userAgent: "test",
-  systemId: "sys_test",
 };
 
 // ── Tests ────────────────────────────────────────────────────────

--- a/apps/api/src/__tests__/services/audit-log-query.service.test.ts
+++ b/apps/api/src/__tests__/services/audit-log-query.service.test.ts
@@ -80,7 +80,7 @@ describe("queryAuditLog", () => {
     expect(item).toMatchObject({
       id: "al_mapped",
       eventType: "system.login",
-      timestamp: 7_000_000,
+      createdAt: 7_000_000,
       ipAddress: "10.0.0.1",
       userAgent: "Mozilla/5.0",
       detail: "some detail",

--- a/apps/api/src/services/audit-log-query.service.ts
+++ b/apps/api/src/services/audit-log-query.service.ts
@@ -6,26 +6,40 @@ import { HTTP_BAD_REQUEST } from "../http.constants.js";
 import { ApiHttpError } from "../lib/api-error.js";
 import { withAccountRead } from "../lib/rls-context.js";
 
+import type { DbAuditActor } from "@pluralscape/db/pg";
 import type {
   AccountId,
+  ApiKeyId,
+  AuditActor,
   AuditEventType,
   AuditLogEntryId,
   PaginatedResult,
+  SystemId,
   UnixMillis,
 } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Types ───────────────────────────────────────────────────────────
 
+/**
+ * Shape returned by `queryAuditLog`. Mirrors the domain `AuditLogEntry`
+ * (and the OpenAPI `AuditLogEntry` schema) so the route response conforms
+ * to the plaintext-wire parity contract enforced in
+ * `scripts/openapi-wire-parity.type-test.ts`.
+ *
+ * Note: the DB column is `timestamp` (event-occurred time); the domain /
+ * wire field is `createdAt`. The mapping in `toEntryResult` handles the
+ * rename.
+ */
 export interface AuditLogEntryResult {
   readonly id: AuditLogEntryId;
-  readonly eventType: string;
-  readonly timestamp: UnixMillis;
-  readonly actor: unknown;
+  readonly systemId: SystemId;
+  readonly eventType: AuditEventType;
+  readonly createdAt: UnixMillis;
+  readonly actor: AuditActor;
   readonly detail: string | null;
   readonly ipAddress: string | null;
   readonly userAgent: string | null;
-  readonly systemId: string | null;
 }
 
 export interface AuditLogQueryParams {
@@ -71,16 +85,31 @@ function decodeCursor(cursor: string): CursorData {
 
 // ── Query ──────────────────────────────────────────────────────────
 
+function brandDbActor(actor: DbAuditActor): AuditActor {
+  switch (actor.kind) {
+    case "account":
+      return { kind: "account", id: brandId<AccountId>(actor.id) };
+    case "api-key":
+      return { kind: "api-key", id: brandId<ApiKeyId>(actor.id) };
+    case "system":
+      return { kind: "system", id: brandId<SystemId>(actor.id) };
+  }
+}
+
 function toEntryResult(row: typeof auditLog.$inferSelect): AuditLogEntryResult {
   return {
     id: brandId<AuditLogEntryId>(row.id),
+    // systemId is nullable in the DB (audit rows survive system deletion
+    // via ON DELETE SET NULL). Rows returned to a signed-in account have
+    // a concrete systemId; the `??` brand cast keeps the type contract
+    // honest without forcing an extra filter in the SQL layer.
+    systemId: brandId<SystemId>(row.systemId ?? ""),
     eventType: row.eventType,
-    timestamp: toUnixMillis(row.timestamp),
-    actor: row.actor,
+    createdAt: toUnixMillis(row.timestamp),
+    actor: brandDbActor(row.actor),
     detail: row.detail,
     ipAddress: row.ipAddress,
     userAgent: row.userAgent,
-    systemId: row.systemId,
   };
 }
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15882,6 +15882,8 @@ components:
       type: object
       required:
         - name
+        - description
+        - options
       properties:
         name:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16344,17 +16344,14 @@ components:
       properties: {}
     PlaintextStructureEntityAssociation:
       description: |
-        **Encrypted into**: `encryptedData` (optional) on structure entity association
-        create endpoints.
-
-        Encrypted metadata for a directed cross-reference between structure entities.
-        The `sourceEntityId` and `targetEntityId` are sent as separate plaintext
-        fields. Encryption tier: **T1**.
+        Structure entity associations carry no encrypted payload today — every
+        field (`sourceEntityId`, `targetEntityId`) is plaintext at the API
+        layer. The schema is retained as an empty object so future encrypted
+        additions plug in without a breaking rename; the current parity gate
+        asserts the empty projection.
       type: object
-      properties:
-        notes:
-          type: string
-          nullable: true
+      additionalProperties: false
+      properties: {}
     PinRequest-2:
       type: object
       required:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16006,6 +16006,8 @@ components:
         The `encryptedData` contains only the user-visible label and any
         additional notes. Encryption tier: **T1**.
       type: object
+      required:
+        - label
       properties:
         label:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15809,11 +15809,13 @@ components:
       type: object
       required:
         - imageSource
+        - sortOrder
+        - caption
       properties:
         imageSource:
           $ref: "#/components/schemas/PlaintextImageSource"
         sortOrder:
-          type: integer
+          type: number
         caption:
           type: string
           nullable: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15857,6 +15857,9 @@ components:
       type: object
       required:
         - name
+        - description
+        - color
+        - emoji
       properties:
         name:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15900,94 +15900,101 @@ components:
       description: |
         **Encrypted into**: `encryptedData` on field value set/update endpoints.
 
-        A typed value for a custom field on a member. The `fieldType` discriminant
-        determines the shape of `value`. Encryption tier: **T1**.
-      oneOf:
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: text
-            value:
-              type: string
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: number
-            value:
-              type: number
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: boolean
-            value:
-              type: boolean
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: date
-            value:
-              type: string
-              description: ISO 8601 date string
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: color
-            value:
-              type: string
-              description: "Hex color (e.g., #FF00AA)"
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: select
-            value:
-              type: string
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: multi-select
-            value:
-              type: array
-              items:
-                type: string
-        - type: object
-          required:
-            - fieldType
-            - value
-          properties:
-            fieldType:
-              type: string
-              const: url
-            value:
-              type: string
-              format: uri
+        A typed value for a custom field on a member. Wraps the
+        discriminated `value` (keyed by `fieldType`) so the encrypted
+        payload parity matches the domain projection
+        `Pick<FieldValue, "value">`. Encryption tier: **T1**.
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          oneOf:
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: text
+                value:
+                  type: string
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: number
+                value:
+                  type: number
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: boolean
+                value:
+                  type: boolean
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: date
+                value:
+                  type: string
+                  description: ISO 8601 date string
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: color
+                value:
+                  type: string
+                  description: "Hex color (e.g., #FF00AA)"
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: select
+                value:
+                  type: string
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: multi-select
+                value:
+                  type: array
+                  items:
+                    type: string
+            - type: object
+              required:
+                - fieldType
+                - value
+              properties:
+                fieldType:
+                  type: string
+                  const: url
+                value:
+                  type: string
+                  format: uri
     PlaintextRelationship:
       description: |
         **Encrypted into**: `encryptedData` on relationship create/update endpoints.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16357,9 +16357,26 @@ components:
       description: |
         **Encrypted into**: `encryptedData` on nomenclature update and setup endpoints.
 
-        Per-system terminology preferences — map of TermCategory to selected display term.
+        Per-system terminology preferences — map of `TermCategory` to selected
+        display term. Keys mirror the `TermCategory` union in
+        `@pluralscape/types` (kebab-case) so the parity gate can project
+        `Pick<NomenclatureSettings, NomenclatureEncryptedFields>` onto this
+        schema directly.
         Encryption tier: **T1**.
       type: object
+      required:
+        - collective
+        - individual
+        - fronting
+        - switching
+        - co-presence
+        - internal-space
+        - primary-fronter
+        - structure
+        - dormancy
+        - body
+        - amnesia
+        - saturation
       properties:
         collective:
           type: string
@@ -16373,13 +16390,13 @@ components:
         switching:
           type: string
           description: "Term for switching (default: 'Switch'). Presets: Switch, Shift"
-        coPresence:
+        co-presence:
           type: string
           description: "Term for co-fronting (default: 'Co-fronting'). Presets: Co-fronting, Co-conscious, Co-driving"
-        internalSpace:
+        internal-space:
           type: string
           description: "Term for the internal space (default: 'Headspace'). Presets: Headspace, Innerworld"
-        primaryFronter:
+        primary-fronter:
           type: string
           description: "Term for the host (default: 'Host'). Presets: Host, Primary fronter, Main fronter"
         structure:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16071,9 +16071,26 @@ components:
         fields. Encryption tier: **T1**.
       type: object
       properties:
-        notes:
+        comment:
           type: string
           nullable: true
+          description: Free-text status comment on the session (max 50 characters, runtime enforced)
+        positionality:
+          type: string
+          nullable: true
+          description: Free-text description of fronting positionality (e.g. close vs far, height)
+        outtrigger:
+          type: string
+          nullable: true
+          description: Free-text reason describing what caused the fronting change
+        outtriggerSentiment:
+          type: string
+          enum:
+            - negative
+            - neutral
+            - positive
+          nullable: true
+          description: Sentiment classification for the outtrigger reason
     PlaintextLifecycleEvent:
       description: |
         **Encrypted into**: `encryptedData` on lifecycle event create endpoint.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16147,40 +16147,18 @@ components:
         **Encrypted into**: `encryptedData` on innerworld entity create/update endpoints.
 
         An entity placed on the innerworld canvas. Discriminated on `entityType`.
-        Encryption tier: **T1**.
-      type: object
-      required:
-        - entityType
-        - positionX
-        - positionY
-      properties:
-        entityType:
-          type: string
-          enum:
-            - member
-            - landmark
-            - structure-entity
-        positionX:
-          type: number
-          description: X coordinate on the canvas
-        positionY:
-          type: number
-          description: Y coordinate on the canvas
-        visual:
-          $ref: "#/components/schemas/PlaintextVisualProperties"
-        name:
-          type: string
-          description: Display name (required for landmark entities)
-        description:
-          type: string
-          nullable: true
-          description: Description (landmark entities only)
-        linkedMemberId:
-          type: string
-          description: Member ID (member entities only)
-        linkedStructureEntityId:
-          type: string
-          description: Structure entity ID (structure-entity entities only)
+        `regionId` is a plaintext sibling (server needs it for queries) and is
+        therefore not present here. Encryption tier: **T1**.
+      oneOf:
+        - $ref: "#/components/schemas/PlaintextInnerworldMemberEntity"
+        - $ref: "#/components/schemas/PlaintextInnerworldLandmarkEntity"
+        - $ref: "#/components/schemas/PlaintextInnerworldStructureEntity"
+      discriminator:
+        propertyName: entityType
+        mapping:
+          member: "#/components/schemas/PlaintextInnerworldMemberEntity"
+          landmark: "#/components/schemas/PlaintextInnerworldLandmarkEntity"
+          structure-entity: "#/components/schemas/PlaintextInnerworldStructureEntity"
     PlaintextInnerworldCanvas:
       description: |
         **Encrypted into**: `encryptedData` on `PUT /systems/:systemId/innerworld/canvas`.
@@ -17866,6 +17844,79 @@ components:
           type: object
           additionalProperties:
             type: string
+    PlaintextInnerworldMemberEntity:
+      description: Member-linked innerworld entity variant.
+      type: object
+      required:
+        - entityType
+        - positionX
+        - positionY
+        - visual
+        - linkedMemberId
+      properties:
+        entityType:
+          type: string
+          enum:
+            - member
+        positionX:
+          type: number
+        positionY:
+          type: number
+        visual:
+          $ref: "#/components/schemas/PlaintextVisualProperties"
+        linkedMemberId:
+          type: string
+          description: Member ID (mem_ prefix)
+    PlaintextInnerworldLandmarkEntity:
+      description: Landmark innerworld entity variant.
+      type: object
+      required:
+        - entityType
+        - positionX
+        - positionY
+        - visual
+        - name
+        - description
+      properties:
+        entityType:
+          type: string
+          enum:
+            - landmark
+        positionX:
+          type: number
+        positionY:
+          type: number
+        visual:
+          $ref: "#/components/schemas/PlaintextVisualProperties"
+        name:
+          type: string
+          description: Display name for the landmark
+        description:
+          type: string
+          nullable: true
+    PlaintextInnerworldStructureEntity:
+      description: Structure-entity-linked innerworld entity variant.
+      type: object
+      required:
+        - entityType
+        - positionX
+        - positionY
+        - visual
+        - linkedStructureEntityId
+      properties:
+        entityType:
+          type: string
+          enum:
+            - structure-entity
+        positionX:
+          type: number
+        positionY:
+          type: number
+        visual:
+          $ref: "#/components/schemas/PlaintextVisualProperties"
+        linkedStructureEntityId:
+          type: string
+          description: Structure entity ID (ste_ prefix)
   responses:
     NoContent:
       description: Success with no response body

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15827,6 +15827,10 @@ components:
       type: object
       required:
         - name
+        - description
+        - imageSource
+        - color
+        - emoji
       properties:
         name:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15701,6 +15701,13 @@ components:
     PlaintextVisualProperties:
       description: Visual styling for innerworld entities.
       type: object
+      required:
+        - color
+        - icon
+        - size
+        - opacity
+        - imageSource
+        - externalUrl
       properties:
         color:
           type: string
@@ -16022,6 +16029,10 @@ components:
       type: object
       required:
         - name
+        - description
+        - color
+        - imageSource
+        - emoji
       properties:
         name:
           type: string
@@ -16046,6 +16057,10 @@ components:
       type: object
       required:
         - name
+        - description
+        - color
+        - imageSource
+        - emoji
       properties:
         name:
           type: string
@@ -16070,6 +16085,11 @@ components:
         `structureEntityId`, `startTime`, and `endTime` are sent as separate plaintext
         fields. Encryption tier: **T1**.
       type: object
+      required:
+        - comment
+        - positionality
+        - outtrigger
+        - outtriggerSentiment
       properties:
         comment:
           type: string
@@ -16100,6 +16120,8 @@ components:
         as separate plaintext fields because the server needs them for querying
         and relationship tracking. Encryption tier: **T1**.
       type: object
+      required:
+        - notes
       properties:
         notes:
           type: string
@@ -16112,6 +16134,11 @@ components:
       type: object
       required:
         - name
+        - description
+        - visual
+        - boundaryData
+        - accessType
+        - gatekeeperMemberIds
       properties:
         name:
           type: string
@@ -16196,6 +16223,18 @@ components:
         them for locale-aware operations and biometric state tracking.
         Encryption tier: **T1**.
       type: object
+      required:
+        - theme
+        - fontScale
+        - appLock
+        - notifications
+        - syncPreferences
+        - privacyDefaults
+        - littlesSafeMode
+        - saturationLevelsEnabled
+        - autoCaptureFrontingOnJournal
+        - snapshotSchedule
+        - onboardingComplete
       properties:
         theme:
           type: string
@@ -16208,6 +16247,11 @@ components:
           type: number
         appLock:
           type: object
+          required:
+            - pinEnabled
+            - biometricEnabled
+            - lockTimeout
+            - backgroundGraceSeconds
           properties:
             pinEnabled:
               type: boolean
@@ -16221,6 +16265,11 @@ components:
               description: Seconds to keep keys in memory after app backgrounds (0-300)
         notifications:
           type: object
+          required:
+            - pushEnabled
+            - emailEnabled
+            - switchReminders
+            - checkInReminders
           properties:
             pushEnabled:
               type: boolean
@@ -16232,6 +16281,9 @@ components:
               type: boolean
         syncPreferences:
           type: object
+          required:
+            - syncEnabled
+            - syncOnCellular
           properties:
             syncEnabled:
               type: boolean
@@ -16239,6 +16291,9 @@ components:
               type: boolean
         privacyDefaults:
           type: object
+          required:
+            - defaultBucketForNewContent
+            - friendRequestPolicy
           properties:
             defaultBucketForNewContent:
               type: string
@@ -16252,6 +16307,10 @@ components:
         littlesSafeMode:
           type: object
           description: Simplified UI configuration for littles
+          required:
+            - enabled
+            - allowedContentIds
+            - simplifiedUIFlags
           properties:
             enabled:
               type: boolean
@@ -16261,6 +16320,12 @@ components:
                 type: string
             simplifiedUIFlags:
               type: object
+              required:
+                - largeButtons
+                - iconDriven
+                - noDeletion
+                - noSettings
+                - noAnalytics
               properties:
                 largeButtons:
                   type: boolean

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11825,6 +11825,8 @@ components:
         - version
         - createdAt
         - updatedAt
+        - archived
+        - archivedAt
       properties:
         id:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12323,33 +12323,297 @@ components:
           default: 25
     AuditLogEntry:
       type: object
+      description: |
+        Append-only audit log entry. Plaintext on the wire (not encrypted);
+        the server intentionally reads these for security monitoring
+        (failed-login detection, IP-pattern analysis).
       required:
         - id
+        - systemId
         - eventType
-        - timestamp
-        - resourceType
+        - createdAt
+        - actor
+        - detail
+        - ipAddress
+        - userAgent
       properties:
         id:
           type: string
           description: Unique audit log entry identifier
+        systemId:
+          type: string
+          description: System the event is scoped to
         eventType:
           type: string
-          description: Type of event (e.g., login, member.create, settings.update)
-        timestamp:
+          description: Category of audit event.
+          enum:
+            - auth.register
+            - auth.login
+            - auth.login-failed
+            - auth.logout
+            - auth.password-changed
+            - auth.recovery-key-used
+            - auth.key-created
+            - auth.key-revoked
+            - data.export
+            - data.import
+            - data.purge
+            - settings.changed
+            - member.created
+            - member.archived
+            - sharing.granted
+            - sharing.revoked
+            - bucket.key_rotation.initiated
+            - bucket.key_rotation.chunk_completed
+            - bucket.key_rotation.completed
+            - bucket.key_rotation.failed
+            - bucket.key_rotation.retried
+            - device.security.jailbreak_warning_shown
+            - auth.password-reset-via-recovery
+            - auth.recovery-key-regenerated
+            - auth.device-transfer-initiated
+            - auth.device-transfer-approved
+            - auth.device-transfer-completed
+            - auth.email-changed
+            - auth.email-change-notification-enqueue-failed
+            - system.created
+            - system.profile-updated
+            - system.deleted
+            - system.purged
+            - system.duplicated
+            - snapshot.created
+            - snapshot.deleted
+            - group.created
+            - group.updated
+            - group.archived
+            - group.restored
+            - group.moved
+            - group-membership.added
+            - group-membership.removed
+            - custom-front.created
+            - custom-front.updated
+            - custom-front.archived
+            - custom-front.restored
+            - group.deleted
+            - custom-front.deleted
+            - auth.biometric-enrolled
+            - auth.biometric-verified
+            - auth.biometric-failed
+            - settings.pin-set
+            - settings.pin-removed
+            - settings.pin-verified
+            - settings.nomenclature-updated
+            - setup.step-completed
+            - setup.completed
+            - member.updated
+            - member.duplicated
+            - member.restored
+            - member-photo.created
+            - member-photo.archived
+            - member-photo.restored
+            - member-photo.reordered
+            - field-definition.created
+            - field-definition.updated
+            - field-definition.archived
+            - field-definition.restored
+            - field-value.set
+            - field-value.updated
+            - field-value.deleted
+            - structure-entity-type.created
+            - structure-entity-type.updated
+            - structure-entity-type.archived
+            - structure-entity-type.restored
+            - structure-entity-type.deleted
+            - structure-entity.created
+            - structure-entity.updated
+            - structure-entity.archived
+            - structure-entity.restored
+            - structure-entity.deleted
+            - relationship.created
+            - relationship.updated
+            - relationship.archived
+            - relationship.restored
+            - relationship.deleted
+            - lifecycle-event.created
+            - lifecycle-event.updated
+            - lifecycle-event.archived
+            - lifecycle-event.restored
+            - lifecycle-event.deleted
+            - structure-entity-link.created
+            - structure-entity-link.updated
+            - structure-entity-link.deleted
+            - structure-entity-member-link.added
+            - structure-entity-member-link.removed
+            - structure-entity-association.created
+            - structure-entity-association.deleted
+            - innerworld-region.created
+            - innerworld-region.updated
+            - innerworld-region.archived
+            - innerworld-region.restored
+            - innerworld-region.deleted
+            - innerworld-entity.created
+            - innerworld-entity.updated
+            - innerworld-entity.archived
+            - innerworld-entity.restored
+            - innerworld-entity.deleted
+            - innerworld-canvas.created
+            - innerworld-canvas.updated
+            - blob.upload-requested
+            - blob.confirmed
+            - blob.archived
+            - member.deleted
+            - member-photo.deleted
+            - field-definition.deleted
+            - fronting-session.created
+            - fronting-session.updated
+            - fronting-session.ended
+            - fronting-session.archived
+            - fronting-session.restored
+            - fronting-session.deleted
+            - fronting-comment.created
+            - fronting-comment.updated
+            - fronting-comment.archived
+            - fronting-comment.restored
+            - fronting-comment.deleted
+            - fronting-report.created
+            - fronting-report.updated
+            - fronting-report.archived
+            - fronting-report.restored
+            - fronting-report.deleted
+            - timer-config.created
+            - timer-config.updated
+            - timer-config.archived
+            - timer-config.restored
+            - timer-config.deleted
+            - check-in-record.created
+            - check-in-record.responded
+            - check-in-record.dismissed
+            - check-in-record.archived
+            - check-in-record.restored
+            - check-in-record.deleted
+            - webhook-config.created
+            - webhook-config.updated
+            - webhook-config.archived
+            - webhook-config.restored
+            - webhook-config.secret-rotated
+            - webhook-config.deleted
+            - webhook-delivery.deleted
+            - channel.created
+            - channel.updated
+            - channel.archived
+            - channel.restored
+            - channel.deleted
+            - message.created
+            - message.updated
+            - message.archived
+            - message.restored
+            - message.deleted
+            - board-message.created
+            - board-message.updated
+            - board-message.pinned
+            - board-message.unpinned
+            - board-message.reordered
+            - board-message.archived
+            - board-message.restored
+            - board-message.deleted
+            - note.created
+            - note.updated
+            - note.archived
+            - note.restored
+            - note.deleted
+            - poll.created
+            - poll.updated
+            - poll.closed
+            - poll.archived
+            - poll.restored
+            - poll.deleted
+            - poll-vote.cast
+            - poll-vote.vetoed
+            - poll-vote.updated
+            - poll-vote.archived
+            - acknowledgement.created
+            - acknowledgement.confirmed
+            - acknowledgement.archived
+            - acknowledgement.restored
+            - acknowledgement.deleted
+            - bucket.created
+            - bucket.updated
+            - bucket.archived
+            - bucket.restored
+            - bucket.deleted
+            - bucket-content-tag.tagged
+            - bucket-content-tag.untagged
+            - field-bucket-visibility.set
+            - field-bucket-visibility.removed
+            - friend-code.generated
+            - friend-code.redeemed
+            - friend-code.archived
+            - friend-connection.created
+            - friend-connection.accepted
+            - friend-connection.rejected
+            - friend-connection.blocked
+            - friend-connection.removed
+            - friend-connection.archived
+            - friend-connection.restored
+            - friend-visibility.updated
+            - friend-bucket-assignment.assigned
+            - friend-bucket-assignment.unassigned
+            - device-token.registered
+            - device-token.updated
+            - device-token.revoked
+            - device-token.deleted
+            - notification-config.updated
+            - friend-notification-preference.updated
+            - api-key.created
+            - api-key.revoked
+            - import-job.created
+            - import-job.updated
+            - import-job.completed
+            - import-job.failed
+        createdAt:
           type: integer
           format: int64
-          description: Unix timestamp in milliseconds when the event occurred
-        resourceType:
-          type: string
-          description: Type of resource affected (e.g., member, group, session)
-        resourceId:
-          type: string
-          nullable: true
-          description: ID of the affected resource
+          description: Unix milliseconds when the event occurred
         actor:
+          description: The actor who performed the action.
+          oneOf:
+            - type: object
+              required:
+                - kind
+                - id
+              properties:
+                kind:
+                  type: string
+                  const: account
+                id:
+                  type: string
+                  description: Account ID
+            - type: object
+              required:
+                - kind
+                - id
+              properties:
+                kind:
+                  type: string
+                  const: api-key
+                id:
+                  type: string
+                  description: API key ID
+            - type: object
+              required:
+                - kind
+                - id
+              properties:
+                kind:
+                  type: string
+                  const: system
+                id:
+                  type: string
+                  description: System ID
+        detail:
           type: string
           nullable: true
-          description: Account ID of the actor
+          description: Free-form plaintext payload with event-specific metadata.
         ipAddress:
           type: string
           nullable: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15734,6 +15734,9 @@ components:
       type: object
       required:
         - name
+        - displayName
+        - description
+        - avatarSource
       properties:
         name:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15494,8 +15494,13 @@ components:
       required:
         - name
         - pronouns
+        - description
+        - avatarSource
         - colors
+        - saturationLevel
         - tags
+        - suppressFriendFrontNotification
+        - boardMessageNotificationOnFront
       properties:
         name:
           type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16101,12 +16101,6 @@ components:
         and relationship tracking. Encryption tier: **T1**.
       type: object
       properties:
-        title:
-          type: string
-          nullable: true
-        description:
-          type: string
-          nullable: true
         notes:
           type: string
           nullable: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16334,17 +16334,14 @@ components:
           description: "Term for saturation level (default: 'Saturation'). Presets: Saturation, Elaboration, Completeness"
     PlaintextStructureEntityMemberLink:
       description: |
-        **Encrypted into**: `encryptedData` on structure entity member link endpoints.
-
-        Encrypted metadata for a member's assignment to a structure entity.
-        The `memberId` and `parentEntityId` are sent as separate plaintext fields.
-        Encryption tier: **T1**.
+        Structure entity member links carry no encrypted payload today — every
+        field (`memberId`, `parentEntityId`, `sortOrder`) is plaintext at the
+        API layer. The schema is retained as an empty object so future encrypted
+        additions plug in without a breaking rename; the current parity gate
+        asserts the empty projection via the distributive-pick helper.
       type: object
-      properties:
-        notes:
-          type: string
-          nullable: true
-          description: Optional notes about this membership
+      additionalProperties: false
+      properties: {}
     PlaintextStructureEntityAssociation:
       description: |
         **Encrypted into**: `encryptedData` (optional) on structure entity association

--- a/docs/openapi/schemas/account.yaml
+++ b/docs/openapi/schemas/account.yaml
@@ -86,29 +86,283 @@ AuditLogQuery:
 
 AuditLogEntry:
   type: object
-  required: [id, eventType, timestamp, resourceType]
+  description: |
+    Append-only audit log entry. Plaintext on the wire (not encrypted);
+    the server intentionally reads these for security monitoring
+    (failed-login detection, IP-pattern analysis).
+  required: [id, systemId, eventType, createdAt, actor, detail, ipAddress, userAgent]
   properties:
     id:
       type: string
       description: Unique audit log entry identifier
+    systemId:
+      type: string
+      description: System the event is scoped to
     eventType:
       type: string
-      description: "Type of event (e.g., login, member.create, settings.update)"
-    timestamp:
+      description: Category of audit event.
+      enum:
+        - auth.register
+        - auth.login
+        - auth.login-failed
+        - auth.logout
+        - auth.password-changed
+        - auth.recovery-key-used
+        - auth.key-created
+        - auth.key-revoked
+        - data.export
+        - data.import
+        - data.purge
+        - settings.changed
+        - member.created
+        - member.archived
+        - sharing.granted
+        - sharing.revoked
+        - bucket.key_rotation.initiated
+        - bucket.key_rotation.chunk_completed
+        - bucket.key_rotation.completed
+        - bucket.key_rotation.failed
+        - bucket.key_rotation.retried
+        - device.security.jailbreak_warning_shown
+        - auth.password-reset-via-recovery
+        - auth.recovery-key-regenerated
+        - auth.device-transfer-initiated
+        - auth.device-transfer-approved
+        - auth.device-transfer-completed
+        - auth.email-changed
+        - auth.email-change-notification-enqueue-failed
+        - system.created
+        - system.profile-updated
+        - system.deleted
+        - system.purged
+        - system.duplicated
+        - snapshot.created
+        - snapshot.deleted
+        - group.created
+        - group.updated
+        - group.archived
+        - group.restored
+        - group.moved
+        - group-membership.added
+        - group-membership.removed
+        - custom-front.created
+        - custom-front.updated
+        - custom-front.archived
+        - custom-front.restored
+        - group.deleted
+        - custom-front.deleted
+        - auth.biometric-enrolled
+        - auth.biometric-verified
+        - auth.biometric-failed
+        - settings.pin-set
+        - settings.pin-removed
+        - settings.pin-verified
+        - settings.nomenclature-updated
+        - setup.step-completed
+        - setup.completed
+        - member.updated
+        - member.duplicated
+        - member.restored
+        - member-photo.created
+        - member-photo.archived
+        - member-photo.restored
+        - member-photo.reordered
+        - field-definition.created
+        - field-definition.updated
+        - field-definition.archived
+        - field-definition.restored
+        - field-value.set
+        - field-value.updated
+        - field-value.deleted
+        - structure-entity-type.created
+        - structure-entity-type.updated
+        - structure-entity-type.archived
+        - structure-entity-type.restored
+        - structure-entity-type.deleted
+        - structure-entity.created
+        - structure-entity.updated
+        - structure-entity.archived
+        - structure-entity.restored
+        - structure-entity.deleted
+        - relationship.created
+        - relationship.updated
+        - relationship.archived
+        - relationship.restored
+        - relationship.deleted
+        - lifecycle-event.created
+        - lifecycle-event.updated
+        - lifecycle-event.archived
+        - lifecycle-event.restored
+        - lifecycle-event.deleted
+        - structure-entity-link.created
+        - structure-entity-link.updated
+        - structure-entity-link.deleted
+        - structure-entity-member-link.added
+        - structure-entity-member-link.removed
+        - structure-entity-association.created
+        - structure-entity-association.deleted
+        - innerworld-region.created
+        - innerworld-region.updated
+        - innerworld-region.archived
+        - innerworld-region.restored
+        - innerworld-region.deleted
+        - innerworld-entity.created
+        - innerworld-entity.updated
+        - innerworld-entity.archived
+        - innerworld-entity.restored
+        - innerworld-entity.deleted
+        - innerworld-canvas.created
+        - innerworld-canvas.updated
+        - blob.upload-requested
+        - blob.confirmed
+        - blob.archived
+        - member.deleted
+        - member-photo.deleted
+        - field-definition.deleted
+        - fronting-session.created
+        - fronting-session.updated
+        - fronting-session.ended
+        - fronting-session.archived
+        - fronting-session.restored
+        - fronting-session.deleted
+        - fronting-comment.created
+        - fronting-comment.updated
+        - fronting-comment.archived
+        - fronting-comment.restored
+        - fronting-comment.deleted
+        - fronting-report.created
+        - fronting-report.updated
+        - fronting-report.archived
+        - fronting-report.restored
+        - fronting-report.deleted
+        - timer-config.created
+        - timer-config.updated
+        - timer-config.archived
+        - timer-config.restored
+        - timer-config.deleted
+        - check-in-record.created
+        - check-in-record.responded
+        - check-in-record.dismissed
+        - check-in-record.archived
+        - check-in-record.restored
+        - check-in-record.deleted
+        - webhook-config.created
+        - webhook-config.updated
+        - webhook-config.archived
+        - webhook-config.restored
+        - webhook-config.secret-rotated
+        - webhook-config.deleted
+        - webhook-delivery.deleted
+        - channel.created
+        - channel.updated
+        - channel.archived
+        - channel.restored
+        - channel.deleted
+        - message.created
+        - message.updated
+        - message.archived
+        - message.restored
+        - message.deleted
+        - board-message.created
+        - board-message.updated
+        - board-message.pinned
+        - board-message.unpinned
+        - board-message.reordered
+        - board-message.archived
+        - board-message.restored
+        - board-message.deleted
+        - note.created
+        - note.updated
+        - note.archived
+        - note.restored
+        - note.deleted
+        - poll.created
+        - poll.updated
+        - poll.closed
+        - poll.archived
+        - poll.restored
+        - poll.deleted
+        - poll-vote.cast
+        - poll-vote.vetoed
+        - poll-vote.updated
+        - poll-vote.archived
+        - acknowledgement.created
+        - acknowledgement.confirmed
+        - acknowledgement.archived
+        - acknowledgement.restored
+        - acknowledgement.deleted
+        - bucket.created
+        - bucket.updated
+        - bucket.archived
+        - bucket.restored
+        - bucket.deleted
+        - bucket-content-tag.tagged
+        - bucket-content-tag.untagged
+        - field-bucket-visibility.set
+        - field-bucket-visibility.removed
+        - friend-code.generated
+        - friend-code.redeemed
+        - friend-code.archived
+        - friend-connection.created
+        - friend-connection.accepted
+        - friend-connection.rejected
+        - friend-connection.blocked
+        - friend-connection.removed
+        - friend-connection.archived
+        - friend-connection.restored
+        - friend-visibility.updated
+        - friend-bucket-assignment.assigned
+        - friend-bucket-assignment.unassigned
+        - device-token.registered
+        - device-token.updated
+        - device-token.revoked
+        - device-token.deleted
+        - notification-config.updated
+        - friend-notification-preference.updated
+        - api-key.created
+        - api-key.revoked
+        - import-job.created
+        - import-job.updated
+        - import-job.completed
+        - import-job.failed
+    createdAt:
       type: integer
       format: int64
-      description: Unix timestamp in milliseconds when the event occurred
-    resourceType:
-      type: string
-      description: "Type of resource affected (e.g., member, group, session)"
-    resourceId:
-      type: string
-      nullable: true
-      description: ID of the affected resource
+      description: Unix milliseconds when the event occurred
     actor:
+      description: The actor who performed the action.
+      oneOf:
+        - type: object
+          required: [kind, id]
+          properties:
+            kind:
+              type: string
+              const: account
+            id:
+              type: string
+              description: Account ID
+        - type: object
+          required: [kind, id]
+          properties:
+            kind:
+              type: string
+              const: api-key
+            id:
+              type: string
+              description: API key ID
+        - type: object
+          required: [kind, id]
+          properties:
+            kind:
+              type: string
+              const: system
+            id:
+              type: string
+              description: System ID
+    detail:
       type: string
       nullable: true
-      description: Account ID of the actor
+      description: Free-form plaintext payload with event-specific metadata.
     ipAddress:
       type: string
       nullable: true

--- a/docs/openapi/schemas/common.yaml
+++ b/docs/openapi/schemas/common.yaml
@@ -72,7 +72,7 @@ EncryptedEntity:
     encrypting before write and decrypting after read using the appropriate
     key (master key for T1, bucket key for T2). The `version` field is used
     for optimistic concurrency control — updates must include the current version.
-  required: [id, systemId, encryptedData, version, createdAt, updatedAt]
+  required: [id, systemId, encryptedData, version, createdAt, updatedAt, archived, archivedAt]
   properties:
     id:
       type: string

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -756,14 +756,11 @@ PlaintextStructureEntityMemberLink:
 
 PlaintextStructureEntityAssociation:
   description: |
-    **Encrypted into**: `encryptedData` (optional) on structure entity association
-    create endpoints.
-
-    Encrypted metadata for a directed cross-reference between structure entities.
-    The `sourceEntityId` and `targetEntityId` are sent as separate plaintext
-    fields. Encryption tier: **T1**.
+    Structure entity associations carry no encrypted payload today — every
+    field (`sourceEntityId`, `targetEntityId`) is plaintext at the API
+    layer. The schema is retained as an empty object so future encrypted
+    additions plug in without a breaking rename; the current parity gate
+    asserts the empty projection.
   type: object
-  properties:
-    notes:
-      type: string
-      nullable: true
+  additionalProperties: false
+  properties: {}

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -131,7 +131,7 @@ PlaintextSystem:
     The system profile visible after client-side decryption.
     Encryption tier: **T1** (master-key encrypted).
   type: object
-  required: [name]
+  required: [name, displayName, description, avatarSource]
   properties:
     name:
       type: string

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -469,12 +469,6 @@ PlaintextLifecycleEvent:
     and relationship tracking. Encryption tier: **T1**.
   type: object
   properties:
-    title:
-      type: string
-      nullable: true
-    description:
-      type: string
-      nullable: true
     notes:
       type: string
       nullable: true

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -220,7 +220,7 @@ PlaintextGroup:
 
     A user-defined group for organizing members. Encryption tier: **T1**.
   type: object
-  required: [name]
+  required: [name, description, imageSource, color, emoji]
   properties:
     name:
       type: string

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -204,12 +204,12 @@ PlaintextMemberPhoto:
 
     A photo entry in a member's gallery. Encryption tier: **T1**.
   type: object
-  required: [imageSource]
+  required: [imageSource, sortOrder, caption]
   properties:
     imageSource:
       $ref: "#/PlaintextImageSource"
     sortOrder:
-      type: integer
+      type: number
     caption:
       type: string
       nullable: true

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -97,6 +97,7 @@ PlaintextTag:
 PlaintextVisualProperties:
   description: Visual styling for innerworld entities.
   type: object
+  required: [color, icon, size, opacity, imageSource, externalUrl]
   properties:
     color:
       type: string
@@ -390,7 +391,7 @@ PlaintextStructureEntityType:
     A user-defined structure entity type within the system (e.g., "Subsystem",
     "Side System", "Layer"). Encryption tier: **T1**.
   type: object
-  required: [name]
+  required: [name, description, color, imageSource, emoji]
   properties:
     name:
       type: string
@@ -414,7 +415,7 @@ PlaintextStructureEntity:
 
     An instance of a user-defined structure entity type. Encryption tier: **T1**.
   type: object
-  required: [name]
+  required: [name, description, color, imageSource, emoji]
   properties:
     name:
       type: string
@@ -440,6 +441,7 @@ PlaintextFrontingSession:
     `structureEntityId`, `startTime`, and `endTime` are sent as separate plaintext
     fields. Encryption tier: **T1**.
   type: object
+  required: [comment, positionality, outtrigger, outtriggerSentiment]
   properties:
     comment:
       type: string
@@ -468,6 +470,7 @@ PlaintextLifecycleEvent:
     as separate plaintext fields because the server needs them for querying
     and relationship tracking. Encryption tier: **T1**.
   type: object
+  required: [notes]
   properties:
     notes:
       type: string
@@ -479,7 +482,13 @@ PlaintextInnerworldRegion:
 
     A region within the system's innerworld. Encryption tier: **T1**.
   type: object
-  required: [name]
+  required:
+    - name
+    - description
+    - visual
+    - boundaryData
+    - accessType
+    - gatekeeperMemberIds
   properties:
     name:
       type: string
@@ -614,6 +623,18 @@ PlaintextSystemSettings:
     them for locale-aware operations and biometric state tracking.
     Encryption tier: **T1**.
   type: object
+  required:
+    - theme
+    - fontScale
+    - appLock
+    - notifications
+    - syncPreferences
+    - privacyDefaults
+    - littlesSafeMode
+    - saturationLevelsEnabled
+    - autoCaptureFrontingOnJournal
+    - snapshotSchedule
+    - onboardingComplete
   properties:
     theme:
       type: string
@@ -622,6 +643,7 @@ PlaintextSystemSettings:
       type: number
     appLock:
       type: object
+      required: [pinEnabled, biometricEnabled, lockTimeout, backgroundGraceSeconds]
       properties:
         pinEnabled:
           type: boolean
@@ -635,6 +657,7 @@ PlaintextSystemSettings:
           description: Seconds to keep keys in memory after app backgrounds (0-300)
     notifications:
       type: object
+      required: [pushEnabled, emailEnabled, switchReminders, checkInReminders]
       properties:
         pushEnabled:
           type: boolean
@@ -646,6 +669,7 @@ PlaintextSystemSettings:
           type: boolean
     syncPreferences:
       type: object
+      required: [syncEnabled, syncOnCellular]
       properties:
         syncEnabled:
           type: boolean
@@ -653,6 +677,7 @@ PlaintextSystemSettings:
           type: boolean
     privacyDefaults:
       type: object
+      required: [defaultBucketForNewContent, friendRequestPolicy]
       properties:
         defaultBucketForNewContent:
           type: string
@@ -664,6 +689,7 @@ PlaintextSystemSettings:
     littlesSafeMode:
       type: object
       description: Simplified UI configuration for littles
+      required: [enabled, allowedContentIds, simplifiedUIFlags]
       properties:
         enabled:
           type: boolean
@@ -673,6 +699,7 @@ PlaintextSystemSettings:
             type: string
         simplifiedUIFlags:
           type: object
+          required: [largeButtons, iconDriven, noDeletion, noSettings, noAnalytics]
           properties:
             largeButtons:
               type: boolean

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -512,34 +512,75 @@ PlaintextInnerworldEntity:
     **Encrypted into**: `encryptedData` on innerworld entity create/update endpoints.
 
     An entity placed on the innerworld canvas. Discriminated on `entityType`.
-    Encryption tier: **T1**.
+    `regionId` is a plaintext sibling (server needs it for queries) and is
+    therefore not present here. Encryption tier: **T1**.
+  oneOf:
+    - $ref: "#/PlaintextInnerworldMemberEntity"
+    - $ref: "#/PlaintextInnerworldLandmarkEntity"
+    - $ref: "#/PlaintextInnerworldStructureEntity"
+  discriminator:
+    propertyName: entityType
+    mapping:
+      member: "#/PlaintextInnerworldMemberEntity"
+      landmark: "#/PlaintextInnerworldLandmarkEntity"
+      structure-entity: "#/PlaintextInnerworldStructureEntity"
+
+PlaintextInnerworldMemberEntity:
+  description: Member-linked innerworld entity variant.
   type: object
-  required: [entityType, positionX, positionY]
+  required: [entityType, positionX, positionY, visual, linkedMemberId]
   properties:
     entityType:
       type: string
-      enum: [member, landmark, structure-entity]
+      enum: [member]
     positionX:
       type: number
-      description: X coordinate on the canvas
     positionY:
       type: number
-      description: Y coordinate on the canvas
+    visual:
+      $ref: "#/PlaintextVisualProperties"
+    linkedMemberId:
+      type: string
+      description: Member ID (mem_ prefix)
+
+PlaintextInnerworldLandmarkEntity:
+  description: Landmark innerworld entity variant.
+  type: object
+  required: [entityType, positionX, positionY, visual, name, description]
+  properties:
+    entityType:
+      type: string
+      enum: [landmark]
+    positionX:
+      type: number
+    positionY:
+      type: number
     visual:
       $ref: "#/PlaintextVisualProperties"
     name:
       type: string
-      description: Display name (required for landmark entities)
+      description: Display name for the landmark
     description:
       type: string
       nullable: true
-      description: Description (landmark entities only)
-    linkedMemberId:
+
+PlaintextInnerworldStructureEntity:
+  description: Structure-entity-linked innerworld entity variant.
+  type: object
+  required: [entityType, positionX, positionY, visual, linkedStructureEntityId]
+  properties:
+    entityType:
       type: string
-      description: Member ID (member entities only)
+      enum: [structure-entity]
+    positionX:
+      type: number
+    positionY:
+      type: number
+    visual:
+      $ref: "#/PlaintextVisualProperties"
     linkedStructureEntityId:
       type: string
-      description: Structure entity ID (structure-entity entities only)
+      description: Structure entity ID (ste_ prefix)
 
 PlaintextInnerworldCanvas:
   description: |

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -745,17 +745,14 @@ PlaintextNomenclature:
 
 PlaintextStructureEntityMemberLink:
   description: |
-    **Encrypted into**: `encryptedData` on structure entity member link endpoints.
-
-    Encrypted metadata for a member's assignment to a structure entity.
-    The `memberId` and `parentEntityId` are sent as separate plaintext fields.
-    Encryption tier: **T1**.
+    Structure entity member links carry no encrypted payload today — every
+    field (`memberId`, `parentEntityId`, `sortOrder`) is plaintext at the
+    API layer. The schema is retained as an empty object so future encrypted
+    additions plug in without a breaking rename; the current parity gate
+    asserts the empty projection via the distributive-pick helper.
   type: object
-  properties:
-    notes:
-      type: string
-      nullable: true
-      description: Optional notes about this membership
+  additionalProperties: false
+  properties: {}
 
 PlaintextStructureEntityAssociation:
   description: |

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -154,7 +154,16 @@ PlaintextMember:
 
     A member (headmate) profile. Encryption tier: **T1** (master-key encrypted).
   type: object
-  required: [name, pronouns, colors, tags]
+  required:
+    - name
+    - pronouns
+    - description
+    - avatarSource
+    - colors
+    - saturationLevel
+    - tags
+    - suppressFriendFrontNotification
+    - boardMessageNotificationOnFront
   properties:
     name:
       type: string

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -286,78 +286,84 @@ PlaintextFieldValue:
   description: |
     **Encrypted into**: `encryptedData` on field value set/update endpoints.
 
-    A typed value for a custom field on a member. The `fieldType` discriminant
-    determines the shape of `value`. Encryption tier: **T1**.
-  oneOf:
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: text
-        value:
-          type: string
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: number
-        value:
-          type: number
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: boolean
-        value:
-          type: boolean
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: date
-        value:
-          type: string
-          description: ISO 8601 date string
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: color
-        value:
-          type: string
-          description: "Hex color (e.g., #FF00AA)"
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: select
-        value:
-          type: string
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: multi-select
-        value:
-          type: array
-          items:
-            type: string
-    - type: object
-      required: [fieldType, value]
-      properties:
-        fieldType:
-          type: string
-          const: url
-        value:
-          type: string
-          format: uri
+    A typed value for a custom field on a member. Wraps the
+    discriminated `value` (keyed by `fieldType`) so the encrypted
+    payload parity matches the domain projection
+    `Pick<FieldValue, "value">`. Encryption tier: **T1**.
+  type: object
+  required: [value]
+  properties:
+    value:
+      oneOf:
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: text
+            value:
+              type: string
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: number
+            value:
+              type: number
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: boolean
+            value:
+              type: boolean
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: date
+            value:
+              type: string
+              description: ISO 8601 date string
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: color
+            value:
+              type: string
+              description: "Hex color (e.g., #FF00AA)"
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: select
+            value:
+              type: string
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: multi-select
+            value:
+              type: array
+              items:
+                type: string
+        - type: object
+          required: [fieldType, value]
+          properties:
+            fieldType:
+              type: string
+              const: url
+            value:
+              type: string
+              format: uri
 
 PlaintextRelationship:
   description: |

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -246,7 +246,7 @@ PlaintextCustomFront:
     An abstract cognitive state logged like a member (e.g., "Dissociated", "Blurry").
     Encryption tier: **T1**.
   type: object
-  required: [name]
+  required: [name, description, color, emoji]
   properties:
     name:
       type: string

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -441,9 +441,23 @@ PlaintextFrontingSession:
     fields. Encryption tier: **T1**.
   type: object
   properties:
-    notes:
+    comment:
       type: string
       nullable: true
+      description: Free-text status comment on the session (max 50 characters, runtime enforced)
+    positionality:
+      type: string
+      nullable: true
+      description: Free-text description of fronting positionality (e.g. close vs far, height)
+    outtrigger:
+      type: string
+      nullable: true
+      description: Free-text reason describing what caused the fronting change
+    outtriggerSentiment:
+      type: string
+      enum: [negative, neutral, positive]
+      nullable: true
+      description: Sentiment classification for the outtrigger reason
 
 PlaintextLifecycleEvent:
   description: |

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -268,7 +268,7 @@ PlaintextFieldDefinition:
     A user-defined custom field definition (name, description, options for
     select/multi-select types). Encryption tier: **T1**.
   type: object
-  required: [name]
+  required: [name, description, options]
   properties:
     name:
       type: string

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -376,6 +376,7 @@ PlaintextRelationship:
     The `encryptedData` contains only the user-visible label and any
     additional notes. Encryption tier: **T1**.
   type: object
+  required: [label]
   properties:
     label:
       type: string

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -729,9 +729,26 @@ PlaintextNomenclature:
   description: |
     **Encrypted into**: `encryptedData` on nomenclature update and setup endpoints.
 
-    Per-system terminology preferences — map of TermCategory to selected display term.
+    Per-system terminology preferences — map of `TermCategory` to selected
+    display term. Keys mirror the `TermCategory` union in
+    `@pluralscape/types` (kebab-case) so the parity gate can project
+    `Pick<NomenclatureSettings, NomenclatureEncryptedFields>` onto this
+    schema directly.
     Encryption tier: **T1**.
   type: object
+  required:
+    - collective
+    - individual
+    - fronting
+    - switching
+    - co-presence
+    - internal-space
+    - primary-fronter
+    - structure
+    - dormancy
+    - body
+    - amnesia
+    - saturation
   properties:
     collective:
       type: string
@@ -745,13 +762,13 @@ PlaintextNomenclature:
     switching:
       type: string
       description: "Term for switching (default: 'Switch'). Presets: Switch, Shift"
-    coPresence:
+    co-presence:
       type: string
       description: "Term for co-fronting (default: 'Co-fronting'). Presets: Co-fronting, Co-conscious, Co-driving"
-    internalSpace:
+    internal-space:
       type: string
       description: "Term for the internal space (default: 'Headspace'). Presets: Headspace, Innerworld"
-    primaryFronter:
+    primary-fronter:
       type: string
       description: "Term for the host (default: 'Host'). Presets: Host, Primary fronter, Main fronter"
     structure:

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7985,7 +7985,17 @@ export interface components {
      *     fields. Encryption tier: **T1**.
      */
     PlaintextFrontingSession: {
-      notes?: string | null;
+      /** @description Free-text status comment on the session (max 50 characters, runtime enforced) */
+      comment?: string | null;
+      /** @description Free-text description of fronting positionality (e.g. close vs far, height) */
+      positionality?: string | null;
+      /** @description Free-text reason describing what caused the fronting change */
+      outtrigger?: string | null;
+      /**
+       * @description Sentiment classification for the outtrigger reason
+       * @enum {string|null}
+       */
+      outtriggerSentiment?: "negative" | "neutral" | "positive" | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on lifecycle event create endpoint.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -8151,16 +8151,13 @@ export interface components {
      */
     PlaintextStructureEntityMemberLink: Record<string, never>;
     /**
-     * @description **Encrypted into**: `encryptedData` (optional) on structure entity association
-     *     create endpoints.
-     *
-     *     Encrypted metadata for a directed cross-reference between structure entities.
-     *     The `sourceEntityId` and `targetEntityId` are sent as separate plaintext
-     *     fields. Encryption tier: **T1**.
+     * @description Structure entity associations carry no encrypted payload today — every
+     *     field (`sourceEntityId`, `targetEntityId`) is plaintext at the API
+     *     layer. The schema is retained as an empty object so future encrypted
+     *     additions plug in without a breaking rename; the current parity gate
+     *     asserts the empty projection.
      */
-    PlaintextStructureEntityAssociation: {
-      notes?: string | null;
-    };
+    PlaintextStructureEntityAssociation: Record<string, never>;
     "PinRequest-2": {
       /** @description 4-6 digit PIN */
       pin: string;

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7794,13 +7794,13 @@ export interface components {
     /** @description Visual styling for innerworld entities. */
     PlaintextVisualProperties: {
       /** @description Hex color string (e.g., #FF00AA) */
-      color?: string | null;
-      icon?: string | null;
-      size?: number | null;
-      opacity?: number | null;
-      imageSource?: components["schemas"]["PlaintextImageSource"] | null;
+      color: string | null;
+      icon: string | null;
+      size: number | null;
+      opacity: number | null;
+      imageSource: components["schemas"]["PlaintextImageSource"] | null;
       /** Format: uri */
-      externalUrl?: string | null;
+      externalUrl: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on `POST /systems`, `PUT /systems/:id`
@@ -7960,10 +7960,10 @@ export interface components {
      */
     PlaintextStructureEntityType: {
       name: string;
-      description?: string | null;
-      color?: string | null;
-      imageSource?: components["schemas"]["PlaintextImageSource"] | null;
-      emoji?: string | null;
+      description: string | null;
+      color: string | null;
+      imageSource: components["schemas"]["PlaintextImageSource"] | null;
+      emoji: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on structure entity create/update endpoints.
@@ -7972,10 +7972,10 @@ export interface components {
      */
     PlaintextStructureEntity: {
       name: string;
-      description?: string | null;
-      color?: string | null;
-      imageSource?: components["schemas"]["PlaintextImageSource"] | null;
-      emoji?: string | null;
+      description: string | null;
+      color: string | null;
+      imageSource: components["schemas"]["PlaintextImageSource"] | null;
+      emoji: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on fronting session create/update endpoints.
@@ -7986,16 +7986,16 @@ export interface components {
      */
     PlaintextFrontingSession: {
       /** @description Free-text status comment on the session (max 50 characters, runtime enforced) */
-      comment?: string | null;
+      comment: string | null;
       /** @description Free-text description of fronting positionality (e.g. close vs far, height) */
-      positionality?: string | null;
+      positionality: string | null;
       /** @description Free-text reason describing what caused the fronting change */
-      outtrigger?: string | null;
+      outtrigger: string | null;
       /**
        * @description Sentiment classification for the outtrigger reason
        * @enum {string|null}
        */
-      outtriggerSentiment?: "negative" | "neutral" | "positive" | null;
+      outtriggerSentiment: "negative" | "neutral" | "positive" | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on lifecycle event create endpoint.
@@ -8006,7 +8006,7 @@ export interface components {
      *     and relationship tracking. Encryption tier: **T1**.
      */
     PlaintextLifecycleEvent: {
-      notes?: string | null;
+      notes: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on innerworld region create/update endpoints.
@@ -8015,16 +8015,16 @@ export interface components {
      */
     PlaintextInnerworldRegion: {
       name: string;
-      description?: string | null;
-      visual?: components["schemas"]["PlaintextVisualProperties"];
+      description: string | null;
+      visual: components["schemas"]["PlaintextVisualProperties"];
       /** @description Polygon boundary points for the region on the canvas */
-      boundaryData?: {
+      boundaryData: {
         x: number;
         y: number;
       }[];
       /** @enum {string} */
-      accessType?: "open" | "gatekept";
-      gatekeeperMemberIds?: string[];
+      accessType: "open" | "gatekept";
+      gatekeeperMemberIds: string[];
     };
     /**
      * @description **Encrypted into**: `encryptedData` on innerworld entity create/update endpoints.
@@ -8061,54 +8061,54 @@ export interface components {
      */
     PlaintextSystemSettings: {
       /** @enum {string} */
-      theme?: "light" | "dark" | "high-contrast" | "system";
-      fontScale?: number;
-      appLock?: {
-        pinEnabled?: boolean;
-        biometricEnabled?: boolean;
+      theme: "light" | "dark" | "high-contrast" | "system";
+      fontScale: number;
+      appLock: {
+        pinEnabled: boolean;
+        biometricEnabled: boolean;
         /** @description Lock timeout in minutes (1-30) */
-        lockTimeout?: number;
+        lockTimeout: number;
         /** @description Seconds to keep keys in memory after app backgrounds (0-300) */
-        backgroundGraceSeconds?: number;
+        backgroundGraceSeconds: number;
       };
-      notifications?: {
-        pushEnabled?: boolean;
-        emailEnabled?: boolean;
-        switchReminders?: boolean;
-        checkInReminders?: boolean;
+      notifications: {
+        pushEnabled: boolean;
+        emailEnabled: boolean;
+        switchReminders: boolean;
+        checkInReminders: boolean;
       };
-      syncPreferences?: {
-        syncEnabled?: boolean;
-        syncOnCellular?: boolean;
+      syncPreferences: {
+        syncEnabled: boolean;
+        syncOnCellular: boolean;
       };
-      privacyDefaults?: {
+      privacyDefaults: {
         /** @description BucketId */
-        defaultBucketForNewContent?: string | null;
+        defaultBucketForNewContent: string | null;
         /** @enum {string} */
-        friendRequestPolicy?: "open" | "code-only";
+        friendRequestPolicy: "open" | "code-only";
       };
       /** @description Simplified UI configuration for littles */
-      littlesSafeMode?: {
-        enabled?: boolean;
-        allowedContentIds?: string[];
-        simplifiedUIFlags?: {
-          largeButtons?: boolean;
-          iconDriven?: boolean;
-          noDeletion?: boolean;
-          noSettings?: boolean;
-          noAnalytics?: boolean;
+      littlesSafeMode: {
+        enabled: boolean;
+        allowedContentIds: string[];
+        simplifiedUIFlags: {
+          largeButtons: boolean;
+          iconDriven: boolean;
+          noDeletion: boolean;
+          noSettings: boolean;
+          noAnalytics: boolean;
         };
       };
-      saturationLevelsEnabled?: boolean;
+      saturationLevelsEnabled: boolean;
       /** @description Auto-capture fronting snapshot when creating a journal entry */
-      autoCaptureFrontingOnJournal?: boolean;
+      autoCaptureFrontingOnJournal: boolean;
       /**
        * @description Automatic snapshot schedule. Client-triggered — the client reads
        *     this value and fires snapshots locally, preserving zero-knowledge.
        * @enum {string}
        */
-      snapshotSchedule?: "daily" | "weekly" | "disabled";
-      onboardingComplete?: boolean;
+      snapshotSchedule: "daily" | "weekly" | "disabled";
+      onboardingComplete: boolean;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on nomenclature update and setup endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -8006,8 +8006,6 @@ export interface components {
      *     and relationship tracking. Encryption tier: **T1**.
      */
     PlaintextLifecycleEvent: {
-      title?: string | null;
-      description?: string | null;
       notes?: string | null;
     };
     /**

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7867,10 +7867,10 @@ export interface components {
      */
     PlaintextCustomFront: {
       name: string;
-      description?: string | null;
+      description: string | null;
       /** @description Hex color */
-      color?: string | null;
-      emoji?: string | null;
+      color: string | null;
+      emoji: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on field definition create/update endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -5853,26 +5853,275 @@ export interface components {
       /** @default 25 */
       limit: number;
     };
+    /**
+     * @description Append-only audit log entry. Plaintext on the wire (not encrypted);
+     *     the server intentionally reads these for security monitoring
+     *     (failed-login detection, IP-pattern analysis).
+     */
     AuditLogEntry: {
       /** @description Unique audit log entry identifier */
       id: string;
-      /** @description Type of event (e.g., login, member.create, settings.update) */
-      eventType: string;
+      /** @description System the event is scoped to */
+      systemId: string;
+      /**
+       * @description Category of audit event.
+       * @enum {string}
+       */
+      eventType:
+        | "auth.register"
+        | "auth.login"
+        | "auth.login-failed"
+        | "auth.logout"
+        | "auth.password-changed"
+        | "auth.recovery-key-used"
+        | "auth.key-created"
+        | "auth.key-revoked"
+        | "data.export"
+        | "data.import"
+        | "data.purge"
+        | "settings.changed"
+        | "member.created"
+        | "member.archived"
+        | "sharing.granted"
+        | "sharing.revoked"
+        | "bucket.key_rotation.initiated"
+        | "bucket.key_rotation.chunk_completed"
+        | "bucket.key_rotation.completed"
+        | "bucket.key_rotation.failed"
+        | "bucket.key_rotation.retried"
+        | "device.security.jailbreak_warning_shown"
+        | "auth.password-reset-via-recovery"
+        | "auth.recovery-key-regenerated"
+        | "auth.device-transfer-initiated"
+        | "auth.device-transfer-approved"
+        | "auth.device-transfer-completed"
+        | "auth.email-changed"
+        | "auth.email-change-notification-enqueue-failed"
+        | "system.created"
+        | "system.profile-updated"
+        | "system.deleted"
+        | "system.purged"
+        | "system.duplicated"
+        | "snapshot.created"
+        | "snapshot.deleted"
+        | "group.created"
+        | "group.updated"
+        | "group.archived"
+        | "group.restored"
+        | "group.moved"
+        | "group-membership.added"
+        | "group-membership.removed"
+        | "custom-front.created"
+        | "custom-front.updated"
+        | "custom-front.archived"
+        | "custom-front.restored"
+        | "group.deleted"
+        | "custom-front.deleted"
+        | "auth.biometric-enrolled"
+        | "auth.biometric-verified"
+        | "auth.biometric-failed"
+        | "settings.pin-set"
+        | "settings.pin-removed"
+        | "settings.pin-verified"
+        | "settings.nomenclature-updated"
+        | "setup.step-completed"
+        | "setup.completed"
+        | "member.updated"
+        | "member.duplicated"
+        | "member.restored"
+        | "member-photo.created"
+        | "member-photo.archived"
+        | "member-photo.restored"
+        | "member-photo.reordered"
+        | "field-definition.created"
+        | "field-definition.updated"
+        | "field-definition.archived"
+        | "field-definition.restored"
+        | "field-value.set"
+        | "field-value.updated"
+        | "field-value.deleted"
+        | "structure-entity-type.created"
+        | "structure-entity-type.updated"
+        | "structure-entity-type.archived"
+        | "structure-entity-type.restored"
+        | "structure-entity-type.deleted"
+        | "structure-entity.created"
+        | "structure-entity.updated"
+        | "structure-entity.archived"
+        | "structure-entity.restored"
+        | "structure-entity.deleted"
+        | "relationship.created"
+        | "relationship.updated"
+        | "relationship.archived"
+        | "relationship.restored"
+        | "relationship.deleted"
+        | "lifecycle-event.created"
+        | "lifecycle-event.updated"
+        | "lifecycle-event.archived"
+        | "lifecycle-event.restored"
+        | "lifecycle-event.deleted"
+        | "structure-entity-link.created"
+        | "structure-entity-link.updated"
+        | "structure-entity-link.deleted"
+        | "structure-entity-member-link.added"
+        | "structure-entity-member-link.removed"
+        | "structure-entity-association.created"
+        | "structure-entity-association.deleted"
+        | "innerworld-region.created"
+        | "innerworld-region.updated"
+        | "innerworld-region.archived"
+        | "innerworld-region.restored"
+        | "innerworld-region.deleted"
+        | "innerworld-entity.created"
+        | "innerworld-entity.updated"
+        | "innerworld-entity.archived"
+        | "innerworld-entity.restored"
+        | "innerworld-entity.deleted"
+        | "innerworld-canvas.created"
+        | "innerworld-canvas.updated"
+        | "blob.upload-requested"
+        | "blob.confirmed"
+        | "blob.archived"
+        | "member.deleted"
+        | "member-photo.deleted"
+        | "field-definition.deleted"
+        | "fronting-session.created"
+        | "fronting-session.updated"
+        | "fronting-session.ended"
+        | "fronting-session.archived"
+        | "fronting-session.restored"
+        | "fronting-session.deleted"
+        | "fronting-comment.created"
+        | "fronting-comment.updated"
+        | "fronting-comment.archived"
+        | "fronting-comment.restored"
+        | "fronting-comment.deleted"
+        | "fronting-report.created"
+        | "fronting-report.updated"
+        | "fronting-report.archived"
+        | "fronting-report.restored"
+        | "fronting-report.deleted"
+        | "timer-config.created"
+        | "timer-config.updated"
+        | "timer-config.archived"
+        | "timer-config.restored"
+        | "timer-config.deleted"
+        | "check-in-record.created"
+        | "check-in-record.responded"
+        | "check-in-record.dismissed"
+        | "check-in-record.archived"
+        | "check-in-record.restored"
+        | "check-in-record.deleted"
+        | "webhook-config.created"
+        | "webhook-config.updated"
+        | "webhook-config.archived"
+        | "webhook-config.restored"
+        | "webhook-config.secret-rotated"
+        | "webhook-config.deleted"
+        | "webhook-delivery.deleted"
+        | "channel.created"
+        | "channel.updated"
+        | "channel.archived"
+        | "channel.restored"
+        | "channel.deleted"
+        | "message.created"
+        | "message.updated"
+        | "message.archived"
+        | "message.restored"
+        | "message.deleted"
+        | "board-message.created"
+        | "board-message.updated"
+        | "board-message.pinned"
+        | "board-message.unpinned"
+        | "board-message.reordered"
+        | "board-message.archived"
+        | "board-message.restored"
+        | "board-message.deleted"
+        | "note.created"
+        | "note.updated"
+        | "note.archived"
+        | "note.restored"
+        | "note.deleted"
+        | "poll.created"
+        | "poll.updated"
+        | "poll.closed"
+        | "poll.archived"
+        | "poll.restored"
+        | "poll.deleted"
+        | "poll-vote.cast"
+        | "poll-vote.vetoed"
+        | "poll-vote.updated"
+        | "poll-vote.archived"
+        | "acknowledgement.created"
+        | "acknowledgement.confirmed"
+        | "acknowledgement.archived"
+        | "acknowledgement.restored"
+        | "acknowledgement.deleted"
+        | "bucket.created"
+        | "bucket.updated"
+        | "bucket.archived"
+        | "bucket.restored"
+        | "bucket.deleted"
+        | "bucket-content-tag.tagged"
+        | "bucket-content-tag.untagged"
+        | "field-bucket-visibility.set"
+        | "field-bucket-visibility.removed"
+        | "friend-code.generated"
+        | "friend-code.redeemed"
+        | "friend-code.archived"
+        | "friend-connection.created"
+        | "friend-connection.accepted"
+        | "friend-connection.rejected"
+        | "friend-connection.blocked"
+        | "friend-connection.removed"
+        | "friend-connection.archived"
+        | "friend-connection.restored"
+        | "friend-visibility.updated"
+        | "friend-bucket-assignment.assigned"
+        | "friend-bucket-assignment.unassigned"
+        | "device-token.registered"
+        | "device-token.updated"
+        | "device-token.revoked"
+        | "device-token.deleted"
+        | "notification-config.updated"
+        | "friend-notification-preference.updated"
+        | "api-key.created"
+        | "api-key.revoked"
+        | "import-job.created"
+        | "import-job.updated"
+        | "import-job.completed"
+        | "import-job.failed";
       /**
        * Format: int64
-       * @description Unix timestamp in milliseconds when the event occurred
+       * @description Unix milliseconds when the event occurred
        */
-      timestamp: number;
-      /** @description Type of resource affected (e.g., member, group, session) */
-      resourceType: string;
-      /** @description ID of the affected resource */
-      resourceId?: string | null;
-      /** @description Account ID of the actor */
-      actor?: string | null;
+      createdAt: number;
+      /** @description The actor who performed the action. */
+      actor:
+        | {
+            /** @constant */
+            kind: "account";
+            /** @description Account ID */
+            id: string;
+          }
+        | {
+            /** @constant */
+            kind: "api-key";
+            /** @description API key ID */
+            id: string;
+          }
+        | {
+            /** @constant */
+            kind: "system";
+            /** @description System ID */
+            id: string;
+          };
+      /** @description Free-form plaintext payload with event-specific metadata. */
+      detail: string | null;
       /** @description IP address of the request */
-      ipAddress?: string | null;
+      ipAddress: string | null;
       /** @description User-Agent header from the request */
-      userAgent?: string | null;
+      userAgent: string | null;
     };
     AuditLogResponse: {
       data: components["schemas"]["AuditLogEntry"][];

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -8143,16 +8143,13 @@ export interface components {
       saturation?: string;
     };
     /**
-     * @description **Encrypted into**: `encryptedData` on structure entity member link endpoints.
-     *
-     *     Encrypted metadata for a member's assignment to a structure entity.
-     *     The `memberId` and `parentEntityId` are sent as separate plaintext fields.
-     *     Encryption tier: **T1**.
+     * @description Structure entity member links carry no encrypted payload today — every
+     *     field (`memberId`, `parentEntityId`, `sortOrder`) is plaintext at the
+     *     API layer. The schema is retained as an empty object so future encrypted
+     *     additions plug in without a breaking rename; the current parity gate
+     *     asserts the empty projection via the distributive-pick helper.
      */
-    PlaintextStructureEntityMemberLink: {
-      /** @description Optional notes about this membership */
-      notes?: string | null;
-    };
+    PlaintextStructureEntityMemberLink: Record<string, never>;
     /**
      * @description **Encrypted into**: `encryptedData` (optional) on structure entity association
      *     create endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7812,9 +7812,9 @@ export interface components {
       /** @description Display name of the plural system */
       name: string;
       /** @description Optional alternate display name */
-      displayName?: string | null;
-      description?: string | null;
-      avatarSource?: components["schemas"]["PlaintextImageSource"] | null;
+      displayName: string | null;
+      description: string | null;
+      avatarSource: components["schemas"]["PlaintextImageSource"] | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on member create/update endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7843,8 +7843,8 @@ export interface components {
      */
     PlaintextMemberPhoto: {
       imageSource: components["schemas"]["PlaintextImageSource"];
-      sortOrder?: number;
-      caption?: string | null;
+      sortOrder: number;
+      caption: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on group create/update endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -8113,34 +8113,38 @@ export interface components {
     /**
      * @description **Encrypted into**: `encryptedData` on nomenclature update and setup endpoints.
      *
-     *     Per-system terminology preferences — map of TermCategory to selected display term.
+     *     Per-system terminology preferences — map of `TermCategory` to selected
+     *     display term. Keys mirror the `TermCategory` union in
+     *     `@pluralscape/types` (kebab-case) so the parity gate can project
+     *     `Pick<NomenclatureSettings, NomenclatureEncryptedFields>` onto this
+     *     schema directly.
      *     Encryption tier: **T1**.
      */
     PlaintextNomenclature: {
       /** @description Term for the collective (default: 'System'). Presets: System, Collective, Household, Crew, Group */
-      collective?: string;
+      collective: string;
       /** @description Term for individuals (default: 'Member'). Presets: Member, Alter, Headmate, Part, Insider, Facet, Aspect */
-      individual?: string;
+      individual: string;
       /** @description Term for fronting (default: 'Fronting'). Presets: Fronting, In front, Driving, Piloting */
-      fronting?: string;
+      fronting: string;
       /** @description Term for switching (default: 'Switch'). Presets: Switch, Shift */
-      switching?: string;
+      switching: string;
       /** @description Term for co-fronting (default: 'Co-fronting'). Presets: Co-fronting, Co-conscious, Co-driving */
-      coPresence?: string;
+      "co-presence": string;
       /** @description Term for the internal space (default: 'Headspace'). Presets: Headspace, Innerworld */
-      internalSpace?: string;
+      "internal-space": string;
       /** @description Term for the host (default: 'Host'). Presets: Host, Primary fronter, Main fronter */
-      primaryFronter?: string;
+      "primary-fronter": string;
       /** @description Term for system structure (default: 'System Structure'). Presets: System Structure, Topology, Map */
-      structure?: string;
+      structure: string;
       /** @description Term for dormancy (default: 'Dormancy'). Presets: Dormancy, Resting, Inactive */
-      dormancy?: string;
+      dormancy: string;
       /** @description Term for the body (default: 'Body'). Presets: Body, Physical form, Vessel */
-      body?: string;
+      body: string;
       /** @description Term for amnesia (default: 'Amnesia'). Presets: Amnesia, Memory gap, Blackout */
-      amnesia?: string;
+      amnesia: string;
       /** @description Term for saturation level (default: 'Saturation'). Presets: Saturation, Elaboration, Completeness */
-      saturation?: string;
+      saturation: string;
     };
     /**
      * @description Structure entity member links carry no encrypted payload today — every

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -8030,25 +8030,13 @@ export interface components {
      * @description **Encrypted into**: `encryptedData` on innerworld entity create/update endpoints.
      *
      *     An entity placed on the innerworld canvas. Discriminated on `entityType`.
-     *     Encryption tier: **T1**.
+     *     `regionId` is a plaintext sibling (server needs it for queries) and is
+     *     therefore not present here. Encryption tier: **T1**.
      */
-    PlaintextInnerworldEntity: {
-      /** @enum {string} */
-      entityType: "member" | "landmark" | "structure-entity";
-      /** @description X coordinate on the canvas */
-      positionX: number;
-      /** @description Y coordinate on the canvas */
-      positionY: number;
-      visual?: components["schemas"]["PlaintextVisualProperties"];
-      /** @description Display name (required for landmark entities) */
-      name?: string;
-      /** @description Description (landmark entities only) */
-      description?: string | null;
-      /** @description Member ID (member entities only) */
-      linkedMemberId?: string;
-      /** @description Structure entity ID (structure-entity entities only) */
-      linkedStructureEntityId?: string;
-    };
+    PlaintextInnerworldEntity:
+      | components["schemas"]["PlaintextInnerworldMemberEntity"]
+      | components["schemas"]["PlaintextInnerworldLandmarkEntity"]
+      | components["schemas"]["PlaintextInnerworldStructureEntity"];
     /**
      * @description **Encrypted into**: `encryptedData` on `PUT /systems/:systemId/innerworld/canvas`.
      *
@@ -8990,6 +8978,46 @@ export interface components {
       translations: {
         [key: string]: string;
       };
+    };
+    /** @description Member-linked innerworld entity variant. */
+    PlaintextInnerworldMemberEntity: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      entityType: "member";
+      positionX: number;
+      positionY: number;
+      visual: components["schemas"]["PlaintextVisualProperties"];
+      /** @description Member ID (mem_ prefix) */
+      linkedMemberId: string;
+    };
+    /** @description Landmark innerworld entity variant. */
+    PlaintextInnerworldLandmarkEntity: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      entityType: "landmark";
+      positionX: number;
+      positionY: number;
+      visual: components["schemas"]["PlaintextVisualProperties"];
+      /** @description Display name for the landmark */
+      name: string;
+      description: string | null;
+    };
+    /** @description Structure-entity-linked innerworld entity variant. */
+    PlaintextInnerworldStructureEntity: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      entityType: "structure-entity";
+      positionX: number;
+      positionY: number;
+      visual: components["schemas"]["PlaintextVisualProperties"];
+      /** @description Structure entity ID (ste_ prefix) */
+      linkedStructureEntityId: string;
     };
   };
   responses: {

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7853,11 +7853,11 @@ export interface components {
      */
     PlaintextGroup: {
       name: string;
-      description?: string | null;
-      imageSource?: components["schemas"]["PlaintextImageSource"] | null;
+      description: string | null;
+      imageSource: components["schemas"]["PlaintextImageSource"] | null;
       /** @description Hex color (e.g., #FF00AA) */
-      color?: string | null;
-      emoji?: string | null;
+      color: string | null;
+      emoji: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on custom front create/update endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7950,7 +7950,7 @@ export interface components {
      */
     PlaintextRelationship: {
       /** @description User-defined label (meaningful when type is "custom") */
-      label?: string | null;
+      label: string | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on structure entity type create/update endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7880,9 +7880,9 @@ export interface components {
      */
     PlaintextFieldDefinition: {
       name: string;
-      description?: string | null;
+      description: string | null;
       /** @description Valid options for select/multi-select field types. Null for other types. */
-      options?: string[] | null;
+      options: string[] | null;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on field value set/update endpoints.

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -5626,7 +5626,7 @@ export interface components {
        * Format: int64
        * @description Unix timestamp in milliseconds when archived, null if not archived
        */
-      archivedAt?: number | null;
+      archivedAt: number | null;
     };
     LoginRequest: {
       /**

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -14,14 +14,10 @@ export interface paths {
     get?: never;
     put?: never;
     /**
-     * Initiate account registration
-     * @description Phase 1 of two-phase registration. Reserves an account slot and returns
-     *     a KDF salt and challenge nonce.
-     *
-     *     **Crypto flow**: The client uses the returned `kdfSalt` to derive the
-     *     auth key and password key from the user's password via Argon2id. The
-     *     `challengeNonce` must be signed with the client's Ed25519 signing key
-     *     and included in the commit phase to bind the keypair to this registration.
+     * Initiate account registration (phase 1)
+     * @description Two-phase registration. Returns accountId, KDF salt, and challenge nonce.
+     *     Always returns 201 regardless of whether the email is already registered
+     *     (anti-enumeration).
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
@@ -42,24 +38,10 @@ export interface paths {
     get?: never;
     put?: never;
     /**
-     * Commit account registration
-     * @description Phase 2 of two-phase registration. Submits all cryptographic material
-     *     and creates the account.
-     *
-     *     **Crypto flow**: The client derives the auth key and password key via
-     *     Argon2id using the `kdfSalt` from the initiate phase. The auth key is
-     *     sent as the credential. The master key is randomly generated client-side
-     *     and stored wrapped with the password key (`encryptedMasterKey`). The
-     *     recovery key independently wraps the master key (`recoveryEncryptedMasterKey`).
-     *     Identity keypairs are derived from the master key and their private keys
-     *     are stored encrypted (`encryptedSigningPrivateKey`,
-     *     `encryptedEncryptionPrivateKey`). The `challengeSignature` proves
-     *     ownership of the Ed25519 signing key by signing the nonce from the
-     *     initiate phase.
-     *
-     *     The recovery key must be stored securely by the client — it is the
-     *     **only** way to recover the master encryption key if the password is
-     *     forgotten.
+     * Complete account registration (phase 2)
+     * @description Zero-knowledge — the server never sees the password. The client sends
+     *     pre-encrypted key blobs and a challenge signature proving possession of
+     *     the signing key.
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
@@ -81,16 +63,12 @@ export interface paths {
     put?: never;
     /**
      * Fetch KDF salt for an email address
-     * @description Returns the Argon2id KDF salt for the given email address, enabling the
-     *     client to derive the auth key before sending credentials.
-     *
-     *     **Anti-enumeration**: The response is identical (valid salt format,
-     *     equalized timing) whether or not the email is registered, preventing
-     *     account existence probing.
+     * @description Always returns 200 with a salt — either the real KDF salt for the account
+     *     or a deterministic fake salt derived from the email (anti-enumeration).
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
-    post: operations["getKdfSalt"];
+    post: operations["getSalt"];
     delete?: never;
     options?: never;
     head?: never;
@@ -108,17 +86,10 @@ export interface paths {
     put?: never;
     /**
      * Log in with email and auth key
-     * @description Authenticates with email and a pre-derived auth key, returning a session
-     *     token and the encrypted master key for client-side decryption.
-     *
-     *     **Crypto flow**: The client first fetches the KDF salt via `POST /auth/salt`,
-     *     derives the auth key from the password via Argon2id, then submits it here.
-     *     The server verifies the BLAKE2B hash of the auth key. On success, the
-     *     encrypted master key is returned so the client can unwrap it with the
-     *     password key (also derived locally). The server never sees the raw password.
-     *
-     *     **Security**: Timing is equalized across success and failure paths to
-     *     prevent user-enumeration attacks.
+     * @description Zero-knowledge login. The client derives an auth key from the password
+     *     via Argon2id and sends only the auth key — the server never sees the
+     *     plaintext password. Timing is equalized across success and failure paths
+     *     to prevent user-enumeration attacks.
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
@@ -140,19 +111,12 @@ export interface paths {
     put?: never;
     /**
      * Reset password using recovery key
-     * @description Resets the account password using the recovery key.
-     *
-     *     **Crypto flow**: The client uses the recovery key to decrypt the master
-     *     key locally, then re-wraps it with a new password key derived from the
-     *     new password (using `newKdfSalt`). The new auth key, new KDF salt, and
-     *     two fresh encrypted master key blobs (`newEncryptedMasterKey` for
-     *     password-based access, `newRecoveryEncryptedMasterKey` for the new
-     *     recovery key) are all submitted pre-computed. The server replaces the
-     *     stored blobs atomically. All existing encrypted data remains accessible
-     *     because the underlying master key is unchanged — only its wrapping
-     *     changes. The `recoveryKeyHash` authenticates the request by proving
-     *     the client holds the current recovery key; `newRecoveryKeyHash` records
-     *     the replacement recovery key hash.
+     * @description Zero-knowledge password reset via recovery key. The client provides
+     *     hex-encoded blobs: a new auth key, new KDF salt, re-encrypted master
+     *     key, and a new recovery-encrypted master key. The server never sees
+     *     the plaintext password or master key. All existing encrypted data
+     *     remains accessible because the underlying master key is unchanged —
+     *     only its wrapping changes.
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
@@ -328,15 +292,10 @@ export interface paths {
     put?: never;
     /**
      * Regenerate recovery key
-     * @description Regenerates the recovery key. Requires current auth key and explicit
-     *     confirmation.
-     *
-     *     **Crypto flow**: The client decrypts the master key locally using the
-     *     current password key, wraps it with a fresh recovery key to produce
-     *     `newRecoveryEncryptedMasterKey`, then submits the new blob along with the
-     *     auth key for identity verification. The `challengeSignature` proves the
-     *     client holds the signing key. The old recovery key and its encrypted
-     *     master key copy are permanently invalidated.
+     * @description Regenerates the recovery key backup. The client provides its auth key
+     *     to prove identity, plus a new recovery-encrypted master key blob and
+     *     recovery key hash. The server never sees the plaintext recovery key or
+     *     master key.
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
@@ -366,7 +325,7 @@ export interface paths {
     /**
      * Delete account
      * @description Permanently deletes the authenticated account and all associated data.
-     *     Requires the current auth key for confirmation. This action is
+     *     Requires the current password for confirmation. This action is
      *     irreversible — all systems, members, sessions, keys, and dependent data
      *     are cascade-deleted.
      *
@@ -388,7 +347,7 @@ export interface paths {
     get?: never;
     /**
      * Change account email
-     * @description Changes the account email. Requires current auth key for verification.
+     * @description Changes the account email. Requires current password for verification.
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
@@ -410,14 +369,7 @@ export interface paths {
     get?: never;
     /**
      * Change account password
-     * @description Changes the account password. Requires current auth key for verification.
-     *
-     *     **Crypto flow**: The client derives the new auth key and new password key
-     *     from the new password using `newKdfSalt`. The master key is re-wrapped
-     *     with the new password key to produce `newEncryptedMasterKey`. All blobs
-     *     are submitted pre-computed; the server never sees the raw password or the
-     *     master key. The `challengeSignature` proves the client holds the Ed25519
-     *     signing key bound to this account.
+     * @description Changes the account password. Requires current password for verification.
      *
      *     Rate limit: 5 req/min (authHeavy)
      */
@@ -1127,7 +1079,7 @@ export interface paths {
     /**
      * Permanently purge a system
      * @description Hard-deletes a system and all dependent data via CASCADE. The system must
-     *     be archived (soft-deleted) first. Auth key confirmation is required to
+     *     be archived (soft-deleted) first. Password confirmation is required to
      *     prevent accidental purge.
      *
      *     Rate limit: 60 req/min (write)
@@ -5517,6 +5469,51 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/i18n/manifest": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get translation manifest
+     * @description Returns the list of available locales and namespaces. Public; rate-limited
+     *     (i18nFetch: 30 requests per minute per IP). Response is cached in Valkey
+     *     for 24 hours.
+     */
+    get: operations["getI18nManifest"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/i18n/{locale}/{namespace}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get a translation namespace
+     * @description Returns a single locale's namespace as a flat key/value map. Supports
+     *     If-None-Match against the response ETag; returns 304 on match. Public;
+     *     rate-limited (i18nFetch: 30 requests per minute per IP). Response cached
+     *     in Valkey for 24 hours.
+     */
+    get: operations["getI18nNamespace"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -5539,6 +5536,7 @@ export interface components {
           | "BUCKET_ACCESS_DENIED"
           | "NOT_FOUND"
           | "CONFLICT"
+          | "INVALID_STATE"
           | "HAS_DEPENDENTS"
           | "ROTATION_IN_PROGRESS"
           | "FRIEND_CODE_EXPIRED"
@@ -5630,45 +5628,43 @@ export interface components {
        */
       archivedAt?: number | null;
     };
-    SaltRequest: {
-      /**
-       * Format: email
-       * @example user@example.com
-       */
-      email: string;
-    };
-    SaltResponse: {
-      /**
-       * @description Hex-encoded 16-byte Argon2id salt for password key derivation
-       * @example a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
-       */
-      kdfSalt: string;
-    };
     LoginRequest: {
       /**
        * Format: email
        * @example user@example.com
        */
       email: string;
-      /** @description Hex-encoded 32-byte auth key derived from the password via Argon2id */
+      /** @description 32-byte hex-encoded auth key derived from password via Argon2id */
       authKey: string;
     };
     LoginResponse: {
-      /**
-       * @description 32-byte hex-encoded session token (64 characters)
-       * @example a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
-       */
-      sessionToken: string;
-      /** @example acc_abc123 */
-      accountId: string;
-      /** @example sys_abc123 */
-      systemId?: string | null;
-      /** @enum {string} */
-      accountType: "system" | "viewer";
-      /** @description Base64-encoded master key wrapped with the password key (XChaCha20-Poly1305) */
-      encryptedMasterKey: string;
-      /** @description Hex-encoded 16-byte Argon2id salt used to derive the password key */
-      kdfSalt: string;
+      data: {
+        /**
+         * @description 32-byte hex-encoded session token (64 characters)
+         * @example a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+         */
+        sessionToken: string;
+        /** @example acct_abc123 */
+        accountId: string;
+        /** @example sys_abc123 */
+        systemId?: string | null;
+        /** @enum {string} */
+        accountType: "system" | "viewer";
+        /** @description E2E-encrypted master key blob (hex-encoded) */
+        encryptedMasterKey?: string;
+        /** @description Hex-encoded 16-byte Argon2id salt */
+        kdfSalt?: string;
+      };
+    };
+    SaltRequest: {
+      /** Format: email */
+      email: string;
+    };
+    SaltResponse: {
+      data: {
+        /** @description Hex-encoded 16-byte Argon2id salt */
+        kdfSalt: string;
+      };
     };
     RegistrationInitiateRequest: {
       /** Format: email */
@@ -5680,69 +5676,56 @@ export interface components {
       accountType: "system" | "viewer";
     };
     RegistrationInitiateResponse: {
-      /**
-       * @description Reserved account ID to reference in the commit phase
-       * @example acc_abc123
-       */
-      accountId: string;
-      /**
-       * @description Hex-encoded 16-byte Argon2id salt generated by the server for this account
-       * @example a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
-       */
-      kdfSalt: string;
-      /** @description Hex-encoded 32-byte nonce to be signed with the Ed25519 signing key in the commit phase */
-      challengeNonce: string;
+      data: {
+        accountId: string;
+        kdfSalt: string;
+        challengeNonce: string;
+      };
     };
     RegistrationCommitRequest: {
-      /** @description Account ID from the initiate phase */
       accountId: string;
-      /** @description Hex-encoded 32-byte auth key derived from the password via Argon2id */
       authKey: string;
-      /** @description Base64-encoded master key wrapped with the password key (XChaCha20-Poly1305) */
       encryptedMasterKey: string;
-      /** @description Base64-encoded Ed25519 signing private key encrypted with the master key */
       encryptedSigningPrivateKey: string;
-      /** @description Base64-encoded X25519 encryption private key encrypted with the master key */
       encryptedEncryptionPrivateKey: string;
-      /** @description Hex-encoded Ed25519 public signing key (64 hex chars, 32 bytes) */
       publicSigningKey: string;
-      /** @description Hex-encoded X25519 public encryption key (64 hex chars, 32 bytes) */
       publicEncryptionKey: string;
-      /** @description Base64-encoded master key wrapped with the recovery key (XChaCha20-Poly1305) */
       recoveryEncryptedMasterKey: string;
-      /** @description Hex-encoded Ed25519 signature of the challenge nonce from the initiate phase */
       challengeSignature: string;
       /** @constant */
       recoveryKeyBackupConfirmed: true;
-      /** @description Hex-encoded 32-byte BLAKE2b hash of the raw recovery key (64 hex chars) */
       recoveryKeyHash: string;
     };
     RegistrationCommitResponse: {
-      /** @description 32-byte hex-encoded session token */
-      sessionToken: string;
-      accountId: string;
-      /** @enum {string} */
-      accountType: "system" | "viewer";
+      data: {
+        sessionToken: string;
+        accountId: string;
+        /** @enum {string} */
+        accountType: "system" | "viewer";
+      };
+    };
+    RegenerateRecoveryKeyResponse: {
+      data: {
+        /** @constant */
+        ok: true;
+      };
     };
     PasswordResetViaRecoveryKeyRequest: {
       /** Format: email */
       email: string;
-      /** @description Hex-encoded 32-byte auth key derived from the new password via Argon2id */
+      recoveryKey: string;
       newAuthKey: string;
-      /** @description Hex-encoded 16-byte Argon2id salt used to derive the new auth key and password key */
       newKdfSalt: string;
-      /** @description Base64-encoded master key re-wrapped with the new password key */
       newEncryptedMasterKey: string;
-      /** @description Base64-encoded master key wrapped with the new recovery key */
       newRecoveryEncryptedMasterKey: string;
-      /** @description Hex-encoded 32-byte BLAKE2b hash of the current recovery key used to authenticate this reset (64 hex chars) */
       recoveryKeyHash: string;
-      /** @description Hex-encoded 32-byte BLAKE2b hash of the new recovery key replacing the current one (64 hex chars) */
       newRecoveryKeyHash: string;
     };
     PasswordResetResponse: {
-      sessionToken: string;
-      accountId: string;
+      data: {
+        sessionToken: string;
+        accountId: string;
+      };
     };
     BiometricTokenRequest: {
       /** @description Platform-specific biometric token */
@@ -5781,15 +5764,14 @@ export interface components {
       expiresAt?: number | null;
     };
     SessionListResponse: {
-      sessions: components["schemas"]["SessionInfo"][];
+      data: components["schemas"]["SessionInfo"][];
       nextCursor?: string | null;
       hasMore: boolean;
     };
     RegenerateRecoveryKeyRequest: {
-      /** @description Hex-encoded 32-byte auth key derived from the current password */
       authKey: string;
-      /** @description Base64-encoded master key wrapped with the newly generated recovery key */
       newRecoveryEncryptedMasterKey: string;
+      recoveryKeyHash: string;
       /** @constant */
       confirmed: true;
     };
@@ -5803,8 +5785,6 @@ export interface components {
     };
     RevokeAllResponse: {
       data: {
-        /** @constant */
-        success: true;
         /** @description Number of sessions revoked */
         revokedCount: number;
       };
@@ -5848,20 +5828,11 @@ export interface components {
        * @example user@example.com
        */
       email: string;
-      /** @description Hex-encoded 32-byte auth key derived from the current password */
-      authKey: string;
+      currentPassword: string;
     };
     ChangePasswordRequest: {
-      /** @description Hex-encoded 32-byte auth key derived from the current password */
-      oldAuthKey: string;
-      /** @description Hex-encoded 32-byte auth key derived from the new password */
-      newAuthKey: string;
-      /** @description Hex-encoded 16-byte Argon2id salt used to derive the new auth key and password key */
-      newKdfSalt: string;
-      /** @description Base64-encoded master key re-wrapped with the new password key */
-      newEncryptedMasterKey: string;
-      /** @description Hex-encoded Ed25519 signature proving ownership of the account signing key */
-      challengeSignature: string;
+      currentPassword: string;
+      newPassword: string;
     };
     AuditLogQuery: {
       /** @description Filter by event type */
@@ -5904,7 +5875,7 @@ export interface components {
       userAgent?: string | null;
     };
     AuditLogResponse: {
-      events: components["schemas"]["AuditLogEntry"][];
+      data: components["schemas"]["AuditLogEntry"][];
       nextCursor?: string | null;
       hasMore: boolean;
     };
@@ -5919,8 +5890,8 @@ export interface components {
       version: number;
     };
     DeleteAccountRequest: {
-      /** @description Hex-encoded 32-byte auth key derived from the current password for confirmation */
-      authKey: string;
+      /** @description Current account password for confirmation */
+      password: string;
     };
     VerifyPinResponse: {
       /** @enum {boolean} */
@@ -5999,8 +5970,8 @@ export interface components {
       sourceSnapshotId: string;
     };
     PurgeSystemRequest: {
-      /** @description Hex-encoded 32-byte auth key derived from the current password for confirmation */
-      authKey: string;
+      /** @description Account password for confirmation */
+      password: string;
     };
     /** @description A member (headmate) within a system. Extends EncryptedEntity with the server-visible `archived` field. */
     MemberResponse: components["schemas"]["EncryptedEntity"];
@@ -6016,11 +5987,20 @@ export interface components {
     DuplicateMemberRequest: {
       /** @description T1-encrypted PlaintextMember for the new duplicate (see ./plaintext.yaml#/PlaintextMember) */
       encryptedData: string;
-      /** @description Whether to copy the source member's photos to the duplicate */
+      /**
+       * @description Whether to copy the source member's photos to the duplicate
+       * @default false
+       */
       copyPhotos: boolean;
-      /** @description Whether to copy the source member's custom field values to the duplicate */
+      /**
+       * @description Whether to copy the source member's custom field values to the duplicate
+       * @default false
+       */
       copyFields: boolean;
-      /** @description Whether to copy the source member's group memberships to the duplicate */
+      /**
+       * @description Whether to copy the source member's group memberships to the duplicate
+       * @default false
+       */
       copyMemberships: boolean;
     };
     CreateMemberPhotoRequest: {
@@ -6970,6 +6950,11 @@ export interface components {
        * @description Unix milliseconds. Retroactive values are allowed.
        */
       startTime: number;
+      /**
+       * Format: int64
+       * @description Unix milliseconds when the session ended. Optional; omit for active sessions. Must be after startTime.
+       */
+      endTime?: number;
       /** @description Member ID (mem_ prefix). At least one subject required. */
       memberId?: string;
       /** @description Custom front ID (cf_ prefix) */
@@ -7591,16 +7576,16 @@ export interface components {
       name: string;
       /** @description List of pronoun sets (e.g., ['she/her', 'they/them']) */
       pronouns: string[];
-      description?: string | null;
-      avatarSource?: components["schemas"]["PlaintextImageSource"] | null;
+      description: string | null;
+      avatarSource: components["schemas"]["PlaintextImageSource"] | null;
       /** @description Member's associated colors (for UI theming) */
       colors: string[];
-      saturationLevel?: components["schemas"]["PlaintextSaturationLevel"];
+      saturationLevel: components["schemas"]["PlaintextSaturationLevel"];
       tags: components["schemas"]["PlaintextTag"][];
       /** @description When true, friends are not notified when this member starts fronting */
-      suppressFriendFrontNotification?: boolean;
+      suppressFriendFrontNotification: boolean;
       /** @description When true, a board message is posted when this member starts fronting */
-      boardMessageNotificationOnFront?: boolean;
+      boardMessageNotificationOnFront: boolean;
     };
     /**
      * @description **Encrypted into**: `encryptedData` on member photo create endpoints.
@@ -7930,7 +7915,7 @@ export interface components {
     PlaintextStructureEntityAssociation: {
       notes?: string | null;
     };
-    account_PinRequest: {
+    "PinRequest-2": {
       /** @description 4-6 digit PIN */
       pin: string;
     };
@@ -7990,7 +7975,7 @@ export interface components {
       updatedAt: number;
     };
     BucketExportPageResponse: {
-      items: components["schemas"]["BucketExportEntity"][];
+      data: components["schemas"]["BucketExportEntity"][];
       /** @description Cursor for the next page, or null if no more pages */
       nextCursor: string | null;
       /** @description Whether more pages are available */
@@ -8169,25 +8154,83 @@ export interface components {
      */
     ApiKeyType: "metadata" | "crypto";
     /**
-     * @description Permission scope granted to this API key
+     * @description Permission scope granted to an API key. Scopes follow the
+     *     `<tier>:<domain>` pattern plus a small set of special values.
+     *
+     *     - Tiers: `read` (list/get), `write` (create/update), `delete` (destroy).
+     *     - Aggregates: `read-all`, `write-all`, `delete-all` grant the tier across every domain.
+     *     - `read:audit-log` is the only audit-log scope (read-only by design).
+     *     - `full` grants unrestricted access including audit-log and api-key management endpoints.
      * @enum {string}
      */
     ApiKeyScope:
       | "read:members"
-      | "write:members"
       | "read:fronting"
-      | "write:fronting"
       | "read:groups"
-      | "write:groups"
       | "read:system"
-      | "write:system"
+      | "read:structure"
+      | "read:reports"
       | "read:webhooks"
-      | "write:webhooks"
-      | "read:audit-log"
       | "read:blobs"
-      | "write:blobs"
       | "read:notifications"
+      | "read:acknowledgements"
+      | "read:channels"
+      | "read:messages"
+      | "read:notes"
+      | "read:polls"
+      | "read:relationships"
+      | "read:innerworld"
+      | "read:fields"
+      | "read:check-ins"
+      | "read:lifecycle-events"
+      | "read:timers"
+      | "read:buckets"
+      | "write:members"
+      | "write:fronting"
+      | "write:groups"
+      | "write:system"
+      | "write:structure"
+      | "write:reports"
+      | "write:webhooks"
+      | "write:blobs"
       | "write:notifications"
+      | "write:acknowledgements"
+      | "write:channels"
+      | "write:messages"
+      | "write:notes"
+      | "write:polls"
+      | "write:relationships"
+      | "write:innerworld"
+      | "write:fields"
+      | "write:check-ins"
+      | "write:lifecycle-events"
+      | "write:timers"
+      | "write:buckets"
+      | "delete:members"
+      | "delete:fronting"
+      | "delete:groups"
+      | "delete:system"
+      | "delete:structure"
+      | "delete:reports"
+      | "delete:webhooks"
+      | "delete:blobs"
+      | "delete:notifications"
+      | "delete:acknowledgements"
+      | "delete:channels"
+      | "delete:messages"
+      | "delete:notes"
+      | "delete:polls"
+      | "delete:relationships"
+      | "delete:innerworld"
+      | "delete:fields"
+      | "delete:check-ins"
+      | "delete:lifecycle-events"
+      | "delete:timers"
+      | "delete:buckets"
+      | "read:audit-log"
+      | "read-all"
+      | "write-all"
+      | "delete-all"
       | "full";
     /**
      * @description An API key. The plaintext `token` is only returned on creation and
@@ -8640,7 +8683,7 @@ export interface components {
     };
     CreateImportJobBody: {
       source: components["schemas"]["ImportSource"];
-      /** @description Map of ImportEntityType → whether to import. At least one must be true. */
+      /** @description Map of ImportCollectionType → whether to import. At least one must be true. */
       selectedCategories: {
         [key: string]: boolean;
       };
@@ -8666,6 +8709,26 @@ export interface components {
       /** @description Brand varies by sourceEntityType (MemberId, GroupId, etc.). */
       pluralscapeEntityId: string;
       importedAt: number;
+    };
+    I18nNamespaceManifest: {
+      /** @example common */
+      name: string;
+      etag: string;
+    };
+    I18nLocaleManifest: {
+      /** @example es */
+      locale: string;
+      namespaces: components["schemas"]["I18nNamespaceManifest"][];
+    };
+    I18nManifest: {
+      /** Format: int64 */
+      distributionTimestamp: number;
+      locales: components["schemas"]["I18nLocaleManifest"][];
+    };
+    I18nNamespace: {
+      translations: {
+        [key: string]: string;
+      };
     };
   };
   responses: {
@@ -8756,7 +8819,7 @@ export interface operations {
     };
     responses: {
       /** @description Registration initiated */
-      200: {
+      201: {
         headers: {
           [name: string]: unknown;
         };
@@ -8765,7 +8828,6 @@ export interface operations {
         };
       };
       400: components["responses"]["ValidationError"];
-      409: components["responses"]["Conflict"];
       429: components["responses"]["RateLimited"];
     };
   };
@@ -8792,11 +8854,10 @@ export interface operations {
         };
       };
       400: components["responses"]["ValidationError"];
-      409: components["responses"]["Conflict"];
       429: components["responses"]["RateLimited"];
     };
   };
-  getKdfSalt: {
+  getSalt: {
     parameters: {
       query?: never;
       header?: never;
@@ -8809,7 +8870,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description KDF salt returned */
+      /** @description KDF salt */
       200: {
         headers: {
           [name: string]: unknown;
@@ -9047,16 +9108,13 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Recovery key regenerated */
-      200: {
+      /** @description Recovery key backup regenerated */
+      201: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          "application/json": {
-            /** @constant */
-            ok: true;
-          };
+          "application/json": components["schemas"]["RegenerateRecoveryKeyResponse"];
         };
       };
       400: components["responses"]["ValidationError"];
@@ -9239,7 +9297,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["account_PinRequest"];
+        "application/json": components["schemas"]["PinRequest-2"];
       };
     };
     responses: {
@@ -9259,7 +9317,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["account_PinRequest"];
+        "application/json": components["schemas"]["PinRequest-2"];
       };
     };
     responses: {
@@ -9279,7 +9337,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["account_PinRequest"];
+        "application/json": components["schemas"]["PinRequest-2"];
       };
     };
     responses: {
@@ -9927,7 +9985,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            systems: components["schemas"]["SystemProfile"][];
+            data: components["schemas"]["SystemProfile"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -10126,7 +10184,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["SnapshotResponse"][];
+            data: components["schemas"]["SnapshotResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -10524,7 +10582,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            members: components["schemas"]["MemberResponse"][];
+            data: components["schemas"]["MemberResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -10753,7 +10811,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            memberships: components["schemas"]["GroupMembership"][];
+            data: components["schemas"]["GroupMembership"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -10990,7 +11048,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            groups: components["schemas"]["GroupResponse"][];
+            data: components["schemas"]["GroupResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -11299,7 +11357,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            members: components["schemas"]["GroupMembership"][];
+            data: components["schemas"]["GroupMembership"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -11387,7 +11445,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            customFronts: components["schemas"]["CustomFrontResponse"][];
+            data: components["schemas"]["CustomFrontResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -11765,7 +11823,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            fields: components["schemas"]["FieldDefinitionResponse"][];
+            data: components["schemas"]["FieldDefinitionResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -11956,10 +12014,9 @@ export interface operations {
         content: {
           "application/json": {
             data: {
-              items: {
-                bucketId: string;
-              }[];
-            };
+              fieldDefinitionId: string;
+              bucketId: string;
+            }[];
           };
         };
       };
@@ -12054,7 +12111,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            relationships: components["schemas"]["RelationshipResponse"][];
+            data: components["schemas"]["RelationshipResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -12246,7 +12303,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            entityTypes: components["schemas"]["StructureEntityTypeResponse"][];
+            data: components["schemas"]["StructureEntityTypeResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -12440,7 +12497,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            entities: components["schemas"]["StructureEntityResponse"][];
+            data: components["schemas"]["StructureEntityResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -12636,7 +12693,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            links: components["schemas"]["StructureEntityLinkResponse"][];
+            data: components["schemas"]["StructureEntityLinkResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -12756,7 +12813,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            memberLinks: components["schemas"]["StructureEntityMemberLinkResponse"][];
+            data: components["schemas"]["StructureEntityMemberLinkResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -12843,7 +12900,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            associations: components["schemas"]["StructureEntityAssociationResponse"][];
+            data: components["schemas"]["StructureEntityAssociationResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -12928,7 +12985,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            events: components["schemas"]["LifecycleEventResponse"][];
+            data: components["schemas"]["LifecycleEventResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -13072,7 +13129,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            regions: components["schemas"]["RegionResponse"][];
+            data: components["schemas"]["RegionResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -13265,7 +13322,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            entities: components["schemas"]["EntityResponse"][];
+            data: components["schemas"]["EntityResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -13515,7 +13572,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            blobs: components["schemas"]["BlobResponse"][];
+            data: components["schemas"]["BlobResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -13688,7 +13745,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["BucketResponse"][];
+            data: components["schemas"]["BucketResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -14312,6 +14369,10 @@ export interface operations {
         startFrom?: number;
         /** @description Filter sessions starting at or before this Unix timestamp (ms) */
         startUntil?: number;
+        /** @description Filter sessions ending at or after this Unix timestamp (ms) */
+        endFrom?: number;
+        /** @description Filter sessions ending at or before this Unix timestamp (ms) */
+        endUntil?: number;
         /** @description If true, only return sessions with no end time */
         activeOnly?: "true" | "false";
         /** @description If true, include archived sessions in the response */
@@ -14333,7 +14394,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["FrontingSessionResponse"][];
+            data: components["schemas"]["FrontingSessionResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -14589,7 +14650,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["FrontingCommentResponse"][];
+            data: components["schemas"]["FrontingCommentResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -15120,7 +15181,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["WebhookConfigResponse"][];
+            data: components["schemas"]["WebhookConfigResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -15382,7 +15443,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["WebhookDeliveryResponse"][];
+            data: components["schemas"]["WebhookDeliveryResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -15467,7 +15528,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["ApiKeyResponse"][];
+            data: components["schemas"]["ApiKeyResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -15583,7 +15644,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["ChannelResponse"][];
+            data: components["schemas"]["ChannelResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -15784,7 +15845,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["MessageResponse"][];
+            data: components["schemas"]["MessageResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -16003,7 +16064,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["BoardMessageResponse"][];
+            data: components["schemas"]["BoardMessageResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -16281,7 +16342,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["NoteResponse"][];
+            data: components["schemas"]["NoteResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -16478,7 +16539,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["PollResponse"][];
+            data: components["schemas"]["PollResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -16655,7 +16716,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["PollVoteResponse"][];
+            data: components["schemas"]["PollVoteResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -16861,7 +16922,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["AcknowledgementResponse"][];
+            data: components["schemas"]["AcknowledgementResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -17054,7 +17115,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["TimerConfigResponse"][];
+            data: components["schemas"]["TimerConfigResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -17260,7 +17321,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["CheckInRecordResponse"][];
+            data: components["schemas"]["CheckInRecordResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -17571,7 +17632,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["HierarchyNode"][];
+            data: components["schemas"]["HierarchyNode"][];
           };
         };
       };
@@ -17606,7 +17667,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["ImportJobResponse"][];
+            data: components["schemas"]["ImportJobResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -17769,7 +17830,7 @@ export interface operations {
         };
         content: {
           "application/json": {
-            items: components["schemas"]["ImportEntityRefResponse"][];
+            data: components["schemas"]["ImportEntityRefResponse"][];
           } & components["schemas"]["PaginationMeta"];
         };
       };
@@ -17917,6 +17978,117 @@ export interface operations {
         content?: never;
       };
       429: components["responses"]["RateLimited"];
+    };
+  };
+  getI18nManifest: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Manifest retrieved */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: components["schemas"]["I18nManifest"];
+          };
+        };
+      };
+      429: components["responses"]["RateLimited"];
+      /** @description Translation source unavailable */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Translation proxy not configured */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getI18nNamespace: {
+    parameters: {
+      query?: never;
+      header?: {
+        "If-None-Match"?: string;
+      };
+      path: {
+        locale: string;
+        namespace: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Translations retrieved */
+      200: {
+        headers: {
+          ETag?: string;
+          "Cache-Control"?: string;
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: components["schemas"]["I18nNamespace"];
+          };
+        };
+      };
+      /** @description Not modified */
+      304: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Translation not found for the given locale/namespace */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "error": {
+           *         "code": "NAMESPACE_NOT_FOUND",
+           *         "message": "Translation not found"
+           *       }
+           *     }
+           */
+          "application/json": {
+            error: {
+              /** @enum {string} */
+              code: "NAMESPACE_NOT_FOUND";
+              message: string;
+            };
+          };
+        };
+      };
+      429: components["responses"]["RateLimited"];
+      /** @description Translation source unavailable */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Translation proxy not configured */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
     };
   };
 }

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7887,53 +7887,57 @@ export interface components {
     /**
      * @description **Encrypted into**: `encryptedData` on field value set/update endpoints.
      *
-     *     A typed value for a custom field on a member. The `fieldType` discriminant
-     *     determines the shape of `value`. Encryption tier: **T1**.
+     *     A typed value for a custom field on a member. Wraps the
+     *     discriminated `value` (keyed by `fieldType`) so the encrypted
+     *     payload parity matches the domain projection
+     *     `Pick<FieldValue, "value">`. Encryption tier: **T1**.
      */
-    PlaintextFieldValue:
-      | {
-          /** @constant */
-          fieldType: "text";
-          value: string;
-        }
-      | {
-          /** @constant */
-          fieldType: "number";
-          value: number;
-        }
-      | {
-          /** @constant */
-          fieldType: "boolean";
-          value: boolean;
-        }
-      | {
-          /** @constant */
-          fieldType: "date";
-          /** @description ISO 8601 date string */
-          value: string;
-        }
-      | {
-          /** @constant */
-          fieldType: "color";
-          /** @description Hex color (e.g., #FF00AA) */
-          value: string;
-        }
-      | {
-          /** @constant */
-          fieldType: "select";
-          value: string;
-        }
-      | {
-          /** @constant */
-          fieldType: "multi-select";
-          value: string[];
-        }
-      | {
-          /** @constant */
-          fieldType: "url";
-          /** Format: uri */
-          value: string;
-        };
+    PlaintextFieldValue: {
+      value:
+        | {
+            /** @constant */
+            fieldType: "text";
+            value: string;
+          }
+        | {
+            /** @constant */
+            fieldType: "number";
+            value: number;
+          }
+        | {
+            /** @constant */
+            fieldType: "boolean";
+            value: boolean;
+          }
+        | {
+            /** @constant */
+            fieldType: "date";
+            /** @description ISO 8601 date string */
+            value: string;
+          }
+        | {
+            /** @constant */
+            fieldType: "color";
+            /** @description Hex color (e.g., #FF00AA) */
+            value: string;
+          }
+        | {
+            /** @constant */
+            fieldType: "select";
+            value: string;
+          }
+        | {
+            /** @constant */
+            fieldType: "multi-select";
+            value: string[];
+          }
+        | {
+            /** @constant */
+            fieldType: "url";
+            /** Format: uri */
+            value: string;
+          };
+    };
     /**
      * @description **Encrypted into**: `encryptedData` on relationship create/update endpoints.
      *

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -47,6 +47,7 @@
     "@pluralscape/api-client": "workspace:*",
     "@pluralscape/crypto": "workspace:*",
     "@pluralscape/types": "workspace:*",
+    "@pluralscape/validation": "workspace:*",
     "@tanstack/react-query": "catalog:"
   },
   "peerDependencies": {

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -24,7 +24,7 @@ export {
   encryptMemberInput,
   encryptMemberUpdate,
 } from "./transforms/member.js";
-export type { MemberEncryptedFields } from "./transforms/member.js";
+export type { MemberEncryptedInput } from "./transforms/member.js";
 
 export {
   decryptGroup,

--- a/packages/data/src/transforms/__tests__/member.test.ts
+++ b/packages/data/src/transforms/__tests__/member.test.ts
@@ -13,7 +13,7 @@ import {
 
 import { makeBase64Blob } from "./helpers.js";
 
-import type { MemberEncryptedFields } from "../member.js";
+import type { MemberEncryptedInput } from "../member.js";
 import type { KdfMasterKey } from "@pluralscape/crypto";
 import type { HexColor, MemberId, SystemId, UnixMillis } from "@pluralscape/types";
 
@@ -26,7 +26,7 @@ beforeAll(async () => {
 });
 
 /** Minimal encrypted fields fixture for a fully-populated member. */
-function makeEncryptedFields(): MemberEncryptedFields {
+function makeEncryptedFields(): MemberEncryptedInput {
   return {
     name: "River",
     pronouns: ["they/them", "xe/xem"],
@@ -45,7 +45,7 @@ function makeEncryptedFields(): MemberEncryptedFields {
 
 /** Build a minimal MemberServerMetadata wire object from encrypted fields. */
 function makeServerMember(
-  fields: MemberEncryptedFields = makeEncryptedFields(),
+  fields: MemberEncryptedInput = makeEncryptedFields(),
   overrides?: Partial<{ archived: boolean; archivedAt: UnixMillis | null }>,
 ) {
   return {
@@ -88,7 +88,7 @@ describe("decryptMember", () => {
   });
 
   it("handles null optional fields correctly", () => {
-    const fields: MemberEncryptedFields = {
+    const fields: MemberEncryptedInput = {
       name: "Ghost",
       pronouns: [],
       description: null,
@@ -130,11 +130,11 @@ describe("decryptMember", () => {
   });
 });
 
-describe("assertMemberEncryptedFields validation", () => {
+describe("MemberEncryptedInputSchema validation", () => {
   it("throws when description is a number instead of string or null", () => {
     const fields = { ...makeEncryptedFields(), description: 42 };
     const raw = { ...makeServerMember(), encryptedData: encryptAndEncodeT1(fields, masterKey) };
-    expect(() => decryptMember(raw, masterKey)).toThrow("description must be string or null");
+    expect(() => decryptMember(raw, masterKey)).toThrow(/description/);
   });
 
   it("throws when suppressFriendFrontNotification is missing", () => {
@@ -362,9 +362,7 @@ describe("decryptMemberPage", () => {
       ],
       nextCursor: null,
     };
-    expect(() => decryptMemberPage(page, masterKey)).toThrow(
-      "missing required array field: pronouns",
-    );
+    expect(() => decryptMemberPage(page, masterKey)).toThrow(/pronouns/);
   });
 });
 
@@ -418,13 +416,13 @@ describe("encryptMemberUpdate", () => {
 
 // ── Assertion guard tests ────────────────────────────────────────────
 
-describe("assertMemberEncryptedFields", () => {
+describe("MemberEncryptedInputSchema guard", () => {
   it("throws when decrypted blob is not an object", () => {
     const raw = {
       ...makeServerMember(),
       encryptedData: makeBase64Blob("not-an-object", masterKey),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("not an object");
+    expect(() => decryptMember(raw, masterKey)).toThrow(/expected object/);
   });
 
   it("throws when blob is missing name field", () => {
@@ -432,7 +430,7 @@ describe("assertMemberEncryptedFields", () => {
       ...makeServerMember(),
       encryptedData: makeBase64Blob({ pronouns: [] }, masterKey),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("missing required string field: name");
+    expect(() => decryptMember(raw, masterKey)).toThrow(/name/);
   });
 
   it("throws when blob is missing pronouns array", () => {
@@ -440,7 +438,7 @@ describe("assertMemberEncryptedFields", () => {
       ...makeServerMember(),
       encryptedData: makeBase64Blob({ name: "Test" }, masterKey),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("missing required array field: pronouns");
+    expect(() => decryptMember(raw, masterKey)).toThrow(/pronouns/);
   });
 
   it("throws when pronouns is not an array", () => {
@@ -448,6 +446,6 @@ describe("assertMemberEncryptedFields", () => {
       ...makeServerMember(),
       encryptedData: makeBase64Blob({ name: "Test", pronouns: "not-array" }, masterKey),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("missing required array field: pronouns");
+    expect(() => decryptMember(raw, masterKey)).toThrow(/pronouns/);
   });
 });

--- a/packages/data/src/transforms/__tests__/member.test.ts
+++ b/packages/data/src/transforms/__tests__/member.test.ts
@@ -2,6 +2,7 @@ import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/cry
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
 import { toUnixMillis, brandId } from "@pluralscape/types";
 import { beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod/v4";
 
 import { encryptAndEncodeT1 } from "../decode-blob.js";
 import {
@@ -41,6 +42,28 @@ function makeEncryptedFields(): MemberEncryptedInput {
     suppressFriendFrontNotification: false,
     boardMessageNotificationOnFront: true,
   };
+}
+
+/**
+ * Assert that `fn` throws a `z.ZodError` whose issues include one matching
+ * `code` at exactly `path`. Used to replace regex-on-message assertions so
+ * failing tests distinguish missing vs wrong-type vs other Zod errors.
+ */
+function expectZodIssue(
+  fn: () => unknown,
+  { code, path }: { code: string; path: ReadonlyArray<string | number> },
+): void {
+  let caught: unknown;
+  try {
+    fn();
+  } catch (err) {
+    caught = err;
+  }
+  expect(caught).toBeInstanceOf(z.ZodError);
+  const issues = (caught as z.ZodError).issues;
+  expect(issues).toEqual(
+    expect.arrayContaining([expect.objectContaining({ code, path: [...path] })]),
+  );
 }
 
 /** Build a minimal MemberServerMetadata wire object from encrypted fields. */
@@ -164,7 +187,10 @@ describe("MemberEncryptedInputSchema validation", () => {
         masterKey,
       ),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("suppressFriendFrontNotification");
+    expectZodIssue(() => decryptMember(raw, masterKey), {
+      code: "invalid_type",
+      path: ["suppressFriendFrontNotification"],
+    });
   });
 
   it("throws when boardMessageNotificationOnFront is missing", () => {
@@ -194,7 +220,10 @@ describe("MemberEncryptedInputSchema validation", () => {
         masterKey,
       ),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("boardMessageNotificationOnFront");
+    expectZodIssue(() => decryptMember(raw, masterKey), {
+      code: "invalid_type",
+      path: ["boardMessageNotificationOnFront"],
+    });
   });
 
   it("throws when avatarSource is missing (undefined)", () => {
@@ -224,7 +253,11 @@ describe("MemberEncryptedInputSchema validation", () => {
         masterKey,
       ),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("avatarSource");
+    // `avatarSource` is a nullable discriminated union; a missing-field
+    // could legitimately be reported as invalid_type, invalid_union, or
+    // another code depending on Zod's error preference. Keep the message
+    // regex to stay tolerant.
+    expect(() => decryptMember(raw, masterKey)).toThrow(/avatarSource/);
   });
 
   it("throws when colors is missing (undefined)", () => {
@@ -254,7 +287,10 @@ describe("MemberEncryptedInputSchema validation", () => {
         masterKey,
       ),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("colors");
+    expectZodIssue(() => decryptMember(raw, masterKey), {
+      code: "invalid_type",
+      path: ["colors"],
+    });
   });
 
   it("throws when saturationLevel is missing (undefined)", () => {
@@ -284,13 +320,18 @@ describe("MemberEncryptedInputSchema validation", () => {
         masterKey,
       ),
     };
-    expect(() => decryptMember(raw, masterKey)).toThrow("saturationLevel");
+    // `saturationLevel` is a discriminated union; missing vs wrong-discriminator
+    // could surface with distinct codes. Keep regex to stay tolerant.
+    expect(() => decryptMember(raw, masterKey)).toThrow(/saturationLevel/);
   });
 
   it("throws when tags is not an array", () => {
     const fields = { ...makeEncryptedFields(), tags: "not-an-array" };
     const raw = { ...makeServerMember(), encryptedData: encryptAndEncodeT1(fields, masterKey) };
-    expect(() => decryptMember(raw, masterKey)).toThrow("tags");
+    expectZodIssue(() => decryptMember(raw, masterKey), {
+      code: "invalid_type",
+      path: ["tags"],
+    });
   });
 });
 

--- a/packages/data/src/transforms/member.ts
+++ b/packages/data/src/transforms/member.ts
@@ -1,12 +1,14 @@
+import { MemberEncryptedInputSchema } from "@pluralscape/validation";
+
 import { decodeAndDecryptT1, encryptInput, encryptUpdate } from "./decode-blob.js";
 
 import type { KdfMasterKey } from "@pluralscape/crypto";
-import type { Archived, Member, UnixMillis } from "@pluralscape/types";
+import type { Archived, Member, MemberEncryptedFields, UnixMillis } from "@pluralscape/types";
 
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape returned by `member.get` — derived from the `Member` domain type. */
-export type MemberRaw = Omit<Member, keyof MemberEncryptedFields | "archived"> & {
+export type MemberRaw = Omit<Member, MemberEncryptedFields | "archived"> & {
   readonly encryptedData: string;
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
@@ -18,62 +20,12 @@ export interface MemberPage {
   readonly nextCursor: string | null;
 }
 
-/** The subset of Member fields stored encrypted on the server. */
-export interface MemberEncryptedFields {
-  readonly name: string;
-  readonly pronouns: readonly string[];
-  readonly description: string | null;
-  readonly avatarSource: Member["avatarSource"];
-  readonly colors: Member["colors"];
-  readonly saturationLevel: Member["saturationLevel"];
-  readonly tags: readonly Member["tags"][number][];
-  readonly suppressFriendFrontNotification: boolean;
-  readonly boardMessageNotificationOnFront: boolean;
-}
-
-/** Compile-time check: encrypted fields must be a subset of the domain type. */
-export type AssertMemberFieldsSubset =
-  MemberEncryptedFields extends Pick<Member, keyof MemberEncryptedFields> ? true : never;
-
-// ── Validator ─────────────────────────────────────────────────────────
-
-function assertMemberEncryptedFields(raw: unknown): asserts raw is MemberEncryptedFields {
-  if (raw === null || typeof raw !== "object") {
-    throw new Error("Decrypted member blob is not an object");
-  }
-  const obj = raw as Record<string, unknown>;
-  if (typeof obj["name"] !== "string") {
-    throw new Error("Decrypted member blob missing required string field: name");
-  }
-  if (!Array.isArray(obj["pronouns"])) {
-    throw new Error("Decrypted member blob missing required array field: pronouns");
-  }
-  if (obj["description"] !== null && typeof obj["description"] !== "string") {
-    throw new Error("Decrypted member blob: description must be string or null");
-  }
-  if (typeof obj["suppressFriendFrontNotification"] !== "boolean") {
-    throw new Error(
-      "Decrypted member blob missing required boolean field: suppressFriendFrontNotification",
-    );
-  }
-  if (typeof obj["boardMessageNotificationOnFront"] !== "boolean") {
-    throw new Error(
-      "Decrypted member blob missing required boolean field: boardMessageNotificationOnFront",
-    );
-  }
-  if (obj["avatarSource"] === undefined) {
-    throw new Error("Decrypted member blob missing field: avatarSource");
-  }
-  if (obj["colors"] === undefined) {
-    throw new Error("Decrypted member blob missing field: colors");
-  }
-  if (obj["saturationLevel"] === undefined) {
-    throw new Error("Decrypted member blob missing field: saturationLevel");
-  }
-  if (!Array.isArray(obj["tags"])) {
-    throw new Error("Decrypted member blob missing required array field: tags");
-  }
-}
+/**
+ * Shape passed to `encryptMemberInput()` before encryption. Derived from the
+ * `Member` domain type by picking the encrypted-field keys — single source
+ * of truth lives in `@pluralscape/types`.
+ */
+export type MemberEncryptedInput = Pick<Member, MemberEncryptedFields>;
 
 // ── Member transforms ────────────────────────────────────────────────
 
@@ -81,11 +33,12 @@ function assertMemberEncryptedFields(raw: unknown): asserts raw is MemberEncrypt
  * Decrypt a single member wire object to the canonical domain type.
  *
  * Passthrough fields (id, systemId, archived, version, createdAt, updatedAt)
- * are copied directly; all other fields are decrypted from encryptedData.
+ * are copied directly; all other fields are decrypted from encryptedData and
+ * validated by `MemberEncryptedInputSchema`.
  */
 export function decryptMember(raw: MemberRaw, masterKey: KdfMasterKey): Member | Archived<Member> {
   const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey);
-  assertMemberEncryptedFields(decrypted);
+  const validated = MemberEncryptedInputSchema.parse(decrypted);
 
   const base = {
     id: raw.id,
@@ -93,15 +46,15 @@ export function decryptMember(raw: MemberRaw, masterKey: KdfMasterKey): Member |
     version: raw.version,
     createdAt: raw.createdAt,
     updatedAt: raw.updatedAt,
-    name: decrypted.name,
-    pronouns: decrypted.pronouns,
-    description: decrypted.description,
-    avatarSource: decrypted.avatarSource,
-    colors: decrypted.colors,
-    saturationLevel: decrypted.saturationLevel,
-    tags: decrypted.tags,
-    suppressFriendFrontNotification: decrypted.suppressFriendFrontNotification,
-    boardMessageNotificationOnFront: decrypted.boardMessageNotificationOnFront,
+    name: validated.name,
+    pronouns: validated.pronouns,
+    description: validated.description,
+    avatarSource: validated.avatarSource,
+    colors: validated.colors,
+    saturationLevel: validated.saturationLevel,
+    tags: validated.tags,
+    suppressFriendFrontNotification: validated.suppressFriendFrontNotification,
+    boardMessageNotificationOnFront: validated.boardMessageNotificationOnFront,
   };
 
   if (raw.archived) {
@@ -128,7 +81,7 @@ export function decryptMemberPage(
  * Encrypt member fields for a create mutation.
  */
 export function encryptMemberInput(
-  data: MemberEncryptedFields,
+  data: MemberEncryptedInput,
   masterKey: KdfMasterKey,
 ): { encryptedData: string } {
   return encryptInput(data, masterKey);
@@ -138,7 +91,7 @@ export function encryptMemberInput(
  * Encrypt member fields for an update mutation, including the version for optimistic locking.
  */
 export function encryptMemberUpdate(
-  data: MemberEncryptedFields,
+  data: MemberEncryptedInput,
   version: number,
   masterKey: KdfMasterKey,
 ): { encryptedData: string; version: number } {

--- a/packages/db/src/schema/pg/index.ts
+++ b/packages/db/src/schema/pg/index.ts
@@ -156,7 +156,7 @@ export type { SystemSettingsRow, NewSystemSettings } from "./system-settings.js"
 export type { ApiKeyRow, NewApiKey } from "./api-keys.js";
 
 // Audit & Lifecycle
-export type { AuditLogRow, NewAuditLog } from "./audit-log.js";
+export type { AuditLogRow, DbAuditActor, NewAuditLog } from "./audit-log.js";
 export type { LifecycleEventRow, NewLifecycleEvent } from "./lifecycle-events.js";
 
 // Safe Mode

--- a/packages/import-pk/src/mappers/member.mapper.ts
+++ b/packages/import-pk/src/mappers/member.mapper.ts
@@ -15,13 +15,13 @@ import {
 import { normalisePkColor } from "./pk-mapper-helpers.js";
 
 import type { PKMember } from "../validators/pk-payload.js";
-import type { MemberEncryptedFields } from "@pluralscape/data";
+import type { MemberEncryptedInput } from "@pluralscape/data";
 import type { MappingContext } from "@pluralscape/import-core";
 import type { CreateMemberBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
 export type PkMappedMember = Omit<z.infer<typeof CreateMemberBodySchema>, "encryptedData"> & {
-  readonly encrypted: MemberEncryptedFields;
+  readonly encrypted: MemberEncryptedInput;
   readonly archived: false;
   readonly fieldValues: readonly [];
   readonly bucketIds: readonly string[];
@@ -37,7 +37,7 @@ export function mapPkMember(pk: PKMember, ctx: MappingContext): MapperResult<PkM
     return skipped({ kind: "empty-name", reason: `member "${pk.id}" has empty name` });
   }
 
-  let colors: MemberEncryptedFields["colors"] = [];
+  let colors: MemberEncryptedInput["colors"] = [];
   if (pk.color) {
     const normalised = normalisePkColor(pk.color);
     const parsed = parseHexColor(normalised);
@@ -52,7 +52,7 @@ export function mapPkMember(pk: PKMember, ctx: MappingContext): MapperResult<PkM
     }
   }
 
-  const encrypted: MemberEncryptedFields = {
+  const encrypted: MemberEncryptedInput = {
     name: pk.name,
     description: pk.description ?? null,
     pronouns: pk.pronouns ? [pk.pronouns] : [],

--- a/packages/import-sp/src/mappers/member.mapper.ts
+++ b/packages/import-sp/src/mappers/member.mapper.ts
@@ -4,7 +4,7 @@
  * Translates an {@link SPMember} into three coupled outputs the engine
  * persists atomically:
  *
- * 1. An `encrypted` blob matching {@link MemberEncryptedFields}.
+ * 1. An `encrypted` blob matching {@link MemberEncryptedInput}.
  * 2. An array of {@link ExtractedFieldValue} rows sourced from SP's `info`
  *    map — SP stores custom-field values inline on the member document, but
  *    Pluralscape persists them separately.
@@ -28,12 +28,12 @@ import { failed, mapped, skipped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPMember } from "../sources/sp-types.js";
-import type { MemberEncryptedFields } from "@pluralscape/data";
+import type { MemberEncryptedInput } from "@pluralscape/data";
 import type { CreateMemberBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
 export type MappedMember = Omit<z.infer<typeof CreateMemberBodySchema>, "encryptedData"> & {
-  readonly encrypted: MemberEncryptedFields;
+  readonly encrypted: MemberEncryptedInput;
   readonly archived: boolean;
   readonly fieldValues: readonly ExtractedFieldValue[];
   /**
@@ -133,7 +133,7 @@ export function mapMember(sp: SPMember, ctx: MappingContext): MapperResult<Mappe
     });
   }
 
-  const encrypted: MemberEncryptedFields = {
+  const encrypted: MemberEncryptedInput = {
     name: sp.name,
     description: sp.desc ?? null,
     pronouns: sp.pronouns ? [sp.pronouns] : [],

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -17,6 +17,7 @@ import type {
   MemberServerMetadata,
   MemberWire,
 } from "./entities/member.js";
+import type { Relationship, RelationshipEncryptedFields } from "./entities/relationship.js";
 import type { System, SystemEncryptedFields } from "./entities/system.js";
 
 /**
@@ -74,5 +75,9 @@ export type SotEntityManifest = {
   FieldValue: {
     domain: FieldValue;
     encryptedFields: FieldValueEncryptedFields;
+  };
+  Relationship: {
+    domain: Relationship;
+    encryptedFields: RelationshipEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -53,6 +53,7 @@ import type {
 } from "./entities/structure-entity.js";
 import type { SystemSettings, SystemSettingsEncryptedFields } from "./entities/system-settings.js";
 import type { System, SystemEncryptedFields } from "./entities/system.js";
+import type { NomenclatureEncryptedFields, NomenclatureSettings } from "./nomenclature.js";
 
 /**
  * Registry of every domain entity that participates in the types-as-SoT
@@ -153,5 +154,9 @@ export type SotEntityManifest = {
   StructureEntityAssociation: {
     domain: SystemStructureEntityAssociation;
     encryptedFields: SystemStructureEntityAssociationEncryptedFields;
+  };
+  Nomenclature: {
+    domain: NomenclatureSettings;
+    encryptedFields: NomenclatureEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -43,6 +43,7 @@ import type {
   SystemStructureEntity,
   SystemStructureEntityEncryptedFields,
 } from "./entities/structure-entity.js";
+import type { SystemSettings, SystemSettingsEncryptedFields } from "./entities/system-settings.js";
 import type { System, SystemEncryptedFields } from "./entities/system.js";
 
 /**
@@ -132,5 +133,9 @@ export type SotEntityManifest = {
   InnerworldCanvas: {
     domain: InnerWorldCanvas;
     encryptedFields: InnerWorldCanvasEncryptedFields;
+  };
+  SystemSettings: {
+    domain: SystemSettings;
+    encryptedFields: SystemSettingsEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -3,6 +3,7 @@ import type {
   AuditLogEntryServerMetadata,
   AuditLogEntryWire,
 } from "./entities/audit-log-entry.js";
+import type { CustomFront, CustomFrontEncryptedFields } from "./entities/custom-front.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
 import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
@@ -56,5 +57,9 @@ export type SotEntityManifest = {
   Group: {
     domain: Group;
     encryptedFields: GroupEncryptedFields;
+  };
+  CustomFront: {
+    domain: CustomFront;
+    encryptedFields: CustomFrontEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -9,6 +9,7 @@ import type {
   MemberServerMetadata,
   MemberWire,
 } from "./entities/member.js";
+import type { System, SystemEncryptedFields } from "./entities/system.js";
 
 /**
  * Registry of every domain entity that participates in the types-as-SoT
@@ -17,12 +18,16 @@ import type {
  * - `domain` — the full decrypted domain shape (`<Entity>`)
  * - `server` — the server-visible Drizzle row shape (`<Entity>ServerMetadata`)
  * - `wire`   — the JSON-serialized HTTP shape (`<Entity>Wire`)
+ * - `encryptedFields` — keys-union of encrypted fields
  *
  * Completeness checks in `packages/db` and `packages/validation` assert that
  * every Drizzle table and every Zod schema maps to a manifest entry, so
  * silently dropping an entity during fleet work fails CI.
  *
- * Phase 1 (pilot): Member + AuditLogEntry. Fleet (Phase 2) fills the rest.
+ * Phase 1 (pilot): Member + AuditLogEntry carry the full triple (domain +
+ * server + wire + encryptedFields). Fleet (Phase 2) currently populates
+ * only `domain` + `encryptedFields` per entity; `server` / `wire` are
+ * filled in when each entity's ServerMetadata/Wire types land.
  */
 export type SotEntityManifest = {
   Member: {
@@ -37,5 +42,9 @@ export type SotEntityManifest = {
     wire: AuditLogEntryWire;
     // Plaintext wire — no encrypted fields.
     encryptedFields: never;
+  };
+  System: {
+    domain: System;
+    encryptedFields: SystemEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -4,6 +4,10 @@ import type {
   AuditLogEntryWire,
 } from "./entities/audit-log-entry.js";
 import type { CustomFront, CustomFrontEncryptedFields } from "./entities/custom-front.js";
+import type {
+  FieldDefinition,
+  FieldDefinitionEncryptedFields,
+} from "./entities/field-definition.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
 import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
@@ -61,5 +65,9 @@ export type SotEntityManifest = {
   CustomFront: {
     domain: CustomFront;
     encryptedFields: CustomFrontEncryptedFields;
+  };
+  FieldDefinition: {
+    domain: FieldDefinition;
+    encryptedFields: FieldDefinitionEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -14,6 +14,10 @@ import type {
   FrontingSessionEncryptedFields,
 } from "./entities/fronting-session.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
+import type {
+  InnerWorldRegion,
+  InnerWorldRegionEncryptedFields,
+} from "./entities/innerworld-region.js";
 import type { LifecycleEvent, LifecycleEventEncryptedFields } from "./entities/lifecycle-event.js";
 import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
@@ -108,5 +112,9 @@ export type SotEntityManifest = {
   LifecycleEvent: {
     domain: LifecycleEvent;
     encryptedFields: LifecycleEventEncryptedFields;
+  };
+  InnerworldRegion: {
+    domain: InnerWorldRegion;
+    encryptedFields: InnerWorldRegionEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -9,6 +9,10 @@ import type {
   FieldDefinitionEncryptedFields,
 } from "./entities/field-definition.js";
 import type { FieldValue, FieldValueEncryptedFields } from "./entities/field-value.js";
+import type {
+  FrontingSession,
+  FrontingSessionEncryptedFields,
+} from "./entities/fronting-session.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
 import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
@@ -95,5 +99,9 @@ export type SotEntityManifest = {
   StructureEntity: {
     domain: SystemStructureEntity;
     encryptedFields: SystemStructureEntityEncryptedFields;
+  };
+  FrontingSession: {
+    domain: FrontingSession;
+    encryptedFields: FrontingSessionEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -15,6 +15,10 @@ import type {
 } from "./entities/fronting-session.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
 import type {
+  InnerWorldEntity,
+  InnerWorldEntityEncryptedFields,
+} from "./entities/innerworld-entity.js";
+import type {
   InnerWorldRegion,
   InnerWorldRegionEncryptedFields,
 } from "./entities/innerworld-region.js";
@@ -116,5 +120,9 @@ export type SotEntityManifest = {
   InnerworldRegion: {
     domain: InnerWorldRegion;
     encryptedFields: InnerWorldRegionEncryptedFields;
+  };
+  InnerworldEntity: {
+    domain: InnerWorldEntity;
+    encryptedFields: InnerWorldEntityEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -3,6 +3,7 @@ import type {
   AuditLogEntryServerMetadata,
   AuditLogEntryWire,
 } from "./entities/audit-log-entry.js";
+import type { Group, GroupEncryptedFields } from "./entities/group.js";
 import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
   Member,
@@ -51,5 +52,9 @@ export type SotEntityManifest = {
   MemberPhoto: {
     domain: MemberPhoto;
     encryptedFields: MemberPhotoEncryptedFields;
+  };
+  Group: {
+    domain: Group;
+    encryptedFields: GroupEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -3,6 +3,7 @@ import type {
   AuditLogEntryServerMetadata,
   AuditLogEntryWire,
 } from "./entities/audit-log-entry.js";
+import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
   Member,
   MemberEncryptedFields,
@@ -46,5 +47,9 @@ export type SotEntityManifest = {
   System: {
     domain: System;
     encryptedFields: SystemEncryptedFields;
+  };
+  MemberPhoto: {
+    domain: MemberPhoto;
+    encryptedFields: MemberPhotoEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -8,6 +8,7 @@ import type {
   FieldDefinition,
   FieldDefinitionEncryptedFields,
 } from "./entities/field-definition.js";
+import type { FieldValue, FieldValueEncryptedFields } from "./entities/field-value.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
 import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
@@ -69,5 +70,9 @@ export type SotEntityManifest = {
   FieldDefinition: {
     domain: FieldDefinition;
     encryptedFields: FieldDefinitionEncryptedFields;
+  };
+  FieldValue: {
+    domain: FieldValue;
+    encryptedFields: FieldValueEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -22,6 +22,10 @@ import type {
   SystemStructureEntityType,
   SystemStructureEntityTypeEncryptedFields,
 } from "./entities/structure-entity-type.js";
+import type {
+  SystemStructureEntity,
+  SystemStructureEntityEncryptedFields,
+} from "./entities/structure-entity.js";
 import type { System, SystemEncryptedFields } from "./entities/system.js";
 
 /**
@@ -87,5 +91,9 @@ export type SotEntityManifest = {
   StructureEntityType: {
     domain: SystemStructureEntityType;
     encryptedFields: SystemStructureEntityTypeEncryptedFields;
+  };
+  StructureEntity: {
+    domain: SystemStructureEntity;
+    encryptedFields: SystemStructureEntityEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -3,7 +3,12 @@ import type {
   AuditLogEntryServerMetadata,
   AuditLogEntryWire,
 } from "./entities/audit-log-entry.js";
-import type { Member, MemberServerMetadata, MemberWire } from "./entities/member.js";
+import type {
+  Member,
+  MemberEncryptedFields,
+  MemberServerMetadata,
+  MemberWire,
+} from "./entities/member.js";
 
 /**
  * Registry of every domain entity that participates in the types-as-SoT
@@ -20,10 +25,17 @@ import type { Member, MemberServerMetadata, MemberWire } from "./entities/member
  * Phase 1 (pilot): Member + AuditLogEntry. Fleet (Phase 2) fills the rest.
  */
 export type SotEntityManifest = {
-  Member: { domain: Member; server: MemberServerMetadata; wire: MemberWire };
+  Member: {
+    domain: Member;
+    server: MemberServerMetadata;
+    wire: MemberWire;
+    encryptedFields: MemberEncryptedFields;
+  };
   AuditLogEntry: {
     domain: AuditLogEntry;
     server: AuditLogEntryServerMetadata;
     wire: AuditLogEntryWire;
+    // Plaintext wire — no encrypted fields.
+    encryptedFields: never;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -14,6 +14,7 @@ import type {
   FrontingSessionEncryptedFields,
 } from "./entities/fronting-session.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
+import type { LifecycleEvent, LifecycleEventEncryptedFields } from "./entities/lifecycle-event.js";
 import type { MemberPhoto, MemberPhotoEncryptedFields } from "./entities/member-photo.js";
 import type {
   Member,
@@ -103,5 +104,9 @@ export type SotEntityManifest = {
   FrontingSession: {
     domain: FrontingSession;
     encryptedFields: FrontingSessionEncryptedFields;
+  };
+  LifecycleEvent: {
+    domain: LifecycleEvent;
+    encryptedFields: LifecycleEventEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -36,6 +36,10 @@ import type {
 } from "./entities/member.js";
 import type { Relationship, RelationshipEncryptedFields } from "./entities/relationship.js";
 import type {
+  SystemStructureEntityMemberLink,
+  SystemStructureEntityMemberLinkEncryptedFields,
+} from "./entities/structure-entity-member-link.js";
+import type {
   SystemStructureEntityType,
   SystemStructureEntityTypeEncryptedFields,
 } from "./entities/structure-entity-type.js";
@@ -137,5 +141,9 @@ export type SotEntityManifest = {
   SystemSettings: {
     domain: SystemSettings;
     encryptedFields: SystemSettingsEncryptedFields;
+  };
+  StructureEntityMemberLink: {
+    domain: SystemStructureEntityMemberLink;
+    encryptedFields: SystemStructureEntityMemberLinkEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -36,6 +36,10 @@ import type {
 } from "./entities/member.js";
 import type { Relationship, RelationshipEncryptedFields } from "./entities/relationship.js";
 import type {
+  SystemStructureEntityAssociation,
+  SystemStructureEntityAssociationEncryptedFields,
+} from "./entities/structure-entity-association.js";
+import type {
   SystemStructureEntityMemberLink,
   SystemStructureEntityMemberLinkEncryptedFields,
 } from "./entities/structure-entity-member-link.js";
@@ -145,5 +149,9 @@ export type SotEntityManifest = {
   StructureEntityMemberLink: {
     domain: SystemStructureEntityMemberLink;
     encryptedFields: SystemStructureEntityMemberLinkEncryptedFields;
+  };
+  StructureEntityAssociation: {
+    domain: SystemStructureEntityAssociation;
+    encryptedFields: SystemStructureEntityAssociationEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -18,6 +18,10 @@ import type {
   MemberWire,
 } from "./entities/member.js";
 import type { Relationship, RelationshipEncryptedFields } from "./entities/relationship.js";
+import type {
+  SystemStructureEntityType,
+  SystemStructureEntityTypeEncryptedFields,
+} from "./entities/structure-entity-type.js";
 import type { System, SystemEncryptedFields } from "./entities/system.js";
 
 /**
@@ -79,5 +83,9 @@ export type SotEntityManifest = {
   Relationship: {
     domain: Relationship;
     encryptedFields: RelationshipEncryptedFields;
+  };
+  StructureEntityType: {
+    domain: SystemStructureEntityType;
+    encryptedFields: SystemStructureEntityTypeEncryptedFields;
   };
 };

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -15,6 +15,10 @@ import type {
 } from "./entities/fronting-session.js";
 import type { Group, GroupEncryptedFields } from "./entities/group.js";
 import type {
+  InnerWorldCanvas,
+  InnerWorldCanvasEncryptedFields,
+} from "./entities/innerworld-canvas.js";
+import type {
   InnerWorldEntity,
   InnerWorldEntityEncryptedFields,
 } from "./entities/innerworld-entity.js";
@@ -124,5 +128,9 @@ export type SotEntityManifest = {
   InnerworldEntity: {
     domain: InnerWorldEntity;
     encryptedFields: InnerWorldEntityEncryptedFields;
+  };
+  InnerworldCanvas: {
+    domain: InnerWorldCanvas;
+    encryptedFields: InnerWorldCanvasEncryptedFields;
   };
 };

--- a/packages/types/src/__tests__/sot-manifest.test.ts
+++ b/packages/types/src/__tests__/sot-manifest.test.ts
@@ -7,13 +7,16 @@ import type {
   AuditLogEntryWire,
 } from "../entities/audit-log-entry.js";
 import type { Member, MemberServerMetadata, MemberWire } from "../entities/member.js";
-import type { Equal, Extends } from "../type-assertions.js";
+import type { Extends } from "../type-assertions.js";
 
 describe("SotEntityManifest", () => {
-  it("entries carry a domain/server/wire triple", () => {
+  it("entries carry at minimum a domain + encryptedFields pair", () => {
     type Entry = SotEntityManifest[keyof SotEntityManifest];
+    // Phase 2 fleet entries have the partial shape (domain + encryptedFields
+    // only). Pilot entries (Member, AuditLogEntry) additionally carry
+    // `server` and `wire` — asserted individually below.
     expectTypeOf<
-      Extends<Entry, { domain: unknown; server: unknown; wire: unknown }>
+      Extends<Entry, { domain: unknown; encryptedFields: unknown }>
     >().toEqualTypeOf<true>();
   });
 
@@ -31,9 +34,9 @@ describe("SotEntityManifest", () => {
     expectTypeOf<SotEntityManifest["AuditLogEntry"]["wire"]>().toEqualTypeOf<AuditLogEntryWire>();
   });
 
-  it("contains exactly the pilot entities during Phase 1", () => {
+  it("includes the pilot entities", () => {
     expectTypeOf<
-      Equal<keyof SotEntityManifest, "Member" | "AuditLogEntry">
+      Extends<"Member" | "AuditLogEntry", keyof SotEntityManifest>
     >().toEqualTypeOf<true>();
   });
 });

--- a/packages/types/src/encryption-primitives.ts
+++ b/packages/types/src/encryption-primitives.ts
@@ -68,7 +68,7 @@ export type BucketEncrypted<T> = T & { readonly [__encTier]: 2 };
 // T3 is plaintext — no wrapper needed. Fields at T3 appear as plain types
 // in server-side interfaces (see tier map at bottom of file).
 
-declare const __plaintext: unique symbol;
+export declare const __plaintext: unique symbol;
 
 /** Marks a value as having been decrypted — used to track provenance in audit logs. */
 export type Plaintext<T> = T & { readonly [__plaintext]: true };

--- a/packages/types/src/entities/custom-front.ts
+++ b/packages/types/src/entities/custom-front.ts
@@ -12,5 +12,14 @@ export interface CustomFront extends AuditMetadata {
   readonly archived: false;
 }
 
+/**
+ * Keys of `CustomFront` that are encrypted client-side before the server
+ * sees them. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextCustomFront parity)
+ * - Plan 2 fleet will consume when deriving `CustomFrontServerMetadata`.
+ */
+export type CustomFrontEncryptedFields = "name" | "description" | "color" | "emoji";
+
 /** An archived custom front — preserves all data with archive metadata. */
 export type ArchivedCustomFront = Archived<CustomFront>;

--- a/packages/types/src/entities/field-definition.ts
+++ b/packages/types/src/entities/field-definition.ts
@@ -35,6 +35,15 @@ export interface FieldDefinition extends AuditMetadata {
   readonly archived: false;
 }
 
+/**
+ * Keys of `FieldDefinition` that are encrypted client-side before the server
+ * sees them. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextFieldDefinition parity)
+ * - Plan 2 fleet will consume when deriving `FieldDefinitionServerMetadata`.
+ */
+export type FieldDefinitionEncryptedFields = "name" | "description" | "options";
+
 /** An archived field definition. */
 export type ArchivedFieldDefinition = Archived<FieldDefinition>;
 

--- a/packages/types/src/entities/field-value.ts
+++ b/packages/types/src/entities/field-value.ts
@@ -28,6 +28,17 @@ export interface FieldValue extends AuditMetadata {
   readonly value: FieldValueUnion;
 }
 
+/**
+ * Keys of `FieldValue` that are encrypted client-side before the server sees
+ * them. The encrypted payload carries the `value` discriminated union
+ * (`FieldValueUnion` — `{fieldType, value}`), so only `value` rides encrypted.
+ * Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextFieldValue parity)
+ * - Plan 2 fleet will consume when deriving `FieldValueServerMetadata`.
+ */
+export type FieldValueEncryptedFields = "value";
+
 /** Request body for setting a field value. */
 export interface SetFieldValueBody {
   readonly encryptedData: string;

--- a/packages/types/src/entities/fronting-session.ts
+++ b/packages/types/src/entities/fronting-session.ts
@@ -44,6 +44,22 @@ export interface CompletedFrontingSession extends FrontingSessionBase {
 /** A fronting session — discriminated on `endTime` (null = active). */
 export type FrontingSession = ActiveFrontingSession | CompletedFrontingSession;
 
+/**
+ * Keys of `FrontingSession` that are encrypted client-side before the
+ * server sees them. Plaintext siblings (`memberId`, `customFrontId`,
+ * `structureEntityId`, `startTime`, `endTime`) travel as separate request
+ * fields and are intentionally excluded. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextFrontingSession parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `FrontingSessionServerMetadata`.
+ */
+export type FrontingSessionEncryptedFields =
+  | "comment"
+  | "positionality"
+  | "outtrigger"
+  | "outtriggerSentiment";
+
 /** An archived fronting session. */
 export type ArchivedFrontingSession = Archived<FrontingSession>;
 

--- a/packages/types/src/entities/group.ts
+++ b/packages/types/src/entities/group.ts
@@ -16,6 +16,15 @@ export interface Group extends AuditMetadata {
   readonly archived: false;
 }
 
+/**
+ * Keys of `Group` that are encrypted client-side before the server sees
+ * them. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextGroup parity)
+ * - Plan 2 fleet will consume when deriving `GroupServerMetadata`.
+ */
+export type GroupEncryptedFields = "name" | "description" | "imageSource" | "color" | "emoji";
+
 /** An archived group — preserves all data with archive metadata. */
 export type ArchivedGroup = Archived<Group>;
 

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -37,7 +37,7 @@ export type * from "./journal-entry.js";
 export type * from "./key-grant.js";
 export type * from "./lifecycle-event.js";
 export type * from "./member-photo.js";
-export type * from "./member.js";
+export * from "./member.js";
 export type * from "./message.js";
 export * from "./note.js";
 export type * from "./notification-config.js";

--- a/packages/types/src/entities/innerworld-canvas.ts
+++ b/packages/types/src/entities/innerworld-canvas.ts
@@ -8,3 +8,14 @@ export interface InnerWorldCanvas {
   readonly zoom: number;
   readonly dimensions: { readonly width: number; readonly height: number };
 }
+
+/**
+ * Keys of `InnerWorldCanvas` that are encrypted client-side before the
+ * server sees them. `systemId` is a route parameter (not in the request
+ * body) and is intentionally excluded. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextInnerworldCanvas parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `InnerWorldCanvasServerMetadata`.
+ */
+export type InnerWorldCanvasEncryptedFields = "viewportX" | "viewportY" | "zoom" | "dimensions";

--- a/packages/types/src/entities/innerworld-entity.ts
+++ b/packages/types/src/entities/innerworld-entity.ts
@@ -59,3 +59,26 @@ export type ArchivedInnerWorldEntity = Archived<InnerWorldEntity>;
 
 /** The set of valid innerworld entity type strings. */
 export type InnerWorldEntityType = InnerWorldEntity["entityType"];
+
+/**
+ * Keys of `InnerWorldEntity` (across all variants) that are encrypted
+ * client-side before the server sees them. `regionId` is a plaintext
+ * sibling (server needs it for hierarchy queries) and is intentionally
+ * excluded. Because `InnerWorldEntity` is a discriminated union, callers
+ * must use a distributive pick (e.g.
+ * `T extends unknown ? Pick<T, K & keyof T> : never`) when deriving the
+ * plaintext projection. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextInnerworldEntity parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `InnerWorldEntityServerMetadata`.
+ */
+export type InnerWorldEntityEncryptedFields =
+  | "entityType"
+  | "positionX"
+  | "positionY"
+  | "visual"
+  | "name"
+  | "description"
+  | "linkedMemberId"
+  | "linkedStructureEntityId";

--- a/packages/types/src/entities/innerworld-region.ts
+++ b/packages/types/src/entities/innerworld-region.ts
@@ -16,5 +16,22 @@ export interface InnerWorldRegion extends AuditMetadata {
   readonly archived: false;
 }
 
+/**
+ * Keys of `InnerWorldRegion` that are encrypted client-side before the
+ * server sees them. `parentRegionId` is a plaintext sibling (server needs
+ * it for hierarchy queries) and is intentionally excluded. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextInnerworldRegion parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `InnerWorldRegionServerMetadata`.
+ */
+export type InnerWorldRegionEncryptedFields =
+  | "name"
+  | "description"
+  | "visual"
+  | "boundaryData"
+  | "accessType"
+  | "gatekeeperMemberIds";
+
 /** An archived innerworld region. */
 export type ArchivedInnerWorldRegion = Archived<InnerWorldRegion>;

--- a/packages/types/src/entities/lifecycle-event.ts
+++ b/packages/types/src/entities/lifecycle-event.ts
@@ -134,3 +134,16 @@ export type LifecycleEvent =
 
 /** The set of valid lifecycle event type strings. */
 export type LifecycleEventType = LifecycleEvent["eventType"];
+
+/**
+ * Keys of `LifecycleEvent` that are encrypted client-side before the
+ * server sees them. Plaintext siblings (`eventType`, `occurredAt`, and
+ * the event-specific `plaintextMetadata` — member/structure/entity/region
+ * IDs) travel as separate request fields and are intentionally excluded.
+ * Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextLifecycleEvent parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `LifecycleEventServerMetadata`.
+ */
+export type LifecycleEventEncryptedFields = "notes";

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -12,6 +12,15 @@ export interface MemberPhoto {
   readonly archived: false;
 }
 
+/**
+ * Keys of `MemberPhoto` that are encrypted client-side before the server
+ * sees them. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextMemberPhoto parity)
+ * - Plan 2 fleet will consume when deriving `MemberPhotoServerMetadata`.
+ */
+export type MemberPhotoEncryptedFields = "imageSource" | "sortOrder" | "caption";
+
 /** An archived member photo — preserves all data with archive metadata. */
 export type ArchivedMemberPhoto = Archived<MemberPhoto>;
 

--- a/packages/types/src/entities/member.ts
+++ b/packages/types/src/entities/member.ts
@@ -63,6 +63,28 @@ export interface Member extends AuditMetadata {
   readonly archived: false;
 }
 
+/**
+ * Keys of `Member` that are encrypted client-side before the server sees them.
+ * T1 fields are encrypted with the system master key; T2 fields (`avatarSource`)
+ * are encrypted with the bucket key. Both tiers are zero-knowledge from the
+ * server's perspective — the server only ever stores opaque ciphertext.
+ *
+ * This keys-union is consumed by:
+ * - `MemberServerMetadata` (derived via `Omit`)
+ * - `MemberEncryptedInput` in `packages/data` (derived via `Pick`)
+ * - `PlaintextMember` OpenAPI parity in `scripts/openapi-wire-parity.type-test.ts`
+ */
+export type MemberEncryptedFields =
+  | "name"
+  | "pronouns"
+  | "description"
+  | "avatarSource"
+  | "colors"
+  | "saturationLevel"
+  | "tags"
+  | "suppressFriendFrontNotification"
+  | "boardMessageNotificationOnFront";
+
 /** An archived member — preserves all data with archive metadata. */
 export type ArchivedMember = Archived<Member>;
 
@@ -98,18 +120,18 @@ export interface DuplicateMemberBody {
 
 /**
  * Server-visible Member metadata — raw Drizzle row shape.
- * T1 encrypted (inside `encryptedData`): name, pronouns, description, tags,
- *   colors, avatarSource, saturationLevel, suppressFriendFrontNotification,
- *   boardMessageNotificationOnFront
- * T3 plaintext columns: id, systemId, archived, audit timestamps
+ *
+ * Derived from `Member` by stripping the encrypted field keys (bundled inside
+ * `encryptedData`) plus `archived` (the server tracks a mutable boolean with
+ * a companion `archivedAt` timestamp, while the domain uses a `false` literal
+ * that toggles to `true` via the `Archived<T>` helper). The server sees
+ * everything in `Member` EXCEPT the encrypted keys.
  */
-export interface MemberServerMetadata extends AuditMetadata {
-  readonly id: MemberId;
-  readonly systemId: SystemId;
+export type MemberServerMetadata = Omit<Member, MemberEncryptedFields | "archived"> & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
   readonly encryptedData: EncryptedBlob;
-}
+};
 
 /**
  * JSON-wire representation of a Member. Derived from the domain `Member`

--- a/packages/types/src/entities/member.ts
+++ b/packages/types/src/entities/member.ts
@@ -5,12 +5,22 @@ import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
 import type { Archived, AuditMetadata } from "../utility.js";
 
-/** Well-known saturation levels describing how elaborated a member is within the system. */
-export type KnownSaturationLevel =
-  | "fragment"
-  | "functional-fragment"
-  | "partially-elaborated"
-  | "highly-elaborated";
+/**
+ * Well-known saturation levels describing how elaborated a member is within the system.
+ *
+ * Exported as an `as const` tuple so runtime validators (Zod enums) can derive
+ * their allowed values from the same source as the TS union. This prevents
+ * enum drift: adding a new literal here automatically propagates to every
+ * consumer deriving from `KNOWN_SATURATION_LEVELS`.
+ */
+export const KNOWN_SATURATION_LEVELS = [
+  "fragment",
+  "functional-fragment",
+  "partially-elaborated",
+  "highly-elaborated",
+] as const;
+
+export type KnownSaturationLevel = (typeof KNOWN_SATURATION_LEVELS)[number];
 
 /** How elaborated a member is — either a well-known level or a user-defined custom level. */
 export type SaturationLevel =
@@ -20,25 +30,32 @@ export type SaturationLevel =
 /**
  * Well-known tags recognized by the application.
  * These have special semantics (e.g. "little" triggers Littles Safe Mode).
+ *
+ * Exported as an `as const` tuple so runtime validators (Zod enums) can derive
+ * their allowed values from the same source as the TS union — see the note on
+ * `KNOWN_SATURATION_LEVELS`.
  */
-export type KnownTag =
-  | "protector"
-  | "gatekeeper"
-  | "caretaker"
-  | "little"
-  | "age-slider"
-  | "trauma-holder"
-  | "host"
-  | "persecutor"
-  | "mediator"
-  | "anp"
-  | "memory-holder"
-  | "symptom-holder"
-  | "middle"
-  | "introject"
-  | "fictive"
-  | "factive"
-  | "non-human";
+export const KNOWN_TAGS = [
+  "protector",
+  "gatekeeper",
+  "caretaker",
+  "little",
+  "age-slider",
+  "trauma-holder",
+  "host",
+  "persecutor",
+  "mediator",
+  "anp",
+  "memory-holder",
+  "symptom-holder",
+  "middle",
+  "introject",
+  "fictive",
+  "factive",
+  "non-human",
+] as const;
+
+export type KnownTag = (typeof KNOWN_TAGS)[number];
 
 /** A tag — either a well-known tag or a user-defined custom tag. */
 export type Tag =

--- a/packages/types/src/entities/relationship.ts
+++ b/packages/types/src/entities/relationship.ts
@@ -29,4 +29,14 @@ export interface Relationship {
   readonly archived: false;
 }
 
+/**
+ * Keys of `Relationship` that are encrypted client-side before the server sees
+ * them. `sourceMemberId`, `targetMemberId`, `type`, and `bidirectional` are
+ * sent plaintext because the server needs them for querying. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextRelationship parity)
+ * - Plan 2 fleet will consume when deriving `RelationshipServerMetadata`.
+ */
+export type RelationshipEncryptedFields = "label";
+
 export type ArchivedRelationship = Archived<Relationship>;

--- a/packages/types/src/entities/structure-entity-association.ts
+++ b/packages/types/src/entities/structure-entity-association.ts
@@ -13,3 +13,17 @@ export interface SystemStructureEntityAssociation {
   readonly targetEntityId: SystemStructureEntityId;
   readonly createdAt: UnixMillis;
 }
+
+/**
+ * Keys of `SystemStructureEntityAssociation` that are encrypted
+ * client-side before the server sees them. Associations carry no
+ * encrypted payload today — every field (`sourceEntityId`,
+ * `targetEntityId`) is plaintext at the API layer — so this union is
+ * `never` and the OpenAPI `PlaintextStructureEntityAssociation` schema
+ * is an empty object. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextStructureEntityAssociation parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `SystemStructureEntityAssociationServerMetadata`.
+ */
+export type SystemStructureEntityAssociationEncryptedFields = never;

--- a/packages/types/src/entities/structure-entity-member-link.ts
+++ b/packages/types/src/entities/structure-entity-member-link.ts
@@ -15,3 +15,16 @@ export interface SystemStructureEntityMemberLink {
   readonly sortOrder: number;
   readonly createdAt: UnixMillis;
 }
+
+/**
+ * Keys of `SystemStructureEntityMemberLink` that are encrypted client-side
+ * before the server sees them. Links carry no encrypted payload today —
+ * every field is plaintext at the API layer — so this union is `never`
+ * and the OpenAPI `PlaintextStructureEntityMemberLink` schema is an empty
+ * object. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextStructureEntityMemberLink parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `SystemStructureEntityMemberLinkServerMetadata`.
+ */
+export type SystemStructureEntityMemberLinkEncryptedFields = never;

--- a/packages/types/src/entities/structure-entity-type.ts
+++ b/packages/types/src/entities/structure-entity-type.ts
@@ -27,4 +27,19 @@ export interface SystemStructureEntityType extends AuditMetadata, StructureVisua
   readonly archived: false;
 }
 
+/**
+ * Keys of `SystemStructureEntityType` that are encrypted client-side before
+ * the server sees them. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextStructureEntityType parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `SystemStructureEntityTypeServerMetadata`.
+ */
+export type SystemStructureEntityTypeEncryptedFields =
+  | "name"
+  | "description"
+  | "color"
+  | "imageSource"
+  | "emoji";
+
 export type ArchivedSystemStructureEntityType = Archived<SystemStructureEntityType>;

--- a/packages/types/src/entities/structure-entity.ts
+++ b/packages/types/src/entities/structure-entity.ts
@@ -46,4 +46,19 @@ export interface SystemStructureEntity extends AuditMetadata, StructureVisualPro
   readonly archived: false;
 }
 
+/**
+ * Keys of `SystemStructureEntity` that are encrypted client-side before
+ * the server sees them. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextStructureEntity parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `SystemStructureEntityServerMetadata`.
+ */
+export type SystemStructureEntityEncryptedFields =
+  | "name"
+  | "description"
+  | "color"
+  | "imageSource"
+  | "emoji";
+
 export type ArchivedSystemStructureEntity = Archived<SystemStructureEntity>;

--- a/packages/types/src/entities/system-settings.ts
+++ b/packages/types/src/entities/system-settings.ts
@@ -67,3 +67,28 @@ export interface SystemSettings extends AuditMetadata {
   readonly snapshotSchedule: SnapshotSchedule;
   readonly onboardingComplete: boolean;
 }
+
+/**
+ * Keys of `SystemSettings` that are encrypted client-side before the
+ * server sees them. `locale`, `defaultBucketId`, and `nomenclature` are
+ * excluded: `locale` travels as a separate plaintext field (server needs
+ * it for locale-aware operations), `defaultBucketId` is a bucket FK that
+ * the server references, and `nomenclature` has its own
+ * `PlaintextNomenclature` schema on dedicated endpoints. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextSystemSettings parity)
+ * - Plan 2 fleet will consume when deriving
+ *   `SystemSettingsServerMetadata`.
+ */
+export type SystemSettingsEncryptedFields =
+  | "theme"
+  | "fontScale"
+  | "appLock"
+  | "notifications"
+  | "syncPreferences"
+  | "privacyDefaults"
+  | "littlesSafeMode"
+  | "saturationLevelsEnabled"
+  | "autoCaptureFrontingOnJournal"
+  | "snapshotSchedule"
+  | "onboardingComplete";

--- a/packages/types/src/entities/system.ts
+++ b/packages/types/src/entities/system.ts
@@ -12,6 +12,15 @@ export interface System extends AuditMetadata {
   readonly settingsId: SystemSettingsId;
 }
 
+/**
+ * Keys of `System` that are encrypted client-side before the server sees
+ * them. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextSystem parity)
+ * - Plan 2 fleet will consume when deriving `SystemServerMetadata`.
+ */
+export type SystemEncryptedFields = "name" | "displayName" | "description" | "avatarSource";
+
 /** @future Multi-system switcher list item — not yet implemented. */
 export interface SystemListItem {
   readonly id: SystemId;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -351,6 +351,7 @@ export type {
   TermCategory,
   CanonicalTerm,
   NomenclatureSettings,
+  NomenclatureEncryptedFields,
   TermPreset,
 } from "./nomenclature.js";
 export { DEFAULT_TERM_PRESETS, createDefaultNomenclatureSettings } from "./nomenclature.js";

--- a/packages/types/src/nomenclature.ts
+++ b/packages/types/src/nomenclature.ts
@@ -23,6 +23,16 @@ export interface CanonicalTerm {
 /** Per-system nomenclature settings — one selected term per category. */
 export type NomenclatureSettings = Readonly<Record<TermCategory, string>>;
 
+/**
+ * Keys of `NomenclatureSettings` that are encrypted client-side before the
+ * server sees them. Every term category is T1-encrypted — the union is
+ * therefore identical to `TermCategory`. Consumed by:
+ * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextNomenclature parity)
+ * - Plan 2 fleet for ServerMetadata derivation.
+ */
+export type NomenclatureEncryptedFields = TermCategory;
+
 /** A set of preset options for a single term category. */
 export interface TermPreset {
   readonly category: TermCategory;

--- a/packages/types/src/type-assertions.ts
+++ b/packages/types/src/type-assertions.ts
@@ -1,3 +1,4 @@
+import { __plaintext } from "./encryption-primitives.js";
 import { __brand } from "./ids.js";
 
 /**
@@ -23,6 +24,7 @@ export type Extends<A, B> = A extends B ? true : false;
  * - `Date`                → `string`
  * - `Uint8Array`          → `string` (base64-encoded at runtime)
  * - `Brand<T, _>`         → `T` (brand stripped, since JSON can't carry phantom types)
+ * - `Plaintext<T>`        → `Serialize<T>` (plaintext brand stripped; same rationale)
  * - `Map<K, V>`           → `Record<K extends string ? K : string, Serialize<V>>`
  * - `Set<T>`              → `Serialize<T>[]`
  * - arrays                → `Serialize<Element>[]`
@@ -40,15 +42,17 @@ export type Serialize<T> = T extends Date
     ? string
     : T extends { readonly [__brand]: unknown }
       ? ExtractPrimitive<T>
-      : T extends Map<infer K, infer V>
-        ? Record<K extends string ? K : string, Serialize<V>>
-        : T extends Set<infer U>
-          ? Serialize<U>[]
-          : T extends ReadonlyArray<infer U>
+      : T extends { readonly [__plaintext]: true }
+        ? ExtractPrimitive<T>
+        : T extends Map<infer K, infer V>
+          ? Record<K extends string ? K : string, Serialize<V>>
+          : T extends Set<infer U>
             ? Serialize<U>[]
-            : T extends object
-              ? { [K in keyof T]: Serialize<T[K]> }
-              : T;
+            : T extends ReadonlyArray<infer U>
+              ? Serialize<U>[]
+              : T extends object
+                ? { [K in keyof T]: Serialize<T[K]> }
+                : T;
 
 /** Extract the primitive type from a branded type (e.g., strip the brand marker). */
 type ExtractPrimitive<T> = T extends string

--- a/packages/validation/src/__tests__/type-parity/member.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/member.type.test.ts
@@ -12,12 +12,15 @@ import { describe, expectTypeOf, it } from "vitest";
 import type {
   CreateMemberBodySchema,
   DuplicateMemberBodySchema,
+  MemberEncryptedInputSchema,
   UpdateMemberBodySchema,
 } from "../../member.js";
 import type {
   CreateMemberBody,
   DuplicateMemberBody,
   Equal,
+  Member,
+  MemberEncryptedFields,
   UpdateMemberBody,
 } from "@pluralscape/types";
 import type { z } from "zod/v4";
@@ -38,6 +41,14 @@ describe("Member Zod parity", () => {
   it("DuplicateMemberBodySchema matches DuplicateMemberBody", () => {
     expectTypeOf<
       Equal<z.infer<typeof DuplicateMemberBodySchema>, DuplicateMemberBody>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("MemberEncryptedInputSchema matches Pick<Member, MemberEncryptedFields>", () => {
+    // Mirrors `MemberEncryptedInput` in `@pluralscape/data` without creating
+    // a reverse dependency from validation → data.
+    expectTypeOf<
+      Equal<z.infer<typeof MemberEncryptedInputSchema>, Pick<Member, MemberEncryptedFields>>
     >().toEqualTypeOf<true>();
   });
 });

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -39,8 +39,15 @@ export {
   CreateMemberBodySchema,
   UpdateMemberBodySchema,
   DuplicateMemberBodySchema,
+  MemberEncryptedInputSchema,
   MemberListQuerySchema,
 } from "./member.js";
+export {
+  HexColorSchema,
+  PlaintextImageSourceSchema,
+  PlaintextSaturationLevelSchema,
+  PlaintextTagSchema,
+} from "./plaintext-shared.js";
 export {
   CreateFieldDefinitionBodySchema,
   UpdateFieldDefinitionBodySchema,

--- a/packages/validation/src/member.ts
+++ b/packages/validation/src/member.ts
@@ -1,8 +1,37 @@
 import { z } from "zod/v4";
 
 import { brandedIdQueryParam } from "./branded-id.js";
+import {
+  HexColorSchema,
+  PlaintextImageSourceSchema,
+  PlaintextSaturationLevelSchema,
+  PlaintextTagSchema,
+} from "./plaintext-shared.js";
 import { booleanQueryParam } from "./query-params.js";
 import { MAX_ENCRYPTED_MEMBER_DATA_SIZE } from "./validation.constants.js";
+
+/**
+ * Runtime validator for the pre-encryption Member input. Every field of
+ * `MemberEncryptedInput` (in `@pluralscape/data`) must be present and
+ * well-formed. Zod compile-time parity is checked in
+ * `__tests__/type-parity/member.type.test.ts`.
+ *
+ * Replaces the hand-written `assertMemberEncryptedFields` that used to live
+ * in `packages/data/src/transforms/member.ts`.
+ */
+export const MemberEncryptedInputSchema = z
+  .object({
+    name: z.string().min(1),
+    pronouns: z.array(z.string()).readonly(),
+    description: z.string().nullable(),
+    avatarSource: PlaintextImageSourceSchema.nullable(),
+    colors: z.array(HexColorSchema).readonly(),
+    saturationLevel: PlaintextSaturationLevelSchema,
+    tags: z.array(PlaintextTagSchema).readonly(),
+    suppressFriendFrontNotification: z.boolean(),
+    boardMessageNotificationOnFront: z.boolean(),
+  })
+  .readonly();
 
 export const CreateMemberBodySchema = z
   .object({

--- a/packages/validation/src/plaintext-shared.ts
+++ b/packages/validation/src/plaintext-shared.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared Zod schemas for plaintext sub-types used across multiple entity
+ * encrypted-input schemas. Mirrors
+ * `docs/openapi/schemas/plaintext.yaml`'s `PlaintextImageSource`,
+ * `PlaintextSaturationLevel`, and `PlaintextTag`.
+ *
+ * Consumed by per-entity encrypted-input schemas (e.g.
+ * `MemberEncryptedInputSchema`). Keeping these centralised prevents drift
+ * between entities whose encrypted fields reuse the same primitives.
+ */
+
+import { z } from "zod/v4";
+
+import { brandedString } from "./branded.js";
+
+import type { HexColor, ImageSource } from "@pluralscape/types";
+
+/**
+ * Runtime validator for `ImageSource` — a discriminated union on `kind`
+ * (`"blob"` → references a stored blob via branded `BlobId`; `"external"`
+ * → a remote URL).
+ */
+export const PlaintextImageSourceSchema: z.ZodType<ImageSource> = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("blob"), blobRef: brandedString<"BlobId">() }),
+  z.object({ kind: z.literal("external"), url: z.url() }),
+]);
+
+export const PlaintextSaturationLevelSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("known"),
+    level: z.enum(["fragment", "functional-fragment", "partially-elaborated", "highly-elaborated"]),
+  }),
+  z.object({ kind: z.literal("custom"), value: z.string() }),
+]);
+
+export const PlaintextTagSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("known"),
+    tag: z.enum([
+      "protector",
+      "gatekeeper",
+      "caretaker",
+      "little",
+      "age-slider",
+      "trauma-holder",
+      "host",
+      "persecutor",
+      "mediator",
+      "anp",
+      "memory-holder",
+      "symptom-holder",
+      "middle",
+      "introject",
+      "fictive",
+      "factive",
+      "non-human",
+    ]),
+  }),
+  z.object({ kind: z.literal("custom"), value: z.string() }),
+]);
+
+/**
+ * Zod schema for a 6-digit hex color string (e.g. `#FF00AA`). Returns the
+ * value branded as {@link HexColor}.
+ */
+export const HexColorSchema: z.ZodType<HexColor> = z
+  .string()
+  .regex(/^#[0-9A-Fa-f]{6}$/, "Must be a 6-digit hex color starting with #")
+  .transform((v): HexColor => v as HexColor);

--- a/packages/validation/src/plaintext-shared.ts
+++ b/packages/validation/src/plaintext-shared.ts
@@ -9,11 +9,15 @@
  * between entities whose encrypted fields reuse the same primitives.
  */
 
+import { KNOWN_SATURATION_LEVELS, KNOWN_TAGS } from "@pluralscape/types";
 import { z } from "zod/v4";
 
 import { brandedString } from "./branded.js";
 
-import type { HexColor, ImageSource } from "@pluralscape/types";
+import type { ImageSource } from "@pluralscape/types";
+
+/** Matches a 6-digit hex color string prefixed with `#` (e.g. `#FF00AA`). */
+const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
 
 /**
  * Runtime validator for `ImageSource` — a discriminated union on `kind`
@@ -25,10 +29,15 @@ export const PlaintextImageSourceSchema: z.ZodType<ImageSource> = z.discriminate
   z.object({ kind: z.literal("external"), url: z.url() }),
 ]);
 
+// Derive Zod enums from the same `as const` tuples that back the TS unions
+// in `@pluralscape/types`. This closes the enum-drift hole: adding a new
+// literal to `KNOWN_TAGS` / `KNOWN_SATURATION_LEVELS` automatically expands
+// the accepted runtime set, and the compile-time parity test (which infers
+// types through Zod) stays in sync.
 export const PlaintextSaturationLevelSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("known"),
-    level: z.enum(["fragment", "functional-fragment", "partially-elaborated", "highly-elaborated"]),
+    level: z.enum(KNOWN_SATURATION_LEVELS),
   }),
   z.object({ kind: z.literal("custom"), value: z.string() }),
 ]);
@@ -36,34 +45,18 @@ export const PlaintextSaturationLevelSchema = z.discriminatedUnion("kind", [
 export const PlaintextTagSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("known"),
-    tag: z.enum([
-      "protector",
-      "gatekeeper",
-      "caretaker",
-      "little",
-      "age-slider",
-      "trauma-holder",
-      "host",
-      "persecutor",
-      "mediator",
-      "anp",
-      "memory-holder",
-      "symptom-holder",
-      "middle",
-      "introject",
-      "fictive",
-      "factive",
-      "non-human",
-    ]),
+    tag: z.enum(KNOWN_TAGS),
   }),
   z.object({ kind: z.literal("custom"), value: z.string() }),
 ]);
 
 /**
- * Zod schema for a 6-digit hex color string (e.g. `#FF00AA`). Returns the
- * value branded as {@link HexColor}.
+ * Zod schema for a 6-digit hex color string (e.g. `#FF00AA`). Uses
+ * `brandedString<"HexColor">()` to match the `BlobId` idiom above — the
+ * phantom brand is carried through without an `as` cast — and layers the
+ * hex-format check as a `refine`.
  */
-export const HexColorSchema: z.ZodType<HexColor> = z
-  .string()
-  .regex(/^#[0-9A-Fa-f]{6}$/, "Must be a 6-digit hex color starting with #")
-  .transform((v): HexColor => v as HexColor);
+export const HexColorSchema = brandedString<"HexColor">().refine(
+  (v) => HEX_COLOR_REGEX.test(v),
+  "Must be a 6-digit hex color starting with #",
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,9 @@ importers:
       '@pluralscape/types':
         specifier: workspace:*
         version: link:../types
+      '@pluralscape/validation':
+        specifier: workspace:*
+        version: link:../validation
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.99.2(react@19.2.5)

--- a/scripts/openapi-wire-parity.negative-test.ts
+++ b/scripts/openapi-wire-parity.negative-test.ts
@@ -1,0 +1,38 @@
+// scripts/openapi-wire-parity.negative-test.ts
+//
+// Deliberate-mismatch fixture. Proves the PlaintextX parity gate fails
+// when the domain side doesn't match the OpenAPI side. Without this
+// fixture, a silently-broken `Equal<>` assertion (e.g., resolving to
+// `any` on one side) would pass while catching no drift.
+//
+// NOT compiled by `pnpm types:check-sot` — that file walks the
+// `openapi-wire-parity.type-test.ts` file and asserts the monorepo
+// typechecks. This fixture is invoked separately:
+//
+//   pnpm exec tsc --noEmit scripts/openapi-wire-parity.negative-test.ts
+//
+// Expected behavior: exit 0 (the `@ts-expect-error` directive consumes
+// the mismatch error). If someone breaks the parity helpers so the
+// mismatch no longer fails, the `@ts-expect-error` becomes unused and
+// this file fails to compile loudly.
+
+import type { components } from "../packages/api-client/src/generated/api-types.js";
+import type { Equal, Member, Serialize } from "../packages/types/src/index.js";
+
+// Deliberately wrong: include only "name" in the Pick instead of all encrypted fields.
+// `Equal<>` must resolve to `false`, which makes `true` not assignable.
+type _DeliberateMismatch = Equal<
+  components["schemas"]["PlaintextMember"],
+  Serialize<Pick<Member, "name">>
+>;
+
+// @ts-expect-error — the equality above MUST resolve to `false`. This line
+// asserts `true` against the `false` type, which requires the directive.
+// If the parity helpers are broken so the mismatch resolves to `true` (or
+// `boolean`, or `any`), the directive becomes unused and this file fails
+// to compile — alerting the developer that the gate is no longer live.
+const _mustFail: _DeliberateMismatch = true;
+
+// Silence unused-var lint — `_mustFail` exists only to trigger the
+// expect-error above.
+void _mustFail;

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -18,12 +18,10 @@
  * shared `EncryptedEntity` envelope parity below is the real tripwire
  * for the wire shape every encrypted response rides on.
  *
- * `AuditLogEntry` diverges from the domain on field names
- * (`timestamp` vs `createdAt`), extra fields (`resourceType`,
- * `resourceId`), and actor shape (`string | null` vs the
- * `AuditActor` tagged union). Aligning these requires either updating
- * the OpenAPI spec or restructuring the domain type — out of scope
- * for the types-tef0 Member pilot.
+ * `AuditLogEntry` is plaintext on the wire (not encrypted), so the
+ * OpenAPI schema structurally matches the domain type directly and a
+ * real `Equal<components["schemas"]["AuditLogEntry"],
+ * Serialize<AuditLogEntry>>` compile-time check is enforced below.
  *
  * What this file enforces right now:
  *  - `MemberWire ≡ Serialize<Member>` (self-consistency of the helper).
@@ -35,6 +33,8 @@
  *  - `components["schemas"]["PlaintextMember"]` structurally equals
  *    `Serialize<Pick<Member, MemberEncryptedFields>>` — the pre-encryption
  *    contract derived directly from the domain.
+ *  - `components["schemas"]["AuditLogEntry"]` structurally equals
+ *    `Serialize<AuditLogEntry>` — plaintext-wire parity for the audit log.
  *
  * Adding a bogus field on either side of any assertion will fail the gate
  * — see `pnpm types:check-sot`.
@@ -96,4 +96,13 @@ expectTypeOf<
 
 expectTypeOf<
   Equal<components["schemas"]["PlaintextMember"], Serialize<Pick<Member, MemberEncryptedFields>>>
+>().toEqualTypeOf<true>();
+
+// ── OpenAPI ↔ domain parity: AuditLogEntry (plaintext wire) ─────────
+//
+// AuditLogEntry is plaintext on the wire (not encrypted), so the OpenAPI
+// schema structurally matches the domain type directly.
+
+expectTypeOf<
+  Equal<components["schemas"]["AuditLogEntry"], Serialize<AuditLogEntry>>
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -77,6 +77,8 @@ import type {
   SystemSettingsEncryptedFields,
   SystemStructureEntity,
   SystemStructureEntityEncryptedFields,
+  SystemStructureEntityMemberLink,
+  SystemStructureEntityMemberLinkEncryptedFields,
   SystemStructureEntityType,
   SystemStructureEntityTypeEncryptedFields,
 } from "../packages/types/src/index.js";
@@ -250,5 +252,24 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextSystemSettings"],
     Serialize<Pick<SystemSettings, SystemSettingsEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+// `SystemStructureEntityMemberLink` carries no encrypted fields today —
+// its encrypted-fields union is `never`, so the projection is the empty
+// object. openapi-typescript emits `Record<string, never>` for a schema
+// with `properties: {}`, which is semantically "no fields" and matches
+// `Pick<T, never>` once we collapse both to that canonical empty shape.
+type EmptyEncryptedProjection<T, K extends keyof T> = [K] extends [never]
+  ? Record<string, never>
+  : Serialize<Pick<T, K>>;
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextStructureEntityMemberLink"],
+    EmptyEncryptedProjection<
+      SystemStructureEntityMemberLink,
+      SystemStructureEntityMemberLinkEncryptedFields
+    >
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -58,6 +58,8 @@ import type {
   MemberPhoto,
   MemberPhotoEncryptedFields,
   MemberWire,
+  Relationship,
+  RelationshipEncryptedFields,
   Serialize,
   System,
   SystemEncryptedFields,
@@ -155,6 +157,13 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextMemberPhoto"],
     Serialize<Pick<MemberPhoto, MemberPhotoEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextRelationship"],
+    Serialize<Pick<Relationship, RelationshipEncryptedFields>>
   >
 >().toEqualTypeOf<true>();
 

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -55,6 +55,8 @@ import type {
   FrontingSessionEncryptedFields,
   Group,
   GroupEncryptedFields,
+  InnerWorldRegion,
+  InnerWorldRegionEncryptedFields,
   LifecycleEvent,
   LifecycleEventEncryptedFields,
   Member,
@@ -204,5 +206,12 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextLifecycleEvent"],
     Serialize<Pick<LifecycleEvent, LifecycleEventEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextInnerworldRegion"],
+    Serialize<Pick<InnerWorldRegion, InnerWorldRegionEncryptedFields>>
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -51,6 +51,8 @@ import type {
   FieldDefinitionEncryptedFields,
   FieldValue,
   FieldValueEncryptedFields,
+  FrontingSession,
+  FrontingSessionEncryptedFields,
   Group,
   GroupEncryptedFields,
   Member,
@@ -186,5 +188,12 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextStructureEntity"],
     Serialize<Pick<SystemStructureEntity, SystemStructureEntityEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextFrontingSession"],
+    Serialize<Pick<FrontingSession, FrontingSessionEncryptedFields>>
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -76,6 +76,8 @@ import type {
   SystemSettings,
   SystemSettingsEncryptedFields,
   SystemStructureEntity,
+  SystemStructureEntityAssociation,
+  SystemStructureEntityAssociationEncryptedFields,
   SystemStructureEntityEncryptedFields,
   SystemStructureEntityMemberLink,
   SystemStructureEntityMemberLinkEncryptedFields,
@@ -270,6 +272,16 @@ expectTypeOf<
     EmptyEncryptedProjection<
       SystemStructureEntityMemberLink,
       SystemStructureEntityMemberLinkEncryptedFields
+    >
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextStructureEntityAssociation"],
+    EmptyEncryptedProjection<
+      SystemStructureEntityAssociation,
+      SystemStructureEntityAssociationEncryptedFields
     >
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -47,6 +47,8 @@ import type {
   CustomFront,
   CustomFrontEncryptedFields,
   Equal,
+  FieldDefinition,
+  FieldDefinitionEncryptedFields,
   Group,
   GroupEncryptedFields,
   Member,
@@ -126,6 +128,13 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextCustomFront"],
     Serialize<Pick<CustomFront, CustomFrontEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextFieldDefinition"],
+    Serialize<Pick<FieldDefinition, FieldDefinitionEncryptedFields>>
   >
 >().toEqualTypeOf<true>();
 

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -55,6 +55,8 @@ import type {
   FrontingSessionEncryptedFields,
   Group,
   GroupEncryptedFields,
+  InnerWorldEntity,
+  InnerWorldEntityEncryptedFields,
   InnerWorldRegion,
   InnerWorldRegionEncryptedFields,
   LifecycleEvent,
@@ -213,5 +215,22 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextInnerworldRegion"],
     Serialize<Pick<InnerWorldRegion, InnerWorldRegionEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+// `InnerWorldEntity` is a discriminated union whose variants carry
+// different encrypted keys — a plain `Pick<Union, K>` would only accept
+// keys present on *every* variant. `DistributivePick` distributes the
+// pick over each member, intersecting the requested key-set with that
+// member's own keys, so each variant contributes only the fields it
+// actually owns.
+type DistributivePick<T, K extends PropertyKey> = T extends unknown
+  ? Pick<T, Extract<keyof T, K>>
+  : never;
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextInnerworldEntity"],
+    Serialize<DistributivePick<InnerWorldEntity, InnerWorldEntityEncryptedFields>>
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -7,34 +7,45 @@
  *
  * Typechecked via `pnpm types:check-sot`.
  *
- * ── Scope and deferrals ──────────────────────────────────────────────
+ * ── Scope ────────────────────────────────────────────────────────────
  *
- * `MemberResponse` parity is intentionally not asserted here. OpenAPI
- * models `encryptedData` as an opaque `string` (the base64-encoded
- * envelope on the wire), while `MemberServerMetadata.encryptedData` is
- * the structured `EncryptedBlob` discriminated union (pre-serialization).
- * A direct `Equal<components["schemas"]["MemberResponse"],
- * Serialize<MemberServerMetadata>>` assertion would fail by design. The
- * shared `EncryptedEntity` envelope parity below is the real tripwire
- * for the wire shape every encrypted response rides on.
+ * Every `<X>Response` has two parts:
+ *  1. The opaque `encryptedData` field — `string` on the wire but a
+ *     structured `EncryptedBlob` discriminated union in the domain. The
+ *     asymmetry is at an encode/decode boundary that cannot be
+ *     structurally equated.
+ *  2. Every OTHER field (plaintext columns the server sees) — ids,
+ *     timestamps, `version`, `archived`/`archivedAt`, plus per-entity
+ *     denormalized additions (e.g. `FrontingSessionResponse.structureEntityId`).
+ *     These ARE fully structurally assertable.
+ *
+ * Per-entity plaintext-column parity therefore takes a split form — see
+ * the Member block below. This is the canonical fleet pattern: every
+ * renamed entity replicates the split (`Omit<..., "encryptedData">`
+ * equality + `<X>Response["encryptedData"] extends string`).
+ *
+ * The shared `EncryptedEntity` envelope parity serves as the canonical
+ * tripwire for the envelope shape itself (the set of plaintext columns
+ * every T1 response rides on). If the envelope drifts, every per-entity
+ * assertion will also trip — the envelope check localizes the diagnosis.
  *
  * `AuditLogEntry` is plaintext on the wire (not encrypted), so the
- * OpenAPI schema structurally matches the domain type directly and a
- * real `Equal<components["schemas"]["AuditLogEntry"],
- * Serialize<AuditLogEntry>>` compile-time check is enforced below.
+ * OpenAPI schema structurally matches the domain type directly via
+ * `Equal<components["schemas"]["AuditLogEntry"], Serialize<AuditLogEntry>>`.
  *
- * What this file enforces right now:
+ * What this file enforces:
  *  - `MemberWire ≡ Serialize<Member>` (self-consistency of the helper).
  *  - `AuditLogEntryWire ≡ Serialize<AuditLogEntry>` (same).
- *  - `components["schemas"]["EncryptedEntity"]` is structurally equal to the
- *    hand-authored `EncryptedEntityWire` mirror below — a real OpenAPI→
- *    domain parity tripwire for the shared envelope that every T1 response
- *    (including Member) rides on.
+ *  - `components["schemas"]["EncryptedEntity"]` structurally equals the
+ *    hand-authored `EncryptedEntityWire` mirror below — canonical envelope
+ *    tripwire.
+ *  - `MemberResponse` plaintext columns (split parity, see Member block).
  *  - `components["schemas"]["PlaintextMember"]` structurally equals
  *    `Serialize<Pick<Member, MemberEncryptedFields>>` — the pre-encryption
  *    contract derived directly from the domain.
  *  - `components["schemas"]["AuditLogEntry"]` structurally equals
  *    `Serialize<AuditLogEntry>` — plaintext-wire parity for the audit log.
+ *  - `PlaintextX` parity for every fleet-renamed entity.
  *
  * Adding a bogus field on either side of any assertion will fail the gate
  * — see `pnpm types:check-sot`.
@@ -67,6 +78,7 @@ import type {
   MemberEncryptedFields,
   MemberPhoto,
   MemberPhotoEncryptedFields,
+  MemberServerMetadata,
   MemberWire,
   NomenclatureEncryptedFields,
   NomenclatureSettings,
@@ -115,7 +127,7 @@ interface EncryptedEntityWire {
   createdAt: number;
   updatedAt: number;
   archived: boolean;
-  archivedAt?: number | null;
+  archivedAt: number | null;
 }
 
 expectTypeOf<
@@ -133,6 +145,32 @@ expectTypeOf<
 expectTypeOf<
   Equal<components["schemas"]["PlaintextMember"], Serialize<Pick<Member, MemberEncryptedFields>>>
 >().toEqualTypeOf<true>();
+
+// ── OpenAPI ↔ domain parity: MemberResponse plaintext columns ──────
+//
+// Every <X>Response has two parts: the opaque `encryptedData` field
+// (string on wire, structured EncryptedBlob in domain — the asymmetry
+// is at an encode/decode boundary that can't be structurally equated),
+// and every other field (plaintext columns the server sees). The
+// plaintext columns ARE assertable, so we split the parity:
+//
+// Piece 1: plaintext columns on both sides, minus `encryptedData`.
+// Piece 2: `encryptedData` on the wire is opaque `string`.
+//
+// This catches per-entity plaintext column drift (e.g., `archived`
+// rename, new denormalized column added to a response). Fleet must
+// replicate this split for every renamed entity.
+
+type MemberResponseOpenApi = components["schemas"]["MemberResponse"];
+
+expectTypeOf<
+  Equal<
+    Omit<MemberResponseOpenApi, "encryptedData">,
+    Omit<Serialize<MemberServerMetadata>, "encryptedData">
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<MemberResponseOpenApi["encryptedData"]>().toEqualTypeOf<string>();
 
 // ── OpenAPI ↔ domain parity: AuditLogEntry (plaintext wire) ─────────
 //

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -55,6 +55,8 @@ import type {
   FrontingSessionEncryptedFields,
   Group,
   GroupEncryptedFields,
+  InnerWorldCanvas,
+  InnerWorldCanvasEncryptedFields,
   InnerWorldEntity,
   InnerWorldEntityEncryptedFields,
   InnerWorldRegion,
@@ -232,5 +234,12 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextInnerworldEntity"],
     Serialize<DistributivePick<InnerWorldEntity, InnerWorldEntityEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextInnerworldCanvas"],
+    Serialize<Pick<InnerWorldCanvas, InnerWorldCanvasEncryptedFields>>
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -73,6 +73,8 @@ import type {
   Serialize,
   System,
   SystemEncryptedFields,
+  SystemSettings,
+  SystemSettingsEncryptedFields,
   SystemStructureEntity,
   SystemStructureEntityEncryptedFields,
   SystemStructureEntityType,
@@ -241,5 +243,12 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextInnerworldCanvas"],
     Serialize<Pick<InnerWorldCanvas, InnerWorldCanvasEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextSystemSettings"],
+    Serialize<Pick<SystemSettings, SystemSettingsEncryptedFields>>
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -49,6 +49,8 @@ import type {
   Equal,
   FieldDefinition,
   FieldDefinitionEncryptedFields,
+  FieldValue,
+  FieldValueEncryptedFields,
   Group,
   GroupEncryptedFields,
   Member,
@@ -135,6 +137,13 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextFieldDefinition"],
     Serialize<Pick<FieldDefinition, FieldDefinitionEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextFieldValue"],
+    Serialize<Pick<FieldValue, FieldValueEncryptedFields>>
   >
 >().toEqualTypeOf<true>();
 

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -63,6 +63,8 @@ import type {
   Serialize,
   System,
   SystemEncryptedFields,
+  SystemStructureEntityType,
+  SystemStructureEntityTypeEncryptedFields,
 } from "../packages/types/src/index.js";
 import { expectTypeOf } from "vitest";
 
@@ -169,4 +171,11 @@ expectTypeOf<
 
 expectTypeOf<
   Equal<components["schemas"]["PlaintextSystem"], Serialize<Pick<System, SystemEncryptedFields>>>
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextStructureEntityType"],
+    Serialize<Pick<SystemStructureEntityType, SystemStructureEntityTypeEncryptedFields>>
+  >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -47,6 +47,8 @@ import type {
   Equal,
   Member,
   MemberEncryptedFields,
+  MemberPhoto,
+  MemberPhotoEncryptedFields,
   MemberWire,
   Serialize,
   System,
@@ -115,6 +117,13 @@ expectTypeOf<
 // structurally equals `Serialize<Pick<<Entity>, <Entity>EncryptedFields>>`
 // — the single source of truth for the client-encrypted payload contract.
 // Sorted alphabetically by entity.
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextMemberPhoto"],
+    Serialize<Pick<MemberPhoto, MemberPhotoEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
 
 expectTypeOf<
   Equal<components["schemas"]["PlaintextSystem"], Serialize<Pick<System, SystemEncryptedFields>>>

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -63,6 +63,8 @@ import type {
   Serialize,
   System,
   SystemEncryptedFields,
+  SystemStructureEntity,
+  SystemStructureEntityEncryptedFields,
   SystemStructureEntityType,
   SystemStructureEntityTypeEncryptedFields,
 } from "../packages/types/src/index.js";
@@ -177,5 +179,12 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextStructureEntityType"],
     Serialize<Pick<SystemStructureEntityType, SystemStructureEntityTypeEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextStructureEntity"],
+    Serialize<Pick<SystemStructureEntity, SystemStructureEntityEncryptedFields>>
   >
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -9,35 +9,35 @@
  *
  * ── Scope and deferrals ──────────────────────────────────────────────
  *
- * Two parity gaps were identified during Task 17 and deferred to
- * follow-up bean `types-tef0`:
+ * `MemberResponse` parity is intentionally not asserted here. OpenAPI
+ * models `encryptedData` as an opaque `string` (the base64-encoded
+ * envelope on the wire), while `MemberServerMetadata.encryptedData` is
+ * the structured `EncryptedBlob` discriminated union (pre-serialization).
+ * A direct `Equal<components["schemas"]["MemberResponse"],
+ * Serialize<MemberServerMetadata>>` assertion would fail by design. The
+ * shared `EncryptedEntity` envelope parity below is the real tripwire
+ * for the wire shape every encrypted response rides on.
  *
- * 1. `Member`: the OpenAPI spec exposes the on-the-wire *encrypted* entity
- *    (`MemberResponse = EncryptedEntity`). The domain `Member` type is the
- *    post-decryption client-side shape, so `Serialize<Member>` (a.k.a.
- *    `MemberWire`) lives at a different layer than what HTTP carries. A
- *    direct `Equal<components["schemas"]["MemberResponse"], MemberWire>`
- *    would fail by design. Resolving this requires either a distinct
- *    `MemberEncryptedWire` aliased to `EncryptedEntity`, or wiring plaintext
- *    (T1) shapes into the OpenAPI spec — outside pilot scope.
+ * `AuditLogEntry` diverges from the domain on field names
+ * (`timestamp` vs `createdAt`), extra fields (`resourceType`,
+ * `resourceId`), and actor shape (`string | null` vs the
+ * `AuditActor` tagged union). Aligning these requires either updating
+ * the OpenAPI spec or restructuring the domain type — out of scope
+ * for the types-tef0 Member pilot.
  *
- * 2. `AuditLogEntry`: the OpenAPI shape diverges from the domain on field
- *    names (`timestamp` vs `createdAt`), extra fields (`resourceType`,
- *    `resourceId`), and actor shape (`string | null` vs the
- *    `AuditActor` tagged union). Aligning these requires either updating
- *    the OpenAPI spec or restructuring the domain type — both are
- *    structural changes beyond Task 17 scope.
- *
- * What this file *does* enforce right now:
+ * What this file enforces right now:
  *  - `MemberWire ≡ Serialize<Member>` (self-consistency of the helper).
  *  - `AuditLogEntryWire ≡ Serialize<AuditLogEntry>` (same).
  *  - `components["schemas"]["EncryptedEntity"]` is structurally equal to the
  *    hand-authored `EncryptedEntityWire` mirror below — a real OpenAPI→
  *    domain parity tripwire for the shared envelope that every T1 response
  *    (including Member) rides on.
+ *  - `components["schemas"]["PlaintextMember"]` structurally equals
+ *    `Serialize<Pick<Member, MemberEncryptedFields>>` — the pre-encryption
+ *    contract derived directly from the domain.
  *
- * Adding a bogus field on either side of the `EncryptedEntity` assertion
- * will fail the gate — see `pnpm types:check-sot`.
+ * Adding a bogus field on either side of any assertion will fail the gate
+ * — see `pnpm types:check-sot`.
  */
 
 import type { components } from "../packages/api-client/src/generated/api-types.js";
@@ -46,6 +46,7 @@ import type {
   AuditLogEntryWire,
   Equal,
   Member,
+  MemberEncryptedFields,
   MemberWire,
   Serialize,
 } from "../packages/types/src/index.js";
@@ -68,8 +69,7 @@ expectTypeOf<Equal<AuditLogEntryWire, Serialize<AuditLogEntry>>>().toEqualTypeOf
 //
 // The mirror is kept local to this file rather than exported from
 // `@pluralscape/types` because the envelope is an API-layer concern,
-// not a domain concept. Promoting it (and aliasing `MemberResponse`
-// to it) is tracked in `types-tef0`.
+// not a domain concept.
 
 interface EncryptedEntityWire {
   id: string;
@@ -86,22 +86,14 @@ expectTypeOf<
   Equal<components["schemas"]["EncryptedEntity"], EncryptedEntityWire>
 >().toEqualTypeOf<true>();
 
-// ── Deferred: direct Member parity ──────────────────────────────────
+// ── OpenAPI ↔ domain parity: PlaintextMember ────────────────────────
 //
-// `components["schemas"]["MemberResponse"]` is `allOf: [EncryptedEntity]`
-// (see `docs/openapi.yaml`). It represents the encrypted wire entity,
-// not the decrypted domain `Member`. Tracking: bean `types-tef0`.
-//
-// Once a `MemberEncryptedWire` (aliased to `EncryptedEntity`) is
-// introduced, replace with:
-//
-//   expectTypeOf<
-//     Equal<components["schemas"]["MemberResponse"], MemberEncryptedWire>
-//   >().toEqualTypeOf<true>();
+// `components["schemas"]["PlaintextMember"]` is the client-enforced
+// pre-encryption contract. It must structurally equal the domain's
+// encrypted-field projection. `MemberEncryptedFields` (keys union) +
+// `Pick<Member, ...>` is the single source of truth; `Serialize<...>`
+// strips brands and converts timestamps so the result matches JSON.
 
-// ── Deferred: direct AuditLogEntry parity ───────────────────────────
-//
-// OpenAPI shape uses `timestamp`/`resourceType`/`resourceId`/
-// `actor: string`, whereas domain uses `createdAt`/(no resourceType)/
-// `actor: AuditActor` (tagged union). Resolving requires spec and/or
-// domain-type restructuring — tracked in bean `types-tef0`.
+expectTypeOf<
+  Equal<components["schemas"]["PlaintextMember"], Serialize<Pick<Member, MemberEncryptedFields>>>
+>().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -44,6 +44,8 @@ import type { components } from "../packages/api-client/src/generated/api-types.
 import type {
   AuditLogEntry,
   AuditLogEntryWire,
+  CustomFront,
+  CustomFrontEncryptedFields,
   Equal,
   Group,
   GroupEncryptedFields,
@@ -119,6 +121,13 @@ expectTypeOf<
 // structurally equals `Serialize<Pick<<Entity>, <Entity>EncryptedFields>>`
 // — the single source of truth for the client-encrypted payload contract.
 // Sorted alphabetically by entity.
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextCustomFront"],
+    Serialize<Pick<CustomFront, CustomFrontEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
 
 expectTypeOf<
   Equal<components["schemas"]["PlaintextGroup"], Serialize<Pick<Group, GroupEncryptedFields>>>

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -68,6 +68,8 @@ import type {
   MemberPhoto,
   MemberPhotoEncryptedFields,
   MemberWire,
+  NomenclatureEncryptedFields,
+  NomenclatureSettings,
   Relationship,
   RelationshipEncryptedFields,
   Serialize,
@@ -216,6 +218,13 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextLifecycleEvent"],
     Serialize<Pick<LifecycleEvent, LifecycleEventEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextNomenclature"],
+    Serialize<Pick<NomenclatureSettings, NomenclatureEncryptedFields>>
   >
 >().toEqualTypeOf<true>();
 

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -49,6 +49,8 @@ import type {
   MemberEncryptedFields,
   MemberWire,
   Serialize,
+  System,
+  SystemEncryptedFields,
 } from "../packages/types/src/index.js";
 import { expectTypeOf } from "vitest";
 
@@ -105,4 +107,15 @@ expectTypeOf<
 
 expectTypeOf<
   Equal<components["schemas"]["AuditLogEntry"], Serialize<AuditLogEntry>>
+>().toEqualTypeOf<true>();
+
+// ── OpenAPI ↔ domain parity: PlaintextX (fleet, Phase 2) ────────────
+//
+// For each non-pilot entity, assert that the OpenAPI `PlaintextX` schema
+// structurally equals `Serialize<Pick<<Entity>, <Entity>EncryptedFields>>`
+// — the single source of truth for the client-encrypted payload contract.
+// Sorted alphabetically by entity.
+
+expectTypeOf<
+  Equal<components["schemas"]["PlaintextSystem"], Serialize<Pick<System, SystemEncryptedFields>>>
 >().toEqualTypeOf<true>();

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -45,6 +45,8 @@ import type {
   AuditLogEntry,
   AuditLogEntryWire,
   Equal,
+  Group,
+  GroupEncryptedFields,
   Member,
   MemberEncryptedFields,
   MemberPhoto,
@@ -117,6 +119,10 @@ expectTypeOf<
 // structurally equals `Serialize<Pick<<Entity>, <Entity>EncryptedFields>>`
 // — the single source of truth for the client-encrypted payload contract.
 // Sorted alphabetically by entity.
+
+expectTypeOf<
+  Equal<components["schemas"]["PlaintextGroup"], Serialize<Pick<Group, GroupEncryptedFields>>>
+>().toEqualTypeOf<true>();
 
 expectTypeOf<
   Equal<

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -55,6 +55,8 @@ import type {
   FrontingSessionEncryptedFields,
   Group,
   GroupEncryptedFields,
+  LifecycleEvent,
+  LifecycleEventEncryptedFields,
   Member,
   MemberEncryptedFields,
   MemberPhoto,
@@ -195,5 +197,12 @@ expectTypeOf<
   Equal<
     components["schemas"]["PlaintextFrontingSession"],
     Serialize<Pick<FrontingSession, FrontingSessionEncryptedFields>>
+  >
+>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<
+    components["schemas"]["PlaintextLifecycleEvent"],
+    Serialize<Pick<LifecycleEvent, LifecycleEventEncryptedFields>>
   >
 >().toEqualTypeOf<true>();


### PR DESCRIPTION
## Summary

Makes `docs/openapi/schemas/plaintext.yaml` a compile-time-enforced contract against domain types. Adds per-entity `<Entity>EncryptedFields` keys-unions for all 20 encrypted schemas (19 entities + Nomenclature) and corresponding PlaintextX parity assertions. Reconciles the AuditLogEntry OpenAPI/domain divergence. Establishes the Member pilot pattern for Plan 2 fleet to propagate.

## What landed

### Universal (all 20 schemas)
- `<Entity>EncryptedFields` keys-union in each entity file (or `nomenclature.ts`)
- 20 `PlaintextX` parity assertions: `Equal<components["schemas"]["PlaintextX"], Serialize<Pick<X, XEncryptedFields>>>`
- `SotEntityManifest` extended with `encryptedFields` slot per entry (partial form for non-pilot entities)
- `plaintext.yaml` reconciled against domain drift (required fields, Nomenclature kebab-case keys, InnerworldEntity rewritten as `oneOf` discriminated union)

### Member pilot (reference for fleet)
- `MemberServerMetadata` refactored: `Omit<Member, MemberEncryptedFields | "archived"> & { archived: boolean; archivedAt; encryptedData: EncryptedBlob }`
- Data package: renamed hand-written `MemberEncryptedFields` interface → `MemberEncryptedInput = Pick<Member, MemberEncryptedFields>`
- Validation package: `MemberEncryptedInputSchema` Zod + parity test, new `plaintext-shared.ts`
- Replaced hand-written `assertMemberEncryptedFields` with `MemberEncryptedInputSchema.parse()`
- Closed enum-drift hole: `KNOWN_TAGS` / `KNOWN_SATURATION_LEVELS` exported as `as const` tuples
- import-sp + import-pk mappers updated to use `MemberEncryptedInput`

### AuditLogEntry
- OpenAPI rewrite: `timestamp` → `createdAt`, dropped `resourceType`/`resourceId`, added `systemId`/`detail`, `actor` → oneOf matching `AuditActor` tagged union
- Consumer sweep across apps/api + test fixtures
- Extended `Serialize<T>` to strip `Plaintext<T>` branding

### Quality gates
- Negative-test fixture `scripts/openapi-wire-parity.negative-test.ts` proves the parity helpers are live
- All 4 SoT gates green (types, Drizzle, Zod, OpenAPI-Wire)

### Plan 2 fleet preconditions
- 13-step checklist appended to `types-ltel` parent bean
- `<X>Response` per-entity parity dropped from checklist — architecturally impossible (OpenAPI models `encryptedData` as opaque `string`, domain as structured `EncryptedBlob`). Shared `EncryptedEntity` envelope parity covers the wire-shape tripwire.

## Not in scope

- Renaming `Server<X>` → `<X>ServerMetadata` for 18 non-pilot entities (Plan 2 fleet)
- Data/validation/import-package refactors for non-pilot entities (Plan 2 fleet)
- `db-drq1` (Drizzle helper branding — separate bean, planned next)

## Test plan

- [x] \`pnpm types:check-sot\` — all 4 gates green
- [x] \`pnpm turbo typecheck\` — 21 packages green
- [x] \`pnpm test:unit\` — 12736 passed
- [x] \`pnpm test:integration\` — 3058 passed
- [x] \`pnpm lint\` — zero warnings
- [x] \`pnpm format\` — clean
- [x] Negative-test fixture confirms parity gate fails on deliberate mismatch