### PR TITLE
refactor(db): C11a — brandedId lift for 5 remaining Drizzle tables

### DIFF
--- a/.beans/ps-6hyr--types-ltel-c11a-brandedid-lift-for-6-remaining-tab.md
+++ b/.beans/ps-6hyr--types-ltel-c11a-brandedid-lift-for-6-remaining-tab.md
@@ -1,11 +1,11 @@
 ---
 # ps-6hyr
-title: "types-ltel C11a: brandedId lift for 6 remaining tables"
+title: "types-ltel C11a: brandedId lift for 5 remaining Drizzle tables"
 status: completed
 type: task
 priority: high
 created_at: 2026-04-24T09:26:42Z
-updated_at: 2026-04-24T10:59:31Z
+updated_at: 2026-04-24T11:36:56Z
 parent: types-ltel
 ---
 

--- a/.beans/ps-6hyr--types-ltel-c11a-brandedid-lift-for-6-remaining-tab.md
+++ b/.beans/ps-6hyr--types-ltel-c11a-brandedid-lift-for-6-remaining-tab.md
@@ -1,11 +1,11 @@
 ---
 # ps-6hyr
 title: "types-ltel C11a: brandedId lift for 6 remaining tables"
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-04-24T09:26:42Z
-updated_at: 2026-04-24T09:26:42Z
+updated_at: 2026-04-24T10:59:31Z
 parent: types-ltel
 ---
 
@@ -15,15 +15,15 @@ First of three sub-PRs closing out the types-ltel epic (C11).
 
 Lift 6 remaining PG schema files to `brandedId<B>()` for all ID / FK columns:
 
-- [ ] `packages/db/src/schema/pg/analytics.ts`
-- [ ] `packages/db/src/schema/pg/audit-log.ts`
-- [ ] `packages/db/src/schema/pg/biometric-tokens.ts`
-- [ ] `packages/db/src/schema/pg/pk-bridge.ts`
-- [ ] `packages/db/src/schema/pg/safe-mode-content.ts`
-- [ ] `packages/db/src/schema/pg/search.ts`
-- [ ] Sqlite siblings where present
-- [ ] Wrap fixture ID literals in affected integration tests with `brandId<XId>()`
-- [ ] Verify `pnpm typecheck` + `pnpm test:integration` green
+- [x] `packages/db/src/schema/pg/analytics.ts`
+- [x] `packages/db/src/schema/pg/audit-log.ts`
+- [x] `packages/db/src/schema/pg/biometric-tokens.ts`
+- [x] `packages/db/src/schema/pg/pk-bridge.ts`
+- [x] `packages/db/src/schema/pg/safe-mode-content.ts`
+- [x] ~~`packages/db/src/schema/pg/search.ts`~~ (N/A — raw SQL DDL, not a pgTable)
+- [x] Sqlite siblings where present
+- [x] Wrap fixture ID literals in affected integration tests with `brandId<XId>()`
+- [x] Verify `pnpm typecheck` + `pnpm test:integration` green
 
 Parity tests for these 6 tables STAY on `StripBrands<>` — tightening happens in C11c.
 
@@ -42,3 +42,11 @@ Parity tests for these 6 tables STAY on `StripBrands<>` — tightening happens i
 ## Spec
 
 docs/superpowers/specs/2026-04-24-types-ltel-c11-cleanup-design.md
+
+## Summary of Changes
+
+Lifted 5 Drizzle schema files (PG + sqlite) to `brandedId<B>()` for all ID and FK columns: audit-log (AuditLogEntryId/AccountId/SystemId), analytics/frontingReports (FrontingReportId/SystemId), biometric-tokens (BiometricTokenId/SessionId), pk-bridge (PKBridgeConfigId/SystemId), safe-mode-content (SafeModeContentId/SystemId). Added `SafeModeContentId` brand + `smc_` prefix in packages/types/src/ids.ts (also exported from package barrel). Fixture literals wrapped with `brandId<XId>()` in 8 integration test files. Cross-package boundary wraps in `apps/api/src/lib/audit-log.ts`, `apps/api/src/services/audit-log-query.service.ts`, `apps/api/src/services/fronting-report/create.ts`, `apps/api/src/services/fronting-report/queries.ts`. `packages/types/src/__tests__/ids.test.ts` count assertion bumped 64→65 for the new prefix.
+
+`packages/db/src/schema/pg/search.ts` re-scoped out — it contains raw SQL DDL, not a Drizzle pgTable, so brandedId does not apply.
+
+Parity tests for these 5 tables remain on `StripBrands<>` — tightening happens in C11c.

--- a/apps/api/src/lib/audit-log.ts
+++ b/apps/api/src/lib/audit-log.ts
@@ -1,10 +1,10 @@
 import { auditLog } from "@pluralscape/db/pg";
-import { createId, now } from "@pluralscape/types";
+import { brandId, createId, now } from "@pluralscape/types";
 
 import { AUDIT_LOG_IP_MAX_LENGTH, AUDIT_LOG_UA_MAX_LENGTH } from "./audit-log.constants.js";
 
 import type { DbAuditActor } from "@pluralscape/db";
-import type { AccountId, AuditEventType, SystemId } from "@pluralscape/types";
+import type { AccountId, AuditEventType, AuditLogEntryId, SystemId } from "@pluralscape/types";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
 /** Parameters for writing an audit log entry. */
@@ -28,7 +28,7 @@ export async function writeAuditLog(
 ): Promise<void> {
   const timestamp = now();
   await db.insert(auditLog).values({
-    id: createId("al_"),
+    id: brandId<AuditLogEntryId>(createId("al_")),
     accountId: params.accountId,
     systemId: params.systemId,
     eventType: params.eventType,

--- a/apps/api/src/services/audit-log-query.service.ts
+++ b/apps/api/src/services/audit-log-query.service.ts
@@ -136,7 +136,7 @@ export async function queryAuditLog(
     const cursor = decodeCursor(params.cursor);
     const cursorCondition = or(
       lt(auditLog.timestamp, cursor.t),
-      and(eq(auditLog.timestamp, cursor.t), lt(auditLog.id, cursor.i)),
+      and(eq(auditLog.timestamp, cursor.t), lt(auditLog.id, brandId<AuditLogEntryId>(cursor.i))),
     );
     if (cursorCondition) {
       conditions.push(cursorCondition);

--- a/apps/api/src/services/audit-log-query.service.ts
+++ b/apps/api/src/services/audit-log-query.service.ts
@@ -55,7 +55,7 @@ export interface AuditLogQueryParams {
 
 interface CursorData {
   readonly t: number;
-  readonly i: string;
+  readonly i: AuditLogEntryId;
 }
 
 function encodeCursor(data: CursorData): string {
@@ -70,12 +70,13 @@ function decodeCursor(cursor: string): CursorData {
       parsed !== null &&
       "t" in parsed &&
       "i" in parsed &&
-      typeof (parsed as CursorData).t === "number" &&
-      (parsed as CursorData).t > 0 &&
-      typeof (parsed as CursorData).i === "string" &&
-      (parsed as CursorData).i.length > 0
+      typeof (parsed as { t: unknown }).t === "number" &&
+      (parsed as { t: number }).t > 0 &&
+      typeof (parsed as { i: unknown }).i === "string" &&
+      (parsed as { i: string }).i.length > 0
     ) {
-      return parsed as CursorData;
+      const raw = parsed as { t: number; i: string };
+      return { t: raw.t, i: brandId<AuditLogEntryId>(raw.i) };
     }
   } catch {
     // fall through
@@ -136,7 +137,7 @@ export async function queryAuditLog(
     const cursor = decodeCursor(params.cursor);
     const cursorCondition = or(
       lt(auditLog.timestamp, cursor.t),
-      and(eq(auditLog.timestamp, cursor.t), lt(auditLog.id, brandId<AuditLogEntryId>(cursor.i))),
+      and(eq(auditLog.timestamp, cursor.t), lt(auditLog.id, cursor.i)),
     );
     if (cursorCondition) {
       conditions.push(cursorCondition);

--- a/apps/api/src/services/fronting-report/create.ts
+++ b/apps/api/src/services/fronting-report/create.ts
@@ -1,5 +1,5 @@
 import { frontingReports } from "@pluralscape/db/pg";
-import { ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
 import { CreateFrontingReportBodySchema } from "@pluralscape/validation";
 
 import { parseAndValidateBlob } from "../../lib/encrypted-blob.js";
@@ -13,7 +13,7 @@ import { toFrontingReportResult } from "./internal.js";
 import type { FrontingReportResult } from "./internal.js";
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
-import type { SystemId } from "@pluralscape/types";
+import type { FrontingReportId, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 export async function createFrontingReport(
@@ -31,7 +31,7 @@ export async function createFrontingReport(
     MAX_ENCRYPTED_DATA_BYTES,
   );
 
-  const reportId = createId(ID_PREFIXES.frontingReport);
+  const reportId = brandId<FrontingReportId>(createId(ID_PREFIXES.frontingReport));
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {

--- a/apps/api/src/services/fronting-report/queries.ts
+++ b/apps/api/src/services/fronting-report/queries.ts
@@ -1,4 +1,5 @@
 import { frontingReports } from "@pluralscape/db/pg";
+import { brandId } from "@pluralscape/types";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 
 import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND } from "../../http.constants.js";
@@ -71,7 +72,10 @@ export async function listFrontingReports(
       const cursor = decodeCursor(opts.cursor);
       const cursorCondition = or(
         lt(frontingReports.generatedAt, cursor.t),
-        and(eq(frontingReports.generatedAt, cursor.t), lt(frontingReports.id, cursor.i)),
+        and(
+          eq(frontingReports.generatedAt, cursor.t),
+          lt(frontingReports.id, brandId<FrontingReportId>(cursor.i)),
+        ),
       );
       if (cursorCondition) conditions.push(cursorCondition);
     }

--- a/apps/api/src/services/fronting-report/queries.ts
+++ b/apps/api/src/services/fronting-report/queries.ts
@@ -25,7 +25,7 @@ export interface FrontingReportListOptions {
 
 interface CursorData {
   readonly t: number;
-  readonly i: string;
+  readonly i: FrontingReportId;
 }
 
 function encodeCursor(data: CursorData): string {
@@ -40,12 +40,13 @@ function decodeCursor(cursor: string): CursorData {
       parsed !== null &&
       "t" in parsed &&
       "i" in parsed &&
-      typeof (parsed as CursorData).t === "number" &&
-      (parsed as CursorData).t >= 0 &&
-      typeof (parsed as CursorData).i === "string" &&
-      (parsed as CursorData).i.length > 0
+      typeof (parsed as { t: unknown }).t === "number" &&
+      (parsed as { t: number }).t >= 0 &&
+      typeof (parsed as { i: unknown }).i === "string" &&
+      (parsed as { i: string }).i.length > 0
     ) {
-      return parsed as CursorData;
+      const raw = parsed as { t: number; i: string };
+      return { t: raw.t, i: brandId<FrontingReportId>(raw.i) };
     }
   } catch {
     // fall through
@@ -72,10 +73,7 @@ export async function listFrontingReports(
       const cursor = decodeCursor(opts.cursor);
       const cursorCondition = or(
         lt(frontingReports.generatedAt, cursor.t),
-        and(
-          eq(frontingReports.generatedAt, cursor.t),
-          lt(frontingReports.id, brandId<FrontingReportId>(cursor.i)),
-        ),
+        and(eq(frontingReports.generatedAt, cursor.t), lt(frontingReports.id, cursor.i)),
       );
       if (cursorCondition) conditions.push(cursorCondition);
     }

--- a/packages/db/src/__tests__/helpers/pg-helpers.ts
+++ b/packages/db/src/__tests__/helpers/pg-helpers.ts
@@ -90,14 +90,35 @@ import { pgTableToCreateDDL, pgTableToIndexDDL } from "./schema-to-ddl.js";
 import type { PGlite } from "@electric-sql/pglite";
 import type {
   AccountId,
+  AuditLogEntryId,
   BucketId,
   ChannelId,
   EncryptedBlob,
+  FrontingReportId,
+  PKBridgeConfigId,
   PollId,
+  SafeModeContentId,
   SystemId,
 } from "@pluralscape/types";
 import type { PgDatabase, PgQueryResultHKT, PgTable } from "drizzle-orm/pg-core";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
+
+// ── Branded-ID fixture factories ───────────────────────────────────
+// One helper per entity whose Drizzle schema uses `brandedId<XId>()`. These
+// centralize the prefix strings used in integration-test fixtures so the
+// prefix is single-sourced with `ID_PREFIXES` in @pluralscape/types.
+
+export const makeAuditLogEntryId = (): AuditLogEntryId =>
+  brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+
+export const makeFrontingReportId = (): FrontingReportId =>
+  brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+
+export const makePkBridgeConfigId = (): PKBridgeConfigId =>
+  brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+
+export const makeSafeModeContentId = (): SafeModeContentId =>
+  brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
 /** Creates a minimal valid EncryptedBlob for test fixtures. */
 export function testBlob(ciphertext: Uint8Array = new Uint8Array([1, 2, 3])): EncryptedBlob {

--- a/packages/db/src/__tests__/helpers/sqlite-helpers.ts
+++ b/packages/db/src/__tests__/helpers/sqlite-helpers.ts
@@ -13,14 +13,35 @@ import { systems } from "../../schema/sqlite/systems.js";
 
 import type {
   AccountId,
+  AuditLogEntryId,
   BucketId,
   ChannelId,
   EncryptedBlob,
+  FrontingReportId,
+  PKBridgeConfigId,
   PollId,
+  SafeModeContentId,
   SystemId,
 } from "@pluralscape/types";
 import type Database from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+
+// ── Branded-ID fixture factories ───────────────────────────────────
+// One helper per entity whose Drizzle schema uses `brandedId<XId>()`. These
+// centralize the prefix strings used in integration-test fixtures so the
+// prefix is single-sourced with `ID_PREFIXES` in @pluralscape/types.
+
+export const makeAuditLogEntryId = (): AuditLogEntryId =>
+  brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+
+export const makeFrontingReportId = (): FrontingReportId =>
+  brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+
+export const makePkBridgeConfigId = (): PKBridgeConfigId =>
+  brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+
+export const makeSafeModeContentId = (): SafeModeContentId =>
+  brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
 /** Creates a minimal valid EncryptedBlob for test fixtures. */
 export function testBlob(ciphertext: Uint8Array = new Uint8Array([1, 2, 3])): EncryptedBlob {

--- a/packages/db/src/__tests__/queries-pg-audit-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-pg-audit-cleanup.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
@@ -10,6 +11,7 @@ import { systems } from "../schema/pg/systems.js";
 import { createPgAuditLogTables, pgInsertAccount, pgInsertSystem } from "./helpers/pg-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
+import type { AccountId, AuditLogEntryId, SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, auditLog };
@@ -40,12 +42,12 @@ describe("pgCleanupAuditLog", () => {
     accountId: string;
     systemId: string;
     timestamp?: number;
-  }): Promise<string> {
-    const id = crypto.randomUUID();
+  }): Promise<AuditLogEntryId> {
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
     await db.insert(auditLog).values({
       id,
-      accountId: opts.accountId,
-      systemId: opts.systemId,
+      accountId: brandId<AccountId>(opts.accountId),
+      systemId: brandId<SystemId>(opts.systemId),
       eventType: "auth.login",
       timestamp: opts.timestamp ?? Date.now(),
       actor: testActor(opts.accountId),

--- a/packages/db/src/__tests__/queries-pg-audit-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-pg-audit-cleanup.integration.test.ts
@@ -8,7 +8,12 @@ import { auditLog } from "../schema/pg/audit-log.js";
 import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 
-import { createPgAuditLogTables, pgInsertAccount, pgInsertSystem } from "./helpers/pg-helpers.js";
+import {
+  createPgAuditLogTables,
+  makeAuditLogEntryId,
+  pgInsertAccount,
+  pgInsertSystem,
+} from "./helpers/pg-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
 import type { AccountId, AuditLogEntryId, SystemId } from "@pluralscape/types";
@@ -43,7 +48,7 @@ describe("pgCleanupAuditLog", () => {
     systemId: string;
     timestamp?: number;
   }): Promise<AuditLogEntryId> {
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
     await db.insert(auditLog).values({
       id,
       accountId: brandId<AccountId>(opts.accountId),

--- a/packages/db/src/__tests__/queries-sqlite-audit-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-audit-cleanup.integration.test.ts
@@ -10,6 +10,7 @@ import { systems } from "../schema/sqlite/systems.js";
 
 import {
   createSqliteAuditLogTables,
+  makeAuditLogEntryId,
   sqliteInsertAccount,
   sqliteInsertSystem,
 } from "./helpers/sqlite-helpers.js";
@@ -48,7 +49,7 @@ describe("sqliteCleanupAuditLog", () => {
     systemId: string;
     timestamp?: number;
   }): AuditLogEntryId {
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
     db.insert(auditLog)
       .values({
         id,

--- a/packages/db/src/__tests__/queries-sqlite-audit-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-audit-cleanup.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import {
 } from "./helpers/sqlite-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
+import type { AccountId, AuditLogEntryId, SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, auditLog };
@@ -45,13 +47,13 @@ describe("sqliteCleanupAuditLog", () => {
     accountId: string;
     systemId: string;
     timestamp?: number;
-  }): string {
-    const id = crypto.randomUUID();
+  }): AuditLogEntryId {
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
     db.insert(auditLog)
       .values({
         id,
-        accountId: opts.accountId,
-        systemId: opts.systemId,
+        accountId: brandId<AccountId>(opts.accountId),
+        systemId: brandId<SystemId>(opts.systemId),
         eventType: "auth.login",
         timestamp: opts.timestamp ?? Date.now(),
         actor: testActor(opts.accountId),

--- a/packages/db/src/__tests__/schema-pg-analytics.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-analytics.integration.test.ts
@@ -10,12 +10,13 @@ import { systems } from "../schema/pg/systems.js";
 
 import {
   createPgAnalyticsTables,
+  makeFrontingReportId,
   pgInsertAccount,
   pgInsertSystem,
   testBlob,
 } from "./helpers/pg-helpers.js";
 
-import type { FrontingReportId, SystemId } from "@pluralscape/types";
+import type { SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, frontingReports };
@@ -45,7 +46,7 @@ describe("PG analytics schema", () => {
     it("round-trips all fields", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const ts = Date.now();
       const blob = testBlob();
 
@@ -75,7 +76,7 @@ describe("PG analytics schema", () => {
     it("accepts pdf format", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const ts = Date.now();
 
       await db.insert(frontingReports).values({
@@ -99,7 +100,7 @@ describe("PG analytics schema", () => {
 
       await expect(
         db.insert(frontingReports).values({
-          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+          id: makeFrontingReportId(),
           systemId,
           encryptedData: testBlob(),
           format: "docx" as "html",
@@ -113,7 +114,7 @@ describe("PG analytics schema", () => {
     it("cascades on system deletion", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const ts = Date.now();
 
       await db.insert(frontingReports).values({
@@ -135,7 +136,7 @@ describe("PG analytics schema", () => {
       const ts = Date.now();
       await expect(
         db.insert(frontingReports).values({
-          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+          id: makeFrontingReportId(),
           systemId: brandId<SystemId>("nonexistent"),
           encryptedData: testBlob(),
           format: "html",
@@ -149,7 +150,7 @@ describe("PG analytics schema", () => {
     it("rejects duplicate primary key", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const ts = Date.now();
       const values = {
         id,
@@ -172,7 +173,7 @@ describe("PG analytics schema", () => {
 
       await db.insert(frontingReports).values([
         {
-          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+          id: makeFrontingReportId(),
           systemId,
           encryptedData: testBlob(new Uint8Array([1])),
           format: "html",
@@ -181,7 +182,7 @@ describe("PG analytics schema", () => {
           updatedAt: ts,
         },
         {
-          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+          id: makeFrontingReportId(),
           systemId,
           encryptedData: testBlob(new Uint8Array([2])),
           format: "pdf",
@@ -201,7 +202,7 @@ describe("PG analytics schema", () => {
     it("round-trips distinct ciphertext payloads", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const ts = Date.now();
       const blob = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
@@ -226,7 +227,7 @@ describe("PG analytics schema", () => {
 
       await expect(
         db.insert(frontingReports).values({
-          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+          id: makeFrontingReportId(),
           systemId,
           encryptedData: testBlob(),
           format: "html",
@@ -246,7 +247,7 @@ describe("PG analytics schema", () => {
       // archived=true but archivedAt=null should fail
       await expect(
         db.insert(frontingReports).values({
-          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+          id: makeFrontingReportId(),
           systemId,
           encryptedData: testBlob(),
           format: "html",

--- a/packages/db/src/__tests__/schema-pg-analytics.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-analytics.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { FrontingReportId, SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, frontingReports };
@@ -43,7 +45,7 @@ describe("PG analytics schema", () => {
     it("round-trips all fields", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const ts = Date.now();
       const blob = testBlob();
 
@@ -73,7 +75,7 @@ describe("PG analytics schema", () => {
     it("accepts pdf format", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const ts = Date.now();
 
       await db.insert(frontingReports).values({
@@ -97,7 +99,7 @@ describe("PG analytics schema", () => {
 
       await expect(
         db.insert(frontingReports).values({
-          id: crypto.randomUUID(),
+          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
           systemId,
           encryptedData: testBlob(),
           format: "docx" as "html",
@@ -111,7 +113,7 @@ describe("PG analytics schema", () => {
     it("cascades on system deletion", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const ts = Date.now();
 
       await db.insert(frontingReports).values({
@@ -133,8 +135,8 @@ describe("PG analytics schema", () => {
       const ts = Date.now();
       await expect(
         db.insert(frontingReports).values({
-          id: crypto.randomUUID(),
-          systemId: "nonexistent",
+          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+          systemId: brandId<SystemId>("nonexistent"),
           encryptedData: testBlob(),
           format: "html",
           generatedAt: ts,
@@ -147,7 +149,7 @@ describe("PG analytics schema", () => {
     it("rejects duplicate primary key", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const ts = Date.now();
       const values = {
         id,
@@ -170,7 +172,7 @@ describe("PG analytics schema", () => {
 
       await db.insert(frontingReports).values([
         {
-          id: crypto.randomUUID(),
+          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
           systemId,
           encryptedData: testBlob(new Uint8Array([1])),
           format: "html",
@@ -179,7 +181,7 @@ describe("PG analytics schema", () => {
           updatedAt: ts,
         },
         {
-          id: crypto.randomUUID(),
+          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
           systemId,
           encryptedData: testBlob(new Uint8Array([2])),
           format: "pdf",
@@ -199,7 +201,7 @@ describe("PG analytics schema", () => {
     it("round-trips distinct ciphertext payloads", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const ts = Date.now();
       const blob = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
@@ -224,7 +226,7 @@ describe("PG analytics schema", () => {
 
       await expect(
         db.insert(frontingReports).values({
-          id: crypto.randomUUID(),
+          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
           systemId,
           encryptedData: testBlob(),
           format: "html",
@@ -244,7 +246,7 @@ describe("PG analytics schema", () => {
       // archived=true but archivedAt=null should fail
       await expect(
         db.insert(frontingReports).values({
-          id: crypto.randomUUID(),
+          id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
           systemId,
           encryptedData: testBlob(),
           format: "html",

--- a/packages/db/src/__tests__/schema-pg-audit-log.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-audit-log.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -10,6 +11,7 @@ import { systems } from "../schema/pg/systems.js";
 import { createPgAuditLogTables, pgInsertAccount, pgInsertSystem } from "./helpers/pg-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
+import type { AuditLogEntryId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, auditLog };
@@ -38,7 +40,7 @@ describe("PG audit_log schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
     const actor = testActor("account", accountId);
 
     await db.insert(auditLog).values({
@@ -67,7 +69,7 @@ describe("PG audit_log schema", () => {
 
   it("allows nullable fields (accountId, systemId, ipAddress, userAgent, detail)", async () => {
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     await db.insert(auditLog).values({
       id,
@@ -89,7 +91,7 @@ describe("PG audit_log schema", () => {
 
     await expect(
       db.insert(auditLog).values({
-        id: crypto.randomUUID(),
+        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
         eventType: "invalid.event" as "auth.login",
         timestamp: now,
         actor: testActor("account", "acc-123"),
@@ -125,7 +127,7 @@ describe("PG audit_log schema", () => {
     const now = Date.now();
     for (const eventType of eventTypes) {
       await db.insert(auditLog).values({
-        id: crypto.randomUUID(),
+        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
         accountId,
         eventType,
         timestamp: now,
@@ -142,7 +144,7 @@ describe("PG audit_log schema", () => {
 
   it("supports api-key actor type", async () => {
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
     const actor = testActor("api-key", "key-123");
 
     await db.insert(auditLog).values({
@@ -159,7 +161,7 @@ describe("PG audit_log schema", () => {
   it("sets account_id to NULL on account deletion (SET NULL)", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     await db.insert(auditLog).values({
       id,
@@ -179,7 +181,7 @@ describe("PG audit_log schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     await db.insert(auditLog).values({
       id,
@@ -198,7 +200,7 @@ describe("PG audit_log schema", () => {
 
   it("rejects duplicate composite primary key (same id + timestamp)", async () => {
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     await db.insert(auditLog).values({
       id,
@@ -218,7 +220,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("allows same id with different timestamps (composite PK)", async () => {
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
     const now = Date.now();
 
     await db.insert(auditLog).values({
@@ -244,7 +246,7 @@ describe("PG audit_log schema", () => {
     const now = Date.now();
 
     await db.insert(auditLog).values({
-      id: crypto.randomUUID(),
+      id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
       eventType: "auth.login",
       timestamp: now,
       actor: testActor("account", "acc-123"),
@@ -257,7 +259,7 @@ describe("PG audit_log schema", () => {
 
     await expect(
       db.insert(auditLog).values({
-        id: crypto.randomUUID(),
+        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
         eventType: "auth.login",
         timestamp: now,
         actor: testActor("account", "acc-123"),

--- a/packages/db/src/__tests__/schema-pg-audit-log.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-audit-log.integration.test.ts
@@ -1,5 +1,4 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -8,10 +7,14 @@ import { auditLog } from "../schema/pg/audit-log.js";
 import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 
-import { createPgAuditLogTables, pgInsertAccount, pgInsertSystem } from "./helpers/pg-helpers.js";
+import {
+  createPgAuditLogTables,
+  makeAuditLogEntryId,
+  pgInsertAccount,
+  pgInsertSystem,
+} from "./helpers/pg-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
-import type { AuditLogEntryId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, auditLog };
@@ -40,7 +43,7 @@ describe("PG audit_log schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
     const actor = testActor("account", accountId);
 
     await db.insert(auditLog).values({
@@ -69,7 +72,7 @@ describe("PG audit_log schema", () => {
 
   it("allows nullable fields (accountId, systemId, ipAddress, userAgent, detail)", async () => {
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
       id,
@@ -91,7 +94,7 @@ describe("PG audit_log schema", () => {
 
     await expect(
       db.insert(auditLog).values({
-        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+        id: makeAuditLogEntryId(),
         eventType: "invalid.event" as "auth.login",
         timestamp: now,
         actor: testActor("account", "acc-123"),
@@ -127,7 +130,7 @@ describe("PG audit_log schema", () => {
     const now = Date.now();
     for (const eventType of eventTypes) {
       await db.insert(auditLog).values({
-        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+        id: makeAuditLogEntryId(),
         accountId,
         eventType,
         timestamp: now,
@@ -144,7 +147,7 @@ describe("PG audit_log schema", () => {
 
   it("supports api-key actor type", async () => {
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
     const actor = testActor("api-key", "key-123");
 
     await db.insert(auditLog).values({
@@ -161,7 +164,7 @@ describe("PG audit_log schema", () => {
   it("sets account_id to NULL on account deletion (SET NULL)", async () => {
     const accountId = await insertAccount();
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
       id,
@@ -181,7 +184,7 @@ describe("PG audit_log schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
       id,
@@ -200,7 +203,7 @@ describe("PG audit_log schema", () => {
 
   it("rejects duplicate composite primary key (same id + timestamp)", async () => {
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
       id,
@@ -220,7 +223,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("allows same id with different timestamps (composite PK)", async () => {
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
     const now = Date.now();
 
     await db.insert(auditLog).values({
@@ -246,7 +249,7 @@ describe("PG audit_log schema", () => {
     const now = Date.now();
 
     await db.insert(auditLog).values({
-      id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+      id: makeAuditLogEntryId(),
       eventType: "auth.login",
       timestamp: now,
       actor: testActor("account", "acc-123"),
@@ -259,7 +262,7 @@ describe("PG audit_log schema", () => {
 
     await expect(
       db.insert(auditLog).values({
-        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+        id: makeAuditLogEntryId(),
         eventType: "auth.login",
         timestamp: now,
         actor: testActor("account", "acc-123"),

--- a/packages/db/src/__tests__/schema-pg-pk-bridge.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-pk-bridge.integration.test.ts
@@ -10,12 +10,13 @@ import { systems } from "../schema/pg/systems.js";
 
 import {
   createPgPkBridgeTables,
+  makePkBridgeConfigId,
   pgInsertAccount,
   pgInsertSystem,
   testBlob,
 } from "./helpers/pg-helpers.js";
 
-import type { PKBridgeConfigId, SystemId } from "@pluralscape/types";
+import type { SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, pkBridgeConfigs };
@@ -43,7 +44,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("round-trips insert and select with all fields", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
     const syncAt = now - 60_000;
     const tokenCiphertext = new Uint8Array([10, 20, 30, 40]);
@@ -84,7 +85,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("defaults enabled to true when omitted", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -108,7 +109,7 @@ describe("PG pk_bridge_configs schema", () => {
     for (const dir of directions) {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
-      const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+      const id = makePkBridgeConfigId();
       const now = Date.now();
       await db.insert(pkBridgeConfigs).values({
         id,
@@ -134,7 +135,7 @@ describe("PG pk_bridge_configs schema", () => {
       client.query(
         `INSERT INTO pk_bridge_configs (id, system_id, enabled, sync_direction, pk_token_encrypted, entity_mappings, error_log, created_at, updated_at, version)
          VALUES ($1, $2, true, 'invalid-dir', '\\x01', '\\x02', '\\x03', NOW(), NOW(), 1)`,
-        [brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`), systemId],
+        [makePkBridgeConfigId(), systemId],
       ),
     ).rejects.toThrow();
   });
@@ -142,7 +143,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("allows null lastSyncAt", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -164,7 +165,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("persists a non-null lastSyncAt value", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
     const syncAt = now - 120_000;
 
@@ -187,7 +188,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("round-trips larger binary data for all BYTEA columns", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
 
     const tokenCiphertext = new Uint8Array(256);
@@ -220,7 +221,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("cascades delete when parent system is deleted", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -248,7 +249,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("defaults version to 1 when omitted", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -270,7 +271,7 @@ describe("PG pk_bridge_configs schema", () => {
     const now = Date.now();
     await expect(
       db.insert(pkBridgeConfigs).values({
-        id: brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`),
+        id: makePkBridgeConfigId(),
         systemId: brandId<SystemId>("nonexistent-system-id"),
         syncDirection: "ps-to-pk",
         pkTokenEncrypted: testBlob(new Uint8Array([1])),
@@ -285,7 +286,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("stores enabled as false and retrieves it correctly", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({

--- a/packages/db/src/__tests__/schema-pg-pk-bridge.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-pk-bridge.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { PKBridgeConfigId, SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, pkBridgeConfigs };
@@ -41,7 +43,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("round-trips insert and select with all fields", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
     const syncAt = now - 60_000;
     const tokenCiphertext = new Uint8Array([10, 20, 30, 40]);
@@ -82,7 +84,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("defaults enabled to true when omitted", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -106,7 +108,7 @@ describe("PG pk_bridge_configs schema", () => {
     for (const dir of directions) {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
       const now = Date.now();
       await db.insert(pkBridgeConfigs).values({
         id,
@@ -132,7 +134,7 @@ describe("PG pk_bridge_configs schema", () => {
       client.query(
         `INSERT INTO pk_bridge_configs (id, system_id, enabled, sync_direction, pk_token_encrypted, entity_mappings, error_log, created_at, updated_at, version)
          VALUES ($1, $2, true, 'invalid-dir', '\\x01', '\\x02', '\\x03', NOW(), NOW(), 1)`,
-        [crypto.randomUUID(), systemId],
+        [brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`), systemId],
       ),
     ).rejects.toThrow();
   });
@@ -140,7 +142,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("allows null lastSyncAt", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -162,7 +164,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("persists a non-null lastSyncAt value", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
     const syncAt = now - 120_000;
 
@@ -185,7 +187,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("round-trips larger binary data for all BYTEA columns", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
 
     const tokenCiphertext = new Uint8Array(256);
@@ -218,7 +220,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("cascades delete when parent system is deleted", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -246,7 +248,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("defaults version to 1 when omitted", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({
@@ -268,8 +270,8 @@ describe("PG pk_bridge_configs schema", () => {
     const now = Date.now();
     await expect(
       db.insert(pkBridgeConfigs).values({
-        id: crypto.randomUUID(),
-        systemId: "nonexistent-system-id",
+        id: brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`),
+        systemId: brandId<SystemId>("nonexistent-system-id"),
         syncDirection: "ps-to-pk",
         pkTokenEncrypted: testBlob(new Uint8Array([1])),
         entityMappings: testBlob(),
@@ -283,7 +285,7 @@ describe("PG pk_bridge_configs schema", () => {
   it("stores enabled as false and retrieves it correctly", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const now = Date.now();
 
     await db.insert(pkBridgeConfigs).values({

--- a/packages/db/src/__tests__/schema-pg-safe-mode-content.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-safe-mode-content.integration.test.ts
@@ -10,12 +10,13 @@ import { systems } from "../schema/pg/systems.js";
 
 import {
   createPgSafeModeContentTables,
+  makeSafeModeContentId,
   pgInsertAccount,
   pgInsertSystem,
   testBlob,
 } from "./helpers/pg-helpers.js";
 
-import type { SafeModeContentId, SystemId } from "@pluralscape/types";
+import type { SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, safeModeContent };
@@ -40,7 +41,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     await db.insert(safeModeContent).values({
@@ -65,7 +66,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({
       id,
@@ -83,7 +84,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({
       id,
@@ -103,9 +104,9 @@ describe("PG safe_mode_content schema", () => {
     const now = Date.now();
 
     const items = [
-      { id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`), sortOrder: 3 },
-      { id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`), sortOrder: 1 },
-      { id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`), sortOrder: 2 },
+      { id: makeSafeModeContentId(), sortOrder: 3 },
+      { id: makeSafeModeContentId(), sortOrder: 1 },
+      { id: makeSafeModeContentId(), sortOrder: 2 },
     ];
 
     for (const item of items) {
@@ -130,7 +131,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
     const blob = testBlob(blobCiphertext);
@@ -151,7 +152,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({
       id,
@@ -170,7 +171,7 @@ describe("PG safe_mode_content schema", () => {
     const now = Date.now();
     await expect(
       db.insert(safeModeContent).values({
-        id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`),
+        id: makeSafeModeContentId(),
         systemId: brandId<SystemId>("nonexistent"),
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -195,7 +196,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({
       id,

--- a/packages/db/src/__tests__/schema-pg-safe-mode-content.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-safe-mode-content.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { brandId } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
+import type { SafeModeContentId, SystemId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, safeModeContent };
@@ -38,7 +40,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     await db.insert(safeModeContent).values({
@@ -63,7 +65,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     await db.insert(safeModeContent).values({
       id,
@@ -81,7 +83,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     await db.insert(safeModeContent).values({
       id,
@@ -101,9 +103,9 @@ describe("PG safe_mode_content schema", () => {
     const now = Date.now();
 
     const items = [
-      { id: crypto.randomUUID(), sortOrder: 3 },
-      { id: crypto.randomUUID(), sortOrder: 1 },
-      { id: crypto.randomUUID(), sortOrder: 2 },
+      { id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`), sortOrder: 3 },
+      { id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`), sortOrder: 1 },
+      { id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`), sortOrder: 2 },
     ];
 
     for (const item of items) {
@@ -128,7 +130,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
     const blob = testBlob(blobCiphertext);
@@ -149,7 +151,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     await db.insert(safeModeContent).values({
       id,
@@ -168,8 +170,8 @@ describe("PG safe_mode_content schema", () => {
     const now = Date.now();
     await expect(
       db.insert(safeModeContent).values({
-        id: crypto.randomUUID(),
-        systemId: "nonexistent",
+        id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`),
+        systemId: brandId<SystemId>("nonexistent"),
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
         updatedAt: now,
@@ -193,7 +195,7 @@ describe("PG safe_mode_content schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     await db.insert(safeModeContent).values({
       id,

--- a/packages/db/src/__tests__/schema-sqlite-analytics.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-analytics.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { FrontingReportId, SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, frontingReports };
@@ -44,7 +46,7 @@ describe("SQLite analytics schema", () => {
     it("round-trips all fields", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const now = Date.now();
       const blob = testBlob();
 
@@ -71,7 +73,7 @@ describe("SQLite analytics schema", () => {
     it("accepts pdf format", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const now = Date.now();
 
       db.insert(frontingReports)
@@ -99,7 +101,7 @@ describe("SQLite analytics schema", () => {
         db
           .insert(frontingReports)
           .values({
-            id: crypto.randomUUID(),
+            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
             systemId,
             encryptedData: testBlob(),
             format: "docx" as "html",
@@ -114,7 +116,7 @@ describe("SQLite analytics schema", () => {
     it("cascades on system deletion", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const now = Date.now();
 
       db.insert(frontingReports)
@@ -140,8 +142,8 @@ describe("SQLite analytics schema", () => {
         db
           .insert(frontingReports)
           .values({
-            id: crypto.randomUUID(),
-            systemId: "nonexistent",
+            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+            systemId: brandId<SystemId>("nonexistent"),
             encryptedData: testBlob(),
             format: "html",
             generatedAt: now,
@@ -155,7 +157,7 @@ describe("SQLite analytics schema", () => {
     it("rejects duplicate primary key", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const now = Date.now();
       const values = {
         id,
@@ -179,7 +181,7 @@ describe("SQLite analytics schema", () => {
       db.insert(frontingReports)
         .values([
           {
-            id: crypto.randomUUID(),
+            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
             systemId,
             encryptedData: testBlob(new Uint8Array([1])),
             format: "html",
@@ -188,7 +190,7 @@ describe("SQLite analytics schema", () => {
             updatedAt: now,
           },
           {
-            id: crypto.randomUUID(),
+            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
             systemId,
             encryptedData: testBlob(new Uint8Array([2])),
             format: "pdf",
@@ -210,7 +212,7 @@ describe("SQLite analytics schema", () => {
     it("round-trips distinct ciphertext payloads", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = crypto.randomUUID();
+      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
       const now = Date.now();
       const blob = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 

--- a/packages/db/src/__tests__/schema-sqlite-analytics.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-analytics.integration.test.ts
@@ -10,12 +10,13 @@ import { systems } from "../schema/sqlite/systems.js";
 
 import {
   createSqliteAnalyticsTables,
+  makeFrontingReportId,
   sqliteInsertAccount,
   sqliteInsertSystem,
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
-import type { FrontingReportId, SystemId } from "@pluralscape/types";
+import type { SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, frontingReports };
@@ -46,7 +47,7 @@ describe("SQLite analytics schema", () => {
     it("round-trips all fields", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const now = Date.now();
       const blob = testBlob();
 
@@ -73,7 +74,7 @@ describe("SQLite analytics schema", () => {
     it("accepts pdf format", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const now = Date.now();
 
       db.insert(frontingReports)
@@ -101,7 +102,7 @@ describe("SQLite analytics schema", () => {
         db
           .insert(frontingReports)
           .values({
-            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+            id: makeFrontingReportId(),
             systemId,
             encryptedData: testBlob(),
             format: "docx" as "html",
@@ -116,7 +117,7 @@ describe("SQLite analytics schema", () => {
     it("cascades on system deletion", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const now = Date.now();
 
       db.insert(frontingReports)
@@ -142,7 +143,7 @@ describe("SQLite analytics schema", () => {
         db
           .insert(frontingReports)
           .values({
-            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+            id: makeFrontingReportId(),
             systemId: brandId<SystemId>("nonexistent"),
             encryptedData: testBlob(),
             format: "html",
@@ -157,7 +158,7 @@ describe("SQLite analytics schema", () => {
     it("rejects duplicate primary key", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const now = Date.now();
       const values = {
         id,
@@ -181,7 +182,7 @@ describe("SQLite analytics schema", () => {
       db.insert(frontingReports)
         .values([
           {
-            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+            id: makeFrontingReportId(),
             systemId,
             encryptedData: testBlob(new Uint8Array([1])),
             format: "html",
@@ -190,7 +191,7 @@ describe("SQLite analytics schema", () => {
             updatedAt: now,
           },
           {
-            id: brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`),
+            id: makeFrontingReportId(),
             systemId,
             encryptedData: testBlob(new Uint8Array([2])),
             format: "pdf",
@@ -212,7 +213,7 @@ describe("SQLite analytics schema", () => {
     it("round-trips distinct ciphertext payloads", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const id = brandId<FrontingReportId>(`fr_${crypto.randomUUID()}`);
+      const id = makeFrontingReportId();
       const now = Date.now();
       const blob = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 

--- a/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -14,6 +15,7 @@ import {
 } from "./helpers/sqlite-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
+import type { AuditLogEntryId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, auditLog };
@@ -43,7 +45,7 @@ describe("SQLite audit_log schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
     const actor = testActor("account", accountId);
 
     db.insert(auditLog)
@@ -74,7 +76,7 @@ describe("SQLite audit_log schema", () => {
 
   it("allows nullable fields (accountId, systemId, ipAddress, userAgent, detail)", () => {
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     db.insert(auditLog)
       .values({
@@ -100,7 +102,7 @@ describe("SQLite audit_log schema", () => {
       db
         .insert(auditLog)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
           eventType: "invalid.event" as "auth.login",
           timestamp: now,
           actor: testActor("account", "acc-123"),
@@ -138,7 +140,7 @@ describe("SQLite audit_log schema", () => {
     for (const eventType of eventTypes) {
       db.insert(auditLog)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
           accountId,
           eventType,
           timestamp: now,
@@ -156,7 +158,7 @@ describe("SQLite audit_log schema", () => {
 
   it("supports api-key actor type", () => {
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
     const actor = testActor("api-key", "key-123");
 
     db.insert(auditLog)
@@ -175,7 +177,7 @@ describe("SQLite audit_log schema", () => {
   it("sets account_id to NULL on account deletion (SET NULL)", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     db.insert(auditLog)
       .values({
@@ -197,7 +199,7 @@ describe("SQLite audit_log schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     db.insert(auditLog)
       .values({
@@ -218,7 +220,7 @@ describe("SQLite audit_log schema", () => {
 
   it("rejects duplicate primary key", () => {
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
 
     db.insert(auditLog)
       .values({
@@ -247,7 +249,7 @@ describe("SQLite audit_log schema", () => {
 
     db.insert(auditLog)
       .values({
-        id: crypto.randomUUID(),
+        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
         eventType: "auth.login",
         timestamp: now,
         actor: testActor("account", "acc-123"),
@@ -263,7 +265,7 @@ describe("SQLite audit_log schema", () => {
       db
         .insert(auditLog)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
           eventType: "auth.login",
           timestamp: now,
           actor: testActor("account", "acc-123"),

--- a/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
@@ -1,4 +1,3 @@
-import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -10,12 +9,12 @@ import { systems } from "../schema/sqlite/systems.js";
 
 import {
   createSqliteAuditLogTables,
+  makeAuditLogEntryId,
   sqliteInsertAccount,
   sqliteInsertSystem,
 } from "./helpers/sqlite-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
-import type { AuditLogEntryId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, auditLog };
@@ -45,7 +44,7 @@ describe("SQLite audit_log schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
     const actor = testActor("account", accountId);
 
     db.insert(auditLog)
@@ -76,7 +75,7 @@ describe("SQLite audit_log schema", () => {
 
   it("allows nullable fields (accountId, systemId, ipAddress, userAgent, detail)", () => {
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
       .values({
@@ -102,7 +101,7 @@ describe("SQLite audit_log schema", () => {
       db
         .insert(auditLog)
         .values({
-          id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+          id: makeAuditLogEntryId(),
           eventType: "invalid.event" as "auth.login",
           timestamp: now,
           actor: testActor("account", "acc-123"),
@@ -140,7 +139,7 @@ describe("SQLite audit_log schema", () => {
     for (const eventType of eventTypes) {
       db.insert(auditLog)
         .values({
-          id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+          id: makeAuditLogEntryId(),
           accountId,
           eventType,
           timestamp: now,
@@ -158,7 +157,7 @@ describe("SQLite audit_log schema", () => {
 
   it("supports api-key actor type", () => {
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
     const actor = testActor("api-key", "key-123");
 
     db.insert(auditLog)
@@ -177,7 +176,7 @@ describe("SQLite audit_log schema", () => {
   it("sets account_id to NULL on account deletion (SET NULL)", () => {
     const accountId = insertAccount();
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
       .values({
@@ -199,7 +198,7 @@ describe("SQLite audit_log schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
       .values({
@@ -220,7 +219,7 @@ describe("SQLite audit_log schema", () => {
 
   it("rejects duplicate primary key", () => {
     const now = Date.now();
-    const id = brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`);
+    const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
       .values({
@@ -249,7 +248,7 @@ describe("SQLite audit_log schema", () => {
 
     db.insert(auditLog)
       .values({
-        id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+        id: makeAuditLogEntryId(),
         eventType: "auth.login",
         timestamp: now,
         actor: testActor("account", "acc-123"),
@@ -265,7 +264,7 @@ describe("SQLite audit_log schema", () => {
       db
         .insert(auditLog)
         .values({
-          id: brandId<AuditLogEntryId>(`al_${crypto.randomUUID()}`),
+          id: makeAuditLogEntryId(),
           eventType: "auth.login",
           timestamp: now,
           actor: testActor("account", "acc-123"),

--- a/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
@@ -9,12 +9,13 @@ import { systems } from "../schema/sqlite/systems.js";
 
 import {
   createSqlitePkBridgeTables,
+  makePkBridgeConfigId,
   sqliteInsertAccount,
   sqliteInsertSystem,
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
-import type { PKBridgeConfigId, SystemId } from "@pluralscape/types";
+import type { SystemId } from "@pluralscape/types";
 import type DatabaseConstructor from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
@@ -41,7 +42,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
     const pkTokenCiphertext = new Uint8Array([10, 20, 30]);
     const pkToken = testBlob(pkTokenCiphertext);
     const entityMappings = testBlob(new Uint8Array([40, 50, 60]));
@@ -81,7 +82,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -108,7 +109,7 @@ describe("SQLite PK Bridge Schema", () => {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
       const now = Date.now();
-      const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+      const id = makePkBridgeConfigId();
 
       db.insert(pkBridgeConfigs)
         .values({
@@ -137,7 +138,7 @@ describe("SQLite PK Bridge Schema", () => {
       db
         .insert(pkBridgeConfigs)
         .values({
-          id: brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`),
+          id: makePkBridgeConfigId(),
           systemId,
           syncDirection: "invalid-direction" as "bidirectional",
           pkTokenEncrypted: testBlob(new Uint8Array([1])),
@@ -154,7 +155,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -179,7 +180,7 @@ describe("SQLite PK Bridge Schema", () => {
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
     const syncTime = now - 60000;
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -203,7 +204,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
 
     const largePkTokenCiphertext = new Uint8Array(256);
     const largeEntityCiphertext = new Uint8Array(512);
@@ -238,7 +239,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -268,7 +269,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -294,7 +295,7 @@ describe("SQLite PK Bridge Schema", () => {
       db
         .insert(pkBridgeConfigs)
         .values({
-          id: brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`),
+          id: makePkBridgeConfigId(),
           systemId: brandId<SystemId>("nonexistent-system-id"),
           syncDirection: "ps-to-pk",
           pkTokenEncrypted: testBlob(new Uint8Array([1])),
@@ -311,7 +312,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
+    const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
       .values({

--- a/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -13,6 +14,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { PKBridgeConfigId, SystemId } from "@pluralscape/types";
 import type DatabaseConstructor from "better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
@@ -39,7 +41,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
     const pkTokenCiphertext = new Uint8Array([10, 20, 30]);
     const pkToken = testBlob(pkTokenCiphertext);
     const entityMappings = testBlob(new Uint8Array([40, 50, 60]));
@@ -79,7 +81,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -106,7 +108,7 @@ describe("SQLite PK Bridge Schema", () => {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
       const now = Date.now();
-      const id = crypto.randomUUID();
+      const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
       db.insert(pkBridgeConfigs)
         .values({
@@ -135,7 +137,7 @@ describe("SQLite PK Bridge Schema", () => {
       db
         .insert(pkBridgeConfigs)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`),
           systemId,
           syncDirection: "invalid-direction" as "bidirectional",
           pkTokenEncrypted: testBlob(new Uint8Array([1])),
@@ -152,7 +154,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -177,7 +179,7 @@ describe("SQLite PK Bridge Schema", () => {
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
     const syncTime = now - 60000;
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -201,7 +203,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
     const largePkTokenCiphertext = new Uint8Array(256);
     const largeEntityCiphertext = new Uint8Array(512);
@@ -236,7 +238,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -266,7 +268,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
     db.insert(pkBridgeConfigs)
       .values({
@@ -292,8 +294,8 @@ describe("SQLite PK Bridge Schema", () => {
       db
         .insert(pkBridgeConfigs)
         .values({
-          id: crypto.randomUUID(),
-          systemId: "nonexistent-system-id",
+          id: brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`),
+          systemId: brandId<SystemId>("nonexistent-system-id"),
           syncDirection: "ps-to-pk",
           pkTokenEncrypted: testBlob(new Uint8Array([1])),
           entityMappings: testBlob(),
@@ -309,7 +311,7 @@ describe("SQLite PK Bridge Schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<PKBridgeConfigId>(`pkb_${crypto.randomUUID()}`);
 
     db.insert(pkBridgeConfigs)
       .values({

--- a/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
@@ -10,12 +10,13 @@ import { systems } from "../schema/sqlite/systems.js";
 
 import {
   createSqliteSafeModeContentTables,
+  makeSafeModeContentId,
   sqliteInsertAccount,
   sqliteInsertSystem,
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
-import type { SafeModeContentId, SystemId } from "@pluralscape/types";
+import type { SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, safeModeContent };
@@ -41,7 +42,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     db.insert(safeModeContent)
@@ -68,7 +69,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)
       .values({
@@ -88,7 +89,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)
       .values({
@@ -112,7 +113,7 @@ describe("SQLite safe_mode_content schema", () => {
     for (let i = 0; i < 3; i++) {
       db.insert(safeModeContent)
         .values({
-          id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`),
+          id: makeSafeModeContentId(),
           systemId,
           sortOrder: i + 1,
           encryptedData: testBlob(new Uint8Array([i + 1])),
@@ -136,7 +137,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
     const blob = testBlob(bigArray);
@@ -159,7 +160,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)
       .values({
@@ -182,7 +183,7 @@ describe("SQLite safe_mode_content schema", () => {
       db
         .insert(safeModeContent)
         .values({
-          id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`),
+          id: makeSafeModeContentId(),
           systemId: brandId<SystemId>("nonexistent"),
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -196,7 +197,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
+    const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)
       .values({

--- a/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
@@ -1,3 +1,4 @@
+import { brandId } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -14,6 +15,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
+import type { SafeModeContentId, SystemId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, safeModeContent };
@@ -39,7 +41,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     db.insert(safeModeContent)
@@ -66,7 +68,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     db.insert(safeModeContent)
       .values({
@@ -86,7 +88,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     db.insert(safeModeContent)
       .values({
@@ -110,7 +112,7 @@ describe("SQLite safe_mode_content schema", () => {
     for (let i = 0; i < 3; i++) {
       db.insert(safeModeContent)
         .values({
-          id: crypto.randomUUID(),
+          id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`),
           systemId,
           sortOrder: i + 1,
           encryptedData: testBlob(new Uint8Array([i + 1])),
@@ -134,7 +136,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
     const blob = testBlob(bigArray);
@@ -157,7 +159,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     db.insert(safeModeContent)
       .values({
@@ -180,8 +182,8 @@ describe("SQLite safe_mode_content schema", () => {
       db
         .insert(safeModeContent)
         .values({
-          id: crypto.randomUUID(),
-          systemId: "nonexistent",
+          id: brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`),
+          systemId: brandId<SystemId>("nonexistent"),
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
           updatedAt: now,
@@ -194,7 +196,7 @@ describe("SQLite safe_mode_content schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const now = Date.now();
-    const id = crypto.randomUUID();
+    const id = brandId<SafeModeContentId>(`smc_${crypto.randomUUID()}`);
 
     db.insert(safeModeContent)
       .values({

--- a/packages/db/src/schema/pg/analytics.ts
+++ b/packages/db/src/schema/pg/analytics.ts
@@ -1,6 +1,6 @@
 import { check, index, pgTable, varchar } from "drizzle-orm/pg-core";
 
-import { pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
+import { brandedId, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
 import {
   archivable,
   archivableConsistencyCheckFor,
@@ -9,19 +9,19 @@ import {
   versionCheckFor,
 } from "../../helpers/audit.pg.js";
 import { enumCheck } from "../../helpers/check.js";
-import { ENUM_MAX_LENGTH, ID_MAX_LENGTH } from "../../helpers/db.constants.js";
+import { ENUM_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { FRONTING_REPORT_FORMATS } from "../../helpers/enums.js";
 
 import { systems } from "./systems.js";
 
-import type { ReportFormat } from "@pluralscape/types";
+import type { FrontingReportId, ReportFormat, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const frontingReports = pgTable(
   "fronting_reports",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH })
+    id: brandedId<FrontingReportId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     encryptedData: pgEncryptedBlob("encrypted_data").notNull(),

--- a/packages/db/src/schema/pg/audit-log.ts
+++ b/packages/db/src/schema/pg/audit-log.ts
@@ -10,20 +10,16 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-import { pgTimestamp } from "../../columns/pg.js";
+import { brandedId, pgTimestamp } from "../../columns/pg.js";
 import { enumCheck } from "../../helpers/check.js";
-import {
-  AUDIT_LOG_DETAIL_MAX_LENGTH,
-  ENUM_MAX_LENGTH,
-  ID_MAX_LENGTH,
-} from "../../helpers/db.constants.js";
+import { AUDIT_LOG_DETAIL_MAX_LENGTH, ENUM_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { AUDIT_EVENT_TYPES } from "../../helpers/enums.js";
 
 import { accounts } from "./auth.js";
 import { systems } from "./systems.js";
 
 import type { DbAuditActor } from "../../helpers/types.js";
-import type { AuditEventType } from "@pluralscape/types";
+import type { AccountId, AuditEventType, AuditLogEntryId, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export type { DbAuditActor } from "../../helpers/types.js";
@@ -34,14 +30,14 @@ export type { DbAuditActor } from "../../helpers/types.js";
 export const auditLog = pgTable(
   "audit_log",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).notNull(),
+    id: brandedId<AuditLogEntryId>("id").notNull(),
     // ON DELETE SET NULL: audit logs survive account/system deletion with nullified references.
     // Intentional exception to the RESTRICT policy — audit history must be preserved.
     /** Denormalized for query performance — avoids joining through systems to get account. */
-    accountId: varchar("account_id", { length: ID_MAX_LENGTH }).references(() => accounts.id, {
+    accountId: brandedId<AccountId>("account_id").references(() => accounts.id, {
       onDelete: "set null",
     }),
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH }).references(() => systems.id, {
+    systemId: brandedId<SystemId>("system_id").references(() => systems.id, {
       onDelete: "set null",
     }),
     eventType: varchar("event_type", { length: ENUM_MAX_LENGTH }).notNull().$type<AuditEventType>(),

--- a/packages/db/src/schema/pg/biometric-tokens.ts
+++ b/packages/db/src/schema/pg/biometric-tokens.ts
@@ -1,18 +1,18 @@
 import { sql } from "drizzle-orm";
 import { index, pgTable, uniqueIndex, varchar } from "drizzle-orm/pg-core";
 
-import { pgTimestamp } from "../../columns/pg.js";
-import { ID_MAX_LENGTH } from "../../helpers/db.constants.js";
+import { brandedId, pgTimestamp } from "../../columns/pg.js";
 
 import { sessions } from "./auth.js";
 
+import type { BiometricTokenId, SessionId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const biometricTokens = pgTable(
   "biometric_tokens",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    sessionId: varchar("session_id", { length: ID_MAX_LENGTH })
+    id: brandedId<BiometricTokenId>("id").primaryKey(),
+    sessionId: brandedId<SessionId>("session_id")
       .notNull()
       .references(() => sessions.id, { onDelete: "cascade" }),
     tokenHash: varchar("token_hash", { length: 128 }).notNull(),

--- a/packages/db/src/schema/pg/pk-bridge.ts
+++ b/packages/db/src/schema/pg/pk-bridge.ts
@@ -1,21 +1,21 @@
 import { boolean, check, pgTable, uniqueIndex, varchar } from "drizzle-orm/pg-core";
 
-import { pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
+import { brandedId, pgEncryptedBlob, pgTimestamp } from "../../columns/pg.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.pg.js";
 import { enumCheck } from "../../helpers/check.js";
-import { ENUM_MAX_LENGTH, ID_MAX_LENGTH } from "../../helpers/db.constants.js";
+import { ENUM_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { PK_SYNC_DIRECTIONS } from "../../helpers/enums.js";
 
 import { systems } from "./systems.js";
 
-import type { PKSyncDirection } from "@pluralscape/types";
+import type { PKBridgeConfigId, PKSyncDirection, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const pkBridgeConfigs = pgTable(
   "pk_bridge_configs",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH })
+    id: brandedId<PKBridgeConfigId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     enabled: boolean("enabled").notNull().default(true),

--- a/packages/db/src/schema/pg/safe-mode-content.ts
+++ b/packages/db/src/schema/pg/safe-mode-content.ts
@@ -1,18 +1,18 @@
-import { index, integer, pgTable, varchar } from "drizzle-orm/pg-core";
+import { index, integer, pgTable } from "drizzle-orm/pg-core";
 
-import { pgEncryptedBlob } from "../../columns/pg.js";
+import { brandedId, pgEncryptedBlob } from "../../columns/pg.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.pg.js";
-import { ID_MAX_LENGTH } from "../../helpers/db.constants.js";
 
 import { systems } from "./systems.js";
 
+import type { SafeModeContentId, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const safeModeContent = pgTable(
   "safe_mode_content",
   {
-    id: varchar("id", { length: ID_MAX_LENGTH }).primaryKey(),
-    systemId: varchar("system_id", { length: ID_MAX_LENGTH })
+    id: brandedId<SafeModeContentId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     sortOrder: integer("sort_order").notNull().default(0),

--- a/packages/db/src/schema/sqlite/analytics.ts
+++ b/packages/db/src/schema/sqlite/analytics.ts
@@ -1,6 +1,6 @@
 import { check, index, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-import { sqliteEncryptedBlob, sqliteTimestamp } from "../../columns/sqlite.js";
+import { brandedId, sqliteEncryptedBlob, sqliteTimestamp } from "../../columns/sqlite.js";
 import {
   archivable,
   archivableConsistencyCheckFor,
@@ -13,14 +13,14 @@ import { FRONTING_REPORT_FORMATS } from "../../helpers/enums.js";
 
 import { systems } from "./systems.js";
 
-import type { ReportFormat } from "@pluralscape/types";
+import type { FrontingReportId, ReportFormat, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const frontingReports = sqliteTable(
   "fronting_reports",
   {
-    id: text("id").primaryKey(),
-    systemId: text("system_id")
+    id: brandedId<FrontingReportId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     encryptedData: sqliteEncryptedBlob("encrypted_data").notNull(),

--- a/packages/db/src/schema/sqlite/audit-log.ts
+++ b/packages/db/src/schema/sqlite/audit-log.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm";
 import { check, index, primaryKey, sqliteTable, text, unique } from "drizzle-orm/sqlite-core";
 
-import { sqliteJson, sqliteTimestamp } from "../../columns/sqlite.js";
+import { brandedId, sqliteJson, sqliteTimestamp } from "../../columns/sqlite.js";
 import { enumCheck } from "../../helpers/check.js";
 import { AUDIT_LOG_DETAIL_MAX_LENGTH } from "../../helpers/db.constants.js";
 import { AUDIT_EVENT_TYPES } from "../../helpers/enums.js";
@@ -10,7 +10,7 @@ import { accounts } from "./auth.js";
 import { systems } from "./systems.js";
 
 import type { DbAuditActor } from "../../helpers/types.js";
-import type { AuditEventType } from "@pluralscape/types";
+import type { AccountId, AuditEventType, AuditLogEntryId, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export type { DbAuditActor } from "../../helpers/types.js";
@@ -18,12 +18,16 @@ export type { DbAuditActor } from "../../helpers/types.js";
 export const auditLog = sqliteTable(
   "audit_log",
   {
-    id: text("id").notNull(),
+    id: brandedId<AuditLogEntryId>("id").notNull(),
     // ON DELETE SET NULL: audit logs survive account/system deletion with nullified references.
     // Intentional exception to the RESTRICT policy — audit history must be preserved.
     /** Denormalized for query performance — avoids joining through systems to get account. */
-    accountId: text("account_id").references(() => accounts.id, { onDelete: "set null" }),
-    systemId: text("system_id").references(() => systems.id, { onDelete: "set null" }),
+    accountId: brandedId<AccountId>("account_id").references(() => accounts.id, {
+      onDelete: "set null",
+    }),
+    systemId: brandedId<SystemId>("system_id").references(() => systems.id, {
+      onDelete: "set null",
+    }),
     eventType: text("event_type").notNull().$type<AuditEventType>(),
     /** Named "timestamp" (not "createdAt") to reflect when the event occurred, not row creation. */
     timestamp: sqliteTimestamp("timestamp").notNull(),

--- a/packages/db/src/schema/sqlite/biometric-tokens.ts
+++ b/packages/db/src/schema/sqlite/biometric-tokens.ts
@@ -1,17 +1,18 @@
 import { sql } from "drizzle-orm";
 import { index, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
-import { sqliteTimestamp } from "../../columns/sqlite.js";
+import { brandedId, sqliteTimestamp } from "../../columns/sqlite.js";
 
 import { sessions } from "./auth.js";
 
+import type { BiometricTokenId, SessionId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const biometricTokens = sqliteTable(
   "biometric_tokens",
   {
-    id: text("id").primaryKey(),
-    sessionId: text("session_id")
+    id: brandedId<BiometricTokenId>("id").primaryKey(),
+    sessionId: brandedId<SessionId>("session_id")
       .notNull()
       .references(() => sessions.id, { onDelete: "cascade" }),
     tokenHash: text("token_hash").notNull(),

--- a/packages/db/src/schema/sqlite/pk-bridge.ts
+++ b/packages/db/src/schema/sqlite/pk-bridge.ts
@@ -1,20 +1,20 @@
 import { check, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
-import { sqliteEncryptedBlob, sqliteTimestamp } from "../../columns/sqlite.js";
+import { brandedId, sqliteEncryptedBlob, sqliteTimestamp } from "../../columns/sqlite.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.sqlite.js";
 import { enumCheck } from "../../helpers/check.js";
 import { PK_SYNC_DIRECTIONS } from "../../helpers/enums.js";
 
 import { systems } from "./systems.js";
 
-import type { PKSyncDirection } from "@pluralscape/types";
+import type { PKBridgeConfigId, PKSyncDirection, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const pkBridgeConfigs = sqliteTable(
   "pk_bridge_configs",
   {
-    id: text("id").primaryKey(),
-    systemId: text("system_id")
+    id: brandedId<PKBridgeConfigId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),

--- a/packages/db/src/schema/sqlite/safe-mode-content.ts
+++ b/packages/db/src/schema/sqlite/safe-mode-content.ts
@@ -1,17 +1,18 @@
-import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { index, integer, sqliteTable } from "drizzle-orm/sqlite-core";
 
-import { sqliteEncryptedBlob } from "../../columns/sqlite.js";
+import { brandedId, sqliteEncryptedBlob } from "../../columns/sqlite.js";
 import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.sqlite.js";
 
 import { systems } from "./systems.js";
 
+import type { SafeModeContentId, SystemId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const safeModeContent = sqliteTable(
   "safe_mode_content",
   {
-    id: text("id").primaryKey(),
-    systemId: text("system_id")
+    id: brandedId<SafeModeContentId>("id").primaryKey(),
+    systemId: brandedId<SystemId>("system_id")
       .notNull()
       .references(() => systems.id, { onDelete: "cascade" }),
     sortOrder: integer("sort_order").notNull().default(0),

--- a/packages/types/src/__tests__/ids.test.ts
+++ b/packages/types/src/__tests__/ids.test.ts
@@ -211,8 +211,11 @@ describe("ID_PREFIXES", () => {
     expect(unique.size).toBe(values.length);
   });
 
-  it("has the same number of entries as EntityType members", () => {
+  it("has an entry for every AnyBrandedId member", () => {
     const prefixCount = Object.keys(ID_PREFIXES).length;
+    // 65 IDs: one per brand in AnyBrandedId. Adding a brand without a prefix
+    // fails AssertAllPrefixesMapped at compile time; removing a prefix entry
+    // silently passes typecheck, so this count catches that drift.
     expect(prefixCount).toBe(65);
   });
 });

--- a/packages/types/src/__tests__/ids.test.ts
+++ b/packages/types/src/__tests__/ids.test.ts
@@ -213,7 +213,7 @@ describe("ID_PREFIXES", () => {
 
   it("has the same number of entries as EntityType members", () => {
     const prefixCount = Object.keys(ID_PREFIXES).length;
-    expect(prefixCount).toBe(64);
+    expect(prefixCount).toBe(65);
   });
 });
 

--- a/packages/types/src/__tests__/littles-safe-mode.test.ts
+++ b/packages/types/src/__tests__/littles-safe-mode.test.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, expectTypeOf, it } from "vitest";
 
-import type { BlobId, SystemId } from "../ids.js";
+import type { BlobId, SafeModeContentId, SystemId } from "../ids.js";
 import type {
   LittlesSafeModeConfig,
   SafeModeContentItem,
@@ -19,7 +19,7 @@ describe("SafeModeUIFlags", () => {
 
 describe("SafeModeContentItem", () => {
   it("has correct field types", () => {
-    expectTypeOf<SafeModeContentItem["id"]>().toEqualTypeOf<string>();
+    expectTypeOf<SafeModeContentItem["id"]>().toEqualTypeOf<SafeModeContentId>();
     expectTypeOf<SafeModeContentItem["systemId"]>().toEqualTypeOf<SystemId>();
     expectTypeOf<SafeModeContentItem["contentType"]>().toEqualTypeOf<"link" | "video" | "media">();
     expectTypeOf<SafeModeContentItem["url"]>().toEqualTypeOf<string | null>();
@@ -46,8 +46,10 @@ describe("LittlesSafeModeConfig", () => {
     expectTypeOf<LittlesSafeModeConfig["enabled"]>().toEqualTypeOf<boolean>();
   });
 
-  it("has allowedContentIds as readonly string array", () => {
-    expectTypeOf<LittlesSafeModeConfig["allowedContentIds"]>().toEqualTypeOf<readonly string[]>();
+  it("has allowedContentIds as readonly SafeModeContentId array", () => {
+    expectTypeOf<LittlesSafeModeConfig["allowedContentIds"]>().toEqualTypeOf<
+      readonly SafeModeContentId[]
+    >();
   });
 
   it("has simplifiedUIFlags as SafeModeUIFlags", () => {

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -81,6 +81,7 @@ export type BucketKeyRotationId = Brand<string, "BucketKeyRotationId">;
 export type BucketRotationItemId = Brand<string, "BucketRotationItemId">;
 export type SystemSnapshotId = Brand<string, "SystemSnapshotId">;
 export type BiometricTokenId = Brand<string, "BiometricTokenId">;
+export type SafeModeContentId = Brand<string, "SafeModeContentId">;
 export type StorageKey = Brand<string, "StorageKey">;
 export type HexColor = Brand<string, "HexColor">;
 export type SlugHash = Brand<string, "SlugHash">;
@@ -160,7 +161,8 @@ export type AnyBrandedId =
   | BucketKeyRotationId
   | BucketRotationItemId
   | SystemSnapshotId
-  | BiometricTokenId;
+  | BiometricTokenId
+  | SafeModeContentId;
 
 // ── Branded value types (not entity IDs) ────────────────────────────
 
@@ -237,6 +239,7 @@ export const ID_PREFIXES = {
   bucketRotationItem: "bri_",
   systemSnapshot: "snap_",
   biometricToken: "bt_",
+  safeModeContent: "smc_",
 } as const;
 
 /** Maps each ID prefix value to its Brand tag string. */
@@ -305,6 +308,7 @@ export interface IdPrefixBrandMap {
   bri_: "BucketRotationItemId";
   snap_: "SystemSnapshotId";
   bt_: "BiometricTokenId";
+  smc_: "SafeModeContentId";
 }
 
 // Helper: constrains T to Record<string, true> — fails at definition site if any value is not `true`.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -84,6 +84,7 @@ export type {
   BucketRotationItemId,
   SystemSnapshotId,
   BiometricTokenId,
+  SafeModeContentId,
   StorageKey,
   HexColor,
   SlugHash,

--- a/packages/types/src/littles-safe-mode.ts
+++ b/packages/types/src/littles-safe-mode.ts
@@ -1,4 +1,4 @@
-import type { BlobId, SystemId } from "./ids.js";
+import type { BlobId, SafeModeContentId, SystemId } from "./ids.js";
 
 /** Feature flags controlling UI simplification in Littles Safe Mode. */
 export interface SafeModeUIFlags {
@@ -11,7 +11,7 @@ export interface SafeModeUIFlags {
 
 /** A content item for Littles Safe Mode — links, videos, or media. */
 export interface SafeModeContentItem {
-  readonly id: string;
+  readonly id: SafeModeContentId;
   readonly systemId: SystemId;
   readonly contentType: "link" | "video" | "media";
   readonly url: string | null;
@@ -24,6 +24,6 @@ export interface SafeModeContentItem {
 /** Configuration for Littles Safe Mode — simplified UI for littles. */
 export interface LittlesSafeModeConfig {
   readonly enabled: boolean;
-  readonly allowedContentIds: readonly string[];
+  readonly allowedContentIds: readonly SafeModeContentId[];
   readonly simplifiedUIFlags: SafeModeUIFlags;
 }


### PR DESCRIPTION
## Summary

First sub-PR of the three-step types-ltel C11 closeout (bean `ps-6hyr`).

Lifts the last 5 Drizzle schema files (PG + sqlite) to use `brandedId<B>()` for all ID and FK columns, so every `<X>Id` brand declared in `@pluralscape/types` flows through Drizzle inference into downstream code. Adds `SafeModeContentId` + `smc_` prefix to complete the ID registry.

Tables converted:

- `audit-log` — id/accountId/systemId (the only SoT-tracked entity in this batch; its parity test's `StripBrands<>` wrapper becomes tightenable in C11c)
- `analytics` (`frontingReports`) — id/systemId
- `biometric-tokens` — id/sessionId
- `pk-bridge` (`pkBridgeConfigs`) — id/systemId
- `safe-mode-content` — id/systemId

`packages/db/src/schema/pg/search.ts` is not touched (raw SQL DDL, not a pgTable).

Parity tests unchanged — they still wrap with `StripBrands<>` which flattens the new brand the same way. C11c (third sub-PR) tightens them and deletes the helper. C11b (the one between) lifts timestamps.

## Test plan

- [x] `pnpm format` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes monorepo-wide
- [x] `pnpm test:unit` passes (12854 tests)
- [x] `pnpm test:integration` passes
- [x] `pnpm test:e2e` passes
- [x] `pnpm test:e2e:slow` passes

Spec: `docs/superpowers/specs/2026-04-24-types-ltel-c11-cleanup-design.md` (local-only)
Plan: `docs/superpowers/plans/2026-04-24-types-ltel-c11a-brandedid-lift.md` (local-only)
Bean: `ps-6hyr`
Epic: `types-ltel`