### PR TITLE
feat(types): types-ltel C1 — Foundation (Account/System/SystemSettings/SystemSnapshot/Nomenclature)

### DIFF
--- a/apps/api/src/__tests__/services/system-duplicate.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/system-duplicate.service.integration.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../helpers/integration-setup.js";
 
 import type { AuthContext } from "../../lib/auth-context.js";
-import type { AccountId, SystemId } from "@pluralscape/types";
+import type { AccountId, SystemId, SystemSnapshotId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const { systems, systemSnapshots } = schema;
@@ -48,7 +48,7 @@ describe("system-duplicate.service (PGlite integration)", () => {
     snapshotId = `snap_${crypto.randomUUID()}`;
     const now = Date.now();
     await db.insert(systemSnapshots).values({
-      id: snapshotId,
+      id: brandId<SystemSnapshotId>(snapshotId),
       systemId,
       snapshotTrigger: "manual",
       encryptedData: testBlob(),
@@ -100,7 +100,7 @@ describe("system-duplicate.service (PGlite integration)", () => {
       const [snapshot] = await db
         .select()
         .from(systemSnapshots)
-        .where(eq(systemSnapshots.id, snapshotId));
+        .where(eq(systemSnapshots.id, brandId<SystemSnapshotId>(snapshotId)));
       expect(snapshot?.id).toBe(snapshotId);
     });
 

--- a/apps/api/src/__tests__/trpc/routers/auth.integration.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/auth.integration.test.ts
@@ -121,7 +121,7 @@ async function insertAccountWithKnownRecoveryKey(db: PostgresJsDatabase): Promis
   const timestamp = Date.now();
 
   await db.insert(accounts).values({
-    id: accountId,
+    id: brandId<AccountId>(accountId),
     accountType: "system",
     emailHash: hashEmail(email),
     emailSalt: toHex(new Uint8Array(randomBytes(16))),
@@ -134,7 +134,7 @@ async function insertAccountWithKnownRecoveryKey(db: PostgresJsDatabase): Promis
 
   await db.insert(recoveryKeys).values({
     id: recoveryKeyId,
-    accountId,
+    accountId: brandId<AccountId>(accountId),
     encryptedMasterKey: new Uint8Array(randomBytes(MASTER_KEY_BLOB_BYTES)),
     recoveryKeyHash,
     createdAt: timestamp,

--- a/apps/api/src/__tests__/trpc/routers/system.integration.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/system.integration.test.ts
@@ -36,7 +36,7 @@ import {
   setupRouterFixture,
 } from "../integration-helpers.js";
 
-import type { SystemSnapshotId } from "@pluralscape/types";
+import type { SystemId, SystemSnapshotId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 const INITIAL_SYSTEM_VERSION = 1;
@@ -71,8 +71,8 @@ async function seedSnapshot(
   const snapshotIdRaw = `snap_${crypto.randomUUID()}`;
   const timestamp = Date.now();
   await db.insert(systemSnapshots).values({
-    id: snapshotIdRaw,
-    systemId: systemIdRaw,
+    id: brandId<SystemSnapshotId>(snapshotIdRaw),
+    systemId: brandId<SystemId>(systemIdRaw),
     snapshotTrigger: "manual",
     encryptedData: testBlob(),
     createdAt: timestamp,

--- a/apps/api/src/lib/email-resolve.ts
+++ b/apps/api/src/lib/email-resolve.ts
@@ -1,8 +1,10 @@
 import { accounts } from "@pluralscape/db/pg";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 
 import { decryptEmail } from "./email-encrypt.js";
 
+import type { AccountId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /**
@@ -22,7 +24,7 @@ export async function resolveAccountEmail(
   const rows = await db
     .select({ encryptedEmail: accounts.encryptedEmail })
     .from(accounts)
-    .where(eq(accounts.id, accountId))
+    .where(eq(accounts.id, brandId<AccountId>(accountId)))
     .limit(1);
 
   const row = rows[0];

--- a/apps/api/src/lib/friend-access.ts
+++ b/apps/api/src/lib/friend-access.ts
@@ -105,7 +105,12 @@ export async function assertFriendAccess(
     const [system] = await tx
       .select({ id: systems.id })
       .from(systems)
-      .where(and(eq(systems.accountId, connection.friendAccountId), eq(systems.archived, false)))
+      .where(
+        and(
+          eq(systems.accountId, brandId<AccountId>(connection.friendAccountId)),
+          eq(systems.archived, false),
+        ),
+      )
       .limit(1);
 
     if (!system) {

--- a/apps/api/src/services/auth/register.ts
+++ b/apps/api/src/services/auth/register.ts
@@ -26,7 +26,7 @@ import { EMAIL_SALT_BYTES, CHALLENGE_NONCE_TTL_MS } from "../../routes/auth/auth
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { ClientPlatform } from "../../routes/auth/auth.constants.js";
 import type { ChallengeNonce } from "@pluralscape/crypto";
-import type { AccountId, AccountType } from "@pluralscape/types";
+import type { AccountId, AccountType, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Registration Phase 1: Initiate ────────────────────────────────
@@ -230,7 +230,7 @@ export async function commitRegistration(
 
     if (account.accountType === "system") {
       await tx.insert(systems).values({
-        id: createId(ID_PREFIXES.system),
+        id: brandId<SystemId>(createId(ID_PREFIXES.system)),
         accountId: account.id,
         createdAt: timestamp,
         updatedAt: timestamp,

--- a/apps/api/src/services/auth/register.ts
+++ b/apps/api/src/services/auth/register.ts
@@ -70,7 +70,7 @@ export async function initiateRegistration(
   try {
     await withAccountTransaction(db, brandId<AccountId>(accountId), async (tx) => {
       await tx.insert(accounts).values({
-        id: accountId,
+        id: brandId<AccountId>(accountId),
         accountType,
         emailHash,
         emailSalt,
@@ -153,7 +153,7 @@ export async function commitRegistration(
   const [account] = await db
     .select()
     .from(accounts)
-    .where(eq(accounts.id, parsed.accountId))
+    .where(eq(accounts.id, brandId<AccountId>(parsed.accountId)))
     .limit(1);
 
   if (!account) {

--- a/apps/api/src/services/snapshot.service.ts
+++ b/apps/api/src/services/snapshot.service.ts
@@ -80,7 +80,7 @@ export async function createSnapshot(
     const [row] = await tx
       .insert(systemSnapshots)
       .values({
-        id: snapshotId,
+        id: brandId<SystemSnapshotId>(snapshotId),
         systemId,
         snapshotTrigger: parsed.snapshotTrigger,
         encryptedData: blob,
@@ -120,7 +120,7 @@ export async function listSnapshots(
     const conditions = [eq(systemSnapshots.systemId, systemId)];
 
     if (cursor) {
-      conditions.push(lt(systemSnapshots.id, cursor));
+      conditions.push(lt(systemSnapshots.id, brandId<SystemSnapshotId>(cursor)));
     }
 
     const rows = await tx

--- a/apps/api/src/services/system-duplicate.service.ts
+++ b/apps/api/src/services/system-duplicate.service.ts
@@ -61,7 +61,12 @@ export async function duplicateSystem(
     const [snapshot] = await tx
       .select({ id: systemSnapshots.id, encryptedData: systemSnapshots.encryptedData })
       .from(systemSnapshots)
-      .where(and(eq(systemSnapshots.id, snapshotId), eq(systemSnapshots.systemId, sourceSystemId)))
+      .where(
+        and(
+          eq(systemSnapshots.id, brandId<SystemSnapshotId>(snapshotId)),
+          eq(systemSnapshots.systemId, sourceSystemId),
+        ),
+      )
       .limit(1);
 
     if (!snapshot) {

--- a/apps/api/src/services/system/create.ts
+++ b/apps/api/src/services/system/create.ts
@@ -22,7 +22,7 @@ export async function createSystem(
     throw new ApiHttpError(HTTP_FORBIDDEN, "FORBIDDEN", "Only system accounts can create systems");
   }
 
-  const systemId = createId(ID_PREFIXES.system);
+  const systemId = brandId<SystemId>(createId(ID_PREFIXES.system));
   const timestamp = now();
 
   const [row] = await withAccountTransaction(db, auth.accountId, async (tx) => {
@@ -40,7 +40,7 @@ export async function createSystem(
       eventType: "system.created",
       actor: { kind: "account", id: auth.accountId },
       detail: "System created",
-      systemId: brandId<SystemId>(systemId),
+      systemId,
     });
 
     return inserted;

--- a/apps/api/src/services/system/list.ts
+++ b/apps/api/src/services/system/list.ts
@@ -1,4 +1,5 @@
 import { systems } from "@pluralscape/db/pg";
+import { brandId } from "@pluralscape/types";
 import { and, eq, gt } from "drizzle-orm";
 
 import { buildPaginatedResult } from "../../lib/pagination.js";
@@ -8,7 +9,7 @@ import { DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT } from "../../service.constants.js";
 import { toSystemProfileResult } from "./internal.js";
 
 import type { SystemProfileResult } from "./internal.js";
-import type { AccountId, PaginatedResult } from "@pluralscape/types";
+import type { AccountId, PaginatedResult, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 export async function listSystems(
@@ -23,7 +24,7 @@ export async function listSystems(
     const conditions = [eq(systems.accountId, accountId), eq(systems.archived, false)];
 
     if (cursor) {
-      conditions.push(gt(systems.id, cursor));
+      conditions.push(gt(systems.id, brandId<SystemId>(cursor)));
     }
 
     const rows = await tx

--- a/packages/db/src/__tests__/helpers/pg-helpers.ts
+++ b/packages/db/src/__tests__/helpers/pg-helpers.ts
@@ -88,7 +88,7 @@ import { webhookConfigs, webhookDeliveries } from "../../schema/pg/webhooks.js";
 import { pgTableToCreateDDL, pgTableToIndexDDL } from "./schema-to-ddl.js";
 
 import type { PGlite } from "@electric-sql/pglite";
-import type { BucketId, EncryptedBlob } from "@pluralscape/types";
+import type { AccountId, BucketId, EncryptedBlob } from "@pluralscape/types";
 import type { PgDatabase, PgQueryResultHKT, PgTable } from "drizzle-orm/pg-core";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
@@ -347,8 +347,8 @@ async function createPgBaseTables(client: PGlite): Promise<void> {
 export async function pgInsertAccount(
   db: PgDatabase<PgQueryResultHKT, Record<string, unknown>>,
   id?: string,
-): Promise<string> {
-  const resolvedId = id ?? crypto.randomUUID();
+): Promise<AccountId> {
+  const resolvedId = brandId<AccountId>(id ?? crypto.randomUUID());
   const now = Date.now();
   await db.insert(accounts).values({
     id: resolvedId,
@@ -372,7 +372,7 @@ export async function pgInsertSystem(
   const now = Date.now();
   await db.insert(systems).values({
     id: resolvedId,
-    accountId,
+    accountId: brandId<AccountId>(accountId),
     createdAt: now,
     updatedAt: now,
   });

--- a/packages/db/src/__tests__/helpers/pg-helpers.ts
+++ b/packages/db/src/__tests__/helpers/pg-helpers.ts
@@ -88,7 +88,7 @@ import { webhookConfigs, webhookDeliveries } from "../../schema/pg/webhooks.js";
 import { pgTableToCreateDDL, pgTableToIndexDDL } from "./schema-to-ddl.js";
 
 import type { PGlite } from "@electric-sql/pglite";
-import type { AccountId, BucketId, EncryptedBlob } from "@pluralscape/types";
+import type { AccountId, BucketId, EncryptedBlob, SystemId } from "@pluralscape/types";
 import type { PgDatabase, PgQueryResultHKT, PgTable } from "drizzle-orm/pg-core";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
@@ -367,8 +367,8 @@ export async function pgInsertSystem(
   db: PgDatabase<PgQueryResultHKT, Record<string, unknown>>,
   accountId: string,
   id?: string,
-): Promise<string> {
-  const resolvedId = id ?? crypto.randomUUID();
+): Promise<SystemId> {
+  const resolvedId = brandId<SystemId>(id ?? crypto.randomUUID());
   const now = Date.now();
   await db.insert(systems).values({
     id: resolvedId,

--- a/packages/db/src/__tests__/helpers/sqlite-helpers.ts
+++ b/packages/db/src/__tests__/helpers/sqlite-helpers.ts
@@ -11,7 +11,7 @@ import { channels, polls } from "../../schema/sqlite/communication.js";
 import { members } from "../../schema/sqlite/members.js";
 import { systems } from "../../schema/sqlite/systems.js";
 
-import type { BucketId, EncryptedBlob } from "@pluralscape/types";
+import type { AccountId, BucketId, EncryptedBlob } from "@pluralscape/types";
 import type Database from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
@@ -1465,8 +1465,8 @@ function createSqliteBaseTables(client: InstanceType<typeof Database>): void {
 export function sqliteInsertAccount(
   db: BetterSQLite3Database<Record<string, unknown>>,
   id?: string,
-): string {
-  const resolvedId = id ?? crypto.randomUUID();
+): AccountId {
+  const resolvedId = brandId<AccountId>(id ?? crypto.randomUUID());
   const now = Date.now();
   db.insert(accounts)
     .values({
@@ -1493,7 +1493,7 @@ export function sqliteInsertSystem(
   db.insert(systems)
     .values({
       id: resolvedId,
-      accountId,
+      accountId: brandId<AccountId>(accountId),
       createdAt: now,
       updatedAt: now,
     })

--- a/packages/db/src/__tests__/helpers/sqlite-helpers.ts
+++ b/packages/db/src/__tests__/helpers/sqlite-helpers.ts
@@ -11,7 +11,7 @@ import { channels, polls } from "../../schema/sqlite/communication.js";
 import { members } from "../../schema/sqlite/members.js";
 import { systems } from "../../schema/sqlite/systems.js";
 
-import type { AccountId, BucketId, EncryptedBlob } from "@pluralscape/types";
+import type { AccountId, BucketId, EncryptedBlob, SystemId } from "@pluralscape/types";
 import type Database from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
@@ -1487,8 +1487,8 @@ export function sqliteInsertSystem(
   db: BetterSQLite3Database<Record<string, unknown>>,
   accountId: string,
   id?: string,
-): string {
-  const resolvedId = id ?? crypto.randomUUID();
+): SystemId {
+  const resolvedId = brandId<SystemId>(id ?? crypto.randomUUID());
   const now = Date.now();
   db.insert(systems)
     .values({

--- a/packages/db/src/__tests__/schema-pg-auth.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-auth.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -13,7 +14,11 @@ import {
 
 import { createPgAuthTables, testBlob } from "./helpers/pg-helpers.js";
 
+import type { AccountId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
+
+/** Branded ID factory for test fixtures — produces an AccountId from crypto.randomUUID(). */
+const newAccountId = (raw?: string): AccountId => brandId<AccountId>(raw ?? crypto.randomUUID());
 
 const ONE_DAY_MS = 86_400_000;
 const ONE_HOUR_MS = 3_600_000;
@@ -37,7 +42,7 @@ describe("PG auth schema", () => {
       updatedAt: number;
     }> = {},
   ): Promise<{
-    id: string;
+    id: AccountId;
     emailHash: string;
     emailSalt: string;
     authKeyHash: Uint8Array;
@@ -47,7 +52,7 @@ describe("PG auth schema", () => {
   }> {
     const now = Date.now();
     const data = {
-      id: overrides.id ?? crypto.randomUUID(),
+      id: newAccountId(overrides.id),
       emailHash: overrides.emailHash ?? `hash_${crypto.randomUUID()}`,
       emailSalt: overrides.emailSalt ?? `salt_${crypto.randomUUID()}`,
       authKeyHash: overrides.authKeyHash ?? new Uint8Array(32),
@@ -61,9 +66,9 @@ describe("PG auth schema", () => {
   }
 
   async function insertSession(
-    accountId: string,
+    accountId: AccountId,
     overrides: Partial<{ id: string; createdAt: number; tokenHash: string }> = {},
-  ): Promise<{ id: string; accountId: string; tokenHash: string; createdAt: number }> {
+  ): Promise<{ id: string; accountId: AccountId; tokenHash: string; createdAt: number }> {
     const data = {
       id: overrides.id ?? crypto.randomUUID(),
       accountId,

--- a/packages/db/src/__tests__/schema-pg-nomenclature-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-nomenclature-settings.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, nomenclatureSettings };
@@ -145,7 +147,7 @@ describe("PG nomenclature_settings schema", () => {
     const now = Date.now();
     await expect(
       db.insert(nomenclatureSettings).values({
-        systemId: "nonexistent",
+        systemId: brandId<SystemId>("nonexistent"),
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
         updatedAt: now,

--- a/packages/db/src/__tests__/schema-pg-snapshots.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-snapshots.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -13,6 +14,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { SystemSnapshotId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { systems, systemSnapshots };
@@ -37,7 +39,7 @@ describe("PG system_snapshots schema", () => {
   it("round-trips insert and select", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
     const now = Date.now();
 
     await db.insert(systemSnapshots).values({
@@ -57,7 +59,7 @@ describe("PG system_snapshots schema", () => {
   it("accepts scheduled-daily trigger", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
 
     await db.insert(systemSnapshots).values({
       id,
@@ -74,7 +76,7 @@ describe("PG system_snapshots schema", () => {
   it("accepts scheduled-weekly trigger", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
 
     await db.insert(systemSnapshots).values({
       id,
@@ -94,7 +96,7 @@ describe("PG system_snapshots schema", () => {
 
     await expect(
       db.insert(systemSnapshots).values({
-        id: crypto.randomUUID(),
+        id: brandId<SystemSnapshotId>(crypto.randomUUID()),
         systemId,
         snapshotTrigger: "invalid" as "manual",
         encryptedData: testBlob(),
@@ -106,7 +108,7 @@ describe("PG system_snapshots schema", () => {
   it("cascades on system deletion", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
 
     await db.insert(systemSnapshots).values({
       id,
@@ -128,7 +130,7 @@ describe("PG system_snapshots schema", () => {
 
     for (let i = 0; i < 3; i++) {
       await db.insert(systemSnapshots).values({
-        id: crypto.randomUUID(),
+        id: brandId<SystemSnapshotId>(crypto.randomUUID()),
         systemId,
         snapshotTrigger: "manual",
         encryptedData: testBlob(),

--- a/packages/db/src/__tests__/schema-pg-system-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-system-settings.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, systemSettings };
@@ -41,7 +43,7 @@ describe("PG system_settings schema", () => {
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     await db.insert(systemSettings).values({
-      id: `sset_${crypto.randomUUID()}`,
+      id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       locale: "en-US",
       pinHash: "$argon2id$hash123",
@@ -69,7 +71,7 @@ describe("PG system_settings schema", () => {
     const now = Date.now();
 
     await db.insert(systemSettings).values({
-      id: `sset_${crypto.randomUUID()}`,
+      id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       encryptedData: testBlob(new Uint8Array([1])),
       createdAt: now,
@@ -89,7 +91,7 @@ describe("PG system_settings schema", () => {
     const now = Date.now();
 
     await db.insert(systemSettings).values({
-      id: `sset_${crypto.randomUUID()}`,
+      id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       encryptedData: testBlob(new Uint8Array([1])),
       createdAt: now,
@@ -110,7 +112,7 @@ describe("PG system_settings schema", () => {
     const now = Date.now();
 
     await db.insert(systemSettings).values({
-      id: `sset_${crypto.randomUUID()}`,
+      id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       encryptedData: testBlob(new Uint8Array([1])),
       createdAt: now,
@@ -130,7 +132,7 @@ describe("PG system_settings schema", () => {
     const now = Date.now();
 
     await db.insert(systemSettings).values({
-      id: `sset_${crypto.randomUUID()}`,
+      id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       encryptedData: testBlob(new Uint8Array([1])),
       createdAt: now,
@@ -139,7 +141,7 @@ describe("PG system_settings schema", () => {
 
     await expect(
       db.insert(systemSettings).values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         encryptedData: testBlob(new Uint8Array([2])),
         createdAt: now,
@@ -154,7 +156,7 @@ describe("PG system_settings schema", () => {
     const now = Date.now();
 
     await db.insert(systemSettings).values({
-      id: `sset_${crypto.randomUUID()}`,
+      id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       encryptedData: testBlob(new Uint8Array([1])),
       createdAt: now,
@@ -173,8 +175,8 @@ describe("PG system_settings schema", () => {
     const now = Date.now();
     await expect(
       db.insert(systemSettings).values({
-        id: `sset_${crypto.randomUUID()}`,
-        systemId: "nonexistent",
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
+        systemId: brandId<SystemId>("nonexistent"),
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
         updatedAt: now,
@@ -215,7 +217,7 @@ describe("PG system_settings schema", () => {
     const blob = testBlob(blobCiphertext);
 
     await db.insert(systemSettings).values({
-      id: `sset_${crypto.randomUUID()}`,
+      id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       encryptedData: blob,
       createdAt: now,

--- a/packages/db/src/__tests__/schema-pg-systems.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-systems.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -8,6 +9,7 @@ import { systems } from "../schema/pg/systems.js";
 
 import { createPgSystemTables, pgInsertAccount, testBlob } from "./helpers/pg-helpers.js";
 
+import type { AccountId, SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems };
@@ -31,7 +33,7 @@ describe("PG systems schema", () => {
   it("inserts and retrieves with all columns", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
     const data = testBlob(new Uint8Array([1, 2, 3, 4, 5]));
 
     await db.insert(systems).values({
@@ -52,7 +54,7 @@ describe("PG systems schema", () => {
   it("allows nullable encrypted_data", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({
       id,
@@ -68,7 +70,7 @@ describe("PG systems schema", () => {
   it("round-trips encrypted_data binary correctly", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
     const blob = testBlob(blobCiphertext);
@@ -88,7 +90,7 @@ describe("PG systems schema", () => {
   it("defaults version to 1", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({
       id,
@@ -104,7 +106,7 @@ describe("PG systems schema", () => {
   it("cascades on account deletion", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({
       id,
@@ -122,8 +124,8 @@ describe("PG systems schema", () => {
     const now = Date.now();
     await expect(
       db.insert(systems).values({
-        id: crypto.randomUUID(),
-        accountId: "nonexistent",
+        id: brandId<SystemId>(crypto.randomUUID()),
+        accountId: brandId<AccountId>("nonexistent"),
         createdAt: now,
         updatedAt: now,
       }),
@@ -133,7 +135,7 @@ describe("PG systems schema", () => {
   it("rejects duplicate primary key", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({
       id,

--- a/packages/db/src/__tests__/schema-sqlite-api-keys.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-api-keys.integration.test.ts
@@ -22,7 +22,7 @@ describe("SQLite api_keys schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
@@ -26,7 +26,7 @@ describe("SQLite audit_log schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-auth.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-auth.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -13,6 +14,7 @@ import {
 
 import { createSqliteAuthTables, testBlob } from "./helpers/sqlite-helpers.js";
 
+import type { AccountId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const ONE_DAY_MS = 86_400_000;
@@ -37,7 +39,7 @@ describe("SQLite auth schema", () => {
       updatedAt: number;
     }> = {},
   ): {
-    id: string;
+    id: AccountId;
     emailHash: string;
     emailSalt: string;
     authKeyHash: Uint8Array;
@@ -47,7 +49,7 @@ describe("SQLite auth schema", () => {
   } {
     const now = Date.now();
     const data = {
-      id: overrides.id ?? crypto.randomUUID(),
+      id: brandId<AccountId>(overrides.id ?? crypto.randomUUID()),
       emailHash: overrides.emailHash ?? `hash_${crypto.randomUUID()}`,
       emailSalt: overrides.emailSalt ?? `salt_${crypto.randomUUID()}`,
       authKeyHash: overrides.authKeyHash ?? new Uint8Array(32),
@@ -61,9 +63,9 @@ describe("SQLite auth schema", () => {
   }
 
   function insertSession(
-    accountId: string,
+    accountId: AccountId,
     overrides: Partial<{ id: string; tokenHash: string; createdAt: number }> = {},
-  ): { id: string; accountId: string; tokenHash: string; createdAt: number } {
+  ): { id: string; accountId: AccountId; tokenHash: string; createdAt: number } {
     const data = {
       id: overrides.id ?? crypto.randomUUID(),
       accountId,

--- a/packages/db/src/__tests__/schema-sqlite-blob-metadata.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-blob-metadata.integration.test.ts
@@ -23,7 +23,7 @@ describe("SQLite blob_metadata schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-blob-metadata.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-blob-metadata.integration.test.ts
@@ -24,8 +24,7 @@ describe("SQLite blob_metadata schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-communication.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-communication.integration.test.ts
@@ -47,7 +47,7 @@ describe("SQLite communication schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>

--- a/packages/db/src/__tests__/schema-sqlite-communication.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-communication.integration.test.ts
@@ -48,8 +48,7 @@ describe("SQLite communication schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>
     sqliteInsertMember(db, systemId, id);
   const insertChannel = (

--- a/packages/db/src/__tests__/schema-sqlite-custom-fields.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-custom-fields.integration.test.ts
@@ -42,7 +42,7 @@ describe("SQLite custom fields schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-custom-fields.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-custom-fields.integration.test.ts
@@ -43,8 +43,7 @@ describe("SQLite custom fields schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   function insertBucket(systemId: string, id = crypto.randomUUID()): string {
     const now = Date.now();

--- a/packages/db/src/__tests__/schema-sqlite-fronting.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-fronting.integration.test.ts
@@ -31,7 +31,7 @@ describe("SQLite fronting schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>

--- a/packages/db/src/__tests__/schema-sqlite-fronting.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-fronting.integration.test.ts
@@ -32,8 +32,7 @@ describe("SQLite fronting schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>
     sqliteInsertMember(db, systemId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-groups.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-groups.integration.test.ts
@@ -30,7 +30,7 @@ describe("SQLite groups schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>

--- a/packages/db/src/__tests__/schema-sqlite-groups.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-groups.integration.test.ts
@@ -31,8 +31,7 @@ describe("SQLite groups schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>
     sqliteInsertMember(db, systemId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-import-export.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-import-export.integration.test.ts
@@ -37,8 +37,7 @@ describe("SQLite import-export schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-import-export.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-import-export.integration.test.ts
@@ -36,7 +36,7 @@ describe("SQLite import-export schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-jobs.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-jobs.integration.test.ts
@@ -26,8 +26,7 @@ describe("SQLite jobs schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-jobs.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-jobs.integration.test.ts
@@ -25,7 +25,7 @@ describe("SQLite jobs schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-journal.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-journal.integration.test.ts
@@ -26,8 +26,7 @@ describe("SQLite journal schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>
     sqliteInsertMember(db, systemId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-journal.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-journal.integration.test.ts
@@ -25,7 +25,7 @@ describe("SQLite journal schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>

--- a/packages/db/src/__tests__/schema-sqlite-lifecycle-events.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-lifecycle-events.integration.test.ts
@@ -22,7 +22,7 @@ describe("SQLite lifecycle_events schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-members.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-members.integration.test.ts
@@ -23,8 +23,7 @@ describe("SQLite members schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   function insertMember(systemId: string, id = crypto.randomUUID()): string {
     const now = Date.now();

--- a/packages/db/src/__tests__/schema-sqlite-members.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-members.integration.test.ts
@@ -22,7 +22,7 @@ describe("SQLite members schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-nomenclature-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-nomenclature-settings.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, nomenclatureSettings };
@@ -165,7 +167,7 @@ describe("SQLite nomenclature_settings schema", () => {
       db
         .insert(nomenclatureSettings)
         .values({
-          systemId: "nonexistent",
+          systemId: brandId<SystemId>("nonexistent"),
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
           updatedAt: now,

--- a/packages/db/src/__tests__/schema-sqlite-nomenclature-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-nomenclature-settings.integration.test.ts
@@ -22,7 +22,7 @@ describe("SQLite nomenclature_settings schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-notifications.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-notifications.integration.test.ts
@@ -34,8 +34,7 @@ describe("SQLite notifications schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-notifications.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-notifications.integration.test.ts
@@ -33,7 +33,7 @@ describe("SQLite notifications schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
@@ -22,7 +22,7 @@ describe("SQLite PK Bridge Schema", () => {
   let client: InstanceType<typeof DatabaseConstructor>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-privacy.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-privacy.integration.test.ts
@@ -40,8 +40,7 @@ describe("SQLite privacy schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   function insertBucket(systemId: string, id = crypto.randomUUID()): string {
     const now = Date.now();

--- a/packages/db/src/__tests__/schema-sqlite-privacy.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-privacy.integration.test.ts
@@ -39,7 +39,7 @@ describe("SQLite privacy schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
@@ -22,7 +22,7 @@ describe("SQLite safe_mode_content schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-snapshots.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-snapshots.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -13,6 +14,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { SystemSnapshotId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { systems, systemSnapshots };
@@ -44,7 +46,7 @@ describe("SQLite system_snapshots schema", () => {
   it("round-trips insert and select", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
     const now = Date.now();
 
     db.insert(systemSnapshots)
@@ -66,7 +68,7 @@ describe("SQLite system_snapshots schema", () => {
   it("accepts scheduled-daily trigger", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
 
     db.insert(systemSnapshots)
       .values({
@@ -85,7 +87,7 @@ describe("SQLite system_snapshots schema", () => {
   it("accepts scheduled-weekly trigger", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
 
     db.insert(systemSnapshots)
       .values({
@@ -109,7 +111,7 @@ describe("SQLite system_snapshots schema", () => {
       db
         .insert(systemSnapshots)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<SystemSnapshotId>(crypto.randomUUID()),
           systemId,
           snapshotTrigger: "invalid" as "manual",
           encryptedData: testBlob(),
@@ -122,7 +124,7 @@ describe("SQLite system_snapshots schema", () => {
   it("cascades on system deletion", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<SystemSnapshotId>(crypto.randomUUID());
 
     db.insert(systemSnapshots)
       .values({
@@ -147,7 +149,7 @@ describe("SQLite system_snapshots schema", () => {
     for (let i = 0; i < 3; i++) {
       db.insert(systemSnapshots)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<SystemSnapshotId>(crypto.randomUUID()),
           systemId,
           snapshotTrigger: "manual",
           encryptedData: testBlob(),

--- a/packages/db/src/__tests__/schema-sqlite-structure.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-structure.integration.test.ts
@@ -41,7 +41,7 @@ describe("SQLite structure schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertMember = (systemId: string, id?: string): string =>
     sqliteInsertMember(db, systemId, id);
   const insertSystem = (accountId: string, id?: string): string =>

--- a/packages/db/src/__tests__/schema-sqlite-structure.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-structure.integration.test.ts
@@ -44,8 +44,7 @@ describe("SQLite structure schema", () => {
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertMember = (systemId: string, id?: string): string =>
     sqliteInsertMember(db, systemId, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-sync.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-sync.integration.test.ts
@@ -22,9 +22,8 @@ describe("SQLite sync schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   /** Insert a minimal valid syncDocuments row and return its documentId. */
   const insertDocument = (systemId: string, docType: SyncDocumentType = "system-core"): string => {

--- a/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
@@ -22,7 +22,7 @@ describe("SQLite system_settings schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, systemSettings };
@@ -43,7 +45,7 @@ describe("SQLite system_settings schema", () => {
 
     db.insert(systemSettings)
       .values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         locale: "en-US",
         pinHash: "$argon2id$test-hash",
@@ -74,7 +76,7 @@ describe("SQLite system_settings schema", () => {
 
     db.insert(systemSettings)
       .values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -97,7 +99,7 @@ describe("SQLite system_settings schema", () => {
 
     db.insert(systemSettings)
       .values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -121,7 +123,7 @@ describe("SQLite system_settings schema", () => {
 
     db.insert(systemSettings)
       .values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -144,7 +146,7 @@ describe("SQLite system_settings schema", () => {
 
     db.insert(systemSettings)
       .values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -156,7 +158,7 @@ describe("SQLite system_settings schema", () => {
       db
         .insert(systemSettings)
         .values({
-          id: `sset_${crypto.randomUUID()}`,
+          id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
           systemId,
           encryptedData: testBlob(new Uint8Array([2])),
           createdAt: now,
@@ -173,7 +175,7 @@ describe("SQLite system_settings schema", () => {
 
     db.insert(systemSettings)
       .values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -210,8 +212,8 @@ describe("SQLite system_settings schema", () => {
       db
         .insert(systemSettings)
         .values({
-          id: `sset_${crypto.randomUUID()}`,
-          systemId: "nonexistent",
+          id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
+          systemId: brandId<SystemId>("nonexistent"),
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
           updatedAt: now,
@@ -230,7 +232,7 @@ describe("SQLite system_settings schema", () => {
 
     db.insert(systemSettings)
       .values({
-        id: `sset_${crypto.randomUUID()}`,
+        id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         encryptedData: blob,
         createdAt: now,

--- a/packages/db/src/__tests__/schema-sqlite-systems.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-systems.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -12,7 +13,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
-import type { AccountId } from "@pluralscape/types";
+import type { AccountId, SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems };
@@ -37,7 +38,7 @@ describe("SQLite systems schema", () => {
   it("inserts and retrieves with all columns", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
     const data = testBlob(new Uint8Array([1, 2, 3, 4, 5]));
 
     db.insert(systems)
@@ -60,7 +61,7 @@ describe("SQLite systems schema", () => {
   it("allows nullable encrypted_data", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)
       .values({
@@ -78,7 +79,7 @@ describe("SQLite systems schema", () => {
   it("round-trips encrypted_data binary correctly", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
     const blob = testBlob(bigArray);
@@ -100,7 +101,7 @@ describe("SQLite systems schema", () => {
   it("defaults version to 1", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)
       .values({
@@ -118,7 +119,7 @@ describe("SQLite systems schema", () => {
   it("cascades on account deletion", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)
       .values({
@@ -140,8 +141,8 @@ describe("SQLite systems schema", () => {
       db
         .insert(systems)
         .values({
-          id: crypto.randomUUID(),
-          accountId: "nonexistent",
+          id: brandId<SystemId>(crypto.randomUUID()),
+          accountId: brandId<AccountId>("nonexistent"),
           createdAt: now,
           updatedAt: now,
         })
@@ -152,7 +153,7 @@ describe("SQLite systems schema", () => {
   it("rejects duplicate primary key", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)
       .values({

--- a/packages/db/src/__tests__/schema-sqlite-systems.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-systems.integration.test.ts
@@ -12,6 +12,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { AccountId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems };
@@ -20,7 +21,7 @@ describe("SQLite systems schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string): AccountId => sqliteInsertAccount(db, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-timers.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-timers.integration.test.ts
@@ -25,8 +25,7 @@ describe("SQLite timers schema", () => {
   let db: BetterSQLite3Database<typeof schema>;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>
     sqliteInsertMember(db, systemId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-timers.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-timers.integration.test.ts
@@ -24,7 +24,7 @@ describe("SQLite timers schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
   const insertMember = (systemId: string, id?: string): string =>

--- a/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
@@ -45,7 +45,7 @@ describe("SQLite views / query helpers", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string): string =>
     sqliteInsertSystem(db, accountId, id);
 

--- a/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
@@ -46,8 +46,7 @@ describe("SQLite views / query helpers", () => {
   let db: BetterSQLite3Database;
 
   const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
@@ -25,9 +25,8 @@ describe("SQLite webhooks schema", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  const insertAccount = (id?: string): string => sqliteInsertAccount(db, id);
-  const insertSystem = (accountId: string, id?: string): string =>
-    sqliteInsertSystem(db, accountId, id);
+  const insertAccount = (id?: string) => sqliteInsertAccount(db, id);
+  const insertSystem = (accountId: string, id?: string) => sqliteInsertSystem(db, accountId, id);
 
   beforeAll(() => {
     client = new Database(":memory:");

--- a/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
@@ -17,6 +17,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, apiKeys, webhookConfigs, webhookDeliveries };
@@ -285,7 +286,7 @@ describe("SQLite webhooks schema", () => {
   });
 
   describe("webhook_deliveries", () => {
-    let deliverySystemId: string;
+    let deliverySystemId: SystemId;
     let deliveryWhId: string;
 
     beforeEach(() => {

--- a/packages/db/src/__tests__/schema-type-parity.test.ts
+++ b/packages/db/src/__tests__/schema-type-parity.test.ts
@@ -29,6 +29,8 @@ import type {
   DateRange,
   EntityType,
   MemberFrontingBreakdown,
+  SystemId,
+  SystemSettingsId,
 } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
@@ -671,15 +673,16 @@ describe("Type-level assertions", () => {
     expectTypeOf<Row["frontingSessionId"]>().toEqualTypeOf<string>();
   });
 
-  // Fix 6 — systemSettings has both id and systemId as string
-  it("PG systemSettings.id infers as string", () => {
+  // Fix 6 — systemSettings has both id and systemId as branded IDs
+  // (was `string` before fleet Cluster 1 applied `brandedId<>` to the ID columns).
+  it("PG systemSettings.id infers as SystemSettingsId", () => {
     type Row = InferSelectModel<typeof pg.systemSettings>;
-    expectTypeOf<Row["id"]>().toEqualTypeOf<string>();
+    expectTypeOf<Row["id"]>().toEqualTypeOf<SystemSettingsId>();
   });
 
-  it("PG systemSettings.systemId infers as string", () => {
+  it("PG systemSettings.systemId infers as SystemId", () => {
     type Row = InferSelectModel<typeof pg.systemSettings>;
-    expectTypeOf<Row["systemId"]>().toEqualTypeOf<string>();
+    expectTypeOf<Row["systemId"]>().toEqualTypeOf<SystemId>();
   });
 
   // Fix 7 — importJobs.updatedAt is number (non-nullable, custom pgTimestamp returns UnixMillis)

--- a/packages/db/src/__tests__/schema-type-parity.test.ts
+++ b/packages/db/src/__tests__/schema-type-parity.test.ts
@@ -675,12 +675,12 @@ describe("Type-level assertions", () => {
 
   // Fix 6 — systemSettings has both id and systemId as branded IDs
   // (was `string` before fleet Cluster 1 applied `brandedId<>` to the ID columns).
-  it("PG systemSettings.id infers as SystemSettingsId", () => {
+  it("PG systemSettings.id is branded (SystemSettingsId)", () => {
     type Row = InferSelectModel<typeof pg.systemSettings>;
     expectTypeOf<Row["id"]>().toEqualTypeOf<SystemSettingsId>();
   });
 
-  it("PG systemSettings.systemId infers as SystemId", () => {
+  it("PG systemSettings.systemId is branded (SystemId)", () => {
     type Row = InferSelectModel<typeof pg.systemSettings>;
     expectTypeOf<Row["systemId"]>().toEqualTypeOf<SystemId>();
   });

--- a/packages/db/src/__tests__/type-parity/account.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/account.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle parity check: the Account row shape inferred from the `accounts`
+ * table structurally matches `AccountServerMetadata` in @pluralscape/types.
+ *
+ * Account is a plaintext entity (no encryption). `AccountServerMetadata`
+ * extends the domain `Account` with server-only columns the domain doesn't
+ * expose: the two-phase registration challenge (nonce + expiry), the
+ * server-held encrypted email (ADR 029), and the `auditLogIpTracking`
+ * toggle (ADR 028). See `member.type.test.ts` for the general rationale
+ * behind the brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { accounts } from "../../schema/pg/auth.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { AccountServerMetadata, Equal } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("Account Drizzle parity", () => {
+  it("accounts Drizzle row has the same property keys as AccountServerMetadata", () => {
+    type Row = InferSelectModel<typeof accounts>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof AccountServerMetadata>();
+  });
+
+  it("accounts Drizzle row equals AccountServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof accounts>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<AccountServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/nomenclature.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/nomenclature.type.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Drizzle parity check: the Nomenclature row shape inferred from the
+ * `nomenclature_settings` table structurally matches
+ * `NomenclatureServerMetadata` in @pluralscape/types.
+ *
+ * Nomenclature types live in `packages/types/src/nomenclature.ts` (no
+ * per-entity file under `entities/`) because the domain type
+ * `NomenclatureSettings` is a `Record<TermCategory, string>` rather
+ * than a conventional entity shape. The DB row carries only audit
+ * metadata + the T1-encrypted blob — every term category is encrypted
+ * (`NomenclatureEncryptedFields` = `TermCategory`), so there is no
+ * unencrypted subset on the server row. See `member.type.test.ts` for
+ * the general rationale behind the brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { nomenclatureSettings } from "../../schema/pg/nomenclature-settings.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { Equal, NomenclatureServerMetadata } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("Nomenclature Drizzle parity", () => {
+  it("nomenclature_settings Drizzle row has the same property keys as NomenclatureServerMetadata", () => {
+    type Row = InferSelectModel<typeof nomenclatureSettings>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof NomenclatureServerMetadata>();
+  });
+
+  it("nomenclature_settings Drizzle row equals NomenclatureServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof nomenclatureSettings>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<NomenclatureServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/system-settings.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/system-settings.type.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Drizzle parity check: the SystemSettings row shape inferred from the
+ * `system_settings` table structurally matches
+ * `SystemSettingsServerMetadata` in @pluralscape/types.
+ *
+ * `SystemSettingsServerMetadata` strips the domain's encrypted fields
+ * (bundled inside `encryptedData`), `defaultBucketId` (carried inside
+ * the blob, not its own column), and `nomenclature` (stored in the
+ * `nomenclature_settings` table). It adds `pinHash` and
+ * `biometricEnabled` (server-visible for device-transfer policy) plus
+ * `encryptedData`. See `member.type.test.ts` for the general rationale
+ * behind the brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { systemSettings } from "../../schema/pg/system-settings.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { Equal, SystemSettingsServerMetadata } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("SystemSettings Drizzle parity", () => {
+  it("system_settings Drizzle row has the same property keys as SystemSettingsServerMetadata", () => {
+    type Row = InferSelectModel<typeof systemSettings>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof SystemSettingsServerMetadata>();
+  });
+
+  it("system_settings Drizzle row equals SystemSettingsServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof systemSettings>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<SystemSettingsServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/system-snapshot.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/system-snapshot.type.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Drizzle parity check: the SystemSnapshot row shape inferred from the
+ * `system_snapshots` table structurally matches
+ * `SystemSnapshotServerMetadata` in @pluralscape/types.
+ *
+ * SystemSnapshot is a hybrid entity: plaintext metadata + opaque
+ * `encryptedData` blob whose decrypted shape (`SnapshotContent`) lives in
+ * its own type, not as a keys-subset of `SystemSnapshot`. The server
+ * metadata renames the domain's `trigger` to the DB column's
+ * `snapshotTrigger`. See `member.type.test.ts` for the general rationale
+ * behind the brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { systemSnapshots } from "../../schema/pg/snapshots.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { Equal, SystemSnapshotServerMetadata } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("SystemSnapshot Drizzle parity", () => {
+  it("system_snapshots Drizzle row has the same property keys as SystemSnapshotServerMetadata", () => {
+    type Row = InferSelectModel<typeof systemSnapshots>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof SystemSnapshotServerMetadata>();
+  });
+
+  it("system_snapshots Drizzle row equals SystemSnapshotServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof systemSnapshots>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<SystemSnapshotServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/system.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/system.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle parity check: the System row shape inferred from the `systems`
+ * table structurally matches `SystemServerMetadata` in @pluralscape/types.
+ *
+ * `SystemServerMetadata` strips the domain's encrypted fields (they live
+ * inside `encryptedData`) and `settingsId` (joined from the companion
+ * `system_settings` table), then adds the DB-only columns: `accountId`,
+ * nullable `encryptedData`, and archivable metadata. See
+ * `member.type.test.ts` for the general rationale behind the
+ * brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { systems } from "../../schema/pg/systems.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { Equal, SystemServerMetadata } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("System Drizzle parity", () => {
+  it("systems Drizzle row has the same property keys as SystemServerMetadata", () => {
+    type Row = InferSelectModel<typeof systems>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof SystemServerMetadata>();
+  });
+
+  it("systems Drizzle row equals SystemServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof systems>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<SystemServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/schema/pg/auth.ts
+++ b/packages/db/src/schema/pg/auth.ts
@@ -1,19 +1,19 @@
 import { sql } from "drizzle-orm";
 import { boolean, check, index, integer, pgTable, uniqueIndex, varchar } from "drizzle-orm/pg-core";
 
-import { pgBinary, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
+import { brandedId, pgBinary, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.pg.js";
 import { enumCheck } from "../../helpers/check.js";
 import { ENUM_MAX_LENGTH, ID_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { ACCOUNT_TYPES, AUTH_KEY_TYPES, DEVICE_TRANSFER_STATUSES } from "../../helpers/enums.js";
 
-import type { AccountType, AuthKeyType, DeviceTransferStatus } from "@pluralscape/types";
+import type { AccountId, AccountType, AuthKeyType, DeviceTransferStatus } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const accounts = pgTable(
   "accounts",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
+    id: brandedId<AccountId>("id").primaryKey(),
     accountType: varchar("account_type", { length: ENUM_MAX_LENGTH })
       .notNull()
       .default("system")

--- a/packages/db/src/schema/pg/nomenclature-settings.ts
+++ b/packages/db/src/schema/pg/nomenclature-settings.ts
@@ -1,17 +1,17 @@
-import { pgTable, varchar } from "drizzle-orm/pg-core";
+import { pgTable } from "drizzle-orm/pg-core";
 
-import { pgEncryptedBlob } from "../../columns/pg.js";
+import { brandedId, pgEncryptedBlob } from "../../columns/pg.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.pg.js";
-import { ID_MAX_LENGTH } from "../../helpers/db.constants.js";
 
 import { systems } from "./systems.js";
 
+import type { SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const nomenclatureSettings = pgTable(
   "nomenclature_settings",
   {
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH })
+    systemId: brandedId<SystemId>("system_id")
       .primaryKey()
       .references(() => systems.id, { onDelete: "cascade" }),
     encryptedData: pgEncryptedBlob("encrypted_data").notNull(),

--- a/packages/db/src/schema/pg/snapshots.ts
+++ b/packages/db/src/schema/pg/snapshots.ts
@@ -1,20 +1,20 @@
 import { check, index, pgTable, varchar } from "drizzle-orm/pg-core";
 
-import { pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
+import { brandedId, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
 import { enumCheck } from "../../helpers/check.js";
-import { ENUM_MAX_LENGTH, ID_MAX_LENGTH } from "../../helpers/db.constants.js";
+import { ENUM_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { SNAPSHOT_TRIGGERS } from "../../helpers/enums.js";
 
 import { systems } from "./systems.js";
 
-import type { SnapshotTrigger } from "@pluralscape/types";
+import type { SnapshotTrigger, SystemId, SystemSnapshotId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const systemSnapshots = pgTable(
   "system_snapshots",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH })
+    id: brandedId<SystemSnapshotId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     snapshotTrigger: varchar("snapshot_trigger", { length: ENUM_MAX_LENGTH })

--- a/packages/db/src/schema/pg/system-settings.ts
+++ b/packages/db/src/schema/pg/system-settings.ts
@@ -1,19 +1,19 @@
 import { sql } from "drizzle-orm";
 import { boolean, check, pgTable, varchar } from "drizzle-orm/pg-core";
 
-import { pgEncryptedBlob } from "../../columns/pg.js";
+import { brandedId, pgEncryptedBlob } from "../../columns/pg.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.pg.js";
-import { ID_MAX_LENGTH } from "../../helpers/db.constants.js";
 
 import { systems } from "./systems.js";
 
+import type { SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const systemSettings = pgTable(
   "system_settings",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH })
+    id: brandedId<SystemSettingsId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .unique()
       .references(() => systems.id, { onDelete: "cascade" }),

--- a/packages/db/src/schema/pg/systems.ts
+++ b/packages/db/src/schema/pg/systems.ts
@@ -1,6 +1,6 @@
-import { index, pgTable, unique, varchar } from "drizzle-orm/pg-core";
+import { index, pgTable, unique } from "drizzle-orm/pg-core";
 
-import { pgEncryptedBlob } from "../../columns/pg.js";
+import { brandedId, pgEncryptedBlob } from "../../columns/pg.js";
 import {
   archivable,
   archivableConsistencyCheckFor,
@@ -8,18 +8,18 @@ import {
   versioned,
   versionCheckFor,
 } from "../../helpers/audit.pg.js";
-import { ID_MAX_LENGTH } from "../../helpers/db.constants.js";
 
 import { accounts } from "./auth.js";
 
+import type { AccountId, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 /** PG systems table — top-level entity for a plural system. */
 export const systems = pgTable(
   "systems",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    accountId: varchar("account_id", { length: ID_MAX_LENGTH })
+    id: brandedId<SystemId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     /** Nullable — system can exist before profile setup during onboarding. */

--- a/packages/db/src/schema/sqlite/auth.ts
+++ b/packages/db/src/schema/sqlite/auth.ts
@@ -1,18 +1,23 @@
 import { sql } from "drizzle-orm";
 import { check, index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
-import { sqliteBinary, sqliteEncryptedBlob, sqliteTimestamp } from "../../columns/sqlite.js";
+import {
+  brandedId,
+  sqliteBinary,
+  sqliteEncryptedBlob,
+  sqliteTimestamp,
+} from "../../columns/sqlite.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.sqlite.js";
 import { enumCheck } from "../../helpers/check.js";
 import { ACCOUNT_TYPES, AUTH_KEY_TYPES, DEVICE_TRANSFER_STATUSES } from "../../helpers/enums.js";
 
-import type { AccountType, AuthKeyType, DeviceTransferStatus } from "@pluralscape/types";
+import type { AccountId, AccountType, AuthKeyType, DeviceTransferStatus } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const accounts = sqliteTable(
   "accounts",
   {
-    id: text("id").primaryKey(),
+    id: brandedId<AccountId>("id").primaryKey(),
     accountType: text("account_type").notNull().default("system").$type<AccountType>(),
     emailHash: text("email_hash").notNull(),
     emailSalt: text("email_salt").notNull(),

--- a/packages/db/src/schema/sqlite/nomenclature-settings.ts
+++ b/packages/db/src/schema/sqlite/nomenclature-settings.ts
@@ -1,16 +1,17 @@
-import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { sqliteTable } from "drizzle-orm/sqlite-core";
 
-import { sqliteEncryptedBlob } from "../../columns/sqlite.js";
+import { brandedId, sqliteEncryptedBlob } from "../../columns/sqlite.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.sqlite.js";
 
 import { systems } from "./systems.js";
 
+import type { SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const nomenclatureSettings = sqliteTable(
   "nomenclature_settings",
   {
-    systemId: text("system_id")
+    systemId: brandedId<SystemId>("system_id")
       .primaryKey()
       .references(() => systems.id, { onDelete: "cascade" }),
     encryptedData: sqliteEncryptedBlob("encrypted_data").notNull(),

--- a/packages/db/src/schema/sqlite/snapshots.ts
+++ b/packages/db/src/schema/sqlite/snapshots.ts
@@ -1,19 +1,19 @@
 import { check, index, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-import { sqliteEncryptedBlob, sqliteTimestamp } from "../../columns/sqlite.js";
+import { brandedId, sqliteEncryptedBlob, sqliteTimestamp } from "../../columns/sqlite.js";
 import { enumCheck } from "../../helpers/check.js";
 import { SNAPSHOT_TRIGGERS } from "../../helpers/enums.js";
 
 import { systems } from "./systems.js";
 
-import type { SnapshotTrigger } from "@pluralscape/types";
+import type { SnapshotTrigger, SystemId, SystemSnapshotId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const systemSnapshots = sqliteTable(
   "system_snapshots",
   {
-    id: text("id").primaryKey(),
-    systemId: text("system_id")
+    id: brandedId<SystemSnapshotId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     snapshotTrigger: text("snapshot_trigger").notNull().$type<SnapshotTrigger>(),

--- a/packages/db/src/schema/sqlite/system-settings.ts
+++ b/packages/db/src/schema/sqlite/system-settings.ts
@@ -1,18 +1,19 @@
 import { sql } from "drizzle-orm";
 import { check, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-import { sqliteEncryptedBlob } from "../../columns/sqlite.js";
+import { brandedId, sqliteEncryptedBlob } from "../../columns/sqlite.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.sqlite.js";
 
 import { systems } from "./systems.js";
 
+import type { SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const systemSettings = sqliteTable(
   "system_settings",
   {
-    id: text("id").primaryKey(),
-    systemId: text("system_id")
+    id: brandedId<SystemSettingsId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .unique()
       .references(() => systems.id, { onDelete: "cascade" }),

--- a/packages/db/src/schema/sqlite/systems.ts
+++ b/packages/db/src/schema/sqlite/systems.ts
@@ -1,6 +1,6 @@
-import { index, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { index, sqliteTable } from "drizzle-orm/sqlite-core";
 
-import { sqliteEncryptedBlob } from "../../columns/sqlite.js";
+import { brandedId, sqliteEncryptedBlob } from "../../columns/sqlite.js";
 import {
   archivable,
   archivableConsistencyCheckFor,
@@ -11,14 +11,15 @@ import {
 
 import { accounts } from "./auth.js";
 
+import type { AccountId, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 /** SQLite systems table — top-level entity for a plural system. */
 export const systems = sqliteTable(
   "systems",
   {
-    id: text("id").primaryKey(),
-    accountId: text("account_id")
+    id: brandedId<SystemId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     /** Nullable — system can exist before profile setup during onboarding. */

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -52,7 +52,12 @@ import type {
   SystemStructureEntity,
   SystemStructureEntityEncryptedFields,
 } from "./entities/structure-entity.js";
-import type { SystemSettings, SystemSettingsEncryptedFields } from "./entities/system-settings.js";
+import type {
+  SystemSettings,
+  SystemSettingsEncryptedFields,
+  SystemSettingsServerMetadata,
+  SystemSettingsWire,
+} from "./entities/system-settings.js";
 import type {
   System,
   SystemEncryptedFields,
@@ -160,6 +165,8 @@ export type SotEntityManifest = {
   };
   SystemSettings: {
     domain: SystemSettings;
+    server: SystemSettingsServerMetadata;
+    wire: SystemSettingsWire;
     encryptedFields: SystemSettingsEncryptedFields;
   };
   StructureEntityMemberLink: {

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -59,6 +59,11 @@ import type {
   SystemSettingsWire,
 } from "./entities/system-settings.js";
 import type {
+  SystemSnapshot,
+  SystemSnapshotServerMetadata,
+  SystemSnapshotWire,
+} from "./entities/system-snapshot.js";
+import type {
   System,
   SystemEncryptedFields,
   SystemServerMetadata,
@@ -168,6 +173,15 @@ export type SotEntityManifest = {
     server: SystemSettingsServerMetadata;
     wire: SystemSettingsWire;
     encryptedFields: SystemSettingsEncryptedFields;
+  };
+  SystemSnapshot: {
+    domain: SystemSnapshot;
+    server: SystemSnapshotServerMetadata;
+    wire: SystemSnapshotWire;
+    // Hybrid entity: plaintext metadata + opaque `encryptedData` blob whose
+    // decrypted shape (`SnapshotContent`) lives in its own type, not as a
+    // keys-subset of `SystemSnapshot`. No `encryptedFields` union.
+    encryptedFields: never;
   };
   StructureEntityMemberLink: {
     domain: SystemStructureEntityMemberLink;

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -53,7 +53,12 @@ import type {
   SystemStructureEntityEncryptedFields,
 } from "./entities/structure-entity.js";
 import type { SystemSettings, SystemSettingsEncryptedFields } from "./entities/system-settings.js";
-import type { System, SystemEncryptedFields } from "./entities/system.js";
+import type {
+  System,
+  SystemEncryptedFields,
+  SystemServerMetadata,
+  SystemWire,
+} from "./entities/system.js";
 import type { NomenclatureEncryptedFields, NomenclatureSettings } from "./nomenclature.js";
 
 /**
@@ -97,6 +102,8 @@ export type SotEntityManifest = {
   };
   System: {
     domain: System;
+    server: SystemServerMetadata;
+    wire: SystemWire;
     encryptedFields: SystemEncryptedFields;
   };
   MemberPhoto: {

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -1,3 +1,4 @@
+import type { Account, AccountServerMetadata, AccountWire } from "./entities/account.js";
 import type {
   AuditLogEntry,
   AuditLogEntryServerMetadata,
@@ -85,6 +86,13 @@ export type SotEntityManifest = {
     server: AuditLogEntryServerMetadata;
     wire: AuditLogEntryWire;
     // Plaintext wire — no encrypted fields.
+    encryptedFields: never;
+  };
+  Account: {
+    domain: Account;
+    server: AccountServerMetadata;
+    wire: AccountWire;
+    // Plaintext entity — no encrypted fields.
     encryptedFields: never;
   };
   System: {

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -69,7 +69,12 @@ import type {
   SystemServerMetadata,
   SystemWire,
 } from "./entities/system.js";
-import type { NomenclatureEncryptedFields, NomenclatureSettings } from "./nomenclature.js";
+import type {
+  NomenclatureEncryptedFields,
+  NomenclatureServerMetadata,
+  NomenclatureSettings,
+  NomenclatureWire,
+} from "./nomenclature.js";
 
 /**
  * Registry of every domain entity that participates in the types-as-SoT
@@ -193,6 +198,8 @@ export type SotEntityManifest = {
   };
   Nomenclature: {
     domain: NomenclatureSettings;
+    server: NomenclatureServerMetadata;
+    wire: NomenclatureWire;
     encryptedFields: NomenclatureEncryptedFields;
   };
 };

--- a/packages/types/src/entities/account.ts
+++ b/packages/types/src/entities/account.ts
@@ -1,4 +1,6 @@
 import type { AccountId, Brand } from "../ids.js";
+import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 import type { AuditMetadata } from "../utility.js";
 
 /** Whether an account belongs to a system or a non-system viewer (therapist, friend). */
@@ -45,3 +47,31 @@ export interface RegistrationCommitInput {
   readonly recoveryKeyBackupConfirmed: boolean;
   readonly recoveryKeyHash: string;
 }
+
+/**
+ * Server-visible Account metadata — raw Drizzle row shape.
+ *
+ * Account is a plaintext entity (no client-side encryption), so `server`
+ * carries the full domain type plus server-only registration + operational
+ * columns the domain doesn't expose: the two-phase registration challenge
+ * (`challengeNonce` + `challengeExpiresAt`), the server-held encrypted email
+ * used for operational mail (ADR 029), and the `auditLogIpTracking` toggle
+ * (ADR 028).
+ */
+export interface AccountServerMetadata extends Account {
+  /** Challenge nonce for two-phase registration. Cleared after successful commit. */
+  readonly challengeNonce: Uint8Array | null;
+  /** Expiry time for the challenge nonce (5 minutes after creation). */
+  readonly challengeExpiresAt: UnixMillis | null;
+  /** Server-side encrypted email for operational communication (ADR 029). Null for pre-migration accounts. */
+  readonly encryptedEmail: Uint8Array | null;
+  /** When true, IP address and user-agent are persisted in audit log entries (ADR 028). */
+  readonly auditLogIpTracking: boolean;
+}
+
+/**
+ * JSON-wire representation of an Account. Derived from the domain `Account`
+ * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
+ * becomes `number`, and `Uint8Array` becomes `string` (base64).
+ */
+export type AccountWire = Serialize<Account>;

--- a/packages/types/src/entities/system-settings.ts
+++ b/packages/types/src/entities/system-settings.ts
@@ -1,7 +1,9 @@
+import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { Locale } from "../i18n.js";
 import type { BucketId, SystemSettingsId, SystemId } from "../ids.js";
 import type { LittlesSafeModeConfig } from "../littles-safe-mode.js";
 import type { NomenclatureSettings } from "../nomenclature.js";
+import type { Serialize } from "../type-assertions.js";
 import type { AuditMetadata } from "../utility.js";
 import type { SnapshotSchedule } from "./system-snapshot.js";
 
@@ -92,3 +94,30 @@ export type SystemSettingsEncryptedFields =
   | "autoCaptureFrontingOnJournal"
   | "snapshotSchedule"
   | "onboardingComplete";
+
+/**
+ * Server-visible SystemSettings metadata — raw Drizzle row shape.
+ *
+ * Derived from `SystemSettings` by stripping the encrypted field keys
+ * (bundled inside `encryptedData`) plus `defaultBucketId` (not stored on
+ * the `system_settings` table — the default bucket is wired through the
+ * encrypted payload) and `nomenclature` (stored in its own
+ * `nomenclature_settings` table). Adds `pinHash` and `biometricEnabled`
+ * (server-visible for device-transfer policy enforcement without
+ * decrypting the settings blob) and `encryptedData`.
+ */
+export type SystemSettingsServerMetadata = Omit<
+  SystemSettings,
+  SystemSettingsEncryptedFields | "defaultBucketId" | "nomenclature"
+> & {
+  readonly pinHash: string | null;
+  readonly biometricEnabled: boolean;
+  readonly encryptedData: EncryptedBlob;
+};
+
+/**
+ * JSON-wire representation of SystemSettings. Derived from the domain
+ * `SystemSettings` type via `Serialize<T>`; branded IDs become plain
+ * strings, `UnixMillis` becomes `number`.
+ */
+export type SystemSettingsWire = Serialize<SystemSettings>;

--- a/packages/types/src/entities/system-snapshot.ts
+++ b/packages/types/src/entities/system-snapshot.ts
@@ -1,3 +1,4 @@
+import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   GroupId,
   InnerWorldEntityId,
@@ -9,6 +10,7 @@ import type {
   SystemStructureEntityTypeId,
 } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 import type { InnerWorldEntityType } from "./innerworld-entity.js";
 import type { Tag, SaturationLevel } from "./member.js";
 import type { RelationshipType } from "./relationship.js";
@@ -31,6 +33,28 @@ export interface SystemSnapshot {
   readonly trigger: SnapshotTrigger;
   readonly createdAt: UnixMillis;
 }
+
+/**
+ * Server-visible SystemSnapshot metadata — raw Drizzle row shape.
+ *
+ * SystemSnapshot is a hybrid entity: it carries plaintext metadata
+ * (id, systemId, createdAt) plus an opaque `encryptedData` column that
+ * stores the T1-encrypted `SnapshotContent` — which lives in its own
+ * type (not as a keys-subset of `SystemSnapshot`), so no
+ * `SystemSnapshotEncryptedFields` union exists. Replaces the domain's
+ * `trigger` with the DB column's `snapshotTrigger` name.
+ */
+export type SystemSnapshotServerMetadata = Omit<SystemSnapshot, "trigger"> & {
+  readonly snapshotTrigger: SnapshotTrigger;
+  readonly encryptedData: EncryptedBlob;
+};
+
+/**
+ * JSON-wire representation of SystemSnapshot. Derived from the domain
+ * `SystemSnapshot` type via `Serialize<T>`; branded IDs become plain
+ * strings, `UnixMillis` becomes `number`.
+ */
+export type SystemSnapshotWire = Serialize<SystemSnapshot>;
 
 // ── Snapshot content (decrypted shape) ────────────────────────────
 

--- a/packages/types/src/entities/system.ts
+++ b/packages/types/src/entities/system.ts
@@ -1,5 +1,8 @@
-import type { SystemId, SystemSettingsId } from "../ids.js";
+import type { EncryptedBlob } from "../encryption-primitives.js";
+import type { AccountId, SystemId, SystemSettingsId } from "../ids.js";
 import type { ImageSource } from "../image-source.js";
+import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 import type { AuditMetadata } from "../utility.js";
 
 /** A plural system — the top-level account entity. */
@@ -17,7 +20,7 @@ export interface System extends AuditMetadata {
  * them. Consumed by:
  * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextSystem parity)
- * - Plan 2 fleet will consume when deriving `SystemServerMetadata`.
+ * - `SystemServerMetadata` (derived via `Omit`)
  */
 export type SystemEncryptedFields = "name" | "displayName" | "description" | "avatarSource";
 
@@ -27,3 +30,28 @@ export interface SystemListItem {
   readonly name: string;
   readonly avatarSource: ImageSource | null;
 }
+
+/**
+ * Server-visible System metadata — raw Drizzle row shape.
+ *
+ * Derived from `System` by stripping the encrypted field keys (bundled
+ * inside `encryptedData`) and `settingsId` (which lives on the companion
+ * `system_settings` table, joined on `systemId`, not as a column on
+ * `systems`). Adds the DB-only columns the domain type doesn't carry:
+ * `accountId` (owning account FK), `encryptedData` (nullable — the system
+ * row can exist in onboarding before a T1 blob is written), and
+ * `archived`/`archivedAt` (archivable metadata).
+ */
+export type SystemServerMetadata = Omit<System, SystemEncryptedFields | "settingsId"> & {
+  readonly accountId: AccountId;
+  readonly encryptedData: EncryptedBlob | null;
+  readonly archived: boolean;
+  readonly archivedAt: UnixMillis | null;
+};
+
+/**
+ * JSON-wire representation of a System. Derived from the domain `System`
+ * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
+ * becomes `number`.
+ */
+export type SystemWire = Serialize<System>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -353,6 +353,8 @@ export type {
   CanonicalTerm,
   NomenclatureSettings,
   NomenclatureEncryptedFields,
+  NomenclatureServerMetadata,
+  NomenclatureWire,
   TermPreset,
 } from "./nomenclature.js";
 export { DEFAULT_TERM_PRESETS, createDefaultNomenclatureSettings } from "./nomenclature.js";

--- a/packages/types/src/nomenclature.ts
+++ b/packages/types/src/nomenclature.ts
@@ -1,3 +1,8 @@
+import type { EncryptedBlob } from "./encryption-primitives.js";
+import type { SystemId } from "./ids.js";
+import type { UnixMillis } from "./timestamps.js";
+import type { Serialize } from "./type-assertions.js";
+
 /** Categories of terminology that can be customized. */
 export type TermCategory =
   | "collective"
@@ -29,9 +34,35 @@ export type NomenclatureSettings = Readonly<Record<TermCategory, string>>;
  * therefore identical to `TermCategory`. Consumed by:
  * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextNomenclature parity)
- * - Plan 2 fleet for ServerMetadata derivation.
+ * - `NomenclatureServerMetadata` (derived via `Omit`)
  */
 export type NomenclatureEncryptedFields = TermCategory;
+
+/**
+ * Server-visible Nomenclature metadata — raw Drizzle row shape for the
+ * `nomenclature_settings` table.
+ *
+ * Nomenclature is a T1-encrypted entity stored in its own table keyed
+ * on `systemId` (no separate `id` column — `systemId` is the primary
+ * key). The decrypted shape `NomenclatureSettings` is a `Record` whose
+ * keys match `NomenclatureEncryptedFields` (= every `TermCategory`),
+ * so there is no unencrypted subset to preserve on the server — only
+ * audit metadata and the opaque blob.
+ */
+export interface NomenclatureServerMetadata {
+  readonly systemId: SystemId;
+  readonly encryptedData: EncryptedBlob;
+  readonly createdAt: UnixMillis;
+  readonly updatedAt: UnixMillis;
+  readonly version: number;
+}
+
+/**
+ * JSON-wire representation of NomenclatureSettings. Each category's
+ * selected term is a plain string on the wire (the blob's decrypted
+ * content, not the Drizzle row).
+ */
+export type NomenclatureWire = Serialize<NomenclatureSettings>;
 
 /** A set of preset options for a single term category. */
 export interface TermPreset {


### PR DESCRIPTION
## Summary

types-ltel fleet Cluster 1 (Foundation): brings 4 fleet entities + 1 embedded special (Nomenclature) through the 4-layer parity stack — the FK-ancestor foundation for the rest of the fleet.

## What landed

- **Account** (plaintext): `AccountServerMetadata` captures server-only registration + operational columns (challengeNonce, challengeExpiresAt, encryptedEmail, auditLogIpTracking); `AccountWire = Serialize<Account>`; Drizzle brand on `accounts.id`; parity test.
- **System** (encrypted): `SystemServerMetadata = Omit<System, encryptedFields | "settingsId"> & { accountId, encryptedData | null, archived/archivedAt }`; Drizzle brand on `systems.id` + `systems.accountId`; parity test; service call-site fixes.
- **SystemSettings** (encrypted): `SystemSettingsServerMetadata` strips encryptedFields + `defaultBucketId` (in blob) + `nomenclature` (separate table), adds `pinHash`, `biometricEnabled`, `encryptedData`; Drizzle brand on both ID columns; parity test; legacy `schema-type-parity.test.ts` updates.
- **SystemSnapshot** (hybrid): plaintext metadata + opaque encryptedData blob whose decrypted shape `SnapshotContent` lives in its own type — no `EncryptedFields` union; `ServerMetadata` renames domain's `trigger` → DB column `snapshotTrigger`; Drizzle brand + parity test; snapshot/duplicate service fixes.
- **Nomenclature** (embedded special): `NomenclatureServerMetadata` added to `nomenclature.ts` (not a per-entity file — types live at the package root because domain is `Record<TermCategory, string>`). Converted `nomenclature_settings` Drizzle table (deviation from plan: plan said "no separate Drizzle" but the table exists) and added parity test.

## Fleet context

- Cluster 1 is serial — FK ancestor for clusters 2-10.
- Uses `StripBrands<>` wrapper in parity tests (fleet pattern; Cluster 11 strips it monorepo-wide).
- Normal pre-push verify (no `--no-verify`).

## Deviations from Appendix A/B

- Plaintext Appendix B said use `<X>` directly as server type; Account needs a dedicated `AccountServerMetadata` because the DB row has server-only columns not on the domain (same precedent as AuditLogEntry pilot).
- Nomenclature plan said "no separate Drizzle table conversion" but the `nomenclature_settings` table exists; converted it + added parity test.
- SystemSnapshot is hybrid (encryptedData exists but no `EncryptedFields` keys-union); manifest entry uses `encryptedFields: never` with an explanatory comment.

## Scope expansion (expected — FK ancestor ripple)

Shared test helpers (`pgInsertAccount`/`Sqlite…`, `pgInsertSystem`/`Sqlite…`) now return branded `AccountId`/`SystemId`; dropped explicit `: string =>` return annotations on ~20 local sqlite test wrappers; branded `"nonexistent"` FK-violation fixtures; 3 API services + 1 API integration test updated.

## Test plan

- [x] `pnpm turbo typecheck` green
- [x] `pnpm types:check-sot` green
- [x] `pnpm lint` zero warnings
- [x] Full pre-push verify passed (includes unit + integration)
- [ ] CI green