### PR TITLE
feat(db): db-drq1 — brandedId<B>() helper for Drizzle brand lifting

### DIFF
--- a/.beans/db-drq1--lift-brands-into-shared-drizzle-column-helpers-tim.md
+++ b/.beans/db-drq1--lift-brands-into-shared-drizzle-column-helpers-tim.md
@@ -1,12 +1,39 @@
 ---
 # db-drq1
 title: Lift brands into shared Drizzle column helpers (timestamps/versioned/archivable)
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-22T22:41:09Z
-updated_at: 2026-04-22T22:41:13Z
+updated_at: 2026-04-23T12:00:48Z
 parent: types-ltel
 ---
 
 Drizzle parity tests currently strip brands via StripBrands<T> wrapper because shared helpers (timestamps(), versioned(), archivable()) return unbranded string/number columns. Fully branding them would cascade ~37 fixture-site updates across integration tests. Follow-up to the Phase 1 pilot (types-ltel): brand the helpers and update fixtures. When complete, remove the StripBrands wrapper from packages/db/src/**tests**/type-parity/\*.type.test.ts so brand-type drift is also caught.
+
+## Summary of Changes
+
+Primitives-only scope (revised from original all-30-tables plan).
+
+**Landed:**
+
+- `AnyBrandedId` union in `packages/types/src/ids.ts` (commit `8f222457`).
+- `brandedId<B>()` helper in `packages/db/src/columns/pg.ts` + `sqlite.ts` (commit `d89f91e6`). Generic constrained to `AnyBrandedId`.
+
+**Deferred to Plan 2 fleet (per-entity):**
+
+- Table conversions (each entity's Drizzle table converts in its fleet PR alongside validation + parity + OpenAPI wiring).
+- Timestamp customType brand lift (`pgTimestamp` / `sqliteTimestamp`) — defers ~1700 fixture wraps; fleet entity PRs wrap their own fixtures, or a dedicated cleanup PR flips the generics once all fleet entities land.
+- `StripBrands<>` removal from parity tests — happens per-entity as each converts.
+
+**Fleet ordering recommendation:**
+
+1. `systems` (FK ancestor).
+2. `accounts` (FK ancestor).
+3. Leaves in any order.
+
+**Why the narrow scope:**
+
+- Full-scope (30 tables) attempt: ~281 files changed, 500+ typecheck errors, codemod contamination. Reverted.
+- Four-table pilot: 100+ files because `systems`/`accounts` are FK ancestors. Reverted.
+- Primitives-only: 2 files, green tree, fleet-ready.

--- a/.beans/types-ltel--types-single-source-of-truth.md
+++ b/.beans/types-ltel--types-single-source-of-truth.md
@@ -5,7 +5,7 @@ status: in-progress
 type: epic
 priority: normal
 created_at: 2026-04-21T13:54:18Z
-updated_at: 2026-04-23T07:03:00Z
+updated_at: 2026-04-23T12:00:30Z
 parent: ps-cd6x
 ---
 
@@ -69,12 +69,34 @@ Each per-entity fleet PR must include these substeps in addition to renaming the
 3. Add `<X>Wire = Serialize<<X>>`.
 4. Delete old `Server<X>` / `Client<X>` declarations from `encryption-primitives.ts`.
 
-**Drizzle schema parity** (`packages/db/src/__tests__/type-parity/<x>.type.test.ts`): 5. Create a new parity test file asserting the Drizzle row shape structurally matches `<X>ServerMetadata`:
+**Drizzle schema conversion + parity** (`packages/db/src/schema/pg/<table>.ts` + `sqlite/<table>.ts` + `packages/db/src/__tests__/type-parity/<x>.type.test.ts`):
+
+5. **Convert the entity's Drizzle table** (both PG + SQLite dialects) to use `brandedId<B>()` for ID columns. Wrap this entity's fixture + service ID/timestamp literals with `brandId<XId>()` / `toUnixMillis()` from `@pluralscape/types`.
+
+```ts
+// packages/db/src/schema/pg/<table>.ts
+import type { <X>Id, SystemId } from "@pluralscape/types";
+import { brandedId, pgEncryptedBlob } from "../../columns/pg.js";
+
+export const <tableName> = pgTable("<table>", {
+  id: brandedId<<X>Id>("id").primaryKey(),
+  systemId: brandedId<SystemId>("system_id").notNull().references(() => systems.id, { onDelete: "cascade" }),
+  // non-ID columns unchanged
+  ...
+});
+```
+
+Note: `db-drq1` landed only the `brandedId<B>()` helper + `AnyBrandedId` union — not the table conversions themselves. Each fleet PR converts its own table.
+
+**Ordering**: convert `systems` (first fleet PR) and `accounts` (second) before leaf entities. They're FK ancestors of nearly every other table's fixtures, so leaf PRs can then rely on branded helpers without scope creep.
+
+**Timestamp lift**: `pgTimestamp` / `sqliteTimestamp` customType generics are still `{ data: number }`. Your fleet PR can either (a) wrap the timestamp literals in its own fixtures with `toUnixMillis()` (matches `brandedId` pattern, sets up future lift), or (b) leave them as plain numbers. Fleet eventually flips the generics to `{ data: UnixMillis }` — last fleet PR to complete, or a dedicated cleanup PR.
+
+6. Create a new parity test file asserting the Drizzle row shape structurally equals `<X>ServerMetadata`:
 
 ```ts
 import { describe, expectTypeOf, it } from "vitest";
 import { <tableName> } from "../../schema/pg/<table-file>.js";
-import type { StripBrands } from "./__helpers__.js";
 import type { Equal, <X>ServerMetadata } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
@@ -84,16 +106,14 @@ describe("<X> Drizzle parity", () => {
     expectTypeOf<keyof Row>().toEqualTypeOf<keyof <X>ServerMetadata>();
   });
 
-  it("row equals <X>ServerMetadata modulo brands and readonly", () => {
+  it("row equals <X>ServerMetadata", () => {
     type Row = InferSelectModel<typeof <tableName>>;
-    expectTypeOf<
-      Equal<StripBrands<Row>, StripBrands<<X>ServerMetadata>>
-    >().toEqualTypeOf<true>();
+    expectTypeOf<Equal<Row, <X>ServerMetadata>>().toEqualTypeOf<true>();
   });
 });
 ```
 
-Uses the existing `StripBrands<T>` wrapper because shared column helpers (`timestamps()`, `versioned()`, `archivable()`) return unbranded columns. `db-drq1` tracks lifting brands into the helpers so the wrapper can be removed and brand-level drift becomes caught too.
+After `db-drq1`, Drizzle column helpers return branded types directly — no `StripBrands<>` wrapper needed. Brand drift between Drizzle and domain is caught at compile time. The `StripBrands<T>` helper in `__helpers__.js` can be deleted once all fleet entities have converted and all parity tests are strict.
 
 **Parity test** (`scripts/openapi-wire-parity.type-test.ts`): 6. Add split-form encrypted-wire parity for the entity:
 

--- a/packages/db/src/columns/pg.ts
+++ b/packages/db/src/columns/pg.ts
@@ -1,7 +1,9 @@
 import { deserializeEncryptedBlob, serializeEncryptedBlob } from "@pluralscape/crypto";
-import { customType } from "drizzle-orm/pg-core";
+import { customType, varchar } from "drizzle-orm/pg-core";
 
-import type { EncryptedBlob } from "@pluralscape/types";
+import { ID_MAX_LENGTH } from "../helpers/db.constants.js";
+
+import type { AnyBrandedId, EncryptedBlob } from "@pluralscape/types";
 
 const JSON_PREVIEW_LENGTH = 100;
 
@@ -106,3 +108,25 @@ export const pgJsonb = customType<{ data: unknown; driverData: string }>({
   toDriver: jsonToDriver,
   fromDriver: jsonFromDriver,
 });
+
+/**
+ * Internal factory — returns a Drizzle varchar column builder with
+ * `.$type<B>()` applied. Exists to let `brandedId` express its return
+ * type as `ReturnType<typeof brandedIdImpl<B>>` without writing out the
+ * full Drizzle builder shape (which drifts across drizzle-orm versions).
+ */
+function brandedIdImpl<B extends AnyBrandedId>(name: string) {
+  return varchar(name, { length: ID_MAX_LENGTH }).$type<B>();
+}
+
+/**
+ * PG varchar column for a branded entity ID. Wraps the standard
+ * `varchar(name, { length: ID_MAX_LENGTH })` with a `.$type<B>()` so
+ * `InferSelectModel` / `InferInsertModel` return the branded type.
+ * Chainable with `.primaryKey()`, `.notNull()`, `.references()`, etc.
+ */
+export function brandedId<B extends AnyBrandedId>(
+  name: string,
+): ReturnType<typeof brandedIdImpl<B>> {
+  return brandedIdImpl<B>(name);
+}

--- a/packages/db/src/columns/sqlite.ts
+++ b/packages/db/src/columns/sqlite.ts
@@ -1,7 +1,7 @@
 import { deserializeEncryptedBlob, serializeEncryptedBlob } from "@pluralscape/crypto";
-import { customType } from "drizzle-orm/sqlite-core";
+import { customType, text } from "drizzle-orm/sqlite-core";
 
-import type { EncryptedBlob } from "@pluralscape/types";
+import type { AnyBrandedId, EncryptedBlob } from "@pluralscape/types";
 
 const JSON_PREVIEW_LENGTH = 100;
 
@@ -95,3 +95,24 @@ export const sqliteJson = customType<{ data: unknown; driverData: string }>({
   toDriver: jsonToDriver,
   fromDriver: jsonFromDriver,
 });
+
+/**
+ * Internal factory — returns a Drizzle text column builder with
+ * `.$type<B>()` applied. Exists to let `brandedId` express its return
+ * type as `ReturnType<typeof brandedIdImpl<B>>` without writing out the
+ * full Drizzle builder shape (which drifts across drizzle-orm versions).
+ */
+function brandedIdImpl<B extends AnyBrandedId>(name: string) {
+  return text(name).$type<B>();
+}
+
+/**
+ * SQLite text column for a branded entity ID. Wraps `text(name)` with
+ * `.$type<B>()` so `InferSelectModel` / `InferInsertModel` return the
+ * branded type. Chainable with `.primaryKey()`, `.notNull()`, `.references()`, etc.
+ */
+export function brandedId<B extends AnyBrandedId>(
+  name: string,
+): ReturnType<typeof brandedIdImpl<B>> {
+  return brandedIdImpl<B>(name);
+}

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -85,6 +85,83 @@ export type StorageKey = Brand<string, "StorageKey">;
 export type HexColor = Brand<string, "HexColor">;
 export type SlugHash = Brand<string, "SlugHash">;
 
+/**
+ * Union of every branded string ID type published by this module. Consumed by
+ * `packages/db/src/columns/pg.ts`'s `brandedId<B>()` helper to constrain the
+ * generic parameter to a known brand, so authors can't accidentally brand a
+ * column with a non-ID type.
+ *
+ * Includes every `<X>Id` brand declared above. Excludes compound/value brands
+ * (`GroupMembershipKey`, `StorageKey`, `HexColor`, `SlugHash`,
+ * `RecoveryKeyDisplay`, `ChecksumHex`) — those are not entity primary-key IDs.
+ */
+export type AnyBrandedId =
+  | SystemId
+  | MemberId
+  | GroupId
+  | BucketId
+  | ChannelId
+  | MessageId
+  | NoteId
+  | PollId
+  | RelationshipId
+  | SystemStructureEntityTypeId
+  | SystemStructureEntityId
+  | SystemStructureEntityLinkId
+  | SystemStructureEntityMemberLinkId
+  | SystemStructureEntityAssociationId
+  | FieldDefinitionId
+  | FieldDefinitionScopeId
+  | FieldValueId
+  | SessionId
+  | LifecycleEventId
+  | AccountId
+  | BlobId
+  | ApiKeyId
+  | WebhookId
+  | TimerId
+  | JournalEntryId
+  | WikiPageId
+  | InnerWorldEntityId
+  | InnerWorldRegionId
+  | InnerWorldCanvasId
+  | AuditLogEntryId
+  | BoardMessageId
+  | AcknowledgementId
+  | CheckInRecordId
+  | FriendConnectionId
+  | KeyGrantId
+  | FrontingSessionId
+  | CustomFrontId
+  | FriendCodeId
+  | PollVoteId
+  | DeviceTokenId
+  | NotificationConfigId
+  | SystemSettingsId
+  | PollOptionId
+  | MemberPhotoId
+  | AuthKeyId
+  | RecoveryKeyId
+  | DeviceTransferRequestId
+  | SyncDocumentId
+  | SyncChangeId
+  | SyncSnapshotId
+  | ImportJobId
+  | ImportEntityRefId
+  | PKBridgeConfigId
+  | AccountPurgeRequestId
+  | ExportRequestId
+  | JobId
+  | SubscriptionId
+  | WebhookDeliveryId
+  | FrontingReportId
+  | FriendNotificationPreferenceId
+  | FrontingCommentId
+  | BucketKeyRotationId
+  | BucketRotationItemId
+  | SystemSnapshotId
+  | BiometricTokenId;
+
 // ── Branded value types (not entity IDs) ────────────────────────────
 
 /** Human-readable recovery key display string (e.g. ABCD-EFGH-...). */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -93,6 +93,7 @@ export type {
   EntityTypeIdMap,
   AssertAllPrefixesMapped,
   AssertAllEntityTypesMapped,
+  AnyBrandedId,
 } from "./ids.js";
 export { ID_PREFIXES } from "./ids.js";
 


### PR DESCRIPTION
## Summary

Adds the shared brand-lifting primitives so Plan 2 fleet entity PRs can convert their own Drizzle tables:

- `AnyBrandedId` union in `packages/types/src/ids.ts` (commit `8f222457`).
- `brandedId<B extends AnyBrandedId>(name)` helper in both PG + SQLite dialects (commit `d89f91e6`).

Usage:

```ts
id: brandedId<MemberId>("id").primaryKey(),
systemId: brandedId<SystemId>("system_id").notNull().references(() => systems.id, { onDelete: "cascade" }),
```

## Why primitives-only

Two prior attempts to do more in this PR proved unworkable:

- **Full 30-table sweep**: ~281 files changed, 500+ typecheck errors, codemod-induced mis-brandings. Every branded ID transitively flows through thousands of fixture/service sites.
- **Four-table pilot** (Member, MemberPhoto, System, AuditLogEntry): 100+ files because `systems` + `accounts` are FK ancestors of nearly every fixture.

Fleet (types-ltel) now owns per-entity table conversion. Updated fleet checklist: `systems` + `accounts` convert first (FK ancestors); leaf entities follow. `StripBrands<>` wrapper removal from parity tests happens per-entity as each converts.

## What did NOT land (intentionally)

- Timestamp customType brand lift (`pgTimestamp` / `sqliteTimestamp` stay `{ data: number }`) — defers ~1700 fixture wraps.
- Any table conversion.
- `StripBrands<>` removal from existing Member + AuditLogEntry parity tests.

## Test plan

- [x] `pnpm turbo typecheck` — green
- [x] `pnpm types:check-sot` — green (unchanged)
- [x] `pnpm test:unit` + `pnpm test:integration` — pass (no runtime change; type-only helper)
- [x] `pnpm lint` — zero warnings
- [x] Pre-push verify passed