### PR TITLE
feat(types): types-ltel C2 — Auth + devices

### DIFF
--- a/apps/api/src/__tests__/routes/account/device-transfer.test.ts
+++ b/apps/api/src/__tests__/routes/account/device-transfer.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -8,7 +9,7 @@ import {
 } from "../../helpers/common-route-mocks.js";
 import { createRouteApp, postJSON } from "../../helpers/route-test-setup.js";
 
-import type { ApiErrorResponse } from "@pluralscape/types";
+import type { ApiErrorResponse, DeviceTransferRequestId } from "@pluralscape/types";
 
 // ── Mocks ────────────────────────────────────────────────────────
 
@@ -63,7 +64,7 @@ describe("POST /account/device-transfer (initiate)", () => {
 
   it("returns 201 on successful initiation", async () => {
     vi.mocked(initiateTransfer).mockResolvedValueOnce({
-      transferId: "dtr_test-id",
+      transferId: brandId<DeviceTransferRequestId>("dtr_test-id"),
       expiresAt: 1_300_000 as never,
     });
 

--- a/apps/api/src/__tests__/routes/auth/sessions.test.ts
+++ b/apps/api/src/__tests__/routes/auth/sessions.test.ts
@@ -1,4 +1,4 @@
-import { PAGINATION } from "@pluralscape/types";
+import { PAGINATION, brandId } from "@pluralscape/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fromCursor, toCursor } from "../../../lib/pagination.js";
@@ -9,7 +9,7 @@ import {
 } from "../../helpers/common-route-mocks.js";
 import { createRouteApp } from "../../helpers/route-test-setup.js";
 
-import type { ApiErrorResponse } from "@pluralscape/types";
+import type { ApiErrorResponse, SessionId } from "@pluralscape/types";
 
 // ── Mocks ────────────────────────────────────────────────────────
 
@@ -106,8 +106,8 @@ describe("sessions route", () => {
     it("returns session list for authenticated user", async () => {
       const mockSessions = {
         sessions: [
-          { id: "sess_1", createdAt: 1000, lastActive: 2000, expiresAt: 9000 },
-          { id: "sess_2", createdAt: 1500, lastActive: 2500, expiresAt: 9500 },
+          { id: brandId<SessionId>("sess_1"), createdAt: 1000, lastActive: 2000, expiresAt: 9000 },
+          { id: brandId<SessionId>("sess_2"), createdAt: 1500, lastActive: 2500, expiresAt: 9500 },
         ],
         nextCursor: toCursor("sess_2"),
       };

--- a/apps/api/src/__tests__/services/auth.service.test.ts
+++ b/apps/api/src/__tests__/services/auth.service.test.ts
@@ -31,7 +31,7 @@ import {
 import { mockDb, type MockChain } from "../helpers/mock-db.js";
 import { createMockLogger } from "../helpers/mock-logger.js";
 
-import type { AccountId } from "@pluralscape/types";
+import type { AccountId, SessionId } from "@pluralscape/types";
 import type { Context } from "hono";
 
 const TEST_ACCOUNT_ID = brandId<AccountId>("acct_123");
@@ -1183,7 +1183,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, "sess_999", TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(db, brandId<SessionId>("sess_999"), TEST_ACCOUNT_ID, mockAudit);
       expect(result).toBe(false);
     });
 
@@ -1191,7 +1191,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, "sess_1", TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit);
       expect(result).toBe(false);
     });
 
@@ -1199,7 +1199,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([{ id: "sess_1" }]);
 
-      const result = await revokeSession(db, "sess_1", TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit);
       expect(result).toBe(true);
       expect(chain.transaction).toHaveBeenCalled();
     });
@@ -1208,7 +1208,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, "sess_target", ATTACKER_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(db, brandId<SessionId>("sess_target"), ATTACKER_ACCOUNT_ID, mockAudit);
       expect(result).toBe(false);
       expect(mockAudit).not.toHaveBeenCalled();
     });
@@ -1217,7 +1217,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, "sess_1", TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit);
       expect(result).toBe(false);
     });
   });
@@ -1229,7 +1229,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const count = await revokeAllSessions(db, TEST_ACCOUNT_ID, "sess_keep", mockAudit);
+      const count = await revokeAllSessions(db, TEST_ACCOUNT_ID, brandId<SessionId>("sess_keep"), mockAudit);
       expect(count).toBe(0);
     });
 
@@ -1237,7 +1237,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([{ id: "sess_1" }, { id: "sess_2" }, { id: "sess_3" }]);
 
-      const count = await revokeAllSessions(db, TEST_ACCOUNT_ID, "sess_keep", mockAudit);
+      const count = await revokeAllSessions(db, TEST_ACCOUNT_ID, brandId<SessionId>("sess_keep"), mockAudit);
       expect(count).toBe(3);
     });
 
@@ -1245,7 +1245,7 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([{ id: "sess_1" }]);
 
-      await revokeAllSessions(db, TEST_ACCOUNT_ID, "sess_keep", mockAudit);
+      await revokeAllSessions(db, TEST_ACCOUNT_ID, brandId<SessionId>("sess_keep"), mockAudit);
       expect(chain.set).toHaveBeenCalledWith({ revoked: true });
     });
   });
@@ -1256,7 +1256,7 @@ describe("auth service", () => {
     it("revokes the session and returns void", async () => {
       const { db, chain } = mockDb();
 
-      await logoutCurrentSession(db, "sess_1", TEST_ACCOUNT_ID, mockAudit);
+      await logoutCurrentSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit);
       expect(chain.update).toHaveBeenCalled();
       expect(chain.set).toHaveBeenCalledWith({ revoked: true });
     });
@@ -1265,7 +1265,7 @@ describe("auth service", () => {
       const { db } = mockDb();
 
       await expect(
-        logoutCurrentSession(db, "sess_1", TEST_ACCOUNT_ID, mockAudit),
+        logoutCurrentSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit),
       ).resolves.toBeUndefined();
     });
   });

--- a/apps/api/src/__tests__/services/auth.service.test.ts
+++ b/apps/api/src/__tests__/services/auth.service.test.ts
@@ -1183,7 +1183,12 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, brandId<SessionId>("sess_999"), TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(
+        db,
+        brandId<SessionId>("sess_999"),
+        TEST_ACCOUNT_ID,
+        mockAudit,
+      );
       expect(result).toBe(false);
     });
 
@@ -1191,7 +1196,12 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(
+        db,
+        brandId<SessionId>("sess_1"),
+        TEST_ACCOUNT_ID,
+        mockAudit,
+      );
       expect(result).toBe(false);
     });
 
@@ -1199,7 +1209,12 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([{ id: "sess_1" }]);
 
-      const result = await revokeSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(
+        db,
+        brandId<SessionId>("sess_1"),
+        TEST_ACCOUNT_ID,
+        mockAudit,
+      );
       expect(result).toBe(true);
       expect(chain.transaction).toHaveBeenCalled();
     });
@@ -1208,7 +1223,12 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, brandId<SessionId>("sess_target"), ATTACKER_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(
+        db,
+        brandId<SessionId>("sess_target"),
+        ATTACKER_ACCOUNT_ID,
+        mockAudit,
+      );
       expect(result).toBe(false);
       expect(mockAudit).not.toHaveBeenCalled();
     });
@@ -1217,7 +1237,12 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const result = await revokeSession(db, brandId<SessionId>("sess_1"), TEST_ACCOUNT_ID, mockAudit);
+      const result = await revokeSession(
+        db,
+        brandId<SessionId>("sess_1"),
+        TEST_ACCOUNT_ID,
+        mockAudit,
+      );
       expect(result).toBe(false);
     });
   });
@@ -1229,7 +1254,12 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([]);
 
-      const count = await revokeAllSessions(db, TEST_ACCOUNT_ID, brandId<SessionId>("sess_keep"), mockAudit);
+      const count = await revokeAllSessions(
+        db,
+        TEST_ACCOUNT_ID,
+        brandId<SessionId>("sess_keep"),
+        mockAudit,
+      );
       expect(count).toBe(0);
     });
 
@@ -1237,7 +1267,12 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       chain.returning.mockResolvedValueOnce([{ id: "sess_1" }, { id: "sess_2" }, { id: "sess_3" }]);
 
-      const count = await revokeAllSessions(db, TEST_ACCOUNT_ID, brandId<SessionId>("sess_keep"), mockAudit);
+      const count = await revokeAllSessions(
+        db,
+        TEST_ACCOUNT_ID,
+        brandId<SessionId>("sess_keep"),
+        mockAudit,
+      );
       expect(count).toBe(3);
     });
 

--- a/apps/api/src/__tests__/services/device-transfer.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/device-transfer.service.integration.test.ts
@@ -25,7 +25,7 @@ import {
 import { initiateTransfer } from "../../services/device-transfer/initiate.js";
 import { asDb, noopAudit, spyAudit } from "../helpers/integration-setup.js";
 
-import type { AccountId, SessionId } from "@pluralscape/types";
+import type { AccountId, DeviceTransferRequestId, SessionId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 // ── Mock the KDF worker offload ───────────────────────────────────────
@@ -74,7 +74,7 @@ function validEncryptedHex(): string {
 
 async function insertSession(
   db: PgliteDatabase<typeof schema>,
-  accountId: string,
+  accountId: AccountId,
 ): Promise<SessionId> {
   const sessionId = brandId<SessionId>(`sess_${randomUUID()}`);
   const now = Date.now();
@@ -268,7 +268,7 @@ describe("device-transfer.service (PGlite integration)", () => {
       await expect(
         completeTransfer(
           asDb(db),
-          "dtr_nonexistent",
+          brandId<DeviceTransferRequestId>("dtr_nonexistent"),
           accountId,
           targetSessionId,
           "1234567890",

--- a/apps/api/src/__tests__/services/device-transfer.service.test.ts
+++ b/apps/api/src/__tests__/services/device-transfer.service.test.ts
@@ -169,7 +169,13 @@ describe("device-transfer.service", () => {
       // UPDATE: set status to approved, returning
       chain.returning.mockResolvedValueOnce([{ id: "dtr_test" }]);
 
-      await approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, SESSION_ID, mockAudit);
+      await approveTransfer(
+        db,
+        brandId<DeviceTransferRequestId>("dtr_test"),
+        ACCOUNT_ID,
+        SESSION_ID,
+        mockAudit,
+      );
 
       expect(chain.update).toHaveBeenCalled();
       expect(mockAudit).toHaveBeenCalledWith(
@@ -183,7 +189,13 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValueOnce([]);
 
       await expect(
-        approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_nonexistent"), ACCOUNT_ID, SESSION_ID, mockAudit),
+        approveTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_nonexistent"),
+          ACCOUNT_ID,
+          SESSION_ID,
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -192,7 +204,13 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValueOnce([{ id: "dtr_test", sourceSessionId: "sess_other" }]);
 
       await expect(
-        approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, SESSION_ID, mockAudit),
+        approveTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          SESSION_ID,
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferSessionMismatchError);
     });
 
@@ -204,7 +222,13 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValueOnce([]);
 
       await expect(
-        approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, SESSION_ID, mockAudit),
+        approveTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          SESSION_ID,
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferNotFoundError);
     });
   });
@@ -223,7 +247,14 @@ describe("device-transfer.service", () => {
       mockIsValidTransferCode.mockReturnValue(false);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "abc", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "abc",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferValidationError);
     });
 
@@ -246,7 +277,14 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow({ encryptedKeyMaterial: null })]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "12345678",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -276,7 +314,14 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow()]);
       chain.returning.mockResolvedValue([{ id: "dtr_test" }]);
 
-      await completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit);
+      await completeTransfer(
+        db,
+        brandId<DeviceTransferRequestId>("dtr_test"),
+        ACCOUNT_ID,
+        TARGET_SESSION_ID,
+        "12345678",
+        mockAudit,
+      );
 
       expect(chain.delete).toHaveBeenCalled();
       expect(chain.returning).toHaveBeenCalled();
@@ -287,7 +332,14 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "12345678",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -300,7 +352,14 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow()]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "12345678",
+          mockAudit,
+        ),
       ).rejects.toThrow(KeyDerivationUnavailableError);
     });
 
@@ -315,7 +374,14 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([{ codeAttempts: 1 }]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "00000000",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferCodeError);
 
       expect(chain.update).toHaveBeenCalled();
@@ -333,7 +399,14 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([{ codeAttempts: 5 }]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "00000000",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferExpiredError);
     });
 
@@ -348,7 +421,14 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "00000000",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -360,7 +440,14 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow()]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "12345678",
+          mockAudit,
+        ),
       ).rejects.toThrow(TypeError);
     });
 
@@ -368,7 +455,14 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          ACCOUNT_ID,
+          TARGET_SESSION_ID,
+          "12345678",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -377,7 +471,14 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), OTHER_ACCOUNT, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(
+          db,
+          brandId<DeviceTransferRequestId>("dtr_test"),
+          OTHER_ACCOUNT,
+          TARGET_SESSION_ID,
+          "12345678",
+          mockAudit,
+        ),
       ).rejects.toThrow(TransferNotFoundError);
     });
   });

--- a/apps/api/src/__tests__/services/device-transfer.service.test.ts
+++ b/apps/api/src/__tests__/services/device-transfer.service.test.ts
@@ -15,7 +15,7 @@ import { initiateTransfer } from "../../services/device-transfer/initiate.js";
 import { mockDb } from "../helpers/mock-db.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AccountId, SessionId } from "@pluralscape/types";
+import type { AccountId, DeviceTransferRequestId, SessionId } from "@pluralscape/types";
 
 // ── Mock external dependencies ─────────────────────────────────────────
 
@@ -169,7 +169,7 @@ describe("device-transfer.service", () => {
       // UPDATE: set status to approved, returning
       chain.returning.mockResolvedValueOnce([{ id: "dtr_test" }]);
 
-      await approveTransfer(db, "dtr_test", ACCOUNT_ID, SESSION_ID, mockAudit);
+      await approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, SESSION_ID, mockAudit);
 
       expect(chain.update).toHaveBeenCalled();
       expect(mockAudit).toHaveBeenCalledWith(
@@ -183,7 +183,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValueOnce([]);
 
       await expect(
-        approveTransfer(db, "dtr_nonexistent", ACCOUNT_ID, SESSION_ID, mockAudit),
+        approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_nonexistent"), ACCOUNT_ID, SESSION_ID, mockAudit),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -192,7 +192,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValueOnce([{ id: "dtr_test", sourceSessionId: "sess_other" }]);
 
       await expect(
-        approveTransfer(db, "dtr_test", ACCOUNT_ID, SESSION_ID, mockAudit),
+        approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, SESSION_ID, mockAudit),
       ).rejects.toThrow(TransferSessionMismatchError);
     });
 
@@ -204,7 +204,7 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValueOnce([]);
 
       await expect(
-        approveTransfer(db, "dtr_test", ACCOUNT_ID, SESSION_ID, mockAudit),
+        approveTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, SESSION_ID, mockAudit),
       ).rejects.toThrow(TransferNotFoundError);
     });
   });
@@ -223,7 +223,7 @@ describe("device-transfer.service", () => {
       mockIsValidTransferCode.mockReturnValue(false);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "abc", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "abc", mockAudit),
       ).rejects.toThrow(TransferValidationError);
     });
 
@@ -233,7 +233,7 @@ describe("device-transfer.service", () => {
       await expect(
         completeTransfer(
           db,
-          "dtr_nonexistent",
+          brandId<DeviceTransferRequestId>("dtr_nonexistent"),
           ACCOUNT_ID,
           TARGET_SESSION_ID,
           "12345678",
@@ -246,7 +246,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow({ encryptedKeyMaterial: null })]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -260,7 +260,7 @@ describe("device-transfer.service", () => {
 
       const result = await completeTransfer(
         db,
-        "dtr_test",
+        brandId<DeviceTransferRequestId>("dtr_test"),
         ACCOUNT_ID,
         TARGET_SESSION_ID,
         "12345678",
@@ -276,7 +276,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow()]);
       chain.returning.mockResolvedValue([{ id: "dtr_test" }]);
 
-      await completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit);
+      await completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit);
 
       expect(chain.delete).toHaveBeenCalled();
       expect(chain.returning).toHaveBeenCalled();
@@ -287,7 +287,7 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -300,7 +300,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow()]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
       ).rejects.toThrow(KeyDerivationUnavailableError);
     });
 
@@ -315,7 +315,7 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([{ codeAttempts: 1 }]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
       ).rejects.toThrow(TransferCodeError);
 
       expect(chain.update).toHaveBeenCalled();
@@ -333,7 +333,7 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([{ codeAttempts: 5 }]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
       ).rejects.toThrow(TransferExpiredError);
     });
 
@@ -348,7 +348,7 @@ describe("device-transfer.service", () => {
       chain.returning.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "00000000", mockAudit),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -360,7 +360,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([makeRow()]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
       ).rejects.toThrow(TypeError);
     });
 
@@ -368,7 +368,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, "dtr_test", ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), ACCOUNT_ID, TARGET_SESSION_ID, "12345678", mockAudit),
       ).rejects.toThrow(TransferNotFoundError);
     });
 
@@ -377,7 +377,7 @@ describe("device-transfer.service", () => {
       chain.limit.mockResolvedValue([]);
 
       await expect(
-        completeTransfer(db, "dtr_test", OTHER_ACCOUNT, TARGET_SESSION_ID, "12345678", mockAudit),
+        completeTransfer(db, brandId<DeviceTransferRequestId>("dtr_test"), OTHER_ACCOUNT, TARGET_SESSION_ID, "12345678", mockAudit),
       ).rejects.toThrow(TransferNotFoundError);
     });
   });

--- a/apps/api/src/__tests__/services/recovery-key.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/recovery-key.service.integration.test.ts
@@ -31,7 +31,7 @@ import { getRecoveryKeyStatus } from "../../services/recovery-key/status.js";
 import { asDb, noopAudit, spyAudit } from "../helpers/integration-setup.js";
 import { createMockLogger } from "../helpers/mock-logger.js";
 
-import type { AccountId } from "@pluralscape/types";
+import type { AccountId, RecoveryKeyId, SessionId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const { accounts, authKeys, recoveryKeys, sessions, systems } = schema;
@@ -91,7 +91,7 @@ describe("recovery-key.service (PGlite integration)", { timeout: 60_000 }, () =>
     const recoveryKeyBytes = randBytes(32);
     const recoveryKeyHashBytes = hashRecoveryKey(recoveryKeyBytes);
     const timestamp = Date.now();
-    const recoveryKeyId = `rk_${crypto.randomUUID()}`;
+    const recoveryKeyId = brandId<RecoveryKeyId>(`rk_${crypto.randomUUID()}`);
 
     await db.insert(accounts).values({
       id: accountId,
@@ -357,7 +357,7 @@ describe("recovery-key.service (PGlite integration)", { timeout: 60_000 }, () =>
 
       const timestamp = Date.now();
       await db.insert(sessions).values({
-        id: `sess_${crypto.randomUUID()}`,
+        id: brandId<SessionId>(`sess_${crypto.randomUUID()}`),
         accountId,
         tokenHash: toHex(randBytes(32)),
         createdAt: timestamp,

--- a/apps/api/src/__tests__/services/session-cascade.test.ts
+++ b/apps/api/src/__tests__/services/session-cascade.test.ts
@@ -28,8 +28,10 @@ describe("session cascade on account deletion (structural verification)", () => 
   });
 
   it("sessions table has accountId as a required field", () => {
-    // accountId must be NOT NULL to ensure every session belongs to an account
-    expect(authSchemaSource).toContain('accountId: varchar("account_id"');
+    // accountId must be NOT NULL to ensure every session belongs to an account.
+    // Column declaration uses the brandedId<AccountId>() helper so the
+    // inferred row type carries the AccountId brand (types-ltel fleet).
+    expect(authSchemaSource).toContain('accountId: brandedId<AccountId>("account_id"');
     // The .notNull() must be chained before .references()
     const sessionBlock = authSchemaSource.slice(authSchemaSource.indexOf("export const sessions"));
     expect(sessionBlock).toContain(".notNull()");

--- a/apps/api/src/__tests__/trpc/routers/account.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/account.test.ts
@@ -9,7 +9,7 @@ import {
   assertProcedureRateLimited,
 } from "../test-helpers.js";
 
-import type { BiometricTokenId, UnixMillis } from "@pluralscape/types";
+import type { BiometricTokenId, DeviceTransferRequestId, UnixMillis } from "@pluralscape/types";
 
 vi.mock("../../../lib/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -599,7 +599,7 @@ describe("account router", () => {
     };
 
     const mockTransferResult = {
-      transferId: "xfer_001",
+      transferId: brandId<DeviceTransferRequestId>("xfer_001"),
       expiresAt: 1_700_003_600_000 as import("@pluralscape/types").UnixMillis,
     };
 

--- a/apps/api/src/__tests__/trpc/routers/auth.integration.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/auth.integration.test.ts
@@ -42,7 +42,7 @@ import { createMockLogger } from "../../helpers/mock-logger.js";
 import { setupRouterFixture } from "../integration-helpers.js";
 
 import type { AuthContext } from "../../../lib/auth-context.js";
-import type { AccountId, SessionId, SystemId } from "@pluralscape/types";
+import type { AccountId, RecoveryKeyId, SessionId, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /** Default page size expected from session.list when no cursor is supplied. */
@@ -111,7 +111,7 @@ async function insertAccountWithKnownRecoveryKey(db: PostgresJsDatabase): Promis
 }> {
   const email = `reset-${crypto.randomUUID()}@test.local`;
   const accountId = `acct_${crypto.randomUUID()}`;
-  const recoveryKeyId = `rk_${crypto.randomUUID()}`;
+  const recoveryKeyId = brandId<RecoveryKeyId>(`rk_${crypto.randomUUID()}`);
   // randomBytes returns Node's Buffer; coerce to plain Uint8Array so the
   // branded `AuthKey` assertion narrows correctly.
   const rawAuthKey = new Uint8Array(randomBytes(RECOVERY_KEY_BYTES));

--- a/apps/api/src/__tests__/trpc/routers/auth.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/auth.test.ts
@@ -318,7 +318,9 @@ describe("auth router", () => {
 
     it("returns paginated sessions", async () => {
       const mockResult = {
-        sessions: [{ id: "sess_1", createdAt: 1000, lastActive: 2000, expiresAt: null }],
+        sessions: [
+          { id: brandId<SessionId>("sess_1"), createdAt: 1000, lastActive: 2000, expiresAt: null },
+        ],
         nextCursor: null,
       };
       vi.mocked(listSessions).mockResolvedValue(mockResult);

--- a/apps/api/src/routes/account/device-transfer.ts
+++ b/apps/api/src/routes/account/device-transfer.ts
@@ -1,5 +1,5 @@
 import { TRANSFER_TIMEOUT_MS } from "@pluralscape/crypto";
-import { MS_PER_HOUR } from "@pluralscape/types";
+import { MS_PER_HOUR, brandId } from "@pluralscape/types";
 import { Hono } from "hono";
 
 import {
@@ -40,6 +40,7 @@ import {
 } from "./device-transfer.schema.js";
 
 import type { AuthEnv } from "../../lib/auth-context.js";
+import type { DeviceTransferRequestId } from "@pluralscape/types";
 import type { Context } from "hono";
 
 /** Extract accountId from an authenticated context for rate-limit keying. */
@@ -113,7 +114,7 @@ deviceTransferRoute.post("/:id/approve", async (c) => {
   const transferId = c.req.param("id");
 
   try {
-    await approveTransfer(db, transferId, auth.accountId, session.sessionId, audit);
+    await approveTransfer(db, brandId<DeviceTransferRequestId>(transferId), auth.accountId, session.sessionId, audit);
     return c.body(null, HTTP_NO_CONTENT);
   } catch (error: unknown) {
     if (error instanceof TransferNotFoundError) {
@@ -159,7 +160,7 @@ deviceTransferRoute.post("/:id/complete", async (c) => {
   try {
     const result = await completeTransfer(
       db,
-      transferId,
+      brandId<DeviceTransferRequestId>(transferId),
       auth.accountId,
       session.sessionId,
       parseResult.data.code,

--- a/apps/api/src/routes/account/device-transfer.ts
+++ b/apps/api/src/routes/account/device-transfer.ts
@@ -114,7 +114,13 @@ deviceTransferRoute.post("/:id/approve", async (c) => {
   const transferId = c.req.param("id");
 
   try {
-    await approveTransfer(db, brandId<DeviceTransferRequestId>(transferId), auth.accountId, session.sessionId, audit);
+    await approveTransfer(
+      db,
+      brandId<DeviceTransferRequestId>(transferId),
+      auth.accountId,
+      session.sessionId,
+      audit,
+    );
     return c.body(null, HTTP_NO_CONTENT);
   } catch (error: unknown) {
     if (error instanceof TransferNotFoundError) {

--- a/apps/api/src/services/api-key/create.ts
+++ b/apps/api/src/services/api-key/create.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 
 import { apiKeys } from "@pluralscape/db/pg";
-import { API_KEY_TOKEN_PREFIX, ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { API_KEY_TOKEN_PREFIX, ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
 import { CreateApiKeyBodySchema } from "@pluralscape/validation";
 
 import { HTTP_BAD_REQUEST } from "../../http.constants.js";
@@ -20,7 +20,7 @@ import {
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
-import type { SystemId } from "@pluralscape/types";
+import type { ApiKeyId, BucketId, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Constants ──────────────────────────────────────────────────────
@@ -65,7 +65,7 @@ export async function createApiKey(
     result.data;
 
   const blob = validateEncryptedBlob(encryptedData);
-  const akId = createId(ID_PREFIXES.apiKey);
+  const akId = brandId<ApiKeyId>(createId(ID_PREFIXES.apiKey));
   const timestamp = now();
   const { token, tokenHash } = await generateTokenPair();
 
@@ -87,7 +87,7 @@ export async function createApiKey(
         lastUsedAt: null,
         revokedAt: null,
         expiresAt: expiresAt ?? null,
-        scopedBucketIds: scopedBucketIds ?? null,
+        scopedBucketIds: scopedBucketIds?.map((id) => brandId<BucketId>(id)) ?? null,
       })
       .returning(API_KEY_SELECT_COLUMNS);
 

--- a/apps/api/src/services/api-key/queries.ts
+++ b/apps/api/src/services/api-key/queries.ts
@@ -1,4 +1,5 @@
 import { apiKeys } from "@pluralscape/db/pg";
+import { brandId } from "@pluralscape/types";
 import { and, desc, eq, isNull, lt } from "drizzle-orm";
 
 import { HTTP_NOT_FOUND } from "../../http.constants.js";
@@ -44,7 +45,7 @@ export async function listApiKeys(
     }
 
     if (opts.cursor) {
-      conditions.push(lt(apiKeys.id, opts.cursor));
+      conditions.push(lt(apiKeys.id, brandId<ApiKeyId>(opts.cursor)));
     }
 
     const rows = await tx

--- a/apps/api/src/services/auth/login.ts
+++ b/apps/api/src/services/auth/login.ts
@@ -31,7 +31,7 @@ import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AppLogger } from "../../lib/logger.js";
 import type { ClientPlatform } from "../../routes/auth/auth.constants.js";
 import type { AuthKey, AuthKeyHash } from "@pluralscape/crypto";
-import type { AccountId, AccountType, SystemId, UnixMillis } from "@pluralscape/types";
+import type { AccountId, AccountType, SessionId, SystemId, UnixMillis } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Login ──────────────────────────────────────────────────────────
@@ -179,7 +179,7 @@ export async function loginAccount(
     );
   }
 
-  const sessionId = createId(ID_PREFIXES.session);
+  const sessionId = brandId<SessionId>(createId(ID_PREFIXES.session));
   const rawToken = generateSessionToken();
   const tokenHash = hashSessionToken(rawToken);
   const timestamp = now();

--- a/apps/api/src/services/auth/register.ts
+++ b/apps/api/src/services/auth/register.ts
@@ -26,7 +26,14 @@ import { EMAIL_SALT_BYTES, CHALLENGE_NONCE_TTL_MS } from "../../routes/auth/auth
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { ClientPlatform } from "../../routes/auth/auth.constants.js";
 import type { ChallengeNonce } from "@pluralscape/crypto";
-import type { AccountId, AccountType, AuthKeyId, RecoveryKeyId, SessionId, SystemId } from "@pluralscape/types";
+import type {
+  AccountId,
+  AccountType,
+  AuthKeyId,
+  RecoveryKeyId,
+  SessionId,
+  SystemId,
+} from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Registration Phase 1: Initiate ────────────────────────────────

--- a/apps/api/src/services/auth/register.ts
+++ b/apps/api/src/services/auth/register.ts
@@ -26,7 +26,7 @@ import { EMAIL_SALT_BYTES, CHALLENGE_NONCE_TTL_MS } from "../../routes/auth/auth
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { ClientPlatform } from "../../routes/auth/auth.constants.js";
 import type { ChallengeNonce } from "@pluralscape/crypto";
-import type { AccountId, AccountType, SystemId } from "@pluralscape/types";
+import type { AccountId, AccountType, AuthKeyId, RecoveryKeyId, SessionId, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Registration Phase 1: Initiate ────────────────────────────────
@@ -202,7 +202,7 @@ export async function commitRegistration(
   const publicEncKeyBytes = fromHex(parsed.publicEncryptionKey);
   const recoveryEncMasterKeyBytes = fromHex(parsed.recoveryEncryptedMasterKey);
 
-  const sessionId = createId(ID_PREFIXES.session);
+  const sessionId = brandId<SessionId>(createId(ID_PREFIXES.session));
   const rawToken = generateSessionToken();
   const tokenHash = hashSessionToken(rawToken);
   const timestamp = now();
@@ -239,7 +239,7 @@ export async function commitRegistration(
 
     await tx.insert(authKeys).values([
       {
-        id: createId(ID_PREFIXES.authKey),
+        id: brandId<AuthKeyId>(createId(ID_PREFIXES.authKey)),
         accountId: account.id,
         encryptedPrivateKey: encEncPrivKeyBytes,
         publicKey: publicEncKeyBytes,
@@ -247,7 +247,7 @@ export async function commitRegistration(
         createdAt: timestamp,
       },
       {
-        id: createId(ID_PREFIXES.authKey),
+        id: brandId<AuthKeyId>(createId(ID_PREFIXES.authKey)),
         accountId: account.id,
         encryptedPrivateKey: encSignPrivKeyBytes,
         publicKey: publicSigningKeyBytes,
@@ -257,7 +257,7 @@ export async function commitRegistration(
     ]);
 
     await tx.insert(recoveryKeys).values({
-      id: createId(ID_PREFIXES.recoveryKey),
+      id: brandId<RecoveryKeyId>(createId(ID_PREFIXES.recoveryKey)),
       accountId: account.id,
       encryptedMasterKey: recoveryEncMasterKeyBytes,
       recoveryKeyHash: fromHex(parsed.recoveryKeyHash),

--- a/apps/api/src/services/auth/sessions.ts
+++ b/apps/api/src/services/auth/sessions.ts
@@ -1,5 +1,5 @@
 import { sessions } from "@pluralscape/db/pg";
-import { now } from "@pluralscape/types";
+import { brandId, now } from "@pluralscape/types";
 import { and, eq, gt, isNull, ne, or } from "drizzle-orm";
 
 import { toCursor } from "../../lib/pagination.js";
@@ -8,13 +8,13 @@ import { buildIdleTimeoutFilter } from "../../lib/session-idle-filter.js";
 import { DEFAULT_SESSION_LIMIT, MAX_SESSION_LIMIT } from "../../routes/auth/auth.constants.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AccountId, PaginationCursor } from "@pluralscape/types";
+import type { AccountId, PaginationCursor, SessionId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Session management ─────────────────────────────────────────────
 
 export interface SessionInfo {
-  readonly id: string;
+  readonly id: SessionId;
   readonly createdAt: number;
   readonly lastActive: number | null;
   readonly expiresAt: number | null;
@@ -39,7 +39,7 @@ export async function listSessions(
       buildIdleTimeoutFilter(currentTime),
     ];
     if (cursor) {
-      conditions.push(gt(sessions.id, cursor));
+      conditions.push(gt(sessions.id, brandId<SessionId>(cursor)));
     }
 
     const rows = await tx
@@ -65,7 +65,7 @@ export async function listSessions(
 
 export async function revokeSession(
   db: PostgresJsDatabase,
-  sessionId: string,
+  sessionId: SessionId,
   actorAccountId: AccountId,
   audit: AuditWriter,
 ): Promise<boolean> {
@@ -99,7 +99,7 @@ export async function revokeSession(
 export async function revokeAllSessions(
   db: PostgresJsDatabase,
   accountId: AccountId,
-  exceptSessionId: string,
+  exceptSessionId: SessionId,
   audit: AuditWriter,
 ): Promise<number> {
   return withAccountTransaction(db, accountId, async (tx) => {
@@ -127,7 +127,7 @@ export async function revokeAllSessions(
 
 export async function logoutCurrentSession(
   db: PostgresJsDatabase,
-  sessionId: string,
+  sessionId: SessionId,
   accountId: AccountId,
   audit: AuditWriter,
 ): Promise<void> {

--- a/apps/api/src/services/device-transfer/approve.ts
+++ b/apps/api/src/services/device-transfer/approve.ts
@@ -6,7 +6,7 @@ import { withAccountTransaction } from "../../lib/rls-context.js";
 import { TransferNotFoundError, TransferSessionMismatchError } from "./errors.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AccountId, SessionId } from "@pluralscape/types";
+import type { AccountId, DeviceTransferRequestId, SessionId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /**
@@ -17,7 +17,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
  */
 export async function approveTransfer(
   db: PostgresJsDatabase,
-  transferId: string,
+  transferId: DeviceTransferRequestId,
   accountId: AccountId,
   sessionId: SessionId,
   audit: AuditWriter,

--- a/apps/api/src/services/device-transfer/complete.ts
+++ b/apps/api/src/services/device-transfer/complete.ts
@@ -23,7 +23,7 @@ import {
 } from "./errors.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AccountId, SessionId } from "@pluralscape/types";
+import type { AccountId, DeviceTransferRequestId, SessionId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 export interface CompleteTransferResult {
@@ -41,7 +41,7 @@ export interface CompleteTransferResult {
  */
 export async function completeTransfer(
   db: PostgresJsDatabase,
-  transferId: string,
+  transferId: DeviceTransferRequestId,
   accountId: AccountId,
   sessionId: SessionId,
   code: string,

--- a/apps/api/src/services/device-transfer/initiate.ts
+++ b/apps/api/src/services/device-transfer/initiate.ts
@@ -1,6 +1,6 @@
 import { PWHASH_SALT_BYTES, TRANSFER_TIMEOUT_MS } from "@pluralscape/crypto";
 import { deviceTransferRequests } from "@pluralscape/db/pg";
-import { createId, now, toUnixMillis } from "@pluralscape/types";
+import { brandId, createId, now, toUnixMillis } from "@pluralscape/types";
 
 import { deserializeEncryptedPayload } from "../../lib/encrypted-payload.js";
 import { fromHex } from "../../lib/hex.js";
@@ -9,7 +9,7 @@ import { withAccountTransaction } from "../../lib/rls-context.js";
 import { TransferValidationError } from "./errors.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AccountId, SessionId, UnixMillis } from "@pluralscape/types";
+import type { AccountId, DeviceTransferRequestId, SessionId, UnixMillis } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 interface InitiateTransferInput {
@@ -18,7 +18,7 @@ interface InitiateTransferInput {
 }
 
 export interface InitiateTransferResult {
-  readonly transferId: string;
+  readonly transferId: DeviceTransferRequestId;
   readonly expiresAt: UnixMillis;
 }
 
@@ -51,7 +51,7 @@ export async function initiateTransfer(
     throw new TransferValidationError("Invalid input format", { cause: error });
   }
 
-  const transferId = createId("dtr_");
+  const transferId = brandId<DeviceTransferRequestId>(createId("dtr_"));
   const createdAt = now();
   // Security: expired transfer records retain their encrypted key material in
   // the DB until completeTransfer's WHERE clause filters them out by expiresAt.

--- a/apps/api/src/services/recovery-key/regenerate.ts
+++ b/apps/api/src/services/recovery-key/regenerate.ts
@@ -1,6 +1,6 @@
 import { assertAuthKey, assertAuthKeyHash, verifyAuthKey } from "@pluralscape/crypto";
 import { accounts, recoveryKeys } from "@pluralscape/db/pg";
-import { ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
 import { RegenerateRecoveryKeySchema } from "@pluralscape/validation";
 import { and, eq, isNull } from "drizzle-orm";
 
@@ -13,7 +13,7 @@ import { INCORRECT_PASSWORD_ERROR } from "../auth.constants.js";
 import { NoActiveRecoveryKeyError } from "./internal.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AccountId } from "@pluralscape/types";
+import type { AccountId, RecoveryKeyId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Regenerate Recovery Key ──────────────────────────────────────
@@ -67,7 +67,7 @@ export async function regenerateRecoveryKeyBackup(
     const newRecoveryEncryptedMasterKeyBytes = fromHex(parsed.newRecoveryEncryptedMasterKey);
     const recoveryKeyHashBytes = fromHex(parsed.recoveryKeyHash);
     const timestamp = now();
-    const newId = createId(ID_PREFIXES.recoveryKey);
+    const newId = brandId<RecoveryKeyId>(createId(ID_PREFIXES.recoveryKey));
 
     const revoked = await tx
       .update(recoveryKeys)

--- a/apps/api/src/services/recovery-key/reset-password.ts
+++ b/apps/api/src/services/recovery-key/reset-password.ts
@@ -20,7 +20,7 @@ import { NoActiveRecoveryKeyError } from "./internal.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { ClientPlatform } from "../../routes/auth/auth.constants.js";
-import type { AccountId, SessionId } from "@pluralscape/types";
+import type { AccountId, RecoveryKeyId, SessionId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Reset Password via Recovery Key ──────────────────────────────
@@ -99,8 +99,8 @@ export async function resetPasswordWithRecoveryKey(
     const timestamp = now();
     const rawToken = generateSessionToken();
     const tokenHash = hashSessionToken(rawToken);
-    const sessionId = createId(ID_PREFIXES.session);
-    const newRecoveryKeyId = createId(ID_PREFIXES.recoveryKey);
+    const sessionId = brandId<SessionId>(createId(ID_PREFIXES.session));
+    const newRecoveryKeyId = brandId<RecoveryKeyId>(createId(ID_PREFIXES.recoveryKey));
     const timeouts = SESSION_TIMEOUTS[platform];
     const expiresAt = timestamp + timeouts.absoluteTtlMs;
 

--- a/apps/api/src/trpc/routers/account.ts
+++ b/apps/api/src/trpc/routers/account.ts
@@ -5,7 +5,7 @@ import {
   PWHASH_SALT_BYTES,
   TRANSFER_TIMEOUT_MS,
 } from "@pluralscape/crypto";
-import { MS_PER_HOUR } from "@pluralscape/types";
+import { MS_PER_HOUR, brandId } from "@pluralscape/types";
 import {
   AuditLogQuerySchema,
   BiometricEnrollBodySchema,
@@ -63,6 +63,8 @@ import {
   createTRPCRateLimiter,
 } from "../middlewares/rate-limit.js";
 import { router } from "../trpc.js";
+
+import type { DeviceTransferRequestId } from "@pluralscape/types";
 
 // ── Device transfer input validation ──────────────────────────────────────────
 // Zod v4 mirror of device-transfer.schema.ts (v3). Constants derived from
@@ -328,7 +330,7 @@ export const accountRouter = router({
       try {
         await approveTransfer(
           ctx.db,
-          input.transferId,
+          brandId<DeviceTransferRequestId>(input.transferId),
           ctx.auth.accountId,
           session.sessionId,
           audit,
@@ -359,7 +361,7 @@ export const accountRouter = router({
       try {
         return await completeTransfer(
           ctx.db,
-          input.transferId,
+          brandId<DeviceTransferRequestId>(input.transferId),
           ctx.auth.accountId,
           session.sessionId,
           input.code,

--- a/packages/db/src/__tests__/queries-sqlite-device-transfer-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-device-transfer-cleanup.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -7,6 +8,11 @@ import { accounts, deviceTransferRequests, sessions } from "../schema/sqlite/aut
 
 import { createSqliteAuthTables, sqliteInsertAccount } from "./helpers/sqlite-helpers.js";
 
+import type {
+  AccountId,
+  DeviceTransferRequestId,
+  SessionId,
+} from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const ONE_HOUR_MS = 3_600_000;
@@ -18,8 +24,8 @@ describe("sqliteCleanupDeviceTransfers", () => {
   let client: InstanceType<typeof Database>;
   let db: BetterSQLite3Database<typeof schema>;
 
-  function insertSession(accountId: string): string {
-    const id = crypto.randomUUID();
+  function insertSession(accountId: AccountId): SessionId {
+    const id = brandId<SessionId>(crypto.randomUUID());
     db.insert(sessions)
       .values({
         id,
@@ -32,14 +38,14 @@ describe("sqliteCleanupDeviceTransfers", () => {
   }
 
   function insertTransfer(opts: {
-    accountId: string;
-    sourceSessionId: string;
+    accountId: AccountId;
+    sourceSessionId: SessionId;
     status?: "pending" | "approved" | "expired";
     createdAt?: number;
     expiresAt?: number;
     encryptedKeyMaterial?: Uint8Array;
-  }): string {
-    const id = crypto.randomUUID();
+  }): DeviceTransferRequestId {
+    const id = brandId<DeviceTransferRequestId>(crypto.randomUUID());
     const now = Date.now();
     db.insert(deviceTransferRequests)
       .values({

--- a/packages/db/src/__tests__/queries-sqlite-device-transfer-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-device-transfer-cleanup.integration.test.ts
@@ -8,11 +8,7 @@ import { accounts, deviceTransferRequests, sessions } from "../schema/sqlite/aut
 
 import { createSqliteAuthTables, sqliteInsertAccount } from "./helpers/sqlite-helpers.js";
 
-import type {
-  AccountId,
-  DeviceTransferRequestId,
-  SessionId,
-} from "@pluralscape/types";
+import type { AccountId, DeviceTransferRequestId, SessionId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const ONE_HOUR_MS = 3_600_000;

--- a/packages/db/src/__tests__/queries-sqlite-recovery-key.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-recovery-key.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -12,6 +13,7 @@ import { accounts, recoveryKeys } from "../schema/sqlite/auth.js";
 
 import { SQLITE_DDL, sqliteInsertAccount } from "./helpers/sqlite-helpers.js";
 
+import type { AccountId, RecoveryKeyId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, recoveryKeys };
@@ -42,9 +44,12 @@ describe("recovery key queries (SQLite)", () => {
     return new Uint8Array(72).fill(0xab);
   }
 
-  function makeRow(accountId: string, overrides: Partial<{ id: string; createdAt: number }> = {}) {
+  function makeRow(
+    accountId: AccountId,
+    overrides: Partial<{ id: RecoveryKeyId; createdAt: number }> = {},
+  ) {
     return {
-      id: overrides.id ?? crypto.randomUUID(),
+      id: overrides.id ?? brandId<RecoveryKeyId>(crypto.randomUUID()),
       accountId,
       encryptedMasterKey: makeEncryptedKey(),
       createdAt: overrides.createdAt ?? Date.now(),
@@ -154,7 +159,7 @@ describe("recovery key queries (SQLite)", () => {
       expect(() => {
         sqliteRevokeRecoveryKey(
           db as BetterSQLite3Database<Record<string, unknown>>,
-          "nonexistent-id",
+          brandId<RecoveryKeyId>("nonexistent-id"),
           Date.now(),
         );
       }).toThrow("Recovery key not found.");
@@ -208,7 +213,7 @@ describe("recovery key queries (SQLite)", () => {
       const newRow = makeRow(accountId);
       expect(() => {
         sqliteReplaceRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, {
-          revokeId: "nonexistent-id",
+          revokeId: brandId<RecoveryKeyId>("nonexistent-id"),
           revokedAt: Date.now(),
           newRow,
         });

--- a/packages/db/src/__tests__/schema-pg-api-keys.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-api-keys.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { AccountId, ApiKeyId, BucketId, SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, apiKeys };
@@ -38,7 +40,7 @@ describe("PG api_keys schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
 
     await db.insert(apiKeys).values({
@@ -66,7 +68,7 @@ describe("PG api_keys schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
     const keyMaterial = new Uint8Array([1, 2, 3, 4, 5]);
 
@@ -79,7 +81,7 @@ describe("PG api_keys schema", () => {
       tokenHash,
       scopes: ["full"],
       encryptedKeyMaterial: keyMaterial,
-      scopedBucketIds: ["bucket-1", "bucket-2"],
+      scopedBucketIds: [brandId<BucketId>("bucket-1"), brandId<BucketId>("bucket-2")],
       createdAt: now,
     });
 
@@ -96,7 +98,7 @@ describe("PG api_keys schema", () => {
 
     await expect(
       db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         encryptedData: testBlob(),
@@ -115,7 +117,7 @@ describe("PG api_keys schema", () => {
     const tokenHash = `hash_${crypto.randomUUID()}`;
 
     await db.insert(apiKeys).values({
-      id: crypto.randomUUID(),
+      id: brandId<ApiKeyId>(crypto.randomUUID()),
       accountId,
       systemId,
       encryptedData: testBlob(),
@@ -127,7 +129,7 @@ describe("PG api_keys schema", () => {
 
     await expect(
       db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         encryptedData: testBlob(),
@@ -143,7 +145,7 @@ describe("PG api_keys schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
       id,
@@ -169,7 +171,7 @@ describe("PG api_keys schema", () => {
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
     const later = now + 86400000;
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
       id,
@@ -195,7 +197,7 @@ describe("PG api_keys schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
       id,
@@ -217,7 +219,7 @@ describe("PG api_keys schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
       id,
@@ -242,8 +244,8 @@ describe("PG api_keys schema", () => {
 
     await expect(
       db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
-        accountId: "nonexistent",
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
+        accountId: brandId<AccountId>("nonexistent"),
         systemId,
         encryptedData: testBlob(),
         keyType: "metadata",
@@ -261,7 +263,7 @@ describe("PG api_keys schema", () => {
 
     await expect(
       db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         encryptedData: testBlob(),
@@ -281,7 +283,7 @@ describe("PG api_keys schema", () => {
 
     await expect(
       db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         encryptedData: testBlob(),
@@ -297,7 +299,7 @@ describe("PG api_keys schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
       id,
@@ -320,9 +322,9 @@ describe("PG api_keys schema", () => {
 
     await expect(
       db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
-        systemId: "nonexistent",
+        systemId: brandId<SystemId>("nonexistent"),
         encryptedData: testBlob(),
         keyType: "metadata",
         tokenHash: `hash_${crypto.randomUUID()}`,
@@ -341,7 +343,7 @@ describe("PG api_keys schema", () => {
     // accountA tries to create an API key referencing accountB's system
     await expect(
       db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId: accountA,
         systemId: systemOfB,
         encryptedData: testBlob(),
@@ -370,7 +372,7 @@ describe("PG api_keys schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
     const blob = testBlob(new Uint8Array([10, 20, 30]));
 
     await db.insert(apiKeys).values({

--- a/packages/db/src/__tests__/schema-pg-auth.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-auth.integration.test.ts
@@ -14,11 +14,22 @@ import {
 
 import { createPgAuthTables, testBlob } from "./helpers/pg-helpers.js";
 
-import type { AccountId } from "@pluralscape/types";
+import type {
+  AccountId,
+  AuthKeyId,
+  DeviceTransferRequestId,
+  RecoveryKeyId,
+  SessionId,
+} from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 /** Branded ID factory for test fixtures — produces an AccountId from crypto.randomUUID(). */
 const newAccountId = (raw?: string): AccountId => brandId<AccountId>(raw ?? crypto.randomUUID());
+const newSessionId = (): SessionId => brandId<SessionId>(crypto.randomUUID());
+const newAuthKeyId = (): AuthKeyId => brandId<AuthKeyId>(crypto.randomUUID());
+const newRecoveryKeyId = (): RecoveryKeyId => brandId<RecoveryKeyId>(crypto.randomUUID());
+const newDeviceTransferRequestId = (): DeviceTransferRequestId =>
+  brandId<DeviceTransferRequestId>(crypto.randomUUID());
 
 const ONE_DAY_MS = 86_400_000;
 const ONE_HOUR_MS = 3_600_000;
@@ -67,10 +78,10 @@ describe("PG auth schema", () => {
 
   async function insertSession(
     accountId: AccountId,
-    overrides: Partial<{ id: string; createdAt: number; tokenHash: string }> = {},
-  ): Promise<{ id: string; accountId: AccountId; tokenHash: string; createdAt: number }> {
+    overrides: Partial<{ id: SessionId; createdAt: number; tokenHash: string }> = {},
+  ): Promise<{ id: SessionId; accountId: AccountId; tokenHash: string; createdAt: number }> {
     const data = {
-      id: overrides.id ?? crypto.randomUUID(),
+      id: overrides.id ?? newSessionId(),
       accountId,
       tokenHash: overrides.tokenHash ?? `tok_${crypto.randomUUID()}`,
       createdAt: overrides.createdAt ?? Date.now(),
@@ -123,7 +134,7 @@ describe("PG auth schema", () => {
     });
 
     it("rejects duplicate primary key", async () => {
-      const id = crypto.randomUUID();
+      const id = newAccountId();
       await insertAccount({ id });
       await expect(insertAccount({ id })).rejects.toThrow();
     });
@@ -158,7 +169,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const privateKey = new Uint8Array([1, 2, 3, 4, 5]);
       const publicKey = new Uint8Array([10, 20, 30, 40, 50]);
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       await db.insert(authKeys).values({
         id,
@@ -178,7 +189,7 @@ describe("PG auth schema", () => {
 
     it("inserts signing key type", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       await db.insert(authKeys).values({
         id,
@@ -197,7 +208,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       await expect(
         db.insert(authKeys).values({
-          id: crypto.randomUUID(),
+          id: newAuthKeyId(),
           accountId: account.id,
           encryptedPrivateKey: new Uint8Array([1]),
           publicKey: new Uint8Array([2]),
@@ -209,7 +220,7 @@ describe("PG auth schema", () => {
 
     it("cascades on account deletion", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       await db.insert(authKeys).values({
         id,
@@ -228,8 +239,8 @@ describe("PG auth schema", () => {
     it("rejects nonexistent accountId FK", async () => {
       await expect(
         db.insert(authKeys).values({
-          id: crypto.randomUUID(),
-          accountId: "nonexistent",
+          id: newAuthKeyId(),
+          accountId: brandId<AccountId>("nonexistent"),
           encryptedPrivateKey: new Uint8Array([1]),
           publicKey: new Uint8Array([2]),
           keyType: "encryption",
@@ -240,7 +251,7 @@ describe("PG auth schema", () => {
 
     it("round-trips empty Uint8Array", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       await db.insert(authKeys).values({
         id,
@@ -271,7 +282,7 @@ describe("PG auth schema", () => {
     it("inserts and retrieves with all fields", async () => {
       const account = await insertAccount();
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       const expiresAt = now + ONE_DAY_MS;
       await db.insert(sessions).values({
@@ -295,7 +306,7 @@ describe("PG auth schema", () => {
 
     it("defaults revoked to false", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       await db.insert(sessions).values({
         id,
@@ -310,7 +321,7 @@ describe("PG auth schema", () => {
 
     it("defaults expiresAt to null", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       await db.insert(sessions).values({
         id,
@@ -325,7 +336,7 @@ describe("PG auth schema", () => {
 
     it("round-trips expiresAt when provided", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
       const expiresAt = Date.now() + ONE_DAY_MS;
 
       await db.insert(sessions).values({
@@ -342,7 +353,7 @@ describe("PG auth schema", () => {
 
     it("handles nullable lastActive", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       await db.insert(sessions).values({
         id,
@@ -357,7 +368,7 @@ describe("PG auth schema", () => {
 
     it("cascades on account deletion", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       await db.insert(sessions).values({
         id,
@@ -381,8 +392,8 @@ describe("PG auth schema", () => {
     it("rejects nonexistent accountId FK", async () => {
       await expect(
         db.insert(sessions).values({
-          id: crypto.randomUUID(),
-          accountId: "nonexistent",
+          id: newSessionId(),
+          accountId: brandId<AccountId>("nonexistent"),
           createdAt: Date.now(),
           tokenHash: `tok_${crypto.randomUUID()}`,
         }),
@@ -395,7 +406,7 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(sessions).values({
-          id: crypto.randomUUID(),
+          id: newSessionId(),
           accountId: account.id,
           createdAt: now,
           expiresAt: now - 1000,
@@ -410,7 +421,7 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(sessions).values({
-          id: crypto.randomUUID(),
+          id: newSessionId(),
           accountId: account.id,
           createdAt: now,
           expiresAt: now,
@@ -421,7 +432,7 @@ describe("PG auth schema", () => {
 
     it("updates expiresAt from null to a value", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
       const now = Date.now();
 
       await db.insert(sessions).values({
@@ -440,7 +451,7 @@ describe("PG auth schema", () => {
 
     it("defaults encryptedData to null", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       await db.insert(sessions).values({
         id,
@@ -455,7 +466,7 @@ describe("PG auth schema", () => {
 
     it("round-trips encryptedData blob", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
       const blob = testBlob(new Uint8Array([10, 20, 30]));
 
       await db.insert(sessions).values({
@@ -475,7 +486,7 @@ describe("PG auth schema", () => {
     it("inserts and round-trips binary encrypted_master_key", async () => {
       const account = await insertAccount();
       const masterKey = new Uint8Array([99, 88, 77, 66, 55, 44, 33, 22, 11]);
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       await db.insert(recoveryKeys).values({
         id,
@@ -492,7 +503,7 @@ describe("PG auth schema", () => {
 
     it("defaults revokedAt to null", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       await db.insert(recoveryKeys).values({
         id,
@@ -508,7 +519,7 @@ describe("PG auth schema", () => {
 
     it("round-trips revokedAt when set", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
       const revokedAt = Date.now();
 
       await db.insert(recoveryKeys).values({
@@ -525,7 +536,7 @@ describe("PG auth schema", () => {
 
     it("cascades on account deletion", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       await db.insert(recoveryKeys).values({
         id,
@@ -543,8 +554,8 @@ describe("PG auth schema", () => {
     it("rejects nonexistent accountId FK", async () => {
       await expect(
         db.insert(recoveryKeys).values({
-          id: crypto.randomUUID(),
-          accountId: "nonexistent",
+          id: newRecoveryKeyId(),
+          accountId: brandId<AccountId>("nonexistent"),
           encryptedMasterKey: new Uint8Array([1]),
           recoveryKeyHash: new Uint8Array(32),
           createdAt: Date.now(),
@@ -554,7 +565,7 @@ describe("PG auth schema", () => {
 
     it("updates revokedAt from null to timestamp", async () => {
       const account = await insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       await db.insert(recoveryKeys).values({
         id,
@@ -578,7 +589,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -605,7 +616,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -630,7 +641,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -654,7 +665,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
       const keyMaterial = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]);
 
       await db.insert(deviceTransferRequests).values({
@@ -680,7 +691,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -704,7 +715,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -730,7 +741,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -758,7 +769,7 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(deviceTransferRequests).values({
-          id: crypto.randomUUID(),
+          id: newDeviceTransferRequestId(),
           accountId: account.id,
           sourceSessionId: source.id,
           targetSessionId: target.id,
@@ -778,7 +789,7 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(deviceTransferRequests).values({
-          id: crypto.randomUUID(),
+          id: newDeviceTransferRequestId(),
           accountId: account.id,
           sourceSessionId: source.id,
           targetSessionId: target.id,
@@ -797,7 +808,7 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(deviceTransferRequests).values({
-          id: crypto.randomUUID(),
+          id: newDeviceTransferRequestId(),
           accountId: account.id,
           sourceSessionId: source.id,
           targetSessionId: target.id,
@@ -813,7 +824,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -838,7 +849,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,
@@ -865,9 +876,9 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(deviceTransferRequests).values({
-          id: crypto.randomUUID(),
+          id: newDeviceTransferRequestId(),
           accountId: account.id,
-          sourceSessionId: "nonexistent",
+          sourceSessionId: brandId<SessionId>("nonexistent"),
           targetSessionId: session.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
@@ -877,10 +888,10 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(deviceTransferRequests).values({
-          id: crypto.randomUUID(),
+          id: newDeviceTransferRequestId(),
           accountId: account.id,
           sourceSessionId: session.id,
-          targetSessionId: "nonexistent",
+          targetSessionId: brandId<SessionId>("nonexistent"),
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
           expiresAt: now + ONE_HOUR_MS,
@@ -896,7 +907,7 @@ describe("PG auth schema", () => {
 
       await expect(
         db.insert(deviceTransferRequests).values({
-          id: crypto.randomUUID(),
+          id: newDeviceTransferRequestId(),
           accountId: account.id,
           sourceSessionId: source.id,
           targetSessionId: target.id,
@@ -913,7 +924,7 @@ describe("PG auth schema", () => {
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
         id,

--- a/packages/db/src/__tests__/schema-pg-views.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-views.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -40,6 +41,13 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type {
+  AccountId,
+  ApiKeyId,
+  DeviceTransferRequestId,
+  SessionId,
+  SystemId,
+} from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 describe("PG views / query helpers", () => {
@@ -49,8 +57,8 @@ describe("PG views / query helpers", () => {
   const insertAccount = (id?: string) => pgInsertAccount(db, id);
   const insertSystem = (accountId: string, id?: string) => pgInsertSystem(db, accountId, id);
 
-  let accountId: string;
-  let systemId: string;
+  let accountId: AccountId;
+  let systemId: SystemId;
   let memberId: string;
 
   beforeAll(async () => {
@@ -208,7 +216,7 @@ describe("PG views / query helpers", () => {
       const now = Date.now();
 
       await db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         encryptedData: testBlob(),
@@ -218,7 +226,7 @@ describe("PG views / query helpers", () => {
         createdAt: now,
       });
       await db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         encryptedData: testBlob(),
@@ -242,7 +250,7 @@ describe("PG views / query helpers", () => {
       const now = Date.now();
 
       await db.insert(apiKeys).values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         keyType: "metadata",
@@ -494,8 +502,8 @@ describe("PG views / query helpers", () => {
   describe("getActiveDeviceTransfers", () => {
     it("returns pending non-expired transfers", async () => {
       const now = Date.now();
-      const sourceSession = crypto.randomUUID();
-      const targetSession = crypto.randomUUID();
+      const sourceSession = brandId<SessionId>(crypto.randomUUID());
+      const targetSession = brandId<SessionId>(crypto.randomUUID());
 
       await db.insert(sessions).values([
         { id: sourceSession, accountId, tokenHash: `tok_${crypto.randomUUID()}`, createdAt: now },
@@ -504,7 +512,7 @@ describe("PG views / query helpers", () => {
 
       // Pending, not expired
       await db.insert(deviceTransferRequests).values({
-        id: crypto.randomUUID(),
+        id: brandId<DeviceTransferRequestId>(crypto.randomUUID()),
         accountId,
         sourceSessionId: sourceSession,
         targetSessionId: targetSession,
@@ -515,14 +523,14 @@ describe("PG views / query helpers", () => {
       });
 
       // Pending but expired
-      const sourceSession2 = crypto.randomUUID();
-      const targetSession2 = crypto.randomUUID();
+      const sourceSession2 = brandId<SessionId>(crypto.randomUUID());
+      const targetSession2 = brandId<SessionId>(crypto.randomUUID());
       await db.insert(sessions).values([
         { id: sourceSession2, accountId, tokenHash: `tok_${crypto.randomUUID()}`, createdAt: now },
         { id: targetSession2, accountId, tokenHash: `tok_${crypto.randomUUID()}`, createdAt: now },
       ]);
       await db.insert(deviceTransferRequests).values({
-        id: crypto.randomUUID(),
+        id: brandId<DeviceTransferRequestId>(crypto.randomUUID()),
         accountId,
         sourceSessionId: sourceSession2,
         targetSessionId: targetSession2,

--- a/packages/db/src/__tests__/schema-pg-webhooks.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-webhooks.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -17,6 +18,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { ApiKeyId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, apiKeys, webhookConfigs, webhookDeliveries };
@@ -115,7 +117,7 @@ describe("PG webhooks schema", () => {
     it("restricts api_key deletion when referenced by webhook config", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const keyId = crypto.randomUUID();
+      const keyId = brandId<ApiKeyId>(crypto.randomUUID());
       const now = Date.now();
 
       await db.insert(apiKeys).values({

--- a/packages/db/src/__tests__/schema-sqlite-api-keys.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-api-keys.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { AccountId, ApiKeyId, BucketId, SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, apiKeys };
@@ -39,7 +41,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
 
     db.insert(apiKeys)
@@ -69,7 +71,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
     const keyMaterial = new Uint8Array([1, 2, 3, 4, 5]);
 
@@ -83,7 +85,7 @@ describe("SQLite api_keys schema", () => {
         tokenHash,
         scopes: ["full"],
         encryptedKeyMaterial: keyMaterial,
-        scopedBucketIds: ["bucket-1", "bucket-2"],
+        scopedBucketIds: [brandId<BucketId>("bucket-1"), brandId<BucketId>("bucket-2")],
         createdAt: now,
       })
       .run();
@@ -103,7 +105,7 @@ describe("SQLite api_keys schema", () => {
       db
         .insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
           accountId,
           systemId,
           encryptedData: testBlob(),
@@ -124,7 +126,7 @@ describe("SQLite api_keys schema", () => {
 
     db.insert(apiKeys)
       .values({
-        id: crypto.randomUUID(),
+        id: brandId<ApiKeyId>(crypto.randomUUID()),
         accountId,
         systemId,
         encryptedData: testBlob(),
@@ -139,7 +141,7 @@ describe("SQLite api_keys schema", () => {
       db
         .insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
           accountId,
           systemId,
           encryptedData: testBlob(),
@@ -156,7 +158,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
       .values({
@@ -184,7 +186,7 @@ describe("SQLite api_keys schema", () => {
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
     const later = now + 86400000;
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
       .values({
@@ -212,7 +214,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
       .values({
@@ -236,7 +238,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
       .values({
@@ -265,8 +267,8 @@ describe("SQLite api_keys schema", () => {
       db
         .insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
-          accountId: "nonexistent",
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
+          accountId: brandId<AccountId>("nonexistent"),
           systemId,
           encryptedData: testBlob(),
           keyType: "metadata",
@@ -286,9 +288,9 @@ describe("SQLite api_keys schema", () => {
       db
         .insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
           accountId,
-          systemId: "nonexistent",
+          systemId: brandId<SystemId>("nonexistent"),
           encryptedData: testBlob(),
           keyType: "metadata",
           tokenHash: `hash_${crypto.randomUUID()}`,
@@ -308,7 +310,7 @@ describe("SQLite api_keys schema", () => {
       db
         .insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
           accountId,
           systemId,
           encryptedData: testBlob(),
@@ -331,7 +333,7 @@ describe("SQLite api_keys schema", () => {
       db
         .insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
           accountId,
           systemId,
           encryptedData: testBlob(),
@@ -348,7 +350,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
       .values({
@@ -371,7 +373,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
     const emptyMaterial = new Uint8Array(0);
 
     db.insert(apiKeys)
@@ -419,7 +421,7 @@ describe("SQLite api_keys schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<ApiKeyId>(crypto.randomUUID());
     const blob = testBlob(new Uint8Array([10, 20, 30]));
 
     db.insert(apiKeys)

--- a/packages/db/src/__tests__/schema-sqlite-auth.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-auth.integration.test.ts
@@ -14,7 +14,13 @@ import {
 
 import { createSqliteAuthTables, testBlob } from "./helpers/sqlite-helpers.js";
 
-import type { AccountId } from "@pluralscape/types";
+import type {
+  AccountId,
+  AuthKeyId,
+  DeviceTransferRequestId,
+  RecoveryKeyId,
+  SessionId,
+} from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const ONE_DAY_MS = 86_400_000;
@@ -23,6 +29,12 @@ const ONE_HOUR_MS = 3_600_000;
 const TEST_CODE_SALT = new Uint8Array(16);
 
 const schema = { accounts, authKeys, sessions, recoveryKeys, deviceTransferRequests };
+
+const newSessionId = (): SessionId => brandId<SessionId>(crypto.randomUUID());
+const newAuthKeyId = (): AuthKeyId => brandId<AuthKeyId>(crypto.randomUUID());
+const newRecoveryKeyId = (): RecoveryKeyId => brandId<RecoveryKeyId>(crypto.randomUUID());
+const newDeviceTransferRequestId = (): DeviceTransferRequestId =>
+  brandId<DeviceTransferRequestId>(crypto.randomUUID());
 
 describe("SQLite auth schema", () => {
   let client: InstanceType<typeof Database>;
@@ -64,10 +76,10 @@ describe("SQLite auth schema", () => {
 
   function insertSession(
     accountId: AccountId,
-    overrides: Partial<{ id: string; tokenHash: string; createdAt: number }> = {},
-  ): { id: string; accountId: AccountId; tokenHash: string; createdAt: number } {
+    overrides: Partial<{ id: SessionId; tokenHash: string; createdAt: number }> = {},
+  ): { id: SessionId; accountId: AccountId; tokenHash: string; createdAt: number } {
     const data = {
-      id: overrides.id ?? crypto.randomUUID(),
+      id: overrides.id ?? newSessionId(),
       accountId,
       tokenHash: overrides.tokenHash ?? `tok_${crypto.randomUUID()}`,
       createdAt: overrides.createdAt ?? Date.now(),
@@ -121,7 +133,7 @@ describe("SQLite auth schema", () => {
     });
 
     it("rejects duplicate primary key", () => {
-      const id = crypto.randomUUID();
+      const id = brandId<AccountId>(crypto.randomUUID());
       insertAccount({ id });
       expect(() => insertAccount({ id })).toThrow(/UNIQUE|constraint/i);
     });
@@ -157,7 +169,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const privateKey = new Uint8Array([1, 2, 3, 4, 5]);
       const publicKey = new Uint8Array([10, 20, 30, 40, 50]);
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       db.insert(authKeys)
         .values({
@@ -179,7 +191,7 @@ describe("SQLite auth schema", () => {
 
     it("inserts signing key type", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       db.insert(authKeys)
         .values({
@@ -202,7 +214,7 @@ describe("SQLite auth schema", () => {
         db
           .insert(authKeys)
           .values({
-            id: crypto.randomUUID(),
+            id: newAuthKeyId(),
             accountId: account.id,
             encryptedPrivateKey: new Uint8Array([1]),
             publicKey: new Uint8Array([2]),
@@ -215,7 +227,7 @@ describe("SQLite auth schema", () => {
 
     it("cascades on account deletion", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       db.insert(authKeys)
         .values({
@@ -238,8 +250,8 @@ describe("SQLite auth schema", () => {
         db
           .insert(authKeys)
           .values({
-            id: crypto.randomUUID(),
-            accountId: "nonexistent",
+            id: newAuthKeyId(),
+            accountId: brandId<AccountId>("nonexistent"),
             encryptedPrivateKey: new Uint8Array([1]),
             publicKey: new Uint8Array([2]),
             keyType: "encryption",
@@ -251,7 +263,7 @@ describe("SQLite auth schema", () => {
 
     it("round-trips empty Uint8Array", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newAuthKeyId();
 
       db.insert(authKeys)
         .values({
@@ -284,7 +296,7 @@ describe("SQLite auth schema", () => {
     it("inserts and retrieves with all fields", () => {
       const account = insertAccount();
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       const expiresAt = now + ONE_DAY_MS;
       db.insert(sessions)
@@ -310,7 +322,7 @@ describe("SQLite auth schema", () => {
 
     it("defaults revoked to false", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       db.insert(sessions)
         .values({
@@ -327,7 +339,7 @@ describe("SQLite auth schema", () => {
 
     it("defaults expiresAt to null", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       db.insert(sessions)
         .values({
@@ -344,7 +356,7 @@ describe("SQLite auth schema", () => {
 
     it("round-trips expiresAt when provided", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
       const expiresAt = Date.now() + ONE_DAY_MS;
 
       db.insert(sessions)
@@ -363,7 +375,7 @@ describe("SQLite auth schema", () => {
 
     it("handles nullable lastActive", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       db.insert(sessions)
         .values({
@@ -380,7 +392,7 @@ describe("SQLite auth schema", () => {
 
     it("cascades on account deletion", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       db.insert(sessions)
         .values({
@@ -408,8 +420,8 @@ describe("SQLite auth schema", () => {
         db
           .insert(sessions)
           .values({
-            id: crypto.randomUUID(),
-            accountId: "nonexistent",
+            id: newSessionId(),
+            accountId: brandId<AccountId>("nonexistent"),
             tokenHash: `tok_${crypto.randomUUID()}`,
             createdAt: Date.now(),
           })
@@ -425,7 +437,7 @@ describe("SQLite auth schema", () => {
         db
           .insert(sessions)
           .values({
-            id: crypto.randomUUID(),
+            id: newSessionId(),
             accountId: account.id,
             tokenHash: `tok_${crypto.randomUUID()}`,
             createdAt: now,
@@ -443,7 +455,7 @@ describe("SQLite auth schema", () => {
         db
           .insert(sessions)
           .values({
-            id: crypto.randomUUID(),
+            id: newSessionId(),
             accountId: account.id,
             tokenHash: `tok_${crypto.randomUUID()}`,
             createdAt: now,
@@ -455,7 +467,7 @@ describe("SQLite auth schema", () => {
 
     it("updates expiresAt from null to a value", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
       const now = Date.now();
 
       db.insert(sessions)
@@ -476,7 +488,7 @@ describe("SQLite auth schema", () => {
 
     it("defaults encryptedData to null", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
 
       db.insert(sessions)
         .values({
@@ -493,7 +505,7 @@ describe("SQLite auth schema", () => {
 
     it("round-trips encryptedData blob", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newSessionId();
       const blob = testBlob(new Uint8Array([10, 20, 30]));
 
       db.insert(sessions)
@@ -515,7 +527,7 @@ describe("SQLite auth schema", () => {
     it("inserts and round-trips binary encrypted_master_key", () => {
       const account = insertAccount();
       const masterKey = new Uint8Array([99, 88, 77, 66, 55, 44, 33, 22, 11]);
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       db.insert(recoveryKeys)
         .values({
@@ -534,7 +546,7 @@ describe("SQLite auth schema", () => {
 
     it("defaults revokedAt to null", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       db.insert(recoveryKeys)
         .values({
@@ -552,7 +564,7 @@ describe("SQLite auth schema", () => {
 
     it("round-trips revokedAt when set", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
       const revokedAt = Date.now();
 
       db.insert(recoveryKeys)
@@ -571,7 +583,7 @@ describe("SQLite auth schema", () => {
 
     it("cascades on account deletion", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       db.insert(recoveryKeys)
         .values({
@@ -593,8 +605,8 @@ describe("SQLite auth schema", () => {
         db
           .insert(recoveryKeys)
           .values({
-            id: crypto.randomUUID(),
-            accountId: "nonexistent",
+            id: newRecoveryKeyId(),
+            accountId: brandId<AccountId>("nonexistent"),
             encryptedMasterKey: new Uint8Array([1]),
             recoveryKeyHash: new Uint8Array(32),
             createdAt: Date.now(),
@@ -605,7 +617,7 @@ describe("SQLite auth schema", () => {
 
     it("updates revokedAt from null to timestamp", () => {
       const account = insertAccount();
-      const id = crypto.randomUUID();
+      const id = newRecoveryKeyId();
 
       db.insert(recoveryKeys)
         .values({
@@ -631,7 +643,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -661,7 +673,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -689,7 +701,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -717,7 +729,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -744,7 +756,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
       const keyMaterial = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]);
 
       db.insert(deviceTransferRequests)
@@ -773,7 +785,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -800,7 +812,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -829,7 +841,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -862,7 +874,7 @@ describe("SQLite auth schema", () => {
         db
           .insert(deviceTransferRequests)
           .values({
-            id: crypto.randomUUID(),
+            id: newDeviceTransferRequestId(),
             accountId: account.id,
             sourceSessionId: source.id,
             targetSessionId: target.id,
@@ -885,7 +897,7 @@ describe("SQLite auth schema", () => {
         db
           .insert(deviceTransferRequests)
           .values({
-            id: crypto.randomUUID(),
+            id: newDeviceTransferRequestId(),
             accountId: account.id,
             sourceSessionId: source.id,
             targetSessionId: target.id,
@@ -907,7 +919,7 @@ describe("SQLite auth schema", () => {
         db
           .insert(deviceTransferRequests)
           .values({
-            id: crypto.randomUUID(),
+            id: newDeviceTransferRequestId(),
             accountId: account.id,
             sourceSessionId: source.id,
             targetSessionId: target.id,
@@ -924,7 +936,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -952,7 +964,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({
@@ -984,9 +996,9 @@ describe("SQLite auth schema", () => {
         db
           .insert(deviceTransferRequests)
           .values({
-            id: crypto.randomUUID(),
+            id: newDeviceTransferRequestId(),
             accountId: account.id,
-            sourceSessionId: "nonexistent",
+            sourceSessionId: brandId<SessionId>("nonexistent"),
             targetSessionId: session.id,
             codeSalt: TEST_CODE_SALT,
             createdAt: now,
@@ -999,10 +1011,10 @@ describe("SQLite auth schema", () => {
         db
           .insert(deviceTransferRequests)
           .values({
-            id: crypto.randomUUID(),
+            id: newDeviceTransferRequestId(),
             accountId: account.id,
             sourceSessionId: session.id,
-            targetSessionId: "nonexistent",
+            targetSessionId: brandId<SessionId>("nonexistent"),
             codeSalt: TEST_CODE_SALT,
             createdAt: now,
             expiresAt: now + ONE_HOUR_MS,
@@ -1021,7 +1033,7 @@ describe("SQLite auth schema", () => {
         db
           .insert(deviceTransferRequests)
           .values({
-            id: crypto.randomUUID(),
+            id: newDeviceTransferRequestId(),
             accountId: account.id,
             sourceSessionId: source.id,
             targetSessionId: target.id,
@@ -1039,7 +1051,7 @@ describe("SQLite auth schema", () => {
       const source = insertSession(account.id);
       const target = insertSession(account.id);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -39,6 +40,13 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type {
+  AccountId,
+  ApiKeyId,
+  DeviceTransferRequestId,
+  SessionId,
+  SystemId,
+} from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 describe("SQLite views / query helpers", () => {
@@ -98,8 +106,8 @@ describe("SQLite views / query helpers", () => {
     client.close();
   });
 
-  let accountId: string;
-  let systemId: string;
+  let accountId: AccountId;
+  let systemId: SystemId;
   let memberId: string;
 
   beforeEach(() => {
@@ -208,7 +216,7 @@ describe("SQLite views / query helpers", () => {
       const now = Date.now();
       db.insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
           accountId,
           systemId,
           encryptedData: testBlob(),
@@ -220,7 +228,7 @@ describe("SQLite views / query helpers", () => {
         .run();
       db.insert(apiKeys)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<ApiKeyId>(crypto.randomUUID()),
           accountId,
           systemId,
           encryptedData: testBlob(),
@@ -569,8 +577,8 @@ describe("SQLite views / query helpers", () => {
 
     it("returns pending non-expired transfers", () => {
       const now = Date.now();
-      const sourceSession = crypto.randomUUID();
-      const targetSession = crypto.randomUUID();
+      const sourceSession = brandId<SessionId>(crypto.randomUUID());
+      const targetSession = brandId<SessionId>(crypto.randomUUID());
 
       db.insert(sessions)
         .values([
@@ -582,7 +590,7 @@ describe("SQLite views / query helpers", () => {
       // Pending, not expired
       db.insert(deviceTransferRequests)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<DeviceTransferRequestId>(crypto.randomUUID()),
           accountId,
           sourceSessionId: sourceSession,
           targetSessionId: targetSession,
@@ -594,8 +602,8 @@ describe("SQLite views / query helpers", () => {
         .run();
 
       // Pending but expired
-      const sourceSession2 = crypto.randomUUID();
-      const targetSession2 = crypto.randomUUID();
+      const sourceSession2 = brandId<SessionId>(crypto.randomUUID());
+      const targetSession2 = brandId<SessionId>(crypto.randomUUID());
       db.insert(sessions)
         .values([
           {
@@ -614,7 +622,7 @@ describe("SQLite views / query helpers", () => {
         .run();
       db.insert(deviceTransferRequests)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<DeviceTransferRequestId>(crypto.randomUUID()),
           accountId,
           sourceSessionId: sourceSession2,
           targetSessionId: targetSession2,

--- a/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -17,7 +18,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
-import type { SystemId } from "@pluralscape/types";
+import type { ApiKeyId, SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, apiKeys, webhookConfigs, webhookDeliveries };
@@ -123,7 +124,7 @@ describe("SQLite webhooks schema", () => {
     it("restricts api_key deletion when referenced by webhook config", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const keyId = crypto.randomUUID();
+      const keyId = brandId<ApiKeyId>(crypto.randomUUID());
       const now = Date.now();
 
       db.insert(apiKeys)

--- a/packages/db/src/__tests__/type-parity/account-purge-request.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/account-purge-request.type.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Drizzle parity check: the AccountPurgeRequest row shape inferred from
+ * the `account_purge_requests` table structurally matches
+ * `AccountPurgeRequestServerMetadata` in @pluralscape/types.
+ *
+ * Account purge requests are plaintext operational metadata the server
+ * owns end-to-end; the DB row matches the domain type exactly. See
+ * `member.type.test.ts` for the general rationale behind the
+ * brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { accountPurgeRequests } from "../../schema/pg/import-export.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { AccountPurgeRequestServerMetadata, Equal } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("AccountPurgeRequest Drizzle parity", () => {
+  it("account_purge_requests Drizzle row has the same property keys as AccountPurgeRequestServerMetadata", () => {
+    type Row = InferSelectModel<typeof accountPurgeRequests>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof AccountPurgeRequestServerMetadata>();
+  });
+
+  it("account_purge_requests Drizzle row equals AccountPurgeRequestServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof accountPurgeRequests>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<AccountPurgeRequestServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/api-key.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/api-key.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle parity check: the ApiKey row shape inferred from the `api_keys`
+ * table structurally matches `ApiKeyServerMetadata` in @pluralscape/types.
+ *
+ * ApiKey is a hybrid entity: the domain type is a discriminated union
+ * (metadata vs crypto) plus AuditMetadata; the server row flattens the
+ * discriminated shape into a single table and stores non-operational
+ * fields (name, publicKey) inside `encryptedData`. The ServerMetadata
+ * type mirrors the actual DB columns. See `member.type.test.ts` for the
+ * general rationale behind the brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { apiKeys } from "../../schema/pg/api-keys.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { ApiKeyServerMetadata, Equal } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("ApiKey Drizzle parity", () => {
+  it("api_keys Drizzle row has the same property keys as ApiKeyServerMetadata", () => {
+    type Row = InferSelectModel<typeof apiKeys>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof ApiKeyServerMetadata>();
+  });
+
+  it("api_keys Drizzle row equals ApiKeyServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof apiKeys>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<ApiKeyServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/auth-key.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/auth-key.type.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Drizzle parity check: the AuthKey row shape inferred from the
+ * `auth_keys` table structurally matches `AuthKeyServerMetadata` in
+ * @pluralscape/types.
+ *
+ * AuthKey is plaintext: the DB row matches the domain type exactly (the
+ * encrypted private key is stored as opaque bytes wrapped under the
+ * account KEK). See `member.type.test.ts` for the general rationale
+ * behind the brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { authKeys } from "../../schema/pg/auth.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { AuthKeyServerMetadata, Equal } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("AuthKey Drizzle parity", () => {
+  it("auth_keys Drizzle row has the same property keys as AuthKeyServerMetadata", () => {
+    type Row = InferSelectModel<typeof authKeys>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof AuthKeyServerMetadata>();
+  });
+
+  it("auth_keys Drizzle row equals AuthKeyServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof authKeys>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<AuthKeyServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/device-token.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/device-token.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle parity check: the DeviceToken row shape inferred from the
+ * `device_tokens` table structurally matches `DeviceTokenServerMetadata`
+ * in @pluralscape/types.
+ *
+ * The server persists only a `tokenHash` (never the raw push token) and
+ * tracks `revokedAt` for invalidation; it does NOT carry `updatedAt` or
+ * `version` from `AuditMetadata` because device-token rows are
+ * insert-and-revoke only. See `member.type.test.ts` for the general
+ * rationale behind the brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { deviceTokens } from "../../schema/pg/notifications.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { DeviceTokenServerMetadata, Equal } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("DeviceToken Drizzle parity", () => {
+  it("device_tokens Drizzle row has the same property keys as DeviceTokenServerMetadata", () => {
+    type Row = InferSelectModel<typeof deviceTokens>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof DeviceTokenServerMetadata>();
+  });
+
+  it("device_tokens Drizzle row equals DeviceTokenServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof deviceTokens>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<DeviceTokenServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/device-transfer-request.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/device-transfer-request.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle parity check: the DeviceTransferRequest row shape inferred
+ * from the `device_transfer_requests` table structurally matches
+ * `DeviceTransferRequestServerMetadata` in @pluralscape/types.
+ *
+ * The server extends the domain type with three transfer-validation
+ * columns (encryptedKeyMaterial, codeSalt, codeAttempts) needed to
+ * enforce Argon2id-derived transfer codes and brute-force caps. See
+ * `member.type.test.ts` for the general rationale behind the
+ * brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { deviceTransferRequests } from "../../schema/pg/auth.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { DeviceTransferRequestServerMetadata, Equal } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("DeviceTransferRequest Drizzle parity", () => {
+  it("device_transfer_requests Drizzle row has the same property keys as DeviceTransferRequestServerMetadata", () => {
+    type Row = InferSelectModel<typeof deviceTransferRequests>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof DeviceTransferRequestServerMetadata>();
+  });
+
+  it("device_transfer_requests Drizzle row equals DeviceTransferRequestServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof deviceTransferRequests>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<DeviceTransferRequestServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/recovery-key.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/recovery-key.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle parity check: the RecoveryKey row shape inferred from the
+ * `recovery_keys` table structurally matches `RecoveryKeyServerMetadata`
+ * in @pluralscape/types.
+ *
+ * RecoveryKey is plaintext: the DB row matches the domain type exactly
+ * (the wrapped master key is stored as opaque bytes; the server only
+ * verifies the recovery key hash to authorize the reset). See
+ * `member.type.test.ts` for the general rationale behind the
+ * brand-stripped comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { recoveryKeys } from "../../schema/pg/auth.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { Equal, RecoveryKeyServerMetadata } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("RecoveryKey Drizzle parity", () => {
+  it("recovery_keys Drizzle row has the same property keys as RecoveryKeyServerMetadata", () => {
+    type Row = InferSelectModel<typeof recoveryKeys>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof RecoveryKeyServerMetadata>();
+  });
+
+  it("recovery_keys Drizzle row equals RecoveryKeyServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof recoveryKeys>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<RecoveryKeyServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/__tests__/type-parity/session.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/session.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Drizzle parity check: the Session row shape inferred from the `sessions`
+ * table structurally matches `SessionServerMetadata` in @pluralscape/types.
+ *
+ * Session is a plaintext entity (no client-encrypted field union). The
+ * server row extends the domain with two server-only columns: `tokenHash`
+ * (opaque-to-domain hash the server compares against on every authenticated
+ * request) and nullable `encryptedData` (T1-wrapped `DeviceInfo`). See
+ * `member.type.test.ts` for the general rationale behind the brand-stripped
+ * comparison.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { sessions } from "../../schema/pg/auth.js";
+
+import type { StripBrands } from "./__helpers__.js";
+import type { Equal, SessionServerMetadata } from "@pluralscape/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+describe("Session Drizzle parity", () => {
+  it("sessions Drizzle row has the same property keys as SessionServerMetadata", () => {
+    type Row = InferSelectModel<typeof sessions>;
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof SessionServerMetadata>();
+  });
+
+  it("sessions Drizzle row equals SessionServerMetadata modulo brands and readonly", () => {
+    type Row = InferSelectModel<typeof sessions>;
+    expectTypeOf<
+      Equal<StripBrands<Row>, StripBrands<SessionServerMetadata>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/db/src/queries/recovery-key.ts
+++ b/packages/db/src/queries/recovery-key.ts
@@ -4,6 +4,7 @@ import { recoveryKeys as pgRecoveryKeys } from "../schema/pg/auth.js";
 import { recoveryKeys as sqliteRecoveryKeys } from "../schema/sqlite/auth.js";
 
 import type { NewRecoveryKey, RecoveryKeyRow } from "../schema/pg/auth.js";
+import type { AccountId, RecoveryKeyId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -12,15 +13,15 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /** Input for storing a new recovery key backup. */
 export interface StoreRecoveryKeyInput {
-  readonly id: string;
-  readonly accountId: string;
+  readonly id: RecoveryKeyId;
+  readonly accountId: AccountId;
   readonly encryptedMasterKey: Uint8Array;
   readonly createdAt: number;
 }
 
 /** Input for atomically replacing a recovery key backup. */
 export interface ReplaceRecoveryKeyInput {
-  readonly revokeId: string;
+  readonly revokeId: RecoveryKeyId;
   readonly revokedAt: number;
   readonly newRow: StoreRecoveryKeyInput;
 }
@@ -48,7 +49,7 @@ export async function pgGetActiveRecoveryKey<
   TSchema extends Record<string, unknown> = Record<string, never>,
 >(
   db: PostgresJsDatabase<TSchema> | PgliteDatabase<TSchema>,
-  accountId: string,
+  accountId: AccountId,
 ): Promise<RecoveryKeyRow | null> {
   const rows = await db
     .select()
@@ -63,7 +64,7 @@ export async function pgRevokeRecoveryKey<
   TSchema extends Record<string, unknown> = Record<string, never>,
 >(
   db: PostgresJsDatabase<TSchema> | PgliteDatabase<TSchema>,
-  id: string,
+  id: RecoveryKeyId,
   revokedAt: number,
 ): Promise<void> {
   const rows = await db
@@ -124,7 +125,7 @@ export function sqliteStoreRecoveryKeyBackup<
 /** Return the active (non-revoked) recovery key for an account, or null if none exists. */
 export function sqliteGetActiveRecoveryKey<
   TSchema extends Record<string, unknown> = Record<string, never>,
->(db: BetterSQLite3Database<TSchema>, accountId: string): RecoveryKeyRow | null {
+>(db: BetterSQLite3Database<TSchema>, accountId: AccountId): RecoveryKeyRow | null {
   const rows = db
     .select()
     .from(sqliteRecoveryKeys)
@@ -137,7 +138,7 @@ export function sqliteGetActiveRecoveryKey<
 /** Set revokedAt on a recovery key row. Throws if no matching row exists. */
 export function sqliteRevokeRecoveryKey<
   TSchema extends Record<string, unknown> = Record<string, never>,
->(db: BetterSQLite3Database<TSchema>, id: string, revokedAt: number): void {
+>(db: BetterSQLite3Database<TSchema>, id: RecoveryKeyId, revokedAt: number): void {
   const result = db
     .update(sqliteRecoveryKeys)
     .set({ revokedAt })

--- a/packages/db/src/schema/pg/api-keys.ts
+++ b/packages/db/src/schema/pg/api-keys.ts
@@ -9,26 +9,33 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-import { pgBinary, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
+import { brandedId, pgBinary, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
 import { enumCheck } from "../../helpers/check.js";
-import { ENUM_MAX_LENGTH, ID_MAX_LENGTH } from "../../helpers/db.constants.js";
+import { ENUM_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { API_KEY_KEY_TYPES } from "../../helpers/enums.js";
 
 import { accounts } from "./auth.js";
 import { systems } from "./systems.js";
 
-import type { ApiKey, ApiKeyScope } from "@pluralscape/types";
+import type {
+  AccountId,
+  ApiKey,
+  ApiKeyId,
+  ApiKeyScope,
+  BucketId,
+  SystemId,
+} from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 /** Composite FK (systemId, accountId) → systems(id, accountId) enforces tenant ownership at DB layer. */
 export const apiKeys = pgTable(
   "api_keys",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    accountId: varchar("account_id", { length: ID_MAX_LENGTH })
+    id: brandedId<ApiKeyId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH }).notNull(),
+    systemId: brandedId<SystemId>("system_id").notNull(),
     keyType: varchar("key_type", { length: ENUM_MAX_LENGTH }).notNull().$type<ApiKey["keyType"]>(),
     tokenHash: varchar("token_hash", { length: 255 }).notNull(),
     scopes: jsonb("scopes").notNull().$type<readonly ApiKeyScope[]>(),
@@ -38,7 +45,7 @@ export const apiKeys = pgTable(
     lastUsedAt: pgTimestamp("last_used_at"),
     revokedAt: pgTimestamp("revoked_at"),
     expiresAt: pgTimestamp("expires_at"),
-    scopedBucketIds: jsonb("scoped_bucket_ids").$type<readonly string[]>(),
+    scopedBucketIds: jsonb("scoped_bucket_ids").$type<readonly BucketId[] | null>(),
   },
   (t) => [
     index("api_keys_account_id_idx").on(t.accountId),

--- a/packages/db/src/schema/pg/auth.ts
+++ b/packages/db/src/schema/pg/auth.ts
@@ -4,10 +4,19 @@ import { boolean, check, index, integer, pgTable, uniqueIndex, varchar } from "d
 import { brandedId, pgBinary, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.pg.js";
 import { enumCheck } from "../../helpers/check.js";
-import { ENUM_MAX_LENGTH, ID_MAX_LENGTH } from "../../helpers/db.constants.js";
+import { ENUM_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { ACCOUNT_TYPES, AUTH_KEY_TYPES, DEVICE_TRANSFER_STATUSES } from "../../helpers/enums.js";
 
-import type { AccountId, AccountType, AuthKeyType, DeviceTransferStatus } from "@pluralscape/types";
+import type {
+  AccountId,
+  AccountType,
+  AuthKeyId,
+  AuthKeyType,
+  DeviceTransferRequestId,
+  DeviceTransferStatus,
+  RecoveryKeyId,
+  SessionId,
+} from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const accounts = pgTable(
@@ -49,8 +58,8 @@ export const accounts = pgTable(
 export const authKeys = pgTable(
   "auth_keys",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    accountId: varchar("account_id", { length: ID_MAX_LENGTH })
+    id: brandedId<AuthKeyId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     encryptedPrivateKey: pgBinary("encrypted_private_key").notNull(),
@@ -67,8 +76,8 @@ export const authKeys = pgTable(
 export const sessions = pgTable(
   "sessions",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    accountId: varchar("account_id", { length: ID_MAX_LENGTH })
+    id: brandedId<SessionId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     tokenHash: varchar("token_hash", { length: 128 }).notNull(),
@@ -97,8 +106,8 @@ export const sessions = pgTable(
 export const recoveryKeys = pgTable(
   "recovery_keys",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    accountId: varchar("account_id", { length: ID_MAX_LENGTH })
+    id: brandedId<RecoveryKeyId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     encryptedMasterKey: pgBinary("encrypted_master_key").notNull(),
@@ -122,17 +131,16 @@ export const recoveryKeys = pgTable(
 export const deviceTransferRequests = pgTable(
   "device_transfer_requests",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    accountId: varchar("account_id", { length: ID_MAX_LENGTH })
+    id: brandedId<DeviceTransferRequestId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
-    sourceSessionId: varchar("source_session_id", { length: ID_MAX_LENGTH })
+    sourceSessionId: brandedId<SessionId>("source_session_id")
       .notNull()
       .references(() => sessions.id, { onDelete: "cascade" }),
-    targetSessionId: varchar("target_session_id", { length: ID_MAX_LENGTH }).references(
-      () => sessions.id,
-      { onDelete: "cascade" },
-    ),
+    targetSessionId: brandedId<SessionId>("target_session_id").references(() => sessions.id, {
+      onDelete: "cascade",
+    }),
     status: varchar("status", { length: ENUM_MAX_LENGTH })
       .notNull()
       .default("pending")

--- a/packages/db/src/schema/sqlite/api-keys.ts
+++ b/packages/db/src/schema/sqlite/api-keys.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import { check, index, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 import {
+  brandedId,
   sqliteBinary,
   sqliteEncryptedBlob,
   sqliteJson,
@@ -13,18 +14,25 @@ import { API_KEY_KEY_TYPES } from "../../helpers/enums.js";
 import { accounts } from "./auth.js";
 import { systems } from "./systems.js";
 
-import type { ApiKey, ApiKeyScope } from "@pluralscape/types";
+import type {
+  AccountId,
+  ApiKey,
+  ApiKeyId,
+  ApiKeyScope,
+  BucketId,
+  SystemId,
+} from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 /** Account-system ownership (ensuring the account owns the system) is enforced at the app layer. */
 export const apiKeys = sqliteTable(
   "api_keys",
   {
-    id: text("id").primaryKey(),
-    accountId: text("account_id")
+    id: brandedId<ApiKeyId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
-    systemId: text("system_id")
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     keyType: text("key_type").notNull().$type<ApiKey["keyType"]>(),
@@ -36,7 +44,7 @@ export const apiKeys = sqliteTable(
     lastUsedAt: sqliteTimestamp("last_used_at"),
     revokedAt: sqliteTimestamp("revoked_at"),
     expiresAt: sqliteTimestamp("expires_at"),
-    scopedBucketIds: sqliteJson("scoped_bucket_ids").$type<readonly string[]>(),
+    scopedBucketIds: sqliteJson("scoped_bucket_ids").$type<readonly BucketId[] | null>(),
   },
   (t) => [
     index("api_keys_account_id_idx").on(t.accountId),

--- a/packages/db/src/schema/sqlite/auth.ts
+++ b/packages/db/src/schema/sqlite/auth.ts
@@ -11,7 +11,16 @@ import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.sqli
 import { enumCheck } from "../../helpers/check.js";
 import { ACCOUNT_TYPES, AUTH_KEY_TYPES, DEVICE_TRANSFER_STATUSES } from "../../helpers/enums.js";
 
-import type { AccountId, AccountType, AuthKeyType, DeviceTransferStatus } from "@pluralscape/types";
+import type {
+  AccountId,
+  AccountType,
+  AuthKeyId,
+  AuthKeyType,
+  DeviceTransferRequestId,
+  DeviceTransferStatus,
+  RecoveryKeyId,
+  SessionId,
+} from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const accounts = sqliteTable(
@@ -52,8 +61,8 @@ export const accounts = sqliteTable(
 export const authKeys = sqliteTable(
   "auth_keys",
   {
-    id: text("id").primaryKey(),
-    accountId: text("account_id")
+    id: brandedId<AuthKeyId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     encryptedPrivateKey: sqliteBinary("encrypted_private_key").notNull(),
@@ -70,8 +79,8 @@ export const authKeys = sqliteTable(
 export const sessions = sqliteTable(
   "sessions",
   {
-    id: text("id").primaryKey(),
-    accountId: text("account_id")
+    id: brandedId<SessionId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     tokenHash: text("token_hash").notNull(),
@@ -98,8 +107,8 @@ export const sessions = sqliteTable(
 export const recoveryKeys = sqliteTable(
   "recovery_keys",
   {
-    id: text("id").primaryKey(),
-    accountId: text("account_id")
+    id: brandedId<RecoveryKeyId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
     encryptedMasterKey: sqliteBinary("encrypted_master_key").notNull(),
@@ -123,14 +132,14 @@ export const recoveryKeys = sqliteTable(
 export const deviceTransferRequests = sqliteTable(
   "device_transfer_requests",
   {
-    id: text("id").primaryKey(),
-    accountId: text("account_id")
+    id: brandedId<DeviceTransferRequestId>("id").primaryKey(),
+    accountId: brandedId<AccountId>("account_id")
       .notNull()
       .references(() => accounts.id, { onDelete: "cascade" }),
-    sourceSessionId: text("source_session_id")
+    sourceSessionId: brandedId<SessionId>("source_session_id")
       .notNull()
       .references(() => sessions.id, { onDelete: "cascade" }),
-    targetSessionId: text("target_session_id").references(() => sessions.id, {
+    targetSessionId: brandedId<SessionId>("target_session_id").references(() => sessions.id, {
       onDelete: "cascade",
     }),
     status: text("status").notNull().default("pending").$type<DeviceTransferStatus>(),

--- a/packages/db/src/views/pg.ts
+++ b/packages/db/src/views/pg.ts
@@ -32,6 +32,7 @@ import type {
   StructureEntityAssociationRow,
   UnconfirmedAcknowledgement,
 } from "./types.js";
+import type { AccountId } from "@pluralscape/types";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
 type PgDb = PgDatabase<PgQueryResultHKT>;
@@ -65,7 +66,7 @@ export async function getCurrentFrontersWithDuration(
 }
 
 /** Get active (non-revoked) API keys. */
-export async function getActiveApiKeys(db: PgDb, accountId: string): Promise<ActiveApiKey[]> {
+export async function getActiveApiKeys(db: PgDb, accountId: AccountId): Promise<ActiveApiKey[]> {
   return db
     .select({
       id: apiKeys.id,
@@ -179,7 +180,7 @@ export async function getActiveFriendConnections(
 /** Get active (non-revoked) device tokens. */
 export async function getActiveDeviceTokens(
   db: PgDb,
-  accountId: string,
+  accountId: AccountId,
 ): Promise<ActiveDeviceToken[]> {
   return db
     .select({
@@ -220,7 +221,7 @@ export async function getCurrentFrontingComments(
 /** Get active (pending, non-expired) device transfer requests. */
 export async function getActiveDeviceTransfers(
   db: PgDb,
-  accountId: string,
+  accountId: AccountId,
 ): Promise<ActiveDeviceTransfer[]> {
   return db
     .select({

--- a/packages/db/src/views/sqlite.ts
+++ b/packages/db/src/views/sqlite.ts
@@ -26,6 +26,7 @@ import type {
   StructureEntityAssociationRow,
   UnconfirmedAcknowledgement,
 } from "./types.js";
+import type { AccountId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 /** Get currently fronting members (end_time IS NULL). */
@@ -64,7 +65,7 @@ export function getCurrentFrontersWithDuration(
 }
 
 /** Get active (non-revoked) API keys. */
-export function getActiveApiKeys(db: BetterSQLite3Database, accountId: string): ActiveApiKey[] {
+export function getActiveApiKeys(db: BetterSQLite3Database, accountId: AccountId): ActiveApiKey[] {
   return db
     .select({
       id: apiKeys.id,
@@ -185,7 +186,7 @@ export function getActiveFriendConnections(
 /** Get active (non-revoked) device tokens. */
 export function getActiveDeviceTokens(
   db: BetterSQLite3Database,
-  accountId: string,
+  accountId: AccountId,
 ): ActiveDeviceToken[] {
   return db
     .select({
@@ -227,7 +228,7 @@ export function getCurrentFrontingComments(
 /** Get active (pending, non-expired) device transfer requests. */
 export function getActiveDeviceTransfers(
   db: BetterSQLite3Database,
-  accountId: string,
+  accountId: AccountId,
 ): ActiveDeviceTransfer[] {
   const now = Date.now();
   return db

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -1,10 +1,27 @@
+import type {
+  AccountPurgeRequest,
+  AccountPurgeRequestServerMetadata,
+  AccountPurgeRequestWire,
+} from "./entities/account-purge-request.js";
 import type { Account, AccountServerMetadata, AccountWire } from "./entities/account.js";
+import type { ApiKey, ApiKeyServerMetadata, ApiKeyWire } from "./entities/api-key.js";
 import type {
   AuditLogEntry,
   AuditLogEntryServerMetadata,
   AuditLogEntryWire,
 } from "./entities/audit-log-entry.js";
+import type { AuthKey, AuthKeyServerMetadata, AuthKeyWire } from "./entities/auth-key.js";
 import type { CustomFront, CustomFrontEncryptedFields } from "./entities/custom-front.js";
+import type {
+  DeviceToken,
+  DeviceTokenServerMetadata,
+  DeviceTokenWire,
+} from "./entities/device-token.js";
+import type {
+  DeviceTransferRequest,
+  DeviceTransferRequestServerMetadata,
+  DeviceTransferRequestWire,
+} from "./entities/device-transfer-request.js";
 import type {
   FieldDefinition,
   FieldDefinitionEncryptedFields,
@@ -35,7 +52,13 @@ import type {
   MemberServerMetadata,
   MemberWire,
 } from "./entities/member.js";
+import type {
+  RecoveryKey,
+  RecoveryKeyServerMetadata,
+  RecoveryKeyWire,
+} from "./entities/recovery-key.js";
 import type { Relationship, RelationshipEncryptedFields } from "./entities/relationship.js";
+import type { Session, SessionServerMetadata, SessionWire } from "./entities/session.js";
 import type {
   SystemStructureEntityAssociation,
   SystemStructureEntityAssociationEncryptedFields,
@@ -195,6 +218,52 @@ export type SotEntityManifest = {
   StructureEntityAssociation: {
     domain: SystemStructureEntityAssociation;
     encryptedFields: SystemStructureEntityAssociationEncryptedFields;
+  };
+  ApiKey: {
+    domain: ApiKey;
+    server: ApiKeyServerMetadata;
+    wire: ApiKeyWire;
+    // Plaintext entity at the domain level — server splits domain fields
+    // across flat columns + opaque `encryptedData`; no domain-level
+    // encryptedFields keys-union exists.
+    encryptedFields: never;
+  };
+  AuthKey: {
+    domain: AuthKey;
+    server: AuthKeyServerMetadata;
+    wire: AuthKeyWire;
+    encryptedFields: never;
+  };
+  DeviceToken: {
+    domain: DeviceToken;
+    server: DeviceTokenServerMetadata;
+    wire: DeviceTokenWire;
+    encryptedFields: never;
+  };
+  RecoveryKey: {
+    domain: RecoveryKey;
+    server: RecoveryKeyServerMetadata;
+    wire: RecoveryKeyWire;
+    encryptedFields: never;
+  };
+  AccountPurgeRequest: {
+    domain: AccountPurgeRequest;
+    server: AccountPurgeRequestServerMetadata;
+    wire: AccountPurgeRequestWire;
+    encryptedFields: never;
+  };
+  DeviceTransferRequest: {
+    domain: DeviceTransferRequest;
+    server: DeviceTransferRequestServerMetadata;
+    wire: DeviceTransferRequestWire;
+    encryptedFields: never;
+  };
+  Session: {
+    domain: Session;
+    server: SessionServerMetadata;
+    wire: SessionWire;
+    // Plaintext entity — no encrypted fields in the domain keyset.
+    encryptedFields: never;
   };
   Nomenclature: {
     domain: NomenclatureSettings;

--- a/packages/types/src/entities/account-purge-request.ts
+++ b/packages/types/src/entities/account-purge-request.ts
@@ -1,5 +1,6 @@
 import type { AccountId, AccountPurgeRequestId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 
 /** Status of an account purge request. */
 export type AccountPurgeStatus = "pending" | "confirmed" | "processing" | "completed" | "cancelled";
@@ -16,3 +17,19 @@ export interface AccountPurgeRequest {
   readonly completedAt: UnixMillis | null;
   readonly cancelledAt: UnixMillis | null;
 }
+
+/**
+ * Server-visible AccountPurgeRequest metadata — raw Drizzle row shape.
+ *
+ * The DB row matches the domain `AccountPurgeRequest` type exactly.
+ * Purge-request rows carry no encrypted or server-only fields; they
+ * are plaintext operational metadata the server owns end-to-end.
+ */
+export type AccountPurgeRequestServerMetadata = AccountPurgeRequest;
+
+/**
+ * JSON-wire representation of an AccountPurgeRequest. Derived from the
+ * domain `AccountPurgeRequest` type via `Serialize<T>`; branded IDs become
+ * plain strings and `UnixMillis` becomes `number`.
+ */
+export type AccountPurgeRequestWire = Serialize<AccountPurgeRequest>;

--- a/packages/types/src/entities/api-key.ts
+++ b/packages/types/src/entities/api-key.ts
@@ -1,6 +1,8 @@
-import type { ApiKeyId, Brand, BucketId, SystemId } from "../ids.js";
+import type { EncryptedBlob } from "../encryption-primitives.js";
+import type { AccountId, ApiKeyId, Brand, BucketId, SystemId } from "../ids.js";
 import type { ScopeDomain, ScopeTier } from "../scope-domains.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 import type { AuditMetadata } from "../utility.js";
 
 /** A branded API key token — prevents accidental logging. */
@@ -53,3 +55,36 @@ export interface ApiKeyWithSecret {
   readonly key: ApiKey;
   readonly token: ApiKeyToken;
 }
+
+/**
+ * Server-visible ApiKey metadata — raw Drizzle row shape.
+ *
+ * The domain `ApiKey` type is a discriminated union (metadata vs crypto)
+ * plus AuditMetadata fields that live in the encrypted blob or are not
+ * stored server-side. The DB row is a flat record: fields like `name` and
+ * `publicKey` are bundled inside `encryptedData`; `updatedAt`/`version`
+ * from AuditMetadata are not tracked on `api_keys`; and `revoked: boolean`
+ * in the domain becomes a nullable `revokedAt` timestamp server-side.
+ */
+export interface ApiKeyServerMetadata {
+  readonly id: ApiKeyId;
+  readonly accountId: AccountId;
+  readonly systemId: SystemId;
+  readonly keyType: ApiKey["keyType"];
+  readonly tokenHash: string;
+  readonly scopes: readonly ApiKeyScope[];
+  readonly encryptedData: EncryptedBlob;
+  readonly encryptedKeyMaterial: Uint8Array | null;
+  readonly createdAt: UnixMillis;
+  readonly lastUsedAt: UnixMillis | null;
+  readonly revokedAt: UnixMillis | null;
+  readonly expiresAt: UnixMillis | null;
+  readonly scopedBucketIds: readonly BucketId[] | null;
+}
+
+/**
+ * JSON-wire representation of an ApiKey. Derived from the domain `ApiKey`
+ * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
+ * becomes `number`, `Uint8Array` becomes `string` (base64).
+ */
+export type ApiKeyWire = Serialize<ApiKey>;

--- a/packages/types/src/entities/auth-key.ts
+++ b/packages/types/src/entities/auth-key.ts
@@ -1,5 +1,6 @@
 import type { AccountId, AuthKeyId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 
 /** Whether an auth key is used for encryption or signing. */
 export type AuthKeyType = "encryption" | "signing";
@@ -13,3 +14,20 @@ export interface AuthKey {
   readonly keyType: AuthKeyType;
   readonly createdAt: UnixMillis;
 }
+
+/**
+ * Server-visible AuthKey metadata — raw Drizzle row shape.
+ *
+ * The `auth_keys` table row matches the domain `AuthKey` type exactly:
+ * the encrypted private key is stored server-side (as an opaque blob
+ * wrapped under the account's KEK) since AuthKey is the account-level
+ * keypair, not a per-bucket key. No extra server-only columns.
+ */
+export type AuthKeyServerMetadata = AuthKey;
+
+/**
+ * JSON-wire representation of an AuthKey. Derived from the domain `AuthKey`
+ * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
+ * becomes `number`, and `Uint8Array` becomes `string` (base64).
+ */
+export type AuthKeyWire = Serialize<AuthKey>;

--- a/packages/types/src/entities/device-token.ts
+++ b/packages/types/src/entities/device-token.ts
@@ -1,5 +1,6 @@
 import type { AccountId, DeviceTokenId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 import type { AuditMetadata } from "../utility.js";
 
 /** Platforms that can receive push notifications. */
@@ -17,3 +18,31 @@ export interface DeviceToken extends AuditMetadata {
   readonly token: string;
   readonly lastActiveAt: UnixMillis | null;
 }
+
+/**
+ * Server-visible DeviceToken metadata — raw Drizzle row shape.
+ *
+ * The server never stores raw push tokens — it keeps only a `tokenHash`
+ * for identification. The DB row also has a nullable `revokedAt`
+ * timestamp (for tracking token invalidation) that the domain type
+ * doesn't expose, and omits the `updatedAt`/`version` fields from
+ * `AuditMetadata` since device token rows are never mutated after
+ * creation (only inserted/revoked).
+ */
+export interface DeviceTokenServerMetadata {
+  readonly id: DeviceTokenId;
+  readonly accountId: AccountId;
+  readonly systemId: SystemId;
+  readonly platform: DeviceTokenPlatform;
+  readonly tokenHash: string;
+  readonly createdAt: UnixMillis;
+  readonly lastActiveAt: UnixMillis | null;
+  readonly revokedAt: UnixMillis | null;
+}
+
+/**
+ * JSON-wire representation of a DeviceToken. Derived from the domain
+ * `DeviceToken` type via `Serialize<T>`; branded IDs become plain strings
+ * and `UnixMillis` becomes `number`.
+ */
+export type DeviceTokenWire = Serialize<DeviceToken>;

--- a/packages/types/src/entities/device-transfer-request.ts
+++ b/packages/types/src/entities/device-transfer-request.ts
@@ -1,5 +1,6 @@
 import type { AccountId, DeviceTransferRequestId, SessionId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 
 /** Status of a device transfer request. */
 export type DeviceTransferStatus = "pending" | "approved" | "expired";
@@ -19,3 +20,26 @@ export interface DeviceTransferRequest {
 export interface DeviceTransferPayload {
   readonly encryptedMasterKey: Uint8Array;
 }
+
+/**
+ * Server-visible DeviceTransferRequest metadata — raw Drizzle row shape.
+ *
+ * Extends the domain `DeviceTransferRequest` with the three server-only
+ * columns required to validate the transfer: the encrypted key material
+ * payload (nullable until the source session approves), the Argon2id
+ * salt used to derive the transfer key from the user-supplied code, and
+ * the attempt counter used to enforce `MAX_TRANSFER_CODE_ATTEMPTS`
+ * against brute-force guesses.
+ */
+export interface DeviceTransferRequestServerMetadata extends DeviceTransferRequest {
+  readonly encryptedKeyMaterial: Uint8Array | null;
+  readonly codeSalt: Uint8Array;
+  readonly codeAttempts: number;
+}
+
+/**
+ * JSON-wire representation of a DeviceTransferRequest. Derived from the
+ * domain `DeviceTransferRequest` type via `Serialize<T>`; branded IDs
+ * become plain strings and `UnixMillis` becomes `number`.
+ */
+export type DeviceTransferRequestWire = Serialize<DeviceTransferRequest>;

--- a/packages/types/src/entities/recovery-key.ts
+++ b/packages/types/src/entities/recovery-key.ts
@@ -1,5 +1,6 @@
 import type { AccountId, RecoveryKeyId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 
 /** An encrypted recovery key for account recovery. Immutable after creation. */
 export interface RecoveryKey {
@@ -10,3 +11,20 @@ export interface RecoveryKey {
   readonly createdAt: UnixMillis;
   readonly revokedAt: UnixMillis | null;
 }
+
+/**
+ * Server-visible RecoveryKey metadata — raw Drizzle row shape.
+ *
+ * The DB row matches the domain `RecoveryKey` type exactly — recovery
+ * keys are stored server-side as opaque blobs (wrapped under the
+ * password-derived recovery key) with no additional server-only columns.
+ */
+export type RecoveryKeyServerMetadata = RecoveryKey;
+
+/**
+ * JSON-wire representation of a RecoveryKey. Derived from the domain
+ * `RecoveryKey` type via `Serialize<T>`; branded IDs become plain strings,
+ * `UnixMillis` becomes `number`, and `Uint8Array` becomes `string`
+ * (base64).
+ */
+export type RecoveryKeyWire = Serialize<RecoveryKey>;

--- a/packages/types/src/entities/session.ts
+++ b/packages/types/src/entities/session.ts
@@ -1,5 +1,7 @@
+import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { AccountId, SessionId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
+import type { Serialize } from "../type-assertions.js";
 
 /** An active session on a device. */
 export interface Session {
@@ -20,3 +22,25 @@ export interface DeviceInfo {
   readonly appVersion: string;
   readonly deviceName: string;
 }
+
+/**
+ * Server-visible Session metadata — raw Drizzle row shape.
+ *
+ * Session is a plaintext entity (the domain type has no client-encrypted
+ * field union), but the DB row carries two server-only columns the domain
+ * doesn't expose: `tokenHash` (opaque-to-domain hash of the session token
+ * the server compares against on every authenticated request) and
+ * `encryptedData` (optional T1 blob wrapping `DeviceInfo` — the server
+ * only sees the ciphertext).
+ */
+export interface SessionServerMetadata extends Session {
+  readonly tokenHash: string;
+  readonly encryptedData: EncryptedBlob | null;
+}
+
+/**
+ * JSON-wire representation of a Session. Derived from the domain `Session`
+ * type via `Serialize<T>`; branded IDs become plain strings and
+ * `UnixMillis` becomes `number`.
+ */
+export type SessionWire = Serialize<Session>;


### PR DESCRIPTION
## Summary

types-ltel Cluster 2 (Auth + devices): 7 plaintext entities through the 4-layer parity stack.

## Entities

- `session` — `SessionServerMetadata extends Session` with server-only `tokenHash` + nullable `encryptedData`.
- `api-key` — `ApiKeyServerMetadata` authored as a standalone interface because the domain `ApiKey` is a discriminated union (metadata vs crypto) plus AuditMetadata fields that live either in the encrypted blob (`name`, `publicKey`) or are not tracked server-side (`updatedAt`, `version`). The server row has `revokedAt` nullable timestamp vs the domain's `revoked` boolean.
- `auth-key` — `AuthKeyServerMetadata = AuthKey` (DB row matches domain exactly).
- `device-token` — `DeviceTokenServerMetadata` stores `tokenHash` (never the raw push token), adds `revokedAt`, and omits `updatedAt`/`version` from `AuditMetadata` (rows are insert-and-revoke only).
- `recovery-key` — `RecoveryKeyServerMetadata = RecoveryKey` (DB row matches domain exactly).
- `account-purge-request` — `AccountPurgeRequestServerMetadata = AccountPurgeRequest` (plaintext operational metadata).
- `device-transfer-request` — `DeviceTransferRequestServerMetadata extends DeviceTransferRequest` with `encryptedKeyMaterial`, `codeSalt`, `codeAttempts` (Argon2id-derived transfer-code validation + brute-force cap).

## Scope

- Full `{ domain, server, wire, encryptedFields: never }` manifest entries for all seven entities.
- Drizzle PG + SQLite ID columns converted to `brandedId<B>()` in `schema/pg/auth.ts`, `schema/pg/api-keys.ts`, `schema/pg/notifications.ts` (device_tokens), `schema/pg/import-export.ts` (account_purge_requests), and SQLite counterparts.
- Drizzle parity tests at `packages/db/src/__tests__/type-parity/` (7 new files, `StripBrands<>` wrapped).
- Call-site threading of the new brands through `apps/api` services (auth/sessions, auth/login, auth/register, device-transfer/{approve,complete,initiate}, recovery-key/{regenerate,reset-password}, api-key/{create,queries}), REST routes + tRPC routers for device-transfer, and the `packages/db` query + view helpers.
- Fixture sweeps in `packages/db/__tests__` and `apps/api/__tests__` for the seven entities' insert payloads (branded IDs, no plain strings).

## Fleet protocol notes

- Pushed with `--no-verify` per fleet parallelism protocol (9 concurrent cluster subagents; pre-push hook would saturate local infra).
- CI is the sole correctness gate for this PR.
- `StripBrands<>` wrapper used in the new parity tests; Cluster 11 strips it monorepo-wide.
- No new encrypted fields, no data-package transforms, no Zod `<X>EncryptedInputSchema` (all cluster entities are plaintext at the domain level — `api-key` has an `encryptedData` blob column but its decrypted shape is not a keys-subset of `ApiKey`, so `encryptedFields: never`).

## Test plan

- [ ] CI green on all jobs (lint, typecheck, types-sot, unit, integration, e2e, security, migration-freshness).