### PR TITLE
feat(db): C11b — lift timestamp customType to UnixMillis

### DIFF
--- a/.beans/ps-ava1--types-ltel-c11b-timestamp-customtype-lift-to-unixm.md
+++ b/.beans/ps-ava1--types-ltel-c11b-timestamp-customtype-lift-to-unixm.md
@@ -1,11 +1,11 @@
 ---
 # ps-ava1
 title: "types-ltel C11b: timestamp customType lift to UnixMillis"
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-04-24T09:27:12Z
-updated_at: 2026-04-24T09:28:50Z
+updated_at: 2026-04-24T13:52:17Z
 parent: types-ltel
 blocked_by:
   - ps-6hyr
@@ -17,13 +17,12 @@ Second of three sub-PRs closing out the types-ltel epic (C11).
 
 Flip `pgTimestamp` / `sqliteTimestamp` `customType` generics from `{ data: number }` to `{ data: UnixMillis }`.
 
-- [ ] Update `packages/db/src/columns/pg.ts` (line 61): `customType<{ data: UnixMillis; driverData: string }>`
-- [ ] Update `packages/db/src/columns/sqlite.ts` (line 45): `customType<{ data: UnixMillis; driverData: number }>`
-- [ ] Add fixture helper `packages/db/src/__tests__/fixtures/timestamps.ts` exporting `fixtureNow()` and `fixtureNowPlus(offsetMs)`
-- [ ] Replace ~126 `Date.now()` timestamp-insert sites across ~30 test files with `fixtureNow()` / `fixtureNowPlus(n)`
-- [ ] Top offenders (verify during implementation): `schema-{pg,sqlite}-auth.integration.test.ts` (20 each), `schema-*-key-rotation.integration.test.ts` (6 each), `schema-pg-sync.integration.test.ts` (6), `bullmq-queue.integration.test.ts` (6)
-- [ ] Verify `pnpm typecheck` green across all packages
-- [ ] Verify `pnpm test` + `pnpm test:integration` green
+- [x] Update `packages/db/src/columns/pg.ts`: `customType<{ data: UnixMillis; driverData: string }>`
+- [x] Update `packages/db/src/columns/sqlite.ts`: `customType<{ data: UnixMillis; driverData: number }>`
+- [x] Add fixture helper `packages/db/src/__tests__/fixtures/timestamps.ts` exporting `fixtureNow()` and `fixtureNowPlus(offsetMs)`
+- [x] Replace `Date.now()` timestamp-insert sites across PG + sqlite integration test suites with `fixtureNow()` / `fixtureNowPlus(n)`
+- [x] Verify `pnpm turbo typecheck --force` green across all packages
+- [x] Verify `/verify` full suite green (unit + integration + E2E + sp-import + pk-import)
 
 ## Why read-side needs no changes
 
@@ -54,3 +53,24 @@ Initial survey flagged `packages/sync/src/post-merge-validator.ts`, but its `det
 ## Spec
 
 `docs/superpowers/specs/2026-04-24-types-ltel-c11-cleanup-design.md`
+
+## Summary of Changes
+
+**Commits on feat/types-ltel-c11b-timestamp-lift:**
+
+- 5a0d3f28 test(db): add fixtureNow/fixtureNowPlus timestamp helpers
+- 0b77293c feat(db): lift timestamp customType to UnixMillis
+- cc779845 test(db): migrate PG fixture timestamps
+- e1fb6fa7 test(db): migrate sqlite fixture timestamps
+- 19799540 refactor(api,queue): narrow timestamp call-sites to UnixMillis
+
+**Scope evolution vs design spec:**
+The design claimed zero production write-sites affected. In practice, flipping the customType surfaced two additional production surfaces:
+
+1. `packages/db/src/columns/{pg,sqlite}.ts` mapper fn signatures (timestampToDriver / timestampFromDriver) — flipped to accept/return UnixMillis.
+2. `packages/db/src/queries/` production call-sites: audit-log-cleanup, device-transfer-cleanup, recovery-key (StoreRecoveryKeyInput, ReplaceRecoveryKeyInput, pg/sqliteRevokeRecoveryKey).
+3. `apps/api/` (~67 files) and `packages/queue/` row-mapper test — production cursor/comparison/threshold sites feeding Drizzle `.where` / `.values` / `.set` needed `toUnixMillis(...)` at the boundary.
+
+Parity tests untouched (C11c tightens them). `/verify` full suite green.
+
+Unblocks ps-z7j6 (C11c, epic closeout).

--- a/apps/api/src/__tests__/lib/check-dependents.integration.test.ts
+++ b/apps/api/src/__tests__/lib/check-dependents.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertSystem,
   testBlob,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -48,7 +48,7 @@ describe("checkDependents (PGlite integration)", () => {
   });
 
   async function insertMember(id: string): Promise<void> {
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     await db.insert(members).values({
       id: brandId<MemberId>(id),
       systemId,
@@ -62,7 +62,7 @@ describe("checkDependents (PGlite integration)", () => {
   }
 
   async function insertNote(id: string): Promise<void> {
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     await db.insert(notes).values({
       id: brandId<NoteId>(id),
       systemId,

--- a/apps/api/src/__tests__/lib/orphan-blob-query.test.ts
+++ b/apps/api/src/__tests__/lib/orphan-blob-query.test.ts
@@ -1,5 +1,5 @@
 import { blobMetadata } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq, isNull, lt } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -37,7 +37,7 @@ describe("OrphanBlobQueryImpl", () => {
       and(
         eq(blobMetadata.systemId, SYSTEM_ID),
         isNull(blobMetadata.uploadedAt),
-        lt(blobMetadata.createdAt, now - ONE_HOUR_MS),
+        lt(blobMetadata.createdAt, toUnixMillis(now - ONE_HOUR_MS)),
         eq(blobMetadata.archived, false),
       ),
     );
@@ -68,7 +68,7 @@ describe("OrphanBlobQueryImpl", () => {
       and(
         eq(blobMetadata.systemId, SYSTEM_ID),
         isNull(blobMetadata.uploadedAt),
-        lt(blobMetadata.createdAt, now - customMs),
+        lt(blobMetadata.createdAt, toUnixMillis(now - customMs)),
         eq(blobMetadata.archived, false),
       ),
     );

--- a/apps/api/src/__tests__/services/audit-log-query.service.test.ts
+++ b/apps/api/src/__tests__/services/audit-log-query.service.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { mockDb } from "../helpers/mock-db.js";
@@ -14,8 +14,8 @@ const { queryAuditLog } = await import("../../services/audit-log-query.service.j
 const ACCOUNT_ID = brandId<AccountId>("acct_test-account");
 
 const BASE_PARAMS = {
-  from: 1_000_000,
-  to: 9_000_000,
+  from: toUnixMillis(1_000_000),
+  to: toUnixMillis(9_000_000),
   limit: 10,
 };
 

--- a/apps/api/src/__tests__/services/board-message.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/board-message.service.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -693,7 +693,7 @@ describe("board-message.service (PGlite integration)", () => {
     it("creates webhook delivery records for each reordered message", async () => {
       // Insert a webhook config subscribed to board-message.reordered
       const webhookId = brandId<WebhookId>(`wh_${crypto.randomUUID()}`);
-      const ts = Date.now();
+      const ts = toUnixMillis(Date.now());
       await db.insert(webhookConfigs).values({
         id: webhookId,
         systemId,

--- a/apps/api/src/__tests__/services/bucket-export.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/bucket-export.service.integration.test.ts
@@ -14,6 +14,7 @@ import {
   ID_PREFIXES,
   now,
   brandId,
+  toUnixMillis,
 } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
@@ -26,6 +27,7 @@ import {
 import { asDb, assertApiError, makeAuth } from "../helpers/integration-setup.js";
 
 import type { AuthContext } from "../../lib/auth-context.js";
+import type { UnixMillis } from "@pluralscape/types";
 import type {
   AccountId,
   BucketContentEntityType,
@@ -137,7 +139,7 @@ describe("bucket-export.service (PGlite integration)", () => {
     return brandId<BucketId>(id);
   }
 
-  async function insertMember(updatedAt?: number): Promise<MemberId> {
+  async function insertMember(updatedAt?: UnixMillis): Promise<MemberId> {
     const id = brandId<MemberId>(createId(ID_PREFIXES.member));
     const ts = updatedAt ?? now();
     await db.insert(members).values({
@@ -150,7 +152,7 @@ describe("bucket-export.service (PGlite integration)", () => {
     return brandId<MemberId>(id);
   }
 
-  async function insertGroup(updatedAt?: number): Promise<GroupId> {
+  async function insertGroup(updatedAt?: UnixMillis): Promise<GroupId> {
     const id = brandId<GroupId>(createId(ID_PREFIXES.group));
     const ts = updatedAt ?? now();
     await db.insert(groups).values({
@@ -164,7 +166,7 @@ describe("bucket-export.service (PGlite integration)", () => {
     return id;
   }
 
-  async function insertCustomFront(updatedAt?: number): Promise<CustomFrontId> {
+  async function insertCustomFront(updatedAt?: UnixMillis): Promise<CustomFrontId> {
     const id = brandId<CustomFrontId>(createId(ID_PREFIXES.customFront));
     const ts = updatedAt ?? now();
     await db.insert(customFronts).values({
@@ -221,7 +223,7 @@ describe("bucket-export.service (PGlite integration)", () => {
   it("returns correct maxUpdatedAt timestamp", async () => {
     const bucketId = await insertBucket();
     const baseTs = now();
-    const laterTs = baseTs + 5000;
+    const laterTs = toUnixMillis(baseTs + 5000);
 
     const m1 = await insertMember(baseTs);
     const m2 = await insertMember(laterTs);
@@ -350,7 +352,7 @@ describe("bucket-export.service (PGlite integration)", () => {
     const bucketId = await insertBucket();
     const baseTs = now();
     for (let i = 0; i < 3; i++) {
-      const mid = await insertMember(baseTs + i * 1000);
+      const mid = await insertMember(toUnixMillis(baseTs + i * 1000));
       await insertBucketTag("member", mid, bucketId);
     }
 
@@ -366,7 +368,7 @@ describe("bucket-export.service (PGlite integration)", () => {
     const baseTs = now();
     const memberIds: MemberId[] = [];
     for (let i = 0; i < 3; i++) {
-      const mid = await insertMember(baseTs + i * 1000);
+      const mid = await insertMember(toUnixMillis(baseTs + i * 1000));
       await insertBucketTag("member", mid, bucketId);
       memberIds.push(mid);
     }
@@ -417,8 +419,8 @@ describe("bucket-export.service (PGlite integration)", () => {
     const bucketId = await insertBucket();
     const baseTs = now();
     const m1 = await insertMember(baseTs);
-    const m2 = await insertMember(baseTs + 2000);
-    const m3 = await insertMember(baseTs + 1000);
+    const m2 = await insertMember(toUnixMillis(baseTs + 2000));
+    const m3 = await insertMember(toUnixMillis(baseTs + 1000));
     await insertBucketTag("member", m1, bucketId);
     await insertBucketTag("member", m2, bucketId);
     await insertBucketTag("member", m3, bucketId);
@@ -524,7 +526,7 @@ describe("bucket-export.service (PGlite integration)", () => {
 
     const manifest1 = await getBucketExportManifest(asDb(db), systemId, bucketId, ownerAuth);
 
-    const m2 = await insertMember(now() + 5000);
+    const m2 = await insertMember(toUnixMillis(now() + 5000));
     await insertBucketTag("member", m2, bucketId);
 
     const manifest2 = await getBucketExportManifest(asDb(db), systemId, bucketId, ownerAuth);

--- a/apps/api/src/__tests__/services/device-transfer.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/device-transfer.service.integration.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@pluralscape/crypto";
 import * as schema from "@pluralscape/db/pg";
 import { createPgAuthTables, pgInsertAccount } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -77,14 +77,14 @@ async function insertSession(
   accountId: AccountId,
 ): Promise<SessionId> {
   const sessionId = brandId<SessionId>(`sess_${randomUUID()}`);
-  const now = Date.now();
+  const now = toUnixMillis(Date.now());
   await db.insert(sessions).values({
     id: sessionId,
     accountId,
     tokenHash: `hash_${randomUUID()}`,
     createdAt: now,
     lastActive: now,
-    expiresAt: now + 86_400_000,
+    expiresAt: toUnixMillis(now + 86_400_000),
   });
   return sessionId;
 }
@@ -395,10 +395,10 @@ describe("device-transfer.service (PGlite integration)", () => {
 
       // Set expiresAt to a time in the past (the check constraint requires
       // expiresAt > createdAt, so we set both to the past)
-      const pastTime = Date.now() - 600_000;
+      const pastTime = toUnixMillis(Date.now() - 600_000);
       await db
         .update(deviceTransferRequests)
-        .set({ createdAt: pastTime - 1000, expiresAt: pastTime })
+        .set({ createdAt: toUnixMillis(pastTime - 1000), expiresAt: pastTime })
         .where(eq(deviceTransferRequests.id, transferId));
 
       const targetSessionId = await insertSession(db, accountId);

--- a/apps/api/src/__tests__/services/friend-code.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/friend-code.service.integration.test.ts
@@ -5,7 +5,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -249,11 +249,11 @@ describe("friend-code.service (PGlite integration)", () => {
       // so that expiresAt > createdAt (satisfying the CHECK constraint) but
       // expiresAt < Date.now() (making it expired at redemption time).
       const created = await generateFriendCode(asDb(db), accountIdA, authA, noopAudit, {
-        expiresAt: Date.now() + 86_400_000,
+        expiresAt: toUnixMillis(Date.now()) + 86_400_000,
       });
 
-      const pastCreated = Date.now() - 172_800_000;
-      const pastExpiry = Date.now() - 86_400_000;
+      const pastCreated = toUnixMillis(Date.now() - 172_800_000);
+      const pastExpiry = toUnixMillis(Date.now() - 86_400_000);
       await db
         .update(friendCodes)
         .set({ createdAt: pastCreated, expiresAt: pastExpiry })

--- a/apps/api/src/__tests__/services/friend-connection.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/friend-connection.service.integration.test.ts
@@ -36,6 +36,7 @@ import {
 } from "../helpers/integration-setup.js";
 
 import type { AuthContext } from "../../lib/auth-context.js";
+import type { UnixMillis } from "@pluralscape/types";
 import type {
   AccountId,
   BucketId,
@@ -58,7 +59,7 @@ async function insertConnection(
     status?: FriendConnectionStatus;
     version?: number;
     archived?: boolean;
-    archivedAt?: number | null;
+    archivedAt?: UnixMillis | null;
   },
 ): Promise<FriendConnectionId> {
   const id = opts.id ?? brandId<FriendConnectionId>(createId(ID_PREFIXES.friendConnection));

--- a/apps/api/src/__tests__/services/friend-export.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/friend-export.service.integration.test.ts
@@ -14,6 +14,7 @@ import {
   ID_PREFIXES,
   now,
   brandId,
+  toUnixMillis,
 } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -25,6 +26,7 @@ import {
 import { asDb, assertApiError, makeAuth } from "../helpers/integration-setup.js";
 
 import type { AuthContext } from "../../lib/auth-context.js";
+import type { UnixMillis } from "@pluralscape/types";
 import type {
   AccountId,
   BucketId,
@@ -173,7 +175,7 @@ describe("friend-export.service (PGlite integration)", () => {
     });
   }
 
-  async function insertMember(updatedAt?: number): Promise<MemberId> {
+  async function insertMember(updatedAt?: UnixMillis): Promise<MemberId> {
     const id = brandId<MemberId>(createId(ID_PREFIXES.member));
     const ts = updatedAt ?? now();
     await db.insert(members).values({
@@ -236,7 +238,7 @@ describe("friend-export.service (PGlite integration)", () => {
     await insertBucketAssignment(ownerConnectionId, bucketId);
 
     const baseTs = now();
-    const laterTs = baseTs + 5000;
+    const laterTs = toUnixMillis(baseTs + 5000);
 
     const m1 = await insertMember(baseTs);
     const m2 = await insertMember(laterTs);
@@ -324,7 +326,7 @@ describe("friend-export.service (PGlite integration)", () => {
     const baseTs = now();
     const memberIds: MemberId[] = [];
     for (let i = 0; i < 8; i++) {
-      const mid = await insertMember(baseTs + i * 1000);
+      const mid = await insertMember(toUnixMillis(baseTs + i * 1000));
       await insertBucketTag("member", mid, bucketId);
       memberIds.push(mid);
     }
@@ -360,7 +362,7 @@ describe("friend-export.service (PGlite integration)", () => {
     const baseTs = now();
     // Create alternating visible/invisible members so filtering removes some per batch
     for (let i = 0; i < 6; i++) {
-      const mid = await insertMember(baseTs + i * 1000);
+      const mid = await insertMember(toUnixMillis(baseTs + i * 1000));
       const bucket = i % 2 === 0 ? assignedBucket : unassignedBucket;
       await insertBucketTag("member", mid, bucket);
     }
@@ -379,8 +381,8 @@ describe("friend-export.service (PGlite integration)", () => {
 
     const baseTs = now();
     const m1 = await insertMember(baseTs);
-    const m2 = await insertMember(baseTs + 2000);
-    const m3 = await insertMember(baseTs + 1000);
+    const m2 = await insertMember(toUnixMillis(baseTs + 2000));
+    const m3 = await insertMember(toUnixMillis(baseTs + 1000));
     await insertBucketTag("member", m1, bucketId);
     await insertBucketTag("member", m2, bucketId);
     await insertBucketTag("member", m3, bucketId);
@@ -402,7 +404,7 @@ describe("friend-export.service (PGlite integration)", () => {
     // Need >= 7 visible items so first batch (6 rows) doesn't exhaust the DB.
     const baseTs = now();
     for (let i = 0; i < 8; i++) {
-      const mid = await insertMember(baseTs + i * 1000);
+      const mid = await insertMember(toUnixMillis(baseTs + i * 1000));
       await insertBucketTag("member", mid, bucketId);
     }
 

--- a/apps/api/src/__tests__/services/friend-notification-preference.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/friend-notification-preference.service.integration.test.ts
@@ -5,7 +5,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
@@ -35,7 +35,7 @@ async function insertFriendConnection(
   friendAccountId: AccountId,
 ): Promise<FriendConnectionId> {
   const id = brandId<FriendConnectionId>(`fc_${crypto.randomUUID()}`);
-  const now = Date.now();
+  const now = toUnixMillis(Date.now());
   await db.insert(friendConnections).values({
     id,
     accountId,

--- a/apps/api/src/__tests__/services/fronting-session.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/fronting-session.service.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertMember,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { ne } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -89,7 +89,7 @@ describe("fronting-session.service (PGlite integration)", () => {
 
   async function insertCustomFront(sysId = systemId): Promise<string> {
     const id = genCustomFrontId();
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     await db.insert(customFronts).values({
       id,
       systemId: sysId,
@@ -110,7 +110,7 @@ describe("fronting-session.service (PGlite integration)", () => {
   ) {
     return {
       encryptedData: testEncryptedDataBase64(),
-      startTime: Date.now(),
+      startTime: toUnixMillis(Date.now()),
       memberId,
       ...overrides,
     };
@@ -166,7 +166,7 @@ describe("fronting-session.service (PGlite integration)", () => {
 
     it("rejects archived member as subject", async () => {
       const archivedMemberId = genMemberId();
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(members).values({
         id: archivedMemberId,
         systemId,
@@ -196,7 +196,7 @@ describe("fronting-session.service (PGlite integration)", () => {
         createFrontingSession(
           asDb(db),
           systemId,
-          { encryptedData: testEncryptedDataBase64(), startTime: Date.now() },
+          { encryptedData: testEncryptedDataBase64(), startTime: toUnixMillis(Date.now()) },
           auth,
           noopAudit,
         ),
@@ -225,14 +225,14 @@ describe("fronting-session.service (PGlite integration)", () => {
       await createFrontingSession(
         asDb(db),
         systemId,
-        createParams({ startTime: Date.now() - 2000 }),
+        createParams({ startTime: toUnixMillis(Date.now()) - 2000 }),
         auth,
         noopAudit,
       );
       await createFrontingSession(
         asDb(db),
         systemId,
-        createParams({ startTime: Date.now() - 1000 }),
+        createParams({ startTime: toUnixMillis(Date.now()) - 1000 }),
         auth,
         noopAudit,
       );
@@ -291,7 +291,7 @@ describe("fronting-session.service (PGlite integration)", () => {
       const s1 = await createFrontingSession(
         asDb(db),
         systemId,
-        createParams({ startTime: Date.now() - 5000 }),
+        createParams({ startTime: toUnixMillis(Date.now()) - 5000 }),
         auth,
         noopAudit,
       );
@@ -301,7 +301,7 @@ describe("fronting-session.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         s1.id,
-        { endTime: Date.now(), version: 1 },
+        { endTime: toUnixMillis(Date.now()), version: 1 },
         auth,
         noopAudit,
       );
@@ -571,7 +571,7 @@ describe("fronting-session.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         created.id,
-        { endTime: Date.now(), version: 1 },
+        { endTime: toUnixMillis(Date.now()), version: 1 },
         auth,
         noopAudit,
       );
@@ -581,7 +581,7 @@ describe("fronting-session.service (PGlite integration)", () => {
           asDb(db),
           systemId,
           created.id,
-          { endTime: Date.now(), version: 2 },
+          { endTime: toUnixMillis(Date.now()), version: 2 },
           auth,
           noopAudit,
         ),
@@ -639,7 +639,7 @@ describe("fronting-session.service (PGlite integration)", () => {
           asDb(db),
           systemId,
           created.id,
-          { endTime: Date.now(), version: 1 },
+          { endTime: toUnixMillis(Date.now()), version: 1 },
           auth,
           noopAudit,
         ),
@@ -654,7 +654,7 @@ describe("fronting-session.service (PGlite integration)", () => {
           asDb(db),
           systemId,
           genFrontingSessionId(),
-          { endTime: Date.now(), version: 1 },
+          { endTime: toUnixMillis(Date.now()), version: 1 },
           auth,
           noopAudit,
         ),
@@ -698,12 +698,12 @@ describe("fronting-session.service (PGlite integration)", () => {
         noopAudit,
       );
 
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(frontingComments).values({
         id: genFrontingCommentId(),
         frontingSessionId: created.id,
         systemId,
-        sessionStartTime: Number(created.startTime),
+        sessionStartTime: toUnixMillis(Number(created.startTime)),
         memberId,
         encryptedData: testBlob(),
         createdAt: now,
@@ -839,7 +839,7 @@ describe("fronting-session.service (PGlite integration)", () => {
       await createFrontingSession(
         asDb(db),
         systemId,
-        createParams({ startTime: Date.now() - 5000 }),
+        createParams({ startTime: toUnixMillis(Date.now()) - 5000 }),
         auth,
         noopAudit,
       );
@@ -847,7 +847,7 @@ describe("fronting-session.service (PGlite integration)", () => {
       const ended = await createFrontingSession(
         asDb(db),
         systemId,
-        createParams({ startTime: Date.now() - 10000 }),
+        createParams({ startTime: toUnixMillis(Date.now()) - 10000 }),
         auth,
         noopAudit,
       );
@@ -855,7 +855,7 @@ describe("fronting-session.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         ended.id,
-        { endTime: Date.now(), version: 1 },
+        { endTime: toUnixMillis(Date.now()), version: 1 },
         auth,
         noopAudit,
       );

--- a/apps/api/src/__tests__/services/key-rotation.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/key-rotation.service.integration.test.ts
@@ -8,7 +8,7 @@ import {
   pgInsertSystem,
   testBlob,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { ROTATION_ITEM_STATUSES, ROTATION_STATES, brandId } from "@pluralscape/types";
+import { ROTATION_ITEM_STATUSES, ROTATION_STATES, brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -29,6 +29,7 @@ import {
 } from "../helpers/integration-setup.js";
 
 import type { AuthContext } from "../../lib/auth-context.js";
+import type { UnixMillis } from "@pluralscape/types";
 import type {
   AccountId,
   BucketId,
@@ -81,7 +82,7 @@ describe("key-rotation.service (PGlite integration)", () => {
 
   async function insertBucket(id?: BucketId): Promise<BucketId> {
     const resolvedId = id ?? genBucketId();
-    const ts = Date.now();
+    const ts = toUnixMillis(Date.now());
     await db.insert(buckets).values({
       id: resolvedId,
       systemId,
@@ -179,7 +180,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         friendAccountId: accountId,
         encryptedKey: Buffer.from("old-key"),
         keyVersion: 1,
-        createdAt: Date.now(),
+        createdAt: toUnixMillis(Date.now()),
       });
 
       await initiateRotation(asDb(db), systemId, bucketId, initiateParams(), auth, noopAudit);
@@ -220,7 +221,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         state: ROTATION_STATES.migrating,
-        initiatedAt: Date.now(),
+        initiatedAt: toUnixMillis(Date.now()),
         totalItems: 1,
         completedItems: 0,
         failedItems: 0,
@@ -245,7 +246,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         state: ROTATION_STATES.initiated,
-        initiatedAt: Date.now(),
+        initiatedAt: toUnixMillis(Date.now()),
         totalItems: 1,
         completedItems: 0,
         failedItems: 0,
@@ -395,8 +396,8 @@ describe("key-rotation.service (PGlite integration)", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         state: ROTATION_STATES.completed,
-        initiatedAt: Date.now(),
-        completedAt: Date.now(),
+        initiatedAt: toUnixMillis(Date.now()),
+        completedAt: toUnixMillis(Date.now()),
         totalItems: 0,
         completedItems: 0,
         failedItems: 0,
@@ -545,7 +546,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         state: ROTATION_STATES.initiated,
-        initiatedAt: Date.now(),
+        initiatedAt: toUnixMillis(Date.now()),
         totalItems: 0,
         completedItems: 0,
         failedItems: 0,
@@ -690,7 +691,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         state: ROTATION_STATES.failed,
-        initiatedAt: Date.now(),
+        initiatedAt: toUnixMillis(Date.now()),
         totalItems: 5,
         completedItems: 2,
         failedItems: 3,
@@ -702,7 +703,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         status:
           | (typeof ROTATION_ITEM_STATUSES)["completed"]
           | (typeof ROTATION_ITEM_STATUSES)["failed"],
-        completedAt: number | null,
+        completedAt: UnixMillis | null,
       ): Promise<BucketRotationItemId> => {
         const itemId = brandId<BucketRotationItemId>(`bri_${crypto.randomUUID()}`);
         await db.insert(bucketRotationItems).values({
@@ -713,7 +714,7 @@ describe("key-rotation.service (PGlite integration)", () => {
           entityId: crypto.randomUUID(),
           status,
           claimedBy: status === ROTATION_ITEM_STATUSES.failed ? "sess_prior-claim" : null,
-          claimedAt: status === ROTATION_ITEM_STATUSES.failed ? Date.now() : null,
+          claimedAt: status === ROTATION_ITEM_STATUSES.failed ? toUnixMillis(Date.now()) : null,
           completedAt,
           attempts: status === ROTATION_ITEM_STATUSES.failed ? 3 : 1,
         });
@@ -721,8 +722,8 @@ describe("key-rotation.service (PGlite integration)", () => {
       };
 
       const completedIds = [
-        await seedItem(ROTATION_ITEM_STATUSES.completed, Date.now()),
-        await seedItem(ROTATION_ITEM_STATUSES.completed, Date.now()),
+        await seedItem(ROTATION_ITEM_STATUSES.completed, toUnixMillis(Date.now())),
+        await seedItem(ROTATION_ITEM_STATUSES.completed, toUnixMillis(Date.now())),
       ];
       const failedIds = [
         await seedItem(ROTATION_ITEM_STATUSES.failed, null),
@@ -781,7 +782,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         state: ROTATION_STATES.failed,
-        initiatedAt: Date.now(),
+        initiatedAt: toUnixMillis(Date.now()),
         totalItems: 2,
         completedItems: 2,
         failedItems: 0,
@@ -797,7 +798,7 @@ describe("key-rotation.service (PGlite integration)", () => {
         status: ROTATION_ITEM_STATUSES.completed,
         claimedBy: null,
         claimedAt: null,
-        completedAt: Date.now(),
+        completedAt: toUnixMillis(Date.now()),
         attempts: 1,
       });
 

--- a/apps/api/src/__tests__/services/member-photo.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/member-photo.service.integration.test.ts
@@ -7,7 +7,7 @@ import {
   pgInsertSystem,
   testBlob,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -38,7 +38,7 @@ async function seedPhotos(
   memberId: MemberId,
   count: number,
 ): Promise<void> {
-  const now = Date.now();
+  const now = toUnixMillis(Date.now());
   const blob = testBlob();
   for (let i = 0; i < count; i++) {
     await db.insert(memberPhotos).values({
@@ -314,7 +314,11 @@ describe("member-photo.service (PGlite integration)", () => {
       if (!toArchive) throw new Error("Expected photo id");
       await db
         .update(memberPhotos)
-        .set({ archived: true, archivedAt: Date.now(), updatedAt: Date.now() })
+        .set({
+          archived: true,
+          archivedAt: toUnixMillis(Date.now()),
+          updatedAt: toUnixMillis(Date.now()),
+        })
         .where(eq(memberPhotos.id, toArchive));
 
       // Fill back to 5 active
@@ -349,7 +353,11 @@ describe("member-photo.service (PGlite integration)", () => {
       );
       await db
         .update(memberPhotos)
-        .set({ archived: true, archivedAt: Date.now(), updatedAt: Date.now() })
+        .set({
+          archived: true,
+          archivedAt: toUnixMillis(Date.now()),
+          updatedAt: toUnixMillis(Date.now()),
+        })
         .where(eq(memberPhotos.id, photoToRestore.id));
 
       // Seed 500 active photos on a second member to hit system quota

--- a/apps/api/src/__tests__/services/member.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/member.service.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertSystem,
   testBlob,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -285,7 +285,7 @@ describe("member.service (PGlite integration)", () => {
       );
 
       const groupId = genGroupId();
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(groups).values({
         id: groupId,
         systemId,
@@ -490,7 +490,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(memberPhotos).values({
         id: brandId<MemberPhotoId>(`mph_${crypto.randomUUID()}`),
         memberId: created.id,
@@ -518,12 +518,12 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(frontingSessions).values({
         id: brandId<FrontingSessionId>(`fs_${crypto.randomUUID()}`),
         systemId,
         memberId: created.id,
-        startTime: now - 3_600_000,
+        startTime: toUnixMillis(now - 3_600_000),
         encryptedData: testBlob(),
         createdAt: now,
         updatedAt: now,
@@ -546,7 +546,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(relationships).values({
         id: brandId<RelationshipId>(`rel_${crypto.randomUUID()}`),
         systemId,
@@ -574,7 +574,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(notes).values({
         id: brandId<NoteId>(`note_${crypto.randomUUID()}`),
         systemId,
@@ -602,7 +602,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(acknowledgements).values({
         id: brandId<AcknowledgementId>(`ack_${crypto.randomUUID()}`),
         systemId,
@@ -629,7 +629,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(polls).values({
         id: brandId<PollId>(`poll_${crypto.randomUUID()}`),
         systemId,
@@ -661,7 +661,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       const timerId = brandId<TimerId>(`tmr_${crypto.randomUUID()}`);
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -696,7 +696,7 @@ describe("member.service (PGlite integration)", () => {
         noopAudit,
       );
       const groupId = genGroupId();
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(groups).values({
         id: groupId,
         systemId,
@@ -729,7 +729,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       const fdId = brandId<FieldDefinitionId>(`fd_${crypto.randomUUID()}`);
       // Insert field definition first (FK constraint)
       await db.insert(fieldDefinitions).values({
@@ -767,7 +767,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(systemStructureEntityMemberLinks).values({
         id: brandId<SystemStructureEntityMemberLinkId>(`ssml_${crypto.randomUUID()}`),
         systemId,
@@ -849,7 +849,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(memberPhotos).values({
         id: brandId<MemberPhotoId>(`mph_${crypto.randomUUID()}`),
         memberId: source.id,
@@ -909,7 +909,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       const fdId = brandId<FieldDefinitionId>(`fd_${crypto.randomUUID()}`);
       await db.insert(fieldDefinitions).values({
         id: fdId,
@@ -979,7 +979,7 @@ describe("member.service (PGlite integration)", () => {
         noopAudit,
       );
       const groupId = genGroupId();
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(groups).values({
         id: groupId,
         systemId,
@@ -1063,7 +1063,7 @@ describe("member.service (PGlite integration)", () => {
         noopAudit,
       );
       const groupId = genGroupId();
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(groups).values({
         id: groupId,
         systemId,
@@ -1093,7 +1093,7 @@ describe("member.service (PGlite integration)", () => {
         auth,
         noopAudit,
       );
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       const linkId = brandId<SystemStructureEntityMemberLinkId>(`ssml_${crypto.randomUUID()}`);
       await db.insert(systemStructureEntityMemberLinks).values({
         id: linkId,

--- a/apps/api/src/__tests__/services/poll-vote.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/poll-vote.service.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertMember,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
@@ -456,7 +456,7 @@ describe("poll-vote.service (PGlite integration)", () => {
       await castVote(asDb(db), systemId, poll.id, makeVoteParams(), auth, noopAudit);
 
       // Archive the vote directly via raw update
-      await db.update(pollVotes).set({ archived: true, archivedAt: Date.now() });
+      await db.update(pollVotes).set({ archived: true, archivedAt: toUnixMillis(Date.now()) });
 
       const result = await listVotes(asDb(db), systemId, poll.id, auth);
       expect(result.data).toHaveLength(0);

--- a/apps/api/src/__tests__/services/poll.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/poll.service.integration.test.ts
@@ -7,7 +7,7 @@ import {
   pgInsertSystem,
   testBlob,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
@@ -448,7 +448,7 @@ describe("poll.service (PGlite integration)", () => {
       const created = await createPoll(asDb(db), systemId, makeCreateParams(), auth, noopAudit);
 
       // Insert a vote row directly
-      const voteNow = Date.now();
+      const voteNow = toUnixMillis(Date.now());
       await db.insert(pollVotes).values({
         id: genPollVoteId(),
         pollId: created.id,

--- a/apps/api/src/__tests__/services/push-notification-worker.integration.test.ts
+++ b/apps/api/src/__tests__/services/push-notification-worker.integration.test.ts
@@ -5,7 +5,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -17,6 +17,7 @@ import {
 import { asDb } from "../helpers/integration-setup.js";
 
 import type { PushProvider } from "../../services/push-notification-worker.js";
+import type { UnixMillis } from "@pluralscape/types";
 import type { AccountId, DeviceTokenId, SystemId } from "@pluralscape/types";
 import type { JobPayloadMap } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
@@ -49,11 +50,11 @@ describe("push-notification-worker (PGlite integration)", () => {
   });
 
   async function insertToken(opts?: {
-    revokedAt?: number;
+    revokedAt?: UnixMillis;
   }): Promise<{ id: DeviceTokenId; tokenHash: string }> {
     const id = brandId<DeviceTokenId>(`dt_${crypto.randomUUID()}`);
     const tokenHash = `hash-${crypto.randomUUID()}`;
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     await db.insert(deviceTokens).values({
       id,
       accountId,
@@ -123,7 +124,7 @@ describe("push-notification-worker (PGlite integration)", () => {
   });
 
   it("returns early without calling send when token is revoked", async () => {
-    const { id: tokenId } = await insertToken({ revokedAt: Date.now() });
+    const { id: tokenId } = await insertToken({ revokedAt: toUnixMillis(Date.now()) });
     const sendSpy = vi.fn();
     const provider: PushProvider = { send: sendSpy };
 

--- a/apps/api/src/__tests__/services/recovery-key.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/recovery-key.service.integration.test.ts
@@ -4,7 +4,7 @@ import { PGlite } from "@electric-sql/pglite";
 import { assertAuthKey, hashAuthKey, hashRecoveryKey, initSodium } from "@pluralscape/crypto";
 import * as schema from "@pluralscape/db/pg";
 import { createPgAuthTables, PG_DDL, pgExec } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -90,7 +90,7 @@ describe("recovery-key.service (PGlite integration)", { timeout: 60_000 }, () =>
     const recoveryEncMasterKey = randBytes(72);
     const recoveryKeyBytes = randBytes(32);
     const recoveryKeyHashBytes = hashRecoveryKey(recoveryKeyBytes);
-    const timestamp = Date.now();
+    const timestamp = toUnixMillis(Date.now());
     const recoveryKeyId = brandId<RecoveryKeyId>(`rk_${crypto.randomUUID()}`);
 
     await db.insert(accounts).values({
@@ -263,7 +263,7 @@ describe("recovery-key.service (PGlite integration)", { timeout: 60_000 }, () =>
     it("throws NoActiveRecoveryKeyError when no active key exists", async () => {
       const { accountId, authKeyHex } = await insertTestAccount();
 
-      await db.update(recoveryKeys).set({ revokedAt: Date.now() });
+      await db.update(recoveryKeys).set({ revokedAt: toUnixMillis(Date.now()) });
 
       await expect(
         regenerateRecoveryKeyBackup(
@@ -340,7 +340,7 @@ describe("recovery-key.service (PGlite integration)", { timeout: 60_000 }, () =>
     it("throws NoActiveRecoveryKeyError when no active key exists", async () => {
       const { email, recoveryKeyHex } = await insertTestAccount();
 
-      await db.update(recoveryKeys).set({ revokedAt: Date.now() });
+      await db.update(recoveryKeys).set({ revokedAt: toUnixMillis(Date.now()) });
 
       await expect(
         resetPasswordWithRecoveryKey(
@@ -355,14 +355,14 @@ describe("recovery-key.service (PGlite integration)", { timeout: 60_000 }, () =>
     it("revokes old sessions after password reset", async () => {
       const { email, accountId, recoveryKeyHex } = await insertTestAccount();
 
-      const timestamp = Date.now();
+      const timestamp = toUnixMillis(Date.now());
       await db.insert(sessions).values({
         id: brandId<SessionId>(`sess_${crypto.randomUUID()}`),
         accountId,
         tokenHash: toHex(randBytes(32)),
         createdAt: timestamp,
         lastActive: timestamp,
-        expiresAt: timestamp + 3_600_000,
+        expiresAt: toUnixMillis(timestamp + 3_600_000),
       });
 
       const before = await client.query<{ count: string }>(

--- a/apps/api/src/__tests__/services/structure-entity-crud.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/structure-entity-crud.service.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertMember,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -405,7 +405,7 @@ describe("structure-entity-crud.service (PGlite integration)", () => {
       );
 
       const memberId = brandId<MemberId>(await pgInsertMember(db, systemId));
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
       await db.insert(systemStructureEntityMemberLinks).values({
         id: brandId<SystemStructureEntityMemberLinkId>(`steml_${crypto.randomUUID()}`),
         systemId,
@@ -444,7 +444,7 @@ describe("structure-entity-crud.service (PGlite integration)", () => {
         systemId,
         sourceEntityId: entityA.id,
         targetEntityId: entityB.id,
-        createdAt: Date.now(),
+        createdAt: toUnixMillis(Date.now()),
       });
 
       await assertApiError(

--- a/apps/api/src/__tests__/services/switch-alert-dispatcher.integration.test.ts
+++ b/apps/api/src/__tests__/services/switch-alert-dispatcher.integration.test.ts
@@ -7,7 +7,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -195,7 +195,7 @@ describe("switch-alert-dispatcher (PGlite integration)", () => {
     memberId: MemberId;
     bucketId: BucketId;
   }> {
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     const memberId = brandId<MemberId>(`mem_${crypto.randomUUID()}`);
     const bucketId = brandId<BucketId>(`bkt_${crypto.randomUUID()}`);
     const connectionId = brandId<FriendConnectionId>(`fc_${crypto.randomUUID()}`);
@@ -434,7 +434,7 @@ describe("switch-alert-dispatcher (PGlite integration)", () => {
     const sessionId = brandId<FrontingSessionId>(`fs_${crypto.randomUUID()}`);
 
     // Revoke the device token
-    await db.update(deviceTokens).set({ revokedAt: Date.now() });
+    await db.update(deviceTokens).set({ revokedAt: toUnixMillis(Date.now()) });
 
     const { queue, enqueuedJobs } = createMockQueue();
     await dispatchSwitchAlertForSession(asDb(db), systemIdA, sessionId, memberId, null, queue);
@@ -486,8 +486,8 @@ describe("switch-alert-dispatcher (PGlite integration)", () => {
       systemId: systemIdB,
       platform: "android",
       tokenHash: `hash-${crypto.randomUUID()}`,
-      createdAt: Date.now(),
-      lastActiveAt: Date.now(),
+      createdAt: toUnixMillis(Date.now()),
+      lastActiveAt: toUnixMillis(Date.now()),
       revokedAt: null,
     });
 
@@ -515,7 +515,7 @@ describe("switch-alert-dispatcher (PGlite integration)", () => {
     await db.delete(friendConnections);
     await db.delete(buckets).catch(() => {});
 
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     const sharedMemberId = brandId<MemberId>(`mem_${crypto.randomUUID()}`);
     const bucketId = brandId<BucketId>(`bkt_${crypto.randomUUID()}`);
 

--- a/apps/api/src/__tests__/services/sync-relay.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/sync-relay.service.integration.test.ts
@@ -1,7 +1,7 @@
 import { PGlite } from "@electric-sql/pglite";
 import * as schema from "@pluralscape/db/pg";
 import { SnapshotVersionConflictError } from "@pluralscape/sync";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
@@ -123,7 +123,7 @@ describe("PgSyncRelayService (PGlite integration)", () => {
   /** Insert a sync document row and return its documentId. */
   async function insertDoc(id?: string): Promise<SyncDocumentId> {
     const raw = id ?? `system-core-sys_${crypto.randomUUID().slice(0, 8)}`;
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     await db.insert(syncDocuments).values({
       documentId: asSyncDocId(raw),
       systemId,

--- a/apps/api/src/__tests__/services/system-duplicate.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/system-duplicate.service.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertSystem,
   testBlob,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -46,7 +46,7 @@ describe("system-duplicate.service (PGlite integration)", () => {
 
     // Create a snapshot for the source system
     snapshotId = `snap_${crypto.randomUUID()}`;
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     await db.insert(systemSnapshots).values({
       id: brandId<SystemSnapshotId>(snapshotId),
       systemId,

--- a/apps/api/src/__tests__/services/system-purge.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/system-purge.service.integration.test.ts
@@ -7,7 +7,7 @@ import {
   pgInsertSystem,
   testBlob,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
@@ -77,7 +77,7 @@ describe("system-purge.service (PGlite integration)", () => {
     const memberB = await pgInsertMember(db, systemId);
 
     // Add a relationship
-    const now = Date.now();
+    const now = toUnixMillis(Date.now());
     await db.insert(relationships).values({
       id: brandId<RelationshipId>(`rel_${crypto.randomUUID()}`),
       systemId,

--- a/apps/api/src/__tests__/services/webhook-config.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/webhook-config.service.integration.test.ts
@@ -5,7 +5,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -171,8 +171,8 @@ describe("webhook-config.service (PGlite integration)", () => {
         secret: new Uint8Array(Buffer.from("test-secret-key-pad-to-32-bytes!")) as ServerSecret,
         eventTypes: ["fronting.started" as const],
         enabled: true,
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
+        createdAt: toUnixMillis(Date.now()),
+        updatedAt: toUnixMillis(Date.now()),
       }));
       await db.insert(webhookConfigs).values(values);
 
@@ -319,7 +319,7 @@ describe("webhook-config.service (PGlite integration)", () => {
         status: "pending",
         attemptCount: 0,
         encryptedData: new Uint8Array([1, 2, 3]),
-        createdAt: Date.now(),
+        createdAt: toUnixMillis(Date.now()),
       });
 
       await assertApiError(
@@ -374,8 +374,8 @@ describe("webhook-config.service (PGlite integration)", () => {
         secret: new Uint8Array(Buffer.from("test-secret-key-pad-to-32-bytes!")) as ServerSecret,
         eventTypes: ["fronting.started" as const],
         enabled: true,
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
+        createdAt: toUnixMillis(Date.now()),
+        updatedAt: toUnixMillis(Date.now()),
       }));
       await db.insert(webhookConfigs).values(values);
 

--- a/apps/api/src/__tests__/services/webhook-delivery-cleanup.integration.test.ts
+++ b/apps/api/src/__tests__/services/webhook-delivery-cleanup.integration.test.ts
@@ -5,7 +5,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
@@ -46,8 +46,8 @@ describe("webhook-delivery-cleanup (PGlite integration)", () => {
       secret: new Uint8Array(Buffer.from("test-secret")) as ServerSecret,
       eventTypes: ["fronting.started"],
       enabled: true,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
+      createdAt: toUnixMillis(Date.now()),
+      updatedAt: toUnixMillis(Date.now()),
     });
   });
 
@@ -64,7 +64,7 @@ describe("webhook-delivery-cleanup (PGlite integration)", () => {
     ageInDays: number,
   ): Promise<WebhookDeliveryId> {
     const id = genWebhookDeliveryId();
-    const createdAt = Date.now() - ageInDays * MS_PER_DAY;
+    const createdAt = toUnixMillis(Date.now() - ageInDays * MS_PER_DAY);
     await db.insert(webhookDeliveries).values({
       id,
       webhookId,

--- a/apps/api/src/__tests__/services/webhook-delivery-worker.integration.test.ts
+++ b/apps/api/src/__tests__/services/webhook-delivery-worker.integration.test.ts
@@ -8,7 +8,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -80,8 +80,8 @@ describe("webhook-delivery-worker (PGlite integration)", () => {
       secret: webhookSecret,
       eventTypes: ["fronting.started"],
       enabled: true,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
+      createdAt: toUnixMillis(Date.now()),
+      updatedAt: toUnixMillis(Date.now()),
     });
   });
 
@@ -107,7 +107,7 @@ describe("webhook-delivery-worker (PGlite integration)", () => {
       status: "pending" as const,
       attemptCount: 0,
       encryptedData: encryptWebhookPayload(TEST_PAYLOAD_JSON, key),
-      createdAt: Date.now(),
+      createdAt: toUnixMillis(Date.now()),
       ...overrides,
     };
     await db.insert(webhookDeliveries).values(values as typeof webhookDeliveries.$inferInsert);
@@ -189,8 +189,8 @@ describe("webhook-delivery-worker (PGlite integration)", () => {
         secret: new Uint8Array(randomBytes(32)) as ServerSecret,
         eventTypes: ["fronting.started"],
         enabled: false,
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
+        createdAt: toUnixMillis(Date.now()),
+        updatedAt: toUnixMillis(Date.now()),
       });
 
       const deliveryId = await insertDelivery({ webhookId: disabledWhId });
@@ -248,13 +248,13 @@ describe("webhook-delivery-worker (PGlite integration)", () => {
     });
 
     it("excludes deliveries with future nextRetryAt", async () => {
-      await insertDelivery({ nextRetryAt: Date.now() + 60000 });
+      await insertDelivery({ nextRetryAt: toUnixMillis(Date.now() + 60000) });
       const results = await findPendingDeliveries(asDb(db), 10);
       expect(results.length).toBe(0);
     });
 
     it("includes deliveries with past nextRetryAt", async () => {
-      const deliveryId = await insertDelivery({ nextRetryAt: Date.now() - 1000 });
+      const deliveryId = await insertDelivery({ nextRetryAt: toUnixMillis(Date.now() - 1000) });
       const results = await findPendingDeliveries(asDb(db), 10);
       expect(results.length).toBe(1);
       expect(results[0]?.id).toBe(deliveryId);

--- a/apps/api/src/__tests__/services/webhook-dispatcher.integration.test.ts
+++ b/apps/api/src/__tests__/services/webhook-dispatcher.integration.test.ts
@@ -6,7 +6,7 @@ import {
   pgInsertAccount,
   pgInsertSystem,
 } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -133,7 +133,7 @@ describe("webhook-dispatcher (PGlite integration)", () => {
     // Archive directly
     await db
       .update(webhookConfigs)
-      .set({ archived: true, archivedAt: Date.now() })
+      .set({ archived: true, archivedAt: toUnixMillis(Date.now()) })
       .where(eq(webhookConfigs.id, wh.id));
 
     const ids = await dispatchWebhookEvent(asDb(db), systemId, "fronting.started", {

--- a/apps/api/src/__tests__/trpc/routers/auth.integration.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/auth.integration.test.ts
@@ -8,7 +8,7 @@ import {
   toHex,
 } from "@pluralscape/crypto";
 import { accounts, recoveryKeys } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 // Ensure EMAIL_HASH_PEPPER is available before env.ts is evaluated. The env
@@ -118,7 +118,7 @@ async function insertAccountWithKnownRecoveryKey(db: PostgresJsDatabase): Promis
   assertAuthKey(rawAuthKey);
   const rawRecoveryKey = new Uint8Array(randomBytes(RECOVERY_KEY_BYTES));
   const recoveryKeyHash = hashRecoveryKey(rawRecoveryKey);
-  const timestamp = Date.now();
+  const timestamp = toUnixMillis(Date.now());
 
   await db.insert(accounts).values({
     id: brandId<AccountId>(accountId),

--- a/apps/api/src/__tests__/trpc/routers/system.integration.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/system.integration.test.ts
@@ -1,6 +1,6 @@
 import { systemSnapshots } from "@pluralscape/db/pg";
 import { pgInsertSystem, testBlob } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { describe, expect, it, vi } from "vitest";
 
 // Hoisted mocks for dispatch-style external services. This same block lives at
@@ -69,7 +69,7 @@ async function seedSnapshot(
   systemIdRaw: string,
 ): Promise<SystemSnapshotId> {
   const snapshotIdRaw = `snap_${crypto.randomUUID()}`;
-  const timestamp = Date.now();
+  const timestamp = toUnixMillis(Date.now());
   await db.insert(systemSnapshots).values({
     id: brandId<SystemSnapshotId>(snapshotIdRaw),
     systemId: brandId<SystemId>(systemIdRaw),

--- a/apps/api/src/jobs/blob-s3-cleanup.ts
+++ b/apps/api/src/jobs/blob-s3-cleanup.ts
@@ -1,4 +1,5 @@
 import { blobMetadata } from "@pluralscape/db/pg";
+import { toUnixMillis } from "@pluralscape/types";
 import { and, eq, inArray, lt } from "drizzle-orm";
 
 import { logger } from "../lib/logger.js";
@@ -68,7 +69,7 @@ export function createBlobS3CleanupHandler(
   return async (_job, ctx) => {
     if (ctx.signal.aborted) return;
 
-    const cutoff = Date.now() - BLOB_S3_CLEANUP_GRACE_PERIOD_MS;
+    const cutoff = toUnixMillis(Date.now() - BLOB_S3_CLEANUP_GRACE_PERIOD_MS);
 
     // Find archived blobs past the grace period
     const rows = await db

--- a/apps/api/src/jobs/check-in-generate.ts
+++ b/apps/api/src/jobs/check-in-generate.ts
@@ -1,5 +1,5 @@
 import { checkInRecords, timerConfigs } from "@pluralscape/db/pg";
-import { ID_PREFIXES, MS_PER_SECOND, brandId, createId } from "@pluralscape/types";
+import { ID_PREFIXES, MS_PER_SECOND, brandId, createId, toUnixMillis } from "@pluralscape/types";
 import { and, asc, eq, gt, isNull, lte } from "drizzle-orm";
 
 import { logger } from "../lib/logger.js";
@@ -47,7 +47,7 @@ export function createCheckInGenerateHandler(
   return async (_job, ctx) => {
     if (isAborted(ctx.signal)) return;
 
-    const nowMs = Date.now();
+    const nowMs = toUnixMillis(Date.now());
 
     let cursor: string | null = null;
     let errorCount = 0;
@@ -103,14 +103,16 @@ export function createCheckInGenerateHandler(
           await db
             .update(timerConfigs)
             .set({
-              nextCheckInAt: computeNextCheckInAt(
-                {
-                  intervalMinutes: config.intervalMinutes,
-                  wakingHoursOnly: config.wakingHoursOnly,
-                  wakingStart: config.wakingStart,
-                  wakingEnd: config.wakingEnd,
-                },
-                nowMs,
+              nextCheckInAt: toUnixMillis(
+                computeNextCheckInAt(
+                  {
+                    intervalMinutes: config.intervalMinutes,
+                    wakingHoursOnly: config.wakingHoursOnly,
+                    wakingStart: config.wakingStart,
+                    wakingEnd: config.wakingEnd,
+                  },
+                  nowMs,
+                ),
               ),
             })
             .where(eq(timerConfigs.id, config.id));

--- a/apps/api/src/lib/orphan-blob-query.ts
+++ b/apps/api/src/lib/orphan-blob-query.ts
@@ -1,4 +1,5 @@
 import { blobMetadata } from "@pluralscape/db/pg";
+import { toUnixMillis } from "@pluralscape/types";
 import { and, eq, isNull, lt } from "drizzle-orm";
 
 import type { OrphanBlobQuery } from "@pluralscape/storage/quota";
@@ -17,7 +18,7 @@ export class OrphanBlobQueryImpl implements OrphanBlobQuery {
   }
 
   async findOrphanedKeys(systemId: SystemId, olderThanMs: number): Promise<readonly StorageKey[]> {
-    const cutoff = Date.now() - olderThanMs;
+    const cutoff = toUnixMillis(Date.now() - olderThanMs);
 
     const rows = await this.db
       .select({ storageKey: blobMetadata.storageKey })

--- a/apps/api/src/lib/session-idle-filter.ts
+++ b/apps/api/src/lib/session-idle-filter.ts
@@ -1,5 +1,5 @@
 import { sessions } from "@pluralscape/db/pg";
-import { SESSION_TIMEOUTS } from "@pluralscape/types";
+import { SESSION_TIMEOUTS, toUnixMillis } from "@pluralscape/types";
 import { and, gte, isNull, not, or, sql } from "drizzle-orm";
 
 import type { SQL } from "drizzle-orm";
@@ -37,7 +37,7 @@ export function buildIdleTimeoutFilter(currentTimeMs: number): SQL {
     } else {
       // Idle timeout applies: must match absoluteTtl AND be within idle window.
       // Use gte() with pre-computed threshold for index-friendly comparison.
-      const thresholdMs = currentTimeMs - config.idleTimeoutMs;
+      const thresholdMs = toUnixMillis(currentTimeMs - config.idleTimeoutMs);
       const condition = and(ttlMatchExpr, gte(sessions.lastActive, thresholdMs));
       if (!condition) throw new Error("Invariant: and() returned undefined with non-empty args");
       conditions.push(condition);
@@ -48,7 +48,7 @@ export function buildIdleTimeoutFilter(currentTimeMs: number): SQL {
   // Build a NOT IN check for all known absoluteTtls, then apply the default idle window.
   const knownTtls = Object.values(SESSION_TIMEOUTS).map((c) => c.absoluteTtlMs);
   const defaultIdleTimeoutMs = SESSION_TIMEOUTS.web.idleTimeoutMs;
-  const defaultThresholdMs = currentTimeMs - defaultIdleTimeoutMs;
+  const defaultThresholdMs = toUnixMillis(currentTimeMs - defaultIdleTimeoutMs);
   const unknownTtlCondition = and(
     not(isNull(sessions.expiresAt)),
     not(isNull(sessions.lastActive)),

--- a/apps/api/src/routes/account/audit-log.ts
+++ b/apps/api/src/routes/account/audit-log.ts
@@ -1,4 +1,4 @@
-import { AUDIT_RETENTION, MS_PER_DAY } from "@pluralscape/types";
+import { AUDIT_RETENTION, MS_PER_DAY, toUnixMillis } from "@pluralscape/types";
 import { AuditLogQuerySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
@@ -25,8 +25,8 @@ auditLogRoute.get("/", async (c) => {
   }
 
   const now = Date.now();
-  const to = parsed.data.to ?? now;
-  const from = parsed.data.from ?? to - MAX_RANGE_MS;
+  const to = toUnixMillis(parsed.data.to ?? now);
+  const from = toUnixMillis(parsed.data.from ?? to - MAX_RANGE_MS);
 
   if (to < from) {
     throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "'to' must be >= 'from'");

--- a/apps/api/src/services/account/friend-codes/generate.ts
+++ b/apps/api/src/services/account/friend-codes/generate.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 
 import { friendCodes } from "@pluralscape/db/pg";
-import { brandId, ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { brandId, ID_PREFIXES, createId, now, toUnixMillis } from "@pluralscape/types";
 import { and, eq } from "drizzle-orm";
 
 import { HTTP_BAD_REQUEST } from "../../../http.constants.js";
@@ -92,7 +92,7 @@ export async function generateFriendCode(
             accountId,
             code,
             createdAt: timestamp,
-            expiresAt: opts?.expiresAt ?? null,
+            expiresAt: opts?.expiresAt !== undefined ? toUnixMillis(opts.expiresAt) : null,
           })
           .returning();
         break;

--- a/apps/api/src/services/account/friends/queries.ts
+++ b/apps/api/src/services/account/friends/queries.ts
@@ -1,5 +1,5 @@
 import { friendConnections } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 
 import { HTTP_NOT_FOUND } from "../../../http.constants.js";
@@ -51,10 +51,11 @@ export async function listFriendConnections(
 
     if (opts.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "friend-connection");
+      const sortValue = toUnixMillis(decoded.sortValue);
       const cursorCondition = or(
-        lt(friendConnections.createdAt, decoded.sortValue),
+        lt(friendConnections.createdAt, sortValue),
         and(
-          eq(friendConnections.createdAt, decoded.sortValue),
+          eq(friendConnections.createdAt, sortValue),
           lt(friendConnections.id, brandId<FriendConnectionId>(decoded.id)),
         ),
       );

--- a/apps/api/src/services/acknowledgement/queries.ts
+++ b/apps/api/src/services/acknowledgement/queries.ts
@@ -1,5 +1,5 @@
 import { acknowledgements } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { AcknowledgementQuerySchema } from "@pluralscape/validation";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 
@@ -77,10 +77,11 @@ export async function listAcknowledgements(
 
     if (opts.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "ack");
+      const sortValue = toUnixMillis(decoded.sortValue);
       const cursorCondition = or(
-        lt(acknowledgements.createdAt, decoded.sortValue),
+        lt(acknowledgements.createdAt, sortValue),
         and(
-          eq(acknowledgements.createdAt, decoded.sortValue),
+          eq(acknowledgements.createdAt, sortValue),
           lt(acknowledgements.id, brandId<AcknowledgementId>(decoded.id)),
         ),
       );

--- a/apps/api/src/services/api-key/create.ts
+++ b/apps/api/src/services/api-key/create.ts
@@ -1,7 +1,14 @@
 import { randomBytes } from "node:crypto";
 
 import { apiKeys } from "@pluralscape/db/pg";
-import { API_KEY_TOKEN_PREFIX, ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
+import {
+  API_KEY_TOKEN_PREFIX,
+  ID_PREFIXES,
+  brandId,
+  createId,
+  now,
+  toUnixMillis,
+} from "@pluralscape/types";
 import { CreateApiKeyBodySchema } from "@pluralscape/validation";
 
 import { HTTP_BAD_REQUEST } from "../../http.constants.js";
@@ -86,7 +93,7 @@ export async function createApiKey(
         createdAt: timestamp,
         lastUsedAt: null,
         revokedAt: null,
-        expiresAt: expiresAt ?? null,
+        expiresAt: expiresAt !== undefined ? toUnixMillis(expiresAt) : null,
         scopedBucketIds: scopedBucketIds?.map((id) => brandId<BucketId>(id)) ?? null,
       })
       .returning(API_KEY_SELECT_COLUMNS);

--- a/apps/api/src/services/audit-log-query.service.ts
+++ b/apps/api/src/services/audit-log-query.service.ts
@@ -45,8 +45,8 @@ export interface AuditLogEntryResult {
 export interface AuditLogQueryParams {
   readonly eventType?: string;
   readonly resourceType?: string;
-  readonly from: number;
-  readonly to: number;
+  readonly from: UnixMillis;
+  readonly to: UnixMillis;
   readonly cursor?: string;
   readonly limit: number;
 }
@@ -54,7 +54,7 @@ export interface AuditLogQueryParams {
 // ── Cursor encoding ────────────────────────────────────────────────
 
 interface CursorData {
-  readonly t: number;
+  readonly t: UnixMillis;
   readonly i: AuditLogEntryId;
 }
 
@@ -76,7 +76,7 @@ function decodeCursor(cursor: string): CursorData {
       (parsed as { i: string }).i.length > 0
     ) {
       const raw = parsed as { t: number; i: string };
-      return { t: raw.t, i: brandId<AuditLogEntryId>(raw.i) };
+      return { t: toUnixMillis(raw.t), i: brandId<AuditLogEntryId>(raw.i) };
     }
   } catch {
     // fall through

--- a/apps/api/src/services/auth/login.ts
+++ b/apps/api/src/services/auth/login.ts
@@ -184,7 +184,7 @@ export async function loginAccount(
   const tokenHash = hashSessionToken(rawToken);
   const timestamp = now();
   const timeouts = SESSION_TIMEOUTS[platform];
-  const expiresAt = timestamp + timeouts.absoluteTtlMs;
+  const expiresAt = toUnixMillis(timestamp + timeouts.absoluteTtlMs);
 
   const systemId = await withAccountTransaction(db, brandId<AccountId>(account.id), async (tx) => {
     // Enforce per-account session limit: evict oldest session if at capacity

--- a/apps/api/src/services/auth/register.ts
+++ b/apps/api/src/services/auth/register.ts
@@ -10,7 +10,14 @@ import {
   verifyChallenge,
 } from "@pluralscape/crypto";
 import { accounts, authKeys, recoveryKeys, sessions, systems } from "@pluralscape/db/pg";
-import { brandId, ID_PREFIXES, SESSION_TIMEOUTS, createId, now } from "@pluralscape/types";
+import {
+  brandId,
+  ID_PREFIXES,
+  SESSION_TIMEOUTS,
+  createId,
+  now,
+  toUnixMillis,
+} from "@pluralscape/types";
 import { RegistrationCommitSchema, RegistrationInitiateSchema } from "@pluralscape/validation";
 import { and, eq, isNotNull } from "drizzle-orm";
 
@@ -60,7 +67,7 @@ export async function initiateRegistration(
   const emailSalt = toHex(adapter.randomBytes(EMAIL_SALT_BYTES));
   const kdfSalt = generateSalt();
   const challengeNonce = generateChallengeNonce();
-  const challengeExpiresAt = now() + CHALLENGE_NONCE_TTL_MS;
+  const challengeExpiresAt = toUnixMillis(now() + CHALLENGE_NONCE_TTL_MS);
 
   // Placeholder: 32 zero bytes indicate incomplete registration
   const placeholderAuthKeyHash = new Uint8Array(AUTH_KEY_HASH_BYTES);
@@ -214,7 +221,7 @@ export async function commitRegistration(
   const tokenHash = hashSessionToken(rawToken);
   const timestamp = now();
   const timeouts = SESSION_TIMEOUTS[platform];
-  const expiresAt = timestamp + timeouts.absoluteTtlMs;
+  const expiresAt = toUnixMillis(timestamp + timeouts.absoluteTtlMs);
 
   await withAccountTransaction(db, brandId<AccountId>(account.id), async (tx) => {
     // Fill in the account shell with real crypto data

--- a/apps/api/src/services/bucket/list.ts
+++ b/apps/api/src/services/bucket/list.ts
@@ -1,5 +1,5 @@
 import { buckets } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { BucketQuerySchema } from "@pluralscape/validation";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 
@@ -39,12 +39,10 @@ export async function listBuckets(
 
     if (opts.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "bucket");
+      const sortValue = toUnixMillis(decoded.sortValue);
       const cursorCondition = or(
-        lt(buckets.createdAt, decoded.sortValue),
-        and(
-          eq(buckets.createdAt, decoded.sortValue),
-          lt(buckets.id, brandId<BucketId>(decoded.id)),
-        ),
+        lt(buckets.createdAt, sortValue),
+        and(eq(buckets.createdAt, sortValue), lt(buckets.id, brandId<BucketId>(decoded.id))),
       );
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/services/check-in-record/create.ts
+++ b/apps/api/src/services/check-in-record/create.ts
@@ -1,5 +1,5 @@
 import { checkInRecords, timerConfigs } from "@pluralscape/db/pg";
-import { ID_PREFIXES, brandId, createId } from "@pluralscape/types";
+import { ID_PREFIXES, brandId, createId, toUnixMillis } from "@pluralscape/types";
 import { CreateCheckInRecordBodySchema } from "@pluralscape/validation";
 import { and, eq } from "drizzle-orm";
 
@@ -68,7 +68,7 @@ export async function createCheckInRecord(
         id: recordId,
         systemId,
         timerConfigId: parsed.timerConfigId,
-        scheduledAt: parsed.scheduledAt,
+        scheduledAt: toUnixMillis(parsed.scheduledAt),
         encryptedData: blob,
       })
       .returning();

--- a/apps/api/src/services/device-token/queries.ts
+++ b/apps/api/src/services/device-token/queries.ts
@@ -1,4 +1,5 @@
 import { deviceTokens } from "@pluralscape/db/pg";
+import { toUnixMillis } from "@pluralscape/types";
 import { and, desc, eq, isNull, lt, or } from "drizzle-orm";
 
 import { buildCompositePaginatedResult, fromCompositeCursor } from "../../lib/pagination.js";
@@ -33,9 +34,10 @@ export async function listDeviceTokens(
 
     if (opts?.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "dt");
+      const sortValue = toUnixMillis(decoded.sortValue);
       const cursorCondition = or(
-        lt(deviceTokens.createdAt, decoded.sortValue),
-        and(eq(deviceTokens.createdAt, decoded.sortValue), lt(deviceTokens.id, decoded.id)),
+        lt(deviceTokens.createdAt, sortValue),
+        and(eq(deviceTokens.createdAt, sortValue), lt(deviceTokens.id, decoded.id)),
       );
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/services/fronting-report/create.ts
+++ b/apps/api/src/services/fronting-report/create.ts
@@ -1,5 +1,5 @@
 import { frontingReports } from "@pluralscape/db/pg";
-import { ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
+import { ID_PREFIXES, brandId, createId, now, toUnixMillis } from "@pluralscape/types";
 import { CreateFrontingReportBodySchema } from "@pluralscape/validation";
 
 import { parseAndValidateBlob } from "../../lib/encrypted-blob.js";
@@ -42,7 +42,7 @@ export async function createFrontingReport(
         systemId,
         encryptedData: blob,
         format: parsed.format,
-        generatedAt: parsed.generatedAt,
+        generatedAt: toUnixMillis(parsed.generatedAt),
         createdAt: timestamp,
         updatedAt: timestamp,
       })

--- a/apps/api/src/services/fronting-report/queries.ts
+++ b/apps/api/src/services/fronting-report/queries.ts
@@ -1,5 +1,5 @@
 import { frontingReports } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 
 import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND } from "../../http.constants.js";
@@ -13,7 +13,7 @@ import { toFrontingReportResult } from "./internal.js";
 
 import type { FrontingReportResult } from "./internal.js";
 import type { AuthContext } from "../../lib/auth-context.js";
-import type { FrontingReportId, PaginatedResult, SystemId } from "@pluralscape/types";
+import type { FrontingReportId, PaginatedResult, SystemId, UnixMillis } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 export interface FrontingReportListOptions {
@@ -24,7 +24,7 @@ export interface FrontingReportListOptions {
 // ── Cursor ───────────────────────────────────────────────────────────
 
 interface CursorData {
-  readonly t: number;
+  readonly t: UnixMillis;
   readonly i: FrontingReportId;
 }
 
@@ -46,7 +46,7 @@ function decodeCursor(cursor: string): CursorData {
       (parsed as { i: string }).i.length > 0
     ) {
       const raw = parsed as { t: number; i: string };
-      return { t: raw.t, i: brandId<FrontingReportId>(raw.i) };
+      return { t: toUnixMillis(raw.t), i: brandId<FrontingReportId>(raw.i) };
     }
   } catch {
     // fall through
@@ -94,7 +94,7 @@ export async function listFrontingReports(
       nextCursor:
         hasMore && lastItem
           ? (encodeCursor({
-              t: lastItem.generatedAt as number,
+              t: lastItem.generatedAt,
               i: lastItem.id,
             }) as PaginatedResult<FrontingReportResult>["nextCursor"])
           : null,

--- a/apps/api/src/services/fronting-session/comments/create.ts
+++ b/apps/api/src/services/fronting-session/comments/create.ts
@@ -17,7 +17,12 @@ import { toFrontingCommentResult } from "./internal.js";
 import type { FrontingCommentResult } from "./internal.js";
 import type { AuditWriter } from "../../../lib/audit-writer.js";
 import type { AuthContext } from "../../../lib/auth-context.js";
-import type { FrontingCommentId, FrontingSessionId, SystemId } from "@pluralscape/types";
+import type {
+  FrontingCommentId,
+  FrontingSessionId,
+  SystemId,
+  UnixMillis,
+} from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /**
@@ -28,7 +33,7 @@ async function resolveSessionStartTime(
   tx: PostgresJsDatabase,
   sessionId: FrontingSessionId,
   systemId: SystemId,
-): Promise<number> {
+): Promise<UnixMillis> {
   const [session] = await tx
     .select({ startTime: frontingSessions.startTime, archived: frontingSessions.archived })
     .from(frontingSessions)

--- a/apps/api/src/services/fronting-session/create.ts
+++ b/apps/api/src/services/fronting-session/create.ts
@@ -1,5 +1,5 @@
 import { frontingSessions } from "@pluralscape/db/pg";
-import { brandId, ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { brandId, ID_PREFIXES, createId, now, toUnixMillis } from "@pluralscape/types";
 import { CreateFrontingSessionBodySchema } from "@pluralscape/validation";
 
 import { HTTP_BAD_REQUEST } from "../../http.constants.js";
@@ -50,8 +50,8 @@ export async function createFrontingSession(
       .values({
         id: fsId,
         systemId,
-        startTime: parsed.startTime,
-        endTime: parsed.endTime ?? null,
+        startTime: toUnixMillis(parsed.startTime),
+        endTime: parsed.endTime !== undefined ? toUnixMillis(parsed.endTime) : null,
         memberId: parsed.memberId ?? null,
         customFrontId: parsed.customFrontId ?? null,
         structureEntityId: parsed.structureEntityId ?? null,

--- a/apps/api/src/services/fronting-session/queries.ts
+++ b/apps/api/src/services/fronting-session/queries.ts
@@ -1,5 +1,5 @@
 import { frontingSessions, systemStructureEntityMemberLinks } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { FrontingSessionQuerySchema } from "@pluralscape/validation";
 import { and, desc, eq, gte, inArray, isNotNull, isNull, lt, lte } from "drizzle-orm";
 
@@ -87,11 +87,11 @@ export async function listFrontingSessions(
     }
 
     if (opts.startFrom !== undefined) {
-      conditions.push(gte(frontingSessions.startTime, opts.startFrom));
+      conditions.push(gte(frontingSessions.startTime, toUnixMillis(opts.startFrom)));
     }
 
     if (opts.startUntil !== undefined) {
-      conditions.push(lte(frontingSessions.startTime, opts.startUntil));
+      conditions.push(lte(frontingSessions.startTime, toUnixMillis(opts.startUntil)));
     }
 
     // End-time filters exclude active sessions (null endTime) by requiring endTime IS NOT NULL
@@ -99,10 +99,10 @@ export async function listFrontingSessions(
       conditions.push(isNotNull(frontingSessions.endTime));
     }
     if (opts.endFrom !== undefined) {
-      conditions.push(gte(frontingSessions.endTime, opts.endFrom));
+      conditions.push(gte(frontingSessions.endTime, toUnixMillis(opts.endFrom)));
     }
     if (opts.endUntil !== undefined) {
-      conditions.push(lte(frontingSessions.endTime, opts.endUntil));
+      conditions.push(lte(frontingSessions.endTime, toUnixMillis(opts.endUntil)));
     }
 
     if (opts.activeOnly) {

--- a/apps/api/src/services/fronting-session/update.ts
+++ b/apps/api/src/services/fronting-session/update.ts
@@ -1,5 +1,5 @@
 import { frontingSessions } from "@pluralscape/db/pg";
-import { now } from "@pluralscape/types";
+import { now, toUnixMillis } from "@pluralscape/types";
 import {
   EndFrontingSessionBodySchema,
   UpdateFrontingSessionBodySchema,
@@ -144,7 +144,7 @@ export async function endFrontingSession(
     const updated = await tx
       .update(frontingSessions)
       .set({
-        endTime,
+        endTime: toUnixMillis(endTime),
         updatedAt: timestamp,
         version: sql`${frontingSessions.version} + 1`,
       })

--- a/apps/api/src/services/lifecycle-event/create.ts
+++ b/apps/api/src/services/lifecycle-event/create.ts
@@ -1,5 +1,5 @@
 import { lifecycleEvents } from "@pluralscape/db/pg";
-import { brandId, ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { brandId, ID_PREFIXES, createId, now, toUnixMillis } from "@pluralscape/types";
 import {
   CreateLifecycleEventBodySchema,
   validateLifecycleMetadata,
@@ -62,7 +62,7 @@ export async function createLifecycleEvent(
         id: eventId,
         systemId,
         eventType: parsed.eventType,
-        occurredAt: parsed.occurredAt,
+        occurredAt: toUnixMillis(parsed.occurredAt),
         recordedAt: timestamp,
         updatedAt: timestamp,
         encryptedData: blob,

--- a/apps/api/src/services/lifecycle-event/update.ts
+++ b/apps/api/src/services/lifecycle-event/update.ts
@@ -1,5 +1,5 @@
 import { lifecycleEvents } from "@pluralscape/db/pg";
-import { brandId, now } from "@pluralscape/types";
+import { brandId, now, toUnixMillis } from "@pluralscape/types";
 import {
   UpdateLifecycleEventBodySchema,
   validateLifecycleMetadata,
@@ -82,7 +82,8 @@ export async function updateLifecycleEvent(
         updatedAt: timestamp,
         version: sql`${lifecycleEvents.version} + 1`,
         eventType: parsed.eventType ?? current.eventType,
-        occurredAt: parsed.occurredAt ?? current.occurredAt,
+        occurredAt:
+          parsed.occurredAt !== undefined ? toUnixMillis(parsed.occurredAt) : current.occurredAt,
         plaintextMetadata: metadata ?? current.plaintextMetadata,
       })
       .where(

--- a/apps/api/src/services/message/create.ts
+++ b/apps/api/src/services/message/create.ts
@@ -1,5 +1,5 @@
 import { channels, messages } from "@pluralscape/db/pg";
-import { brandId, ID_PREFIXES, createId, now } from "@pluralscape/types";
+import { brandId, ID_PREFIXES, createId, now, toUnixMillis } from "@pluralscape/types";
 import { CreateMessageBodySchema } from "@pluralscape/validation";
 import { and, eq } from "drizzle-orm";
 
@@ -65,7 +65,7 @@ export async function createMessage(
         channelId,
         systemId,
         replyToId: parsed.replyToId ?? null,
-        timestamp: parsed.timestamp,
+        timestamp: toUnixMillis(parsed.timestamp),
         encryptedData: blob,
         createdAt: ts,
         updatedAt: ts,

--- a/apps/api/src/services/message/queries.ts
+++ b/apps/api/src/services/message/queries.ts
@@ -1,5 +1,5 @@
 import { messages } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq, gt, lt, or, sql } from "drizzle-orm";
 
 import { HTTP_NOT_FOUND } from "../../http.constants.js";
@@ -60,12 +60,10 @@ export async function listMessages(
     // Composite cursor: (timestamp, id) descending
     if (opts.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "message");
+      const sortValue = toUnixMillis(decoded.sortValue);
       const cursorCondition = or(
-        lt(messages.timestamp, decoded.sortValue),
-        and(
-          eq(messages.timestamp, decoded.sortValue),
-          lt(messages.id, brandId<MessageId>(decoded.id)),
-        ),
+        lt(messages.timestamp, sortValue),
+        and(eq(messages.timestamp, sortValue), lt(messages.id, brandId<MessageId>(decoded.id))),
       );
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/services/note/queries.ts
+++ b/apps/api/src/services/note/queries.ts
@@ -1,5 +1,5 @@
 import { notes } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { NoteQuerySchema } from "@pluralscape/validation";
 import { and, desc, eq, isNull, lt, or } from "drizzle-orm";
 
@@ -99,10 +99,11 @@ export async function listNotes(
 
     if (opts.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "note");
+      const sortValue = toUnixMillis(decoded.sortValue);
       // or() returns SQL | undefined in drizzle types; always defined with concrete args
       const cursorCondition = or(
-        lt(notes.createdAt, decoded.sortValue),
-        and(eq(notes.createdAt, decoded.sortValue), lt(notes.id, brandId<NoteId>(decoded.id))),
+        lt(notes.createdAt, sortValue),
+        and(eq(notes.createdAt, sortValue), lt(notes.id, brandId<NoteId>(decoded.id))),
       );
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/services/poll-vote/list.ts
+++ b/apps/api/src/services/poll-vote/list.ts
@@ -1,5 +1,5 @@
 import { polls, pollVotes } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { PollVoteQuerySchema } from "@pluralscape/validation";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 
@@ -56,12 +56,10 @@ export async function listVotes(
 
     if (opts.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "vote");
+      const sortValue = toUnixMillis(decoded.sortValue);
       const cursorCondition = or(
-        lt(pollVotes.createdAt, decoded.sortValue),
-        and(
-          eq(pollVotes.createdAt, decoded.sortValue),
-          lt(pollVotes.id, brandId<PollVoteId>(decoded.id)),
-        ),
+        lt(pollVotes.createdAt, sortValue),
+        and(eq(pollVotes.createdAt, sortValue), lt(pollVotes.id, brandId<PollVoteId>(decoded.id))),
       );
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/services/poll/create.ts
+++ b/apps/api/src/services/poll/create.ts
@@ -1,5 +1,5 @@
 import { polls } from "@pluralscape/db/pg";
-import { ID_PREFIXES, createId, now, brandId } from "@pluralscape/types";
+import { ID_PREFIXES, createId, now, brandId, toUnixMillis } from "@pluralscape/types";
 import { CreatePollBodySchema } from "@pluralscape/validation";
 
 import { parseAndValidateBlob } from "../../lib/encrypted-blob.js";
@@ -45,7 +45,7 @@ export async function createPoll(
         kind: parsed.kind,
         status: POLL_STATUS_OPEN,
         closedAt: null,
-        endsAt: parsed.endsAt ?? null,
+        endsAt: parsed.endsAt !== undefined ? toUnixMillis(parsed.endsAt) : null,
         allowMultipleVotes: parsed.allowMultipleVotes,
         maxVotesPerMember: parsed.maxVotesPerMember,
         allowAbstain: parsed.allowAbstain,

--- a/apps/api/src/services/poll/list.ts
+++ b/apps/api/src/services/poll/list.ts
@@ -1,5 +1,5 @@
 import { polls } from "@pluralscape/db/pg";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { PollQuerySchema } from "@pluralscape/validation";
 import { and, desc, eq, lt, or } from "drizzle-orm";
 
@@ -40,9 +40,10 @@ export async function listPolls(
 
     if (opts.cursor) {
       const decoded = fromCompositeCursor(opts.cursor, "poll");
+      const sortValue = toUnixMillis(decoded.sortValue);
       const cursorCondition = or(
-        lt(polls.createdAt, decoded.sortValue),
-        and(eq(polls.createdAt, decoded.sortValue), lt(polls.id, brandId<PollId>(decoded.id))),
+        lt(polls.createdAt, sortValue),
+        and(eq(polls.createdAt, sortValue), lt(polls.id, brandId<PollId>(decoded.id))),
       );
       if (cursorCondition) {
         conditions.push(cursorCondition);

--- a/apps/api/src/services/recovery-key/reset-password.ts
+++ b/apps/api/src/services/recovery-key/reset-password.ts
@@ -5,7 +5,14 @@ import {
   verifyRecoveryKey,
 } from "@pluralscape/crypto";
 import { accounts, recoveryKeys, sessions } from "@pluralscape/db/pg";
-import { brandId, ID_PREFIXES, SESSION_TIMEOUTS, createId, now } from "@pluralscape/types";
+import {
+  brandId,
+  ID_PREFIXES,
+  SESSION_TIMEOUTS,
+  createId,
+  now,
+  toUnixMillis,
+} from "@pluralscape/types";
 import { PasswordResetViaRecoveryKeySchema } from "@pluralscape/validation";
 import { and, eq, isNull } from "drizzle-orm";
 
@@ -102,7 +109,7 @@ export async function resetPasswordWithRecoveryKey(
     const sessionId = brandId<SessionId>(createId(ID_PREFIXES.session));
     const newRecoveryKeyId = brandId<RecoveryKeyId>(createId(ID_PREFIXES.recoveryKey));
     const timeouts = SESSION_TIMEOUTS[platform];
-    const expiresAt = timestamp + timeouts.absoluteTtlMs;
+    const expiresAt = toUnixMillis(timestamp + timeouts.absoluteTtlMs);
 
     await withAccountTransaction(db, brandId<AccountId>(account.id), async (tx) => {
       // Update account: new auth key hash, KDF salt, encrypted master key

--- a/apps/api/src/services/sync-relay.service.ts
+++ b/apps/api/src/services/sync-relay.service.ts
@@ -1,7 +1,7 @@
 import { assertAeadNonce, assertSignature, assertSignPublicKey } from "@pluralscape/crypto";
 import { syncChanges, syncDocuments, syncSnapshots } from "@pluralscape/db/pg";
 import { DocumentNotFoundError, SnapshotVersionConflictError } from "@pluralscape/sync";
-import { brandId, createId, ID_PREFIXES } from "@pluralscape/types";
+import { brandId, createId, ID_PREFIXES, toUnixMillis } from "@pluralscape/types";
 import { and, eq, gt, sql } from "drizzle-orm";
 
 import { logger } from "../lib/logger.js";
@@ -47,7 +47,7 @@ export class PgSyncRelayService implements SyncRelayService {
 
   async submit(envelope: Omit<EncryptedChangeEnvelope, "seq">): Promise<number> {
     return this.withCtx(async (tx) => {
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
 
       // M8: Atomically increment last_seq and get the new value (query 1 of 2)
       const [updated] = await tx
@@ -145,7 +145,7 @@ export class PgSyncRelayService implements SyncRelayService {
 
   async submitSnapshot(envelope: EncryptedSnapshotEnvelope): Promise<void> {
     await this.withCtx(async (tx) => {
-      const now = Date.now();
+      const now = toUnixMillis(Date.now());
 
       // Atomic conditional UPDATE eliminates TOCTOU race
       const [atomicResult] = await tx

--- a/apps/api/src/services/timer-config/create.ts
+++ b/apps/api/src/services/timer-config/create.ts
@@ -1,5 +1,5 @@
 import { timerConfigs } from "@pluralscape/db/pg";
-import { ID_PREFIXES, createId, now, brandId } from "@pluralscape/types";
+import { ID_PREFIXES, createId, now, brandId, toUnixMillis } from "@pluralscape/types";
 import { CreateTimerConfigBodySchema } from "@pluralscape/validation";
 
 import { parseAndValidateBlob } from "../../lib/encrypted-blob.js";
@@ -40,14 +40,16 @@ export async function createTimerConfig(
   // Compute initial nextCheckInAt if the timer is enabled with a valid interval
   const nextCheckInAt =
     isEnabled && intervalMinutes !== null
-      ? computeNextCheckInAt(
-          {
-            intervalMinutes,
-            wakingHoursOnly: parsed.wakingHoursOnly ?? null,
-            wakingStart: parsed.wakingStart ?? null,
-            wakingEnd: parsed.wakingEnd ?? null,
-          },
-          Date.now(),
+      ? toUnixMillis(
+          computeNextCheckInAt(
+            {
+              intervalMinutes,
+              wakingHoursOnly: parsed.wakingHoursOnly ?? null,
+              wakingStart: parsed.wakingStart ?? null,
+              wakingEnd: parsed.wakingEnd ?? null,
+            },
+            Date.now(),
+          ),
         )
       : null;
 

--- a/apps/api/src/services/timer-config/update.ts
+++ b/apps/api/src/services/timer-config/update.ts
@@ -1,5 +1,5 @@
 import { timerConfigs } from "@pluralscape/db/pg";
-import { now } from "@pluralscape/types";
+import { now, toUnixMillis } from "@pluralscape/types";
 import { UpdateTimerConfigBodySchema } from "@pluralscape/validation";
 import { and, eq, sql } from "drizzle-orm";
 
@@ -85,14 +85,16 @@ export async function updateTimerConfig(
         const effectiveInterval = parsed.intervalMinutes ?? current.intervalMinutes;
 
         if (effectiveEnabled && effectiveInterval !== null) {
-          setClause.nextCheckInAt = computeNextCheckInAt(
-            {
-              intervalMinutes: effectiveInterval,
-              wakingHoursOnly: parsed.wakingHoursOnly ?? current.wakingHoursOnly,
-              wakingStart: parsed.wakingStart ?? current.wakingStart,
-              wakingEnd: parsed.wakingEnd ?? current.wakingEnd,
-            },
-            Date.now(),
+          setClause.nextCheckInAt = toUnixMillis(
+            computeNextCheckInAt(
+              {
+                intervalMinutes: effectiveInterval,
+                wakingHoursOnly: parsed.wakingHoursOnly ?? current.wakingHoursOnly,
+                wakingStart: parsed.wakingStart ?? current.wakingStart,
+                wakingEnd: parsed.wakingEnd ?? current.wakingEnd,
+              },
+              Date.now(),
+            ),
           );
         } else {
           setClause.nextCheckInAt = null;

--- a/apps/api/src/services/webhook-delivery-cleanup.ts
+++ b/apps/api/src/services/webhook-delivery-cleanup.ts
@@ -1,5 +1,5 @@
 import { webhookDeliveries } from "@pluralscape/db/pg";
-import { now } from "@pluralscape/types";
+import { now, toUnixMillis } from "@pluralscape/types";
 import { and, eq, inArray, lt, or, sql } from "drizzle-orm";
 
 import {
@@ -23,7 +23,7 @@ export async function cleanupWebhookDeliveries(
   retentionDays: number = WEBHOOK_DELIVERY_RETENTION_DAYS,
   batchSize: number = WEBHOOK_DELIVERY_CLEANUP_BATCH_SIZE,
 ): Promise<number> {
-  const cutoff = now() - retentionDays * MS_PER_DAY;
+  const cutoff = toUnixMillis(now() - retentionDays * MS_PER_DAY);
   let totalDeleted = 0;
   let deletedCount = 0;
 

--- a/apps/api/src/services/webhook-delivery-worker.ts
+++ b/apps/api/src/services/webhook-delivery-worker.ts
@@ -2,7 +2,7 @@ import { createHmac } from "node:crypto";
 
 import { getSodium } from "@pluralscape/crypto";
 import { webhookConfigs, webhookDeliveries } from "@pluralscape/db/pg";
-import { MS_PER_SECOND, now } from "@pluralscape/types";
+import { MS_PER_SECOND, now, toUnixMillis } from "@pluralscape/types";
 import { and, eq, isNull, lte, or, sql } from "drizzle-orm";
 
 import { buildIpPinnedFetchArgs, resolveAndValidateUrl } from "../lib/ip-validation.js";
@@ -202,7 +202,7 @@ export async function processWebhookDelivery(
     });
     await db
       .update(webhookDeliveries)
-      .set({ nextRetryAt: now() + WEBHOOK_HOST_THROTTLE_DELAY_MS })
+      .set({ nextRetryAt: toUnixMillis(now() + WEBHOOK_HOST_THROTTLE_DELAY_MS) })
       .where(eq(webhookDeliveries.id, deliveryId));
     return;
   }
@@ -255,7 +255,7 @@ export async function processWebhookDelivery(
     }
 
     const backoffMs = calculateBackoffMs(row.attemptCount + 1, WEBHOOK_BASE_BACKOFF_MS);
-    const nextRetryAt = timestamp + backoffMs;
+    const nextRetryAt = toUnixMillis(timestamp + backoffMs);
 
     await db
       .update(webhookDeliveries)

--- a/apps/api/src/services/webhook-delivery.service.ts
+++ b/apps/api/src/services/webhook-delivery.service.ts
@@ -121,11 +121,11 @@ export async function listWebhookDeliveries(
     }
 
     if (opts.fromDate !== undefined) {
-      conditions.push(gte(webhookDeliveries.createdAt, opts.fromDate));
+      conditions.push(gte(webhookDeliveries.createdAt, toUnixMillis(opts.fromDate)));
     }
 
     if (opts.toDate !== undefined) {
-      conditions.push(lte(webhookDeliveries.createdAt, opts.toDate));
+      conditions.push(lte(webhookDeliveries.createdAt, toUnixMillis(opts.toDate)));
     }
 
     if (opts.cursor) {

--- a/apps/api/src/trpc/routers/account.ts
+++ b/apps/api/src/trpc/routers/account.ts
@@ -5,7 +5,7 @@ import {
   PWHASH_SALT_BYTES,
   TRANSFER_TIMEOUT_MS,
 } from "@pluralscape/crypto";
-import { MS_PER_HOUR, brandId } from "@pluralscape/types";
+import { MS_PER_HOUR, brandId, toUnixMillis } from "@pluralscape/types";
 import {
   AuditLogQuerySchema,
   BiometricEnrollBodySchema,
@@ -276,8 +276,8 @@ export const accountRouter = router({
       return queryAuditLog(ctx.db, ctx.auth.accountId, {
         eventType: input.event_type,
         resourceType: input.resource_type,
-        from: input.from ?? 0,
-        to: input.to ?? now,
+        from: toUnixMillis(input.from ?? 0),
+        to: toUnixMillis(input.to ?? now),
         cursor: input.cursor ?? undefined,
         limit: input.limit,
       });

--- a/packages/db/src/__tests__/columns-pg.test.ts
+++ b/packages/db/src/__tests__/columns-pg.test.ts
@@ -1,5 +1,5 @@
 import { AEAD_NONCE_BYTES } from "@pluralscape/crypto";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -18,7 +18,7 @@ import type { BucketId } from "@pluralscape/types";
 
 describe("pgTimestamp mapping", () => {
   it("converts UnixMillis to ISO string", () => {
-    const ms = 1704067200000; // 2024-01-01T00:00:00.000Z
+    const ms = toUnixMillis(1704067200000); // 2024-01-01T00:00:00.000Z
     expect(timestampToDriver(ms)).toBe("2024-01-01T00:00:00.000Z");
   });
 
@@ -27,25 +27,31 @@ describe("pgTimestamp mapping", () => {
   });
 
   it("round-trips through toDriver/fromDriver", () => {
-    const ms = Date.now();
+    const ms = toUnixMillis(Date.now());
     expect(timestampFromDriver(timestampToDriver(ms))).toBe(ms);
   });
 
   it("accepts negative timestamps (dates before epoch)", () => {
-    const ms = -1000;
+    const ms = toUnixMillis(-1000);
     expect(timestampFromDriver(timestampToDriver(ms))).toBe(ms);
   });
 
   it("throws on NaN", () => {
-    expect(() => timestampToDriver(NaN)).toThrow("not a finite number");
+    expect(() => timestampToDriver(NaN as ReturnType<typeof toUnixMillis>)).toThrow(
+      "not a finite number",
+    );
   });
 
   it("throws on Infinity", () => {
-    expect(() => timestampToDriver(Infinity)).toThrow("not a finite number");
+    expect(() => timestampToDriver(Infinity as ReturnType<typeof toUnixMillis>)).toThrow(
+      "not a finite number",
+    );
   });
 
   it("throws on -Infinity", () => {
-    expect(() => timestampToDriver(-Infinity)).toThrow("not a finite number");
+    expect(() => timestampToDriver(-Infinity as ReturnType<typeof toUnixMillis>)).toThrow(
+      "not a finite number",
+    );
   });
 
   it("throws on unparseable date string", () => {

--- a/packages/db/src/__tests__/columns-sqlite.test.ts
+++ b/packages/db/src/__tests__/columns-sqlite.test.ts
@@ -1,5 +1,5 @@
 import { AEAD_NONCE_BYTES } from "@pluralscape/crypto";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -11,31 +11,39 @@ import {
   timestampToDriver,
 } from "../columns/sqlite.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
+
 import type { EncryptedBlob } from "@pluralscape/types";
 import type { BucketId } from "@pluralscape/types";
 
 describe("sqliteTimestamp mapping", () => {
   it("passes through integer values", () => {
-    const ms = 1704067200000;
+    const ms = toUnixMillis(1704067200000);
     expect(timestampToDriver(ms)).toBe(ms);
     expect(timestampFromDriver(ms)).toBe(ms);
   });
 
   it("round-trips through toDriver/fromDriver", () => {
-    const ms = Date.now();
+    const ms = fixtureNow();
     expect(timestampFromDriver(timestampToDriver(ms))).toBe(ms);
   });
 
   it("throws on NaN in toDriver", () => {
-    expect(() => timestampToDriver(NaN)).toThrow("not a finite number");
+    expect(() => timestampToDriver(NaN as ReturnType<typeof toUnixMillis>)).toThrow(
+      "not a finite number",
+    );
   });
 
   it("throws on Infinity in toDriver", () => {
-    expect(() => timestampToDriver(Infinity)).toThrow("not a finite number");
+    expect(() => timestampToDriver(Infinity as ReturnType<typeof toUnixMillis>)).toThrow(
+      "not a finite number",
+    );
   });
 
   it("throws on -Infinity in toDriver", () => {
-    expect(() => timestampToDriver(-Infinity)).toThrow("not a finite number");
+    expect(() => timestampToDriver(-Infinity as ReturnType<typeof toUnixMillis>)).toThrow(
+      "not a finite number",
+    );
   });
 
   it("throws on NaN in fromDriver", () => {

--- a/packages/db/src/__tests__/fixtures/timestamps.ts
+++ b/packages/db/src/__tests__/fixtures/timestamps.ts
@@ -1,0 +1,5 @@
+import { toUnixMillis, type UnixMillis } from "@pluralscape/types";
+
+export const fixtureNow = (): UnixMillis => toUnixMillis(Date.now());
+
+export const fixtureNowPlus = (offsetMs: number): UnixMillis => toUnixMillis(Date.now() + offsetMs);

--- a/packages/db/src/__tests__/helpers/pg-helpers.ts
+++ b/packages/db/src/__tests__/helpers/pg-helpers.ts
@@ -84,6 +84,7 @@ import { systemSettings } from "../../schema/pg/system-settings.js";
 import { systems } from "../../schema/pg/systems.js";
 import { checkInRecords, timerConfigs } from "../../schema/pg/timers.js";
 import { webhookConfigs, webhookDeliveries } from "../../schema/pg/webhooks.js";
+import { fixtureNow } from "../fixtures/timestamps.js";
 
 import { pgTableToCreateDDL, pgTableToIndexDDL } from "./schema-to-ddl.js";
 
@@ -377,7 +378,7 @@ export async function pgInsertAccount(
   id?: string,
 ): Promise<AccountId> {
   const resolvedId = brandId<AccountId>(id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   await db.insert(accounts).values({
     id: resolvedId,
     emailHash: `hash_${crypto.randomUUID()}`,
@@ -397,7 +398,7 @@ export async function pgInsertSystem(
   id?: string,
 ): Promise<SystemId> {
   const resolvedId = brandId<SystemId>(id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   await db.insert(systems).values({
     id: resolvedId,
     accountId: brandId<AccountId>(accountId),
@@ -548,7 +549,7 @@ export async function pgInsertMember(
   id?: string,
 ): Promise<string> {
   const resolvedId = id ?? crypto.randomUUID();
-  const now = Date.now();
+  const now = fixtureNow();
   await db.insert(members).values({
     id: resolvedId,
     systemId,
@@ -570,7 +571,7 @@ export async function pgInsertChannel(
   } = {},
 ): Promise<ChannelId> {
   const id = brandId<ChannelId>(opts.id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   await db.insert(channels).values({
     id,
     systemId: brandId<SystemId>(systemId),
@@ -593,7 +594,7 @@ export async function pgInsertPoll(
   opts: { id?: string } = {},
 ): Promise<PollId> {
   const id = brandId<PollId>(opts.id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   await db.insert(polls).values({
     id,
     systemId: brandId<SystemId>(systemId),

--- a/packages/db/src/__tests__/helpers/sqlite-helpers.ts
+++ b/packages/db/src/__tests__/helpers/sqlite-helpers.ts
@@ -10,6 +10,7 @@ import { accounts } from "../../schema/sqlite/auth.js";
 import { channels, polls } from "../../schema/sqlite/communication.js";
 import { members } from "../../schema/sqlite/members.js";
 import { systems } from "../../schema/sqlite/systems.js";
+import { fixtureNow } from "../fixtures/timestamps.js";
 
 import type {
   AccountId,
@@ -1495,7 +1496,7 @@ export function sqliteInsertAccount(
   id?: string,
 ): AccountId {
   const resolvedId = brandId<AccountId>(id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   db.insert(accounts)
     .values({
       id: resolvedId,
@@ -1517,7 +1518,7 @@ export function sqliteInsertSystem(
   id?: string,
 ): SystemId {
   const resolvedId = brandId<SystemId>(id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   db.insert(systems)
     .values({
       id: resolvedId,
@@ -1666,7 +1667,7 @@ export function sqliteInsertMember(
   id?: string,
 ): string {
   const resolvedId = id ?? crypto.randomUUID();
-  const now = Date.now();
+  const now = fixtureNow();
   db.insert(members)
     .values({
       id: resolvedId,
@@ -1690,7 +1691,7 @@ export function sqliteInsertChannel(
   } = {},
 ): ChannelId {
   const id = brandId<ChannelId>(opts.id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   db.insert(channels)
     .values({
       id,
@@ -1715,7 +1716,7 @@ export function sqliteInsertPoll(
   opts: { id?: string } = {},
 ): PollId {
   const id = brandId<PollId>(opts.id ?? crypto.randomUUID());
-  const now = Date.now();
+  const now = fixtureNow();
   db.insert(polls)
     .values({
       id,

--- a/packages/db/src/__tests__/queries-pg-audit-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-pg-audit-cleanup.integration.test.ts
@@ -8,6 +8,7 @@ import { auditLog } from "../schema/pg/audit-log.js";
 import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow, fixtureNowPlus } from "./fixtures/timestamps.js";
 import {
   createPgAuditLogTables,
   makeAuditLogEntryId,
@@ -16,7 +17,7 @@ import {
 } from "./helpers/pg-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
-import type { AccountId, AuditLogEntryId, SystemId } from "@pluralscape/types";
+import type { AccountId, AuditLogEntryId, SystemId, UnixMillis } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, auditLog };
@@ -46,7 +47,7 @@ describe("pgCleanupAuditLog", () => {
   async function insertAuditEntry(opts: {
     accountId: string;
     systemId: string;
-    timestamp?: number;
+    timestamp?: UnixMillis;
   }): Promise<AuditLogEntryId> {
     const id = makeAuditLogEntryId();
     await db.insert(auditLog).values({
@@ -54,7 +55,7 @@ describe("pgCleanupAuditLog", () => {
       accountId: brandId<AccountId>(opts.accountId),
       systemId: brandId<SystemId>(opts.systemId),
       eventType: "auth.login",
-      timestamp: opts.timestamp ?? Date.now(),
+      timestamp: opts.timestamp ?? fixtureNow(),
       actor: testActor(opts.accountId),
     });
     return id;
@@ -64,7 +65,7 @@ describe("pgCleanupAuditLog", () => {
     const accountId = await pgInsertAccount(db);
     const systemId = await pgInsertSystem(db, accountId);
 
-    const thirtyDaysAgoMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const thirtyDaysAgoMs = fixtureNowPlus(-30 * 24 * 60 * 60 * 1000);
     const oldId = await insertAuditEntry({ accountId, systemId, timestamp: thirtyDaysAgoMs });
     const recentId = await insertAuditEntry({ accountId, systemId });
 

--- a/packages/db/src/__tests__/queries-pg-orphan-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-pg-orphan-cleanup.integration.test.ts
@@ -10,6 +10,7 @@ import { members } from "../schema/pg/members.js";
 import { bucketContentTags, buckets } from "../schema/pg/privacy.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgGroupsTables,
   pgExec,
@@ -54,7 +55,7 @@ describe("pgCleanupOrphanedTags", () => {
 
   async function insertBucket(systemId: SystemId): Promise<BucketId> {
     const id = brandId<BucketId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(buckets).values({
       id,
       systemId,

--- a/packages/db/src/__tests__/queries-sqlite-audit-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-audit-cleanup.integration.test.ts
@@ -8,6 +8,7 @@ import { auditLog } from "../schema/sqlite/audit-log.js";
 import { accounts } from "../schema/sqlite/auth.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow, fixtureNowPlus } from "./fixtures/timestamps.js";
 import {
   createSqliteAuditLogTables,
   makeAuditLogEntryId,
@@ -16,7 +17,7 @@ import {
 } from "./helpers/sqlite-helpers.js";
 
 import type { DbAuditActor } from "../helpers/types.js";
-import type { AccountId, AuditLogEntryId, SystemId } from "@pluralscape/types";
+import type { AccountId, AuditLogEntryId, SystemId, UnixMillis } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, auditLog };
@@ -47,7 +48,7 @@ describe("sqliteCleanupAuditLog", () => {
   function insertAuditEntry(opts: {
     accountId: string;
     systemId: string;
-    timestamp?: number;
+    timestamp?: UnixMillis;
   }): AuditLogEntryId {
     const id = makeAuditLogEntryId();
     db.insert(auditLog)
@@ -56,7 +57,7 @@ describe("sqliteCleanupAuditLog", () => {
         accountId: brandId<AccountId>(opts.accountId),
         systemId: brandId<SystemId>(opts.systemId),
         eventType: "auth.login",
-        timestamp: opts.timestamp ?? Date.now(),
+        timestamp: opts.timestamp ?? fixtureNow(),
         actor: testActor(opts.accountId),
       })
       .run();
@@ -67,7 +68,7 @@ describe("sqliteCleanupAuditLog", () => {
     const accountId = sqliteInsertAccount(db);
     const systemId = sqliteInsertSystem(db, accountId);
 
-    const thirtyDaysAgoMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const thirtyDaysAgoMs = fixtureNowPlus(-(30 * 24 * 60 * 60 * 1000));
     const oldId = insertAuditEntry({ accountId, systemId, timestamp: thirtyDaysAgoMs });
     const recentId = insertAuditEntry({ accountId, systemId });
 
@@ -83,7 +84,7 @@ describe("sqliteCleanupAuditLog", () => {
     const accountId = sqliteInsertAccount(db);
     const systemId = sqliteInsertSystem(db, accountId);
 
-    const oldTs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const oldTs = fixtureNowPlus(-(30 * 24 * 60 * 60 * 1000));
     insertAuditEntry({ accountId, systemId, timestamp: oldTs });
     insertAuditEntry({ accountId, systemId, timestamp: oldTs });
     insertAuditEntry({ accountId, systemId, timestamp: oldTs });

--- a/packages/db/src/__tests__/queries-sqlite-device-transfer-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-device-transfer-cleanup.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -6,9 +6,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { sqliteCleanupDeviceTransfers } from "../queries/device-transfer-cleanup.js";
 import { accounts, deviceTransferRequests, sessions } from "../schema/sqlite/auth.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import { createSqliteAuthTables, sqliteInsertAccount } from "./helpers/sqlite-helpers.js";
 
-import type { AccountId, DeviceTransferRequestId, SessionId } from "@pluralscape/types";
+import type { AccountId, DeviceTransferRequestId, SessionId, UnixMillis } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const ONE_HOUR_MS = 3_600_000;
@@ -27,7 +28,7 @@ describe("sqliteCleanupDeviceTransfers", () => {
         id,
         accountId,
         tokenHash: `tok_${crypto.randomUUID()}`,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       })
       .run();
     return id;
@@ -37,12 +38,12 @@ describe("sqliteCleanupDeviceTransfers", () => {
     accountId: AccountId;
     sourceSessionId: SessionId;
     status?: "pending" | "approved" | "expired";
-    createdAt?: number;
-    expiresAt?: number;
+    createdAt?: UnixMillis;
+    expiresAt?: UnixMillis;
     encryptedKeyMaterial?: Uint8Array;
   }): DeviceTransferRequestId {
     const id = brandId<DeviceTransferRequestId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(deviceTransferRequests)
       .values({
         id,
@@ -51,8 +52,8 @@ describe("sqliteCleanupDeviceTransfers", () => {
         status: opts.status ?? "pending",
         codeSalt: TEST_CODE_SALT,
         encryptedKeyMaterial: opts.encryptedKeyMaterial ?? null,
-        createdAt: opts.createdAt ?? now - ONE_HOUR_MS,
-        expiresAt: opts.expiresAt ?? now + ONE_HOUR_MS,
+        createdAt: opts.createdAt ?? toUnixMillis(now - ONE_HOUR_MS),
+        expiresAt: opts.expiresAt ?? toUnixMillis(now + ONE_HOUR_MS),
       })
       .run();
     return id;
@@ -78,15 +79,15 @@ describe("sqliteCleanupDeviceTransfers", () => {
   it("expires pending transfers past their expiresAt", () => {
     const accountId = sqliteInsertAccount(db);
     const sessionId = insertSession(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     // Expired pending transfer (expiresAt in the past)
     const expiredId = insertTransfer({
       accountId,
       sourceSessionId: sessionId,
       status: "pending",
-      createdAt: now - ONE_HOUR_MS * 2,
-      expiresAt: now - ONE_HOUR_MS,
+      createdAt: toUnixMillis(now - ONE_HOUR_MS * 2),
+      expiresAt: toUnixMillis(now - ONE_HOUR_MS),
     });
 
     // Non-expired pending transfer (expiresAt in the future)
@@ -94,8 +95,8 @@ describe("sqliteCleanupDeviceTransfers", () => {
       accountId,
       sourceSessionId: sessionId,
       status: "pending",
-      createdAt: now - ONE_HOUR_MS,
-      expiresAt: now + ONE_HOUR_MS,
+      createdAt: toUnixMillis(now - ONE_HOUR_MS),
+      expiresAt: toUnixMillis(now + ONE_HOUR_MS),
     });
 
     const result = sqliteCleanupDeviceTransfers(db);
@@ -112,15 +113,15 @@ describe("sqliteCleanupDeviceTransfers", () => {
   it("does not touch already-approved transfers", () => {
     const accountId = sqliteInsertAccount(db);
     const sessionId = insertSession(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     insertTransfer({
       accountId,
       sourceSessionId: sessionId,
       status: "approved",
       encryptedKeyMaterial: new Uint8Array([1, 2, 3]),
-      createdAt: now - ONE_HOUR_MS * 2,
-      expiresAt: now - ONE_HOUR_MS,
+      createdAt: toUnixMillis(now - ONE_HOUR_MS * 2),
+      expiresAt: toUnixMillis(now - ONE_HOUR_MS),
     });
 
     const result = sqliteCleanupDeviceTransfers(db);
@@ -134,14 +135,14 @@ describe("sqliteCleanupDeviceTransfers", () => {
   it("does not touch already-expired transfers", () => {
     const accountId = sqliteInsertAccount(db);
     const sessionId = insertSession(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     insertTransfer({
       accountId,
       sourceSessionId: sessionId,
       status: "expired",
-      createdAt: now - ONE_HOUR_MS * 2,
-      expiresAt: now - ONE_HOUR_MS,
+      createdAt: toUnixMillis(now - ONE_HOUR_MS * 2),
+      expiresAt: toUnixMillis(now - ONE_HOUR_MS),
     });
 
     const result = sqliteCleanupDeviceTransfers(db);
@@ -156,22 +157,22 @@ describe("sqliteCleanupDeviceTransfers", () => {
   it("expires multiple pending transfers in a single pass", () => {
     const accountId = sqliteInsertAccount(db);
     const sessionId = insertSession(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     insertTransfer({
       accountId,
       sourceSessionId: sessionId,
       status: "pending",
-      createdAt: now - ONE_HOUR_MS * 3,
-      expiresAt: now - ONE_HOUR_MS * 2,
+      createdAt: toUnixMillis(now - ONE_HOUR_MS * 3),
+      expiresAt: toUnixMillis(now - ONE_HOUR_MS * 2),
     });
 
     insertTransfer({
       accountId,
       sourceSessionId: sessionId,
       status: "pending",
-      createdAt: now - ONE_HOUR_MS * 2,
-      expiresAt: now - ONE_HOUR_MS,
+      createdAt: toUnixMillis(now - ONE_HOUR_MS * 2),
+      expiresAt: toUnixMillis(now - ONE_HOUR_MS),
     });
 
     const result = sqliteCleanupDeviceTransfers(db);

--- a/packages/db/src/__tests__/queries-sqlite-orphan-cleanup.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-orphan-cleanup.integration.test.ts
@@ -13,6 +13,7 @@ import { members } from "../schema/sqlite/members.js";
 import { bucketContentTags, buckets } from "../schema/sqlite/privacy.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteGroupsTables,
   sqliteInsertAccount,
@@ -56,7 +57,7 @@ describe("sqliteCleanupOrphanedTags", () => {
 
   function insertBucket(systemId: SystemId): BucketId {
     const id = brandId<BucketId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(buckets)
       .values({
         id,

--- a/packages/db/src/__tests__/queries-sqlite-recovery-key.integration.test.ts
+++ b/packages/db/src/__tests__/queries-sqlite-recovery-key.integration.test.ts
@@ -11,9 +11,10 @@ import {
 } from "../queries/recovery-key.js";
 import { accounts, recoveryKeys } from "../schema/sqlite/auth.js";
 
+import { fixtureNow, fixtureNowPlus } from "./fixtures/timestamps.js";
 import { SQLITE_DDL, sqliteInsertAccount } from "./helpers/sqlite-helpers.js";
 
-import type { AccountId, RecoveryKeyId } from "@pluralscape/types";
+import type { AccountId, RecoveryKeyId, UnixMillis } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, recoveryKeys };
@@ -46,13 +47,13 @@ describe("recovery key queries (SQLite)", () => {
 
   function makeRow(
     accountId: AccountId,
-    overrides: Partial<{ id: RecoveryKeyId; createdAt: number }> = {},
+    overrides: Partial<{ id: RecoveryKeyId; createdAt: UnixMillis }> = {},
   ) {
     return {
       id: overrides.id ?? brandId<RecoveryKeyId>(crypto.randomUUID()),
       accountId,
       encryptedMasterKey: makeEncryptedKey(),
-      createdAt: overrides.createdAt ?? Date.now(),
+      createdAt: overrides.createdAt ?? fixtureNow(),
     };
   }
 
@@ -108,7 +109,7 @@ describe("recovery key queries (SQLite)", () => {
       sqliteRevokeRecoveryKey(
         db as BetterSQLite3Database<Record<string, unknown>>,
         row.id,
-        Date.now(),
+        fixtureNow(),
       );
 
       const result = sqliteGetActiveRecoveryKey(
@@ -120,14 +121,14 @@ describe("recovery key queries (SQLite)", () => {
 
     it("ignores revoked keys and returns active one", () => {
       const accountId = sqliteInsertAccount(db as BetterSQLite3Database<Record<string, unknown>>);
-      const oldRow = makeRow(accountId, { createdAt: Date.now() - 10_000 });
+      const oldRow = makeRow(accountId, { createdAt: fixtureNowPlus(-10_000) });
       const newRow = makeRow(accountId);
       sqliteStoreRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, oldRow);
       sqliteStoreRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, newRow);
       sqliteRevokeRecoveryKey(
         db as BetterSQLite3Database<Record<string, unknown>>,
         oldRow.id,
-        Date.now(),
+        fixtureNow(),
       );
 
       const result = sqliteGetActiveRecoveryKey(
@@ -144,7 +145,7 @@ describe("recovery key queries (SQLite)", () => {
       const row = makeRow(accountId);
       sqliteStoreRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, row);
 
-      const revokedAt = Date.now();
+      const revokedAt = fixtureNow();
       sqliteRevokeRecoveryKey(
         db as BetterSQLite3Database<Record<string, unknown>>,
         row.id,
@@ -160,7 +161,7 @@ describe("recovery key queries (SQLite)", () => {
         sqliteRevokeRecoveryKey(
           db as BetterSQLite3Database<Record<string, unknown>>,
           brandId<RecoveryKeyId>("nonexistent-id"),
-          Date.now(),
+          fixtureNow(),
         );
       }).toThrow("Recovery key not found.");
     });
@@ -175,7 +176,7 @@ describe("recovery key queries (SQLite)", () => {
       sqliteRevokeRecoveryKey(
         db as BetterSQLite3Database<Record<string, unknown>>,
         row1.id,
-        Date.now(),
+        fixtureNow(),
       );
 
       const all = db.select().from(recoveryKeys).all();
@@ -191,7 +192,7 @@ describe("recovery key queries (SQLite)", () => {
       sqliteStoreRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, oldRow);
 
       const newRow = makeRow(accountId);
-      const revokedAt = Date.now();
+      const revokedAt = fixtureNow();
       sqliteReplaceRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, {
         revokeId: oldRow.id,
         revokedAt,
@@ -214,7 +215,7 @@ describe("recovery key queries (SQLite)", () => {
       expect(() => {
         sqliteReplaceRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, {
           revokeId: brandId<RecoveryKeyId>("nonexistent-id"),
-          revokedAt: Date.now(),
+          revokedAt: fixtureNow(),
           newRow,
         });
       }).toThrow("Recovery key not found.");
@@ -228,7 +229,7 @@ describe("recovery key queries (SQLite)", () => {
       const newRow = makeRow(accountId);
       sqliteReplaceRecoveryKeyBackup(db as BetterSQLite3Database<Record<string, unknown>>, {
         revokeId: oldRow.id,
-        revokedAt: Date.now(),
+        revokedAt: fixtureNow(),
         newRow,
       });
 

--- a/packages/db/src/__tests__/rls-policies.integration.test.ts
+++ b/packages/db/src/__tests__/rls-policies.integration.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../rls/policies.js";
 import { members } from "../schema/pg/members.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgSyncTables,
   pgInsertAccount,
@@ -345,7 +346,7 @@ describe("RLS cross-tenant isolation — system scope (PGlite)", () => {
     await setSessionSystemId(db, systemIdA);
 
     const crossTenantId = crypto.randomUUID();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(members).values({

--- a/packages/db/src/__tests__/schema-pg-analytics.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-analytics.integration.test.ts
@@ -8,6 +8,7 @@ import { frontingReports } from "../schema/pg/analytics.js";
 import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgAnalyticsTables,
   makeFrontingReportId,
@@ -47,7 +48,7 @@ describe("PG analytics schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = makeFrontingReportId();
-      const ts = Date.now();
+      const ts = fixtureNow();
       const blob = testBlob();
 
       await db.insert(frontingReports).values({
@@ -77,7 +78,7 @@ describe("PG analytics schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = makeFrontingReportId();
-      const ts = Date.now();
+      const ts = fixtureNow();
 
       await db.insert(frontingReports).values({
         id,
@@ -96,7 +97,7 @@ describe("PG analytics schema", () => {
     it("rejects invalid format value", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const ts = Date.now();
+      const ts = fixtureNow();
 
       await expect(
         db.insert(frontingReports).values({
@@ -115,7 +116,7 @@ describe("PG analytics schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = makeFrontingReportId();
-      const ts = Date.now();
+      const ts = fixtureNow();
 
       await db.insert(frontingReports).values({
         id,
@@ -133,7 +134,7 @@ describe("PG analytics schema", () => {
     });
 
     it("rejects nonexistent systemId FK", async () => {
-      const ts = Date.now();
+      const ts = fixtureNow();
       await expect(
         db.insert(frontingReports).values({
           id: makeFrontingReportId(),
@@ -151,7 +152,7 @@ describe("PG analytics schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = makeFrontingReportId();
-      const ts = Date.now();
+      const ts = fixtureNow();
       const values = {
         id,
         systemId,
@@ -169,7 +170,7 @@ describe("PG analytics schema", () => {
     it("queries multiple reports by systemId", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const ts = Date.now();
+      const ts = fixtureNow();
 
       await db.insert(frontingReports).values([
         {
@@ -203,7 +204,7 @@ describe("PG analytics schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = makeFrontingReportId();
-      const ts = Date.now();
+      const ts = fixtureNow();
       const blob = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(frontingReports).values({
@@ -223,7 +224,7 @@ describe("PG analytics schema", () => {
     it("enforces version >= 1 check constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const ts = Date.now();
+      const ts = fixtureNow();
 
       await expect(
         db.insert(frontingReports).values({
@@ -242,7 +243,7 @@ describe("PG analytics schema", () => {
     it("enforces archived consistency check", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const ts = Date.now();
+      const ts = fixtureNow();
 
       // archived=true but archivedAt=null should fail
       await expect(

--- a/packages/db/src/__tests__/schema-pg-api-keys.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-api-keys.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import { apiKeys } from "../schema/pg/api-keys.js";
 import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgApiKeysTables,
   pgInsertAccount,
@@ -39,7 +40,7 @@ describe("PG api_keys schema", () => {
   it("inserts and retrieves a metadata API key", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
 
@@ -67,7 +68,7 @@ describe("PG api_keys schema", () => {
   it("inserts and retrieves a crypto API key", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
     const keyMaterial = new Uint8Array([1, 2, 3, 4, 5]);
@@ -94,7 +95,7 @@ describe("PG api_keys schema", () => {
   it("rejects invalid key_type via CHECK constraint", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(apiKeys).values({
@@ -113,7 +114,7 @@ describe("PG api_keys schema", () => {
   it("enforces unique token_hash", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const tokenHash = `hash_${crypto.randomUUID()}`;
 
     await db.insert(apiKeys).values({
@@ -144,7 +145,7 @@ describe("PG api_keys schema", () => {
   it("allows nullable optional fields", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
@@ -169,8 +170,8 @@ describe("PG api_keys schema", () => {
   it("stores and retrieves timestamps (lastUsedAt, revokedAt, expiresAt)", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
-    const later = now + 86400000;
+    const now = fixtureNow();
+    const later = toUnixMillis(now + 86400000);
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
@@ -196,7 +197,7 @@ describe("PG api_keys schema", () => {
   it("cascades on account deletion", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
@@ -218,7 +219,7 @@ describe("PG api_keys schema", () => {
   it("cascades on system deletion", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
@@ -240,7 +241,7 @@ describe("PG api_keys schema", () => {
   it("rejects nonexistent accountId FK", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(apiKeys).values({
@@ -259,7 +260,7 @@ describe("PG api_keys schema", () => {
   it("rejects metadata key with encrypted_key_material", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(apiKeys).values({
@@ -279,7 +280,7 @@ describe("PG api_keys schema", () => {
   it("rejects crypto key without encrypted_key_material", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(apiKeys).values({
@@ -298,7 +299,7 @@ describe("PG api_keys schema", () => {
   it("round-trips empty scopes array", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     await db.insert(apiKeys).values({
@@ -318,7 +319,7 @@ describe("PG api_keys schema", () => {
 
   it("rejects nonexistent systemId FK", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(apiKeys).values({
@@ -338,7 +339,7 @@ describe("PG api_keys schema", () => {
     const accountA = await insertAccount();
     const accountB = await insertAccount();
     const systemOfB = await pgInsertSystem(db, accountB);
-    const now = Date.now();
+    const now = fixtureNow();
 
     // accountA tries to create an API key referencing accountB's system
     await expect(
@@ -371,7 +372,7 @@ describe("PG api_keys schema", () => {
   it("round-trips encryptedData blob", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const blob = testBlob(new Uint8Array([10, 20, 30]));
 

--- a/packages/db/src/__tests__/schema-pg-audit-log.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-audit-log.integration.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
+import { toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -7,6 +8,7 @@ import { auditLog } from "../schema/pg/audit-log.js";
 import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgAuditLogTables,
   makeAuditLogEntryId,
@@ -42,7 +44,7 @@ describe("PG audit_log schema", () => {
   it("inserts and retrieves with all columns", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
     const actor = testActor("account", accountId);
 
@@ -71,7 +73,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("allows nullable fields (accountId, systemId, ipAddress, userAgent, detail)", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
@@ -90,7 +92,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("rejects invalid event_type via CHECK constraint", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(auditLog).values({
@@ -127,7 +129,7 @@ describe("PG audit_log schema", () => {
     ] as const;
 
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     for (const eventType of eventTypes) {
       await db.insert(auditLog).values({
         id: makeAuditLogEntryId(),
@@ -146,7 +148,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("supports api-key actor type", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
     const actor = testActor("api-key", "key-123");
 
@@ -163,7 +165,7 @@ describe("PG audit_log schema", () => {
 
   it("sets account_id to NULL on account deletion (SET NULL)", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
@@ -183,7 +185,7 @@ describe("PG audit_log schema", () => {
   it("sets system_id to NULL on system deletion (SET NULL)", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
@@ -202,7 +204,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("rejects duplicate composite primary key (same id + timestamp)", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     await db.insert(auditLog).values({
@@ -224,7 +226,7 @@ describe("PG audit_log schema", () => {
 
   it("allows same id with different timestamps (composite PK)", async () => {
     const id = makeAuditLogEntryId();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(auditLog).values({
       id,
@@ -236,7 +238,7 @@ describe("PG audit_log schema", () => {
     await db.insert(auditLog).values({
       id,
       eventType: "auth.logout",
-      timestamp: now + 1000,
+      timestamp: toUnixMillis(now + 1000),
       actor: testActor("account", "acc-1"),
     });
 
@@ -246,7 +248,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("accepts detail at exactly 2048 characters", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(auditLog).values({
       id: makeAuditLogEntryId(),
@@ -258,7 +260,7 @@ describe("PG audit_log schema", () => {
   });
 
   it("rejects detail exceeding 2048 characters", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(auditLog).values({

--- a/packages/db/src/__tests__/schema-pg-auth.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-auth.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -12,6 +12,7 @@ import {
   sessions,
 } from "../schema/pg/auth.js";
 
+import { fixtureNow, fixtureNowPlus } from "./fixtures/timestamps.js";
 import { createPgAuthTables, testBlob } from "./helpers/pg-helpers.js";
 
 import type {
@@ -20,6 +21,7 @@ import type {
   DeviceTransferRequestId,
   RecoveryKeyId,
   SessionId,
+  UnixMillis,
 } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
@@ -49,8 +51,8 @@ describe("PG auth schema", () => {
       emailSalt: string;
       authKeyHash: Uint8Array;
       kdfSalt: string;
-      createdAt: number;
-      updatedAt: number;
+      createdAt: UnixMillis;
+      updatedAt: UnixMillis;
     }> = {},
   ): Promise<{
     id: AccountId;
@@ -58,10 +60,10 @@ describe("PG auth schema", () => {
     emailSalt: string;
     authKeyHash: Uint8Array;
     kdfSalt: string;
-    createdAt: number;
-    updatedAt: number;
+    createdAt: UnixMillis;
+    updatedAt: UnixMillis;
   }> {
-    const now = Date.now();
+    const now = fixtureNow();
     const data = {
       id: newAccountId(overrides.id),
       emailHash: overrides.emailHash ?? `hash_${crypto.randomUUID()}`,
@@ -78,13 +80,13 @@ describe("PG auth schema", () => {
 
   async function insertSession(
     accountId: AccountId,
-    overrides: Partial<{ id: SessionId; createdAt: number; tokenHash: string }> = {},
-  ): Promise<{ id: SessionId; accountId: AccountId; tokenHash: string; createdAt: number }> {
+    overrides: Partial<{ id: SessionId; createdAt: UnixMillis; tokenHash: string }> = {},
+  ): Promise<{ id: SessionId; accountId: AccountId; tokenHash: string; createdAt: UnixMillis }> {
     const data = {
       id: overrides.id ?? newSessionId(),
       accountId,
       tokenHash: overrides.tokenHash ?? `tok_${crypto.randomUUID()}`,
-      createdAt: overrides.createdAt ?? Date.now(),
+      createdAt: overrides.createdAt ?? fixtureNow(),
     };
     await db.insert(sessions).values(data);
     return data;
@@ -147,7 +149,7 @@ describe("PG auth schema", () => {
     });
 
     it("rejects null kdfSalt", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       await expect(
         client.query(
           "INSERT INTO accounts (id, email_hash, email_salt, auth_key_hash, kdf_salt, created_at, updated_at, version) VALUES ($1, $2, $3, $4, NULL, $5, $6, 1)",
@@ -177,7 +179,7 @@ describe("PG auth schema", () => {
         encryptedPrivateKey: privateKey,
         publicKey,
         keyType: "encryption",
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       const rows = await db.select().from(authKeys).where(eq(authKeys.id, id));
@@ -197,7 +199,7 @@ describe("PG auth schema", () => {
         encryptedPrivateKey: new Uint8Array([1]),
         publicKey: new Uint8Array([2]),
         keyType: "signing",
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       const rows = await db.select().from(authKeys).where(eq(authKeys.id, id));
@@ -213,7 +215,7 @@ describe("PG auth schema", () => {
           encryptedPrivateKey: new Uint8Array([1]),
           publicKey: new Uint8Array([2]),
           keyType: "invalid" as "encryption",
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -228,7 +230,7 @@ describe("PG auth schema", () => {
         encryptedPrivateKey: new Uint8Array([1]),
         publicKey: new Uint8Array([2]),
         keyType: "encryption",
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       await db.delete(accounts).where(eq(accounts.id, account.id));
@@ -244,7 +246,7 @@ describe("PG auth schema", () => {
           encryptedPrivateKey: new Uint8Array([1]),
           publicKey: new Uint8Array([2]),
           keyType: "encryption",
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -259,7 +261,7 @@ describe("PG auth schema", () => {
         encryptedPrivateKey: new Uint8Array(0),
         publicKey: new Uint8Array(0),
         keyType: "encryption",
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       const rows = await db.select().from(authKeys).where(eq(authKeys.id, id));
@@ -281,10 +283,10 @@ describe("PG auth schema", () => {
   describe("sessions", () => {
     it("inserts and retrieves with all fields", async () => {
       const account = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newSessionId();
 
-      const expiresAt = now + ONE_DAY_MS;
+      const expiresAt = toUnixMillis(now + ONE_DAY_MS);
       await db.insert(sessions).values({
         id,
         accountId: account.id,
@@ -311,7 +313,7 @@ describe("PG auth schema", () => {
       await db.insert(sessions).values({
         id,
         accountId: account.id,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
 
@@ -326,7 +328,7 @@ describe("PG auth schema", () => {
       await db.insert(sessions).values({
         id,
         accountId: account.id,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
 
@@ -337,12 +339,12 @@ describe("PG auth schema", () => {
     it("round-trips expiresAt when provided", async () => {
       const account = await insertAccount();
       const id = newSessionId();
-      const expiresAt = Date.now() + ONE_DAY_MS;
+      const expiresAt = fixtureNowPlus(ONE_DAY_MS);
 
       await db.insert(sessions).values({
         id,
         accountId: account.id,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         expiresAt,
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
@@ -358,7 +360,7 @@ describe("PG auth schema", () => {
       await db.insert(sessions).values({
         id,
         accountId: account.id,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
 
@@ -373,7 +375,7 @@ describe("PG auth schema", () => {
       await db.insert(sessions).values({
         id,
         accountId: account.id,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
 
@@ -394,7 +396,7 @@ describe("PG auth schema", () => {
         db.insert(sessions).values({
           id: newSessionId(),
           accountId: brandId<AccountId>("nonexistent"),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
           tokenHash: `tok_${crypto.randomUUID()}`,
         }),
       ).rejects.toThrow();
@@ -402,14 +404,14 @@ describe("PG auth schema", () => {
 
     it("rejects expiresAt <= createdAt via CHECK", async () => {
       const account = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(sessions).values({
           id: newSessionId(),
           accountId: account.id,
           createdAt: now,
-          expiresAt: now - 1000,
+          expiresAt: toUnixMillis(now - 1000),
           tokenHash: `tok_${crypto.randomUUID()}`,
         }),
       ).rejects.toThrow();
@@ -417,7 +419,7 @@ describe("PG auth schema", () => {
 
     it("rejects expiresAt === createdAt via CHECK (boundary)", async () => {
       const account = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(sessions).values({
@@ -433,7 +435,7 @@ describe("PG auth schema", () => {
     it("updates expiresAt from null to a value", async () => {
       const account = await insertAccount();
       const id = newSessionId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(sessions).values({
         id,
@@ -442,7 +444,7 @@ describe("PG auth schema", () => {
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
 
-      const expiresAt = now + ONE_DAY_MS;
+      const expiresAt = toUnixMillis(now + ONE_DAY_MS);
       await db.update(sessions).set({ expiresAt }).where(eq(sessions.id, id));
 
       const rows = await db.select().from(sessions).where(eq(sessions.id, id));
@@ -456,7 +458,7 @@ describe("PG auth schema", () => {
       await db.insert(sessions).values({
         id,
         accountId: account.id,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
 
@@ -473,7 +475,7 @@ describe("PG auth schema", () => {
         id,
         accountId: account.id,
         encryptedData: blob,
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         tokenHash: `tok_${crypto.randomUUID()}`,
       });
 
@@ -493,7 +495,7 @@ describe("PG auth schema", () => {
         accountId: account.id,
         encryptedMasterKey: masterKey,
         recoveryKeyHash: new Uint8Array(32),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       const rows = await db.select().from(recoveryKeys).where(eq(recoveryKeys.id, id));
@@ -510,7 +512,7 @@ describe("PG auth schema", () => {
         accountId: account.id,
         encryptedMasterKey: new Uint8Array([1, 2, 3]),
         recoveryKeyHash: new Uint8Array(32),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       const rows = await db.select().from(recoveryKeys).where(eq(recoveryKeys.id, id));
@@ -520,13 +522,13 @@ describe("PG auth schema", () => {
     it("round-trips revokedAt when set", async () => {
       const account = await insertAccount();
       const id = newRecoveryKeyId();
-      const revokedAt = Date.now();
+      const revokedAt = fixtureNow();
 
       await db.insert(recoveryKeys).values({
         id,
         accountId: account.id,
         encryptedMasterKey: new Uint8Array([1, 2, 3]),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
         revokedAt,
       });
 
@@ -543,7 +545,7 @@ describe("PG auth schema", () => {
         accountId: account.id,
         encryptedMasterKey: new Uint8Array([1]),
         recoveryKeyHash: new Uint8Array(32),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       await db.delete(accounts).where(eq(accounts.id, account.id));
@@ -558,7 +560,7 @@ describe("PG auth schema", () => {
           accountId: brandId<AccountId>("nonexistent"),
           encryptedMasterKey: new Uint8Array([1]),
           recoveryKeyHash: new Uint8Array(32),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -572,10 +574,10 @@ describe("PG auth schema", () => {
         accountId: account.id,
         encryptedMasterKey: new Uint8Array([1, 2, 3]),
         recoveryKeyHash: new Uint8Array(32),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
-      const revokedAt = Date.now();
+      const revokedAt = fixtureNow();
       await db.update(recoveryKeys).set({ revokedAt }).where(eq(recoveryKeys.id, id));
 
       const rows = await db.select().from(recoveryKeys).where(eq(recoveryKeys.id, id));
@@ -588,7 +590,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -598,7 +600,7 @@ describe("PG auth schema", () => {
         targetSessionId: target.id,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const rows = await db
@@ -615,7 +617,7 @@ describe("PG auth schema", () => {
     it("accepts targetSessionId as null", async () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -625,7 +627,7 @@ describe("PG auth schema", () => {
         targetSessionId: null,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const rows = await db
@@ -640,7 +642,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -650,7 +652,7 @@ describe("PG auth schema", () => {
         targetSessionId: target.id,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const rows = await db
@@ -664,7 +666,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
       const keyMaterial = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]);
 
@@ -676,7 +678,7 @@ describe("PG auth schema", () => {
         encryptedKeyMaterial: keyMaterial,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const rows = await db
@@ -690,7 +692,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -700,7 +702,7 @@ describe("PG auth schema", () => {
         targetSessionId: target.id,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const rows = await db
@@ -714,7 +716,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -726,7 +728,7 @@ describe("PG auth schema", () => {
         encryptedKeyMaterial: new Uint8Array([1, 2, 3]),
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const rows = await db
@@ -740,7 +742,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -751,7 +753,7 @@ describe("PG auth schema", () => {
         status: "expired",
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const rows = await db
@@ -765,7 +767,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(deviceTransferRequests).values({
@@ -776,7 +778,7 @@ describe("PG auth schema", () => {
           status: "invalid" as "pending",
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         }),
       ).rejects.toThrow();
     });
@@ -785,7 +787,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(deviceTransferRequests).values({
@@ -795,7 +797,7 @@ describe("PG auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now - 1000,
+          expiresAt: toUnixMillis(now - 1000),
         }),
       ).rejects.toThrow();
     });
@@ -804,7 +806,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(deviceTransferRequests).values({
@@ -823,7 +825,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -833,7 +835,7 @@ describe("PG auth schema", () => {
         targetSessionId: target.id,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       await db.delete(accounts).where(eq(accounts.id, account.id));
@@ -848,7 +850,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -858,7 +860,7 @@ describe("PG auth schema", () => {
         targetSessionId: target.id,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       await db.delete(sessions).where(eq(sessions.id, source.id));
@@ -872,7 +874,7 @@ describe("PG auth schema", () => {
     it("validates both source and target session FKs", async () => {
       const account = await insertAccount();
       const session = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(deviceTransferRequests).values({
@@ -882,7 +884,7 @@ describe("PG auth schema", () => {
           targetSessionId: session.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         }),
       ).rejects.toThrow();
 
@@ -894,7 +896,7 @@ describe("PG auth schema", () => {
           targetSessionId: brandId<SessionId>("nonexistent"),
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         }),
       ).rejects.toThrow();
     });
@@ -903,7 +905,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(deviceTransferRequests).values({
@@ -914,7 +916,7 @@ describe("PG auth schema", () => {
           status: "approved",
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         }),
       ).rejects.toThrow();
     });
@@ -923,7 +925,7 @@ describe("PG auth schema", () => {
       const account = await insertAccount();
       const source = await insertSession(account.id);
       const target = await insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       await db.insert(deviceTransferRequests).values({
@@ -933,7 +935,7 @@ describe("PG auth schema", () => {
         targetSessionId: target.id,
         codeSalt: TEST_CODE_SALT,
         createdAt: now,
-        expiresAt: now + ONE_HOUR_MS,
+        expiresAt: toUnixMillis(now + ONE_HOUR_MS),
       });
 
       const keyMaterial = new Uint8Array([10, 20, 30, 40]);

--- a/packages/db/src/__tests__/schema-pg-blob-metadata.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-blob-metadata.integration.test.ts
@@ -9,6 +9,7 @@ import { blobMetadata } from "../schema/pg/blob-metadata.js";
 import { buckets } from "../schema/pg/privacy.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgBlobMetadataTables,
   pgInsertAccount,
@@ -46,7 +47,7 @@ describe("PG blob_metadata schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(blobMetadata).values({
       id,
@@ -75,7 +76,7 @@ describe("PG blob_metadata schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const storageKey = `blobs/${crypto.randomUUID()}`;
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(blobMetadata).values({
       id: brandId<BlobId>(crypto.randomUUID()),
@@ -107,7 +108,7 @@ describe("PG blob_metadata schema", () => {
   it("rejects size_bytes <= 0", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(blobMetadata).values({
@@ -127,7 +128,7 @@ describe("PG blob_metadata schema", () => {
   it("rejects invalid encryption_tier", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       // @ts-expect-error — intentionally testing CHECK constraint with invalid tier value
@@ -148,7 +149,7 @@ describe("PG blob_metadata schema", () => {
   it("rejects invalid purpose", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(blobMetadata).values({
@@ -169,7 +170,7 @@ describe("PG blob_metadata schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(blobMetadata).values({
       id,
@@ -192,7 +193,7 @@ describe("PG blob_metadata schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const bucketId = brandId<BucketId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(buckets).values({
       id: bucketId,
@@ -254,7 +255,7 @@ describe("PG blob_metadata schema", () => {
   it("rejects checksum not exactly 64 characters", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(blobMetadata).values({
@@ -288,7 +289,7 @@ describe("PG blob_metadata schema", () => {
   it("accepts size_bytes at exactly 10 GB", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(blobMetadata).values({
       id: brandId<BlobId>(crypto.randomUUID()),
@@ -306,7 +307,7 @@ describe("PG blob_metadata schema", () => {
   it("rejects size_bytes exceeding 10 GB", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(blobMetadata).values({
@@ -327,7 +328,7 @@ describe("PG blob_metadata schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(blobMetadata).values({
       id,
@@ -350,7 +351,7 @@ describe("PG blob_metadata schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(blobMetadata).values({
       id,
@@ -375,7 +376,7 @@ describe("PG blob_metadata schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(blobMetadata).values({
       id,
@@ -389,7 +390,7 @@ describe("PG blob_metadata schema", () => {
       uploadedAt: now,
     });
 
-    const archiveTime = Date.now();
+    const archiveTime = fixtureNow();
     await db
       .update(blobMetadata)
       .set({ archived: true, archivedAt: archiveTime })
@@ -403,7 +404,7 @@ describe("PG blob_metadata schema", () => {
   it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       client.query(
@@ -427,7 +428,7 @@ describe("PG blob_metadata schema", () => {
   it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       client.query(

--- a/packages/db/src/__tests__/schema-pg-communication.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-communication.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -17,6 +17,7 @@ import {
 import { members } from "../schema/pg/members.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgCommunicationTables,
   pgInsertAccount,
@@ -91,7 +92,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const data = testBlob(new Uint8Array([10, 20, 30]));
       const id = brandId<ChannelId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(channels).values({
         id,
@@ -113,7 +114,7 @@ describe("PG communication schema", () => {
     it("rejects invalid type via CHECK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(channels).values({
@@ -131,7 +132,7 @@ describe("PG communication schema", () => {
     it("rejects negative sort_order via CHECK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(channels).values({
@@ -180,7 +181,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ChannelId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(channels).values({
         id,
@@ -204,7 +205,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(channels)
         .set({ archived: true, archivedAt: archiveTime })
@@ -218,7 +219,7 @@ describe("PG communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -231,7 +232,7 @@ describe("PG communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -248,7 +249,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
       const id = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([5, 6, 7]));
 
       await db.insert(messages).values({
@@ -274,7 +275,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
       const id = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(messages).values({
         id,
@@ -298,7 +299,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
       const id = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(messages).values({
         id,
@@ -310,7 +311,7 @@ describe("PG communication schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(messages)
         .set({ archived: true, archivedAt: archiveTime })
@@ -326,8 +327,8 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
       const id = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
-      const editedAt = now + 1000;
+      const now = fixtureNow();
+      const editedAt = toUnixMillis(now + 1000);
 
       await db.insert(messages).values({
         id,
@@ -348,7 +349,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const msgId = brandId<MessageId>(crypto.randomUUID());
 
       await db.insert(messages).values({
@@ -368,7 +369,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const msgId = brandId<MessageId>(crypto.randomUUID());
 
       await db.insert(messages).values({
@@ -390,7 +391,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -404,7 +405,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -418,7 +419,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<MessageId>(crypto.randomUUID());
 
       await db.insert(messages).values({
@@ -441,7 +442,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<MessageId>(crypto.randomUUID());
 
       await db.insert(messages).values({
@@ -471,7 +472,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const channelId = await insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<MessageId>(crypto.randomUUID());
 
       await db.insert(messages).values({
@@ -488,7 +489,7 @@ describe("PG communication schema", () => {
         id,
         channelId,
         systemId,
-        timestamp: now + 1000,
+        timestamp: toUnixMillis(now + 1000),
         encryptedData: testBlob(new Uint8Array([2])),
         createdAt: now,
         updatedAt: now,
@@ -504,7 +505,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(boardMessages).values({
         id,
@@ -526,7 +527,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(boardMessages).values({
         id,
@@ -545,7 +546,7 @@ describe("PG communication schema", () => {
     it("rejects negative sort_order via CHECK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(boardMessages).values({
@@ -563,7 +564,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(boardMessages).values({
         id,
@@ -583,7 +584,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(boardMessages).values({
         id,
@@ -603,7 +604,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(boardMessages).values({
         id,
@@ -625,7 +626,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(boardMessages).values({
         id,
@@ -636,7 +637,7 @@ describe("PG communication schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(boardMessages)
         .set({ archived: true, archivedAt: archiveTime })
@@ -650,7 +651,7 @@ describe("PG communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -663,7 +664,7 @@ describe("PG communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -679,7 +680,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notes).values({
         id,
@@ -700,7 +701,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notes).values({
         id,
@@ -747,7 +748,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notes).values({
         id,
@@ -766,7 +767,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notes).values({
         id,
@@ -787,7 +788,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notes).values({
         id,
@@ -797,7 +798,7 @@ describe("PG communication schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(notes)
         .set({ archived: true, archivedAt: archiveTime })
@@ -812,7 +813,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notes).values({
         id,
@@ -830,7 +831,7 @@ describe("PG communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -843,7 +844,7 @@ describe("PG communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -859,7 +860,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(polls).values({
         id,
@@ -893,7 +894,7 @@ describe("PG communication schema", () => {
     it("rejects invalid status via CHECK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(polls).values({
@@ -927,7 +928,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(polls).values({
         id,
@@ -961,7 +962,7 @@ describe("PG communication schema", () => {
     it("rejects invalid kind via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(polls).values({
@@ -984,7 +985,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(polls).values({
         id,
@@ -1006,7 +1007,7 @@ describe("PG communication schema", () => {
     it("rejects nonexistent createdByMemberId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(polls).values({
@@ -1039,7 +1040,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(polls).values({
         id,
@@ -1066,7 +1067,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(polls)
         .set({ archived: true, archivedAt: archiveTime })
@@ -1080,7 +1081,7 @@ describe("PG communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -1093,7 +1094,7 @@ describe("PG communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -1110,7 +1111,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20]));
 
       await db.insert(pollVotes).values({
@@ -1150,7 +1151,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const voteId = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(pollVotes).values({
         id: voteId,
@@ -1171,7 +1172,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const voteId = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(pollVotes).values({
         id: voteId,
@@ -1194,8 +1195,8 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
-      const votedAt = Date.now();
+      const now = fixtureNow();
+      const votedAt = fixtureNow();
 
       await db.insert(pollVotes).values({
         id,
@@ -1222,7 +1223,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(pollVotes).values({
         id,
@@ -1245,7 +1246,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(pollVotes).values({
         id,
@@ -1268,7 +1269,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(pollVotes).values({
         id,
@@ -1293,7 +1294,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(pollVotes).values({
         id,
@@ -1306,7 +1307,7 @@ describe("PG communication schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(pollVotes)
         .set({ archived: true, archivedAt: archiveTime })
@@ -1321,7 +1322,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -1335,7 +1336,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const pollId = await insertPoll(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -1351,7 +1352,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1370,7 +1371,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1389,7 +1390,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1409,7 +1410,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1428,7 +1429,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1447,7 +1448,7 @@ describe("PG communication schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1464,7 +1465,7 @@ describe("PG communication schema", () => {
     it("rejects nonexistent createdByMemberId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(acknowledgements).values({
@@ -1482,7 +1483,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1501,7 +1502,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1522,7 +1523,7 @@ describe("PG communication schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id,
@@ -1532,7 +1533,7 @@ describe("PG communication schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(acknowledgements)
         .set({ archived: true, archivedAt: archiveTime })
@@ -1546,7 +1547,7 @@ describe("PG communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -1559,7 +1560,7 @@ describe("PG communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(

--- a/packages/db/src/__tests__/schema-pg-custom-fields.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-custom-fields.integration.test.ts
@@ -16,6 +16,7 @@ import { buckets } from "../schema/pg/privacy.js";
 import { systemStructureEntities, systemStructureEntityTypes } from "../schema/pg/structure.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgCustomFieldsTables,
   pgInsertAccount,
@@ -61,7 +62,7 @@ describe("PG custom fields schema", () => {
     systemId: SystemId,
     id: BucketId = brandId<BucketId>(crypto.randomUUID()),
   ): Promise<BucketId> {
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(buckets).values({
       id,
       systemId,
@@ -76,7 +77,7 @@ describe("PG custom fields schema", () => {
     systemId: SystemId,
     id: FieldDefinitionId = brandId<FieldDefinitionId>(crypto.randomUUID()),
   ): Promise<FieldDefinitionId> {
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(fieldDefinitions).values({
       id,
       systemId,
@@ -109,7 +110,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(fieldDefinitions).values({
@@ -131,7 +132,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitions).values({
         id,
@@ -162,7 +163,7 @@ describe("PG custom fields schema", () => {
     });
 
     it("rejects nonexistent systemId FK", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       await expect(
         db.insert(fieldDefinitions).values({
           id: brandId<FieldDefinitionId>(crypto.randomUUID()),
@@ -179,7 +180,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitions).values({
         id,
@@ -201,7 +202,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitions).values({
         id,
@@ -212,7 +213,7 @@ describe("PG custom fields schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(fieldDefinitions)
         .set({ archived: true, archivedAt: archiveTime })
@@ -227,7 +228,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitions).values({
         id,
@@ -250,7 +251,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitions).values({
         id,
@@ -270,7 +271,7 @@ describe("PG custom fields schema", () => {
     it("rejects invalid fieldType via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldDefinitions).values({
@@ -287,7 +288,7 @@ describe("PG custom fields schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -300,7 +301,7 @@ describe("PG custom fields schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -317,7 +318,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(fieldValues).values({
@@ -341,7 +342,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id,
@@ -361,7 +362,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const valueId = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: valueId,
@@ -382,7 +383,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const valueId = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: valueId,
@@ -401,7 +402,7 @@ describe("PG custom fields schema", () => {
     it("rejects nonexistent fieldDefinitionId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldValues).values({
@@ -421,7 +422,7 @@ describe("PG custom fields schema", () => {
       const memberId = brandId<MemberId>(await pgInsertMember(db, systemId));
       const fieldDefId = await insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id,
@@ -443,7 +444,7 @@ describe("PG custom fields schema", () => {
       const memberId1 = brandId<MemberId>(await pgInsertMember(db, systemId));
       const memberId2 = brandId<MemberId>(await pgInsertMember(db, systemId));
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),
@@ -476,7 +477,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = brandId<MemberId>(await pgInsertMember(db, systemId));
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),
@@ -505,7 +506,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),
@@ -533,7 +534,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = brandId<MemberId>(await pgInsertMember(db, systemId));
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),
@@ -565,7 +566,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id,
@@ -721,7 +722,7 @@ describe("PG custom fields schema", () => {
       systemId: SystemId,
       id = brandId<SystemStructureEntityTypeId>(crypto.randomUUID()),
     ): Promise<SystemStructureEntityTypeId> {
-      const now = Date.now();
+      const now = fixtureNow();
       await db.insert(systemStructureEntityTypes).values({
         id,
         systemId,
@@ -738,7 +739,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const id = brandId<FieldDefinitionScopeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitionScopes).values({
         id,
@@ -763,7 +764,7 @@ describe("PG custom fields schema", () => {
     it("rejects nonexistent field_definition_id FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldDefinitionScopes).values({
@@ -781,7 +782,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldDefinitionScopes).values({
@@ -800,7 +801,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -815,7 +816,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const entityTypeId = brandId<SystemStructureEntityTypeId>(await insertEntityType(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -829,7 +830,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitionScopes).values({
         id: brandId<FieldDefinitionScopeId>(crypto.randomUUID()),
@@ -856,7 +857,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -871,7 +872,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const id = brandId<FieldDefinitionScopeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitionScopes).values({
         id,
@@ -894,7 +895,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldDefinitionScopes).values({
         id: brandId<FieldDefinitionScopeId>(crypto.randomUUID()),
@@ -916,7 +917,7 @@ describe("PG custom fields schema", () => {
       systemId: SystemId,
       id = brandId<SystemStructureEntityTypeId>(crypto.randomUUID()),
     ): Promise<SystemStructureEntityTypeId> {
-      const now = Date.now();
+      const now = fixtureNow();
       await db.insert(systemStructureEntityTypes).values({
         id,
         systemId,
@@ -933,7 +934,7 @@ describe("PG custom fields schema", () => {
       entityTypeId: SystemStructureEntityTypeId,
       id = brandId<SystemStructureEntityId>(crypto.randomUUID()),
     ): Promise<SystemStructureEntityId> {
-      const now = Date.now();
+      const now = fixtureNow();
       await db.insert(systemStructureEntities).values({
         id,
         systemId,
@@ -948,7 +949,7 @@ describe("PG custom fields schema", () => {
 
     async function insertGroup(systemId: string, raw = crypto.randomUUID()): Promise<GroupId> {
       const id = brandId<GroupId>(raw);
-      const now = Date.now();
+      const now = fixtureNow();
       await db.insert(groups).values({
         id,
         systemId: brandId<SystemId>(systemId),
@@ -967,7 +968,7 @@ describe("PG custom fields schema", () => {
       const entityTypeId = brandId<SystemStructureEntityTypeId>(await insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(await insertEntity(systemId, entityTypeId));
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id,
@@ -992,7 +993,7 @@ describe("PG custom fields schema", () => {
       const fieldDefId = await insertFieldDefinition(systemId);
       const groupId = brandId<GroupId>(await insertGroup(systemId));
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id,
@@ -1018,7 +1019,7 @@ describe("PG custom fields schema", () => {
       const memberId = brandId<MemberId>(await pgInsertMember(db, systemId));
       const entityTypeId = brandId<SystemStructureEntityTypeId>(await insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(await insertEntity(systemId, entityTypeId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldValues).values({
@@ -1040,7 +1041,7 @@ describe("PG custom fields schema", () => {
       const fieldDefId = await insertFieldDefinition(systemId);
       const memberId = brandId<MemberId>(await pgInsertMember(db, systemId));
       const groupId = brandId<GroupId>(await insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldValues).values({
@@ -1063,7 +1064,7 @@ describe("PG custom fields schema", () => {
       const entityTypeId = brandId<SystemStructureEntityTypeId>(await insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(await insertEntity(systemId, entityTypeId));
       const groupId = brandId<GroupId>(await insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldValues).values({
@@ -1087,7 +1088,7 @@ describe("PG custom fields schema", () => {
       const entityTypeId = brandId<SystemStructureEntityTypeId>(await insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(await insertEntity(systemId, entityTypeId));
       const groupId = brandId<GroupId>(await insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldValues).values({
@@ -1110,7 +1111,7 @@ describe("PG custom fields schema", () => {
       const fieldDefId = await insertFieldDefinition(systemId);
       const entityTypeId = brandId<SystemStructureEntityTypeId>(await insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(await insertEntity(systemId, entityTypeId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),
@@ -1132,7 +1133,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const groupId = brandId<GroupId>(await insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),
@@ -1151,7 +1152,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldValues).values({
@@ -1170,7 +1171,7 @@ describe("PG custom fields schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(fieldValues).values({
@@ -1191,7 +1192,7 @@ describe("PG custom fields schema", () => {
       const fieldDefId = await insertFieldDefinition(systemId);
       const entityTypeId = brandId<SystemStructureEntityTypeId>(await insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(await insertEntity(systemId, entityTypeId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),
@@ -1221,7 +1222,7 @@ describe("PG custom fields schema", () => {
       const systemId = await insertSystem(accountId);
       const fieldDefId = await insertFieldDefinition(systemId);
       const groupId = brandId<GroupId>(await insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(fieldValues).values({
         id: brandId<FieldValueId>(crypto.randomUUID()),

--- a/packages/db/src/__tests__/schema-pg-fronting.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-fronting.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -9,6 +9,7 @@ import { customFronts, frontingComments, frontingSessions } from "../schema/pg/f
 import { members } from "../schema/pg/members.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgFrontingTables,
   pgInsertAccount,
@@ -22,6 +23,7 @@ import type {
   FrontingCommentId,
   FrontingSessionId,
   SystemId,
+  UnixMillis,
 } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
@@ -47,7 +49,7 @@ describe("PG fronting schema", () => {
     raw = crypto.randomUUID(),
   ): Promise<CustomFrontId> {
     const id = brandId<CustomFrontId>(raw);
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(customFronts).values({
       id,
       systemId: brandId<SystemId>(systemId),
@@ -61,9 +63,9 @@ describe("PG fronting schema", () => {
   async function insertFrontingSession(
     systemId: SystemId,
     id = crypto.randomUUID(),
-  ): Promise<{ id: FrontingSessionId; startTime: number }> {
+  ): Promise<{ id: FrontingSessionId; startTime: UnixMillis }> {
     const sessionId = brandId<FrontingSessionId>(id);
-    const now = Date.now();
+    const now = fixtureNow();
     const memberId = await insertMember(systemId);
     await db.insert(frontingSessions).values({
       id: sessionId,
@@ -99,14 +101,14 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(frontingSessions).values({
         id,
         systemId,
         startTime: now,
-        endTime: now + 60000,
+        endTime: toUnixMillis(now + 60000),
         memberId,
         encryptedData: data,
         createdAt: now,
@@ -126,7 +128,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -147,7 +149,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -189,8 +191,8 @@ describe("PG fronting schema", () => {
           startTime,
           memberId,
           encryptedData: testBlob(new Uint8Array([1])),
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
+          createdAt: fixtureNow(),
+          updatedAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -200,7 +202,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -215,11 +217,11 @@ describe("PG fronting schema", () => {
       await db.insert(frontingSessions).values({
         id,
         systemId,
-        startTime: now + 60000,
+        startTime: toUnixMillis(now + 60000),
         memberId,
         encryptedData: testBlob(new Uint8Array([2])),
-        createdAt: now + 60000,
-        updatedAt: now + 60000,
+        createdAt: toUnixMillis(now + 60000),
+        updatedAt: toUnixMillis(now + 60000),
       });
 
       const rows = await db.select().from(frontingSessions).where(eq(frontingSessions.id, id));
@@ -227,7 +229,7 @@ describe("PG fronting schema", () => {
     });
 
     it("rejects nonexistent systemId FK", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       await expect(
         db.insert(frontingSessions).values({
           id: brandId<FrontingSessionId>(crypto.randomUUID()),
@@ -245,7 +247,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(frontingSessions).values({
@@ -265,7 +267,7 @@ describe("PG fronting schema", () => {
           id: brandId<FrontingSessionId>(crypto.randomUUID()),
           systemId,
           startTime: now,
-          endTime: now - 1000,
+          endTime: toUnixMillis(now - 1000),
           memberId,
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -278,7 +280,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       const id1 = brandId<FrontingSessionId>(crypto.randomUUID());
       const id2 = brandId<FrontingSessionId>(crypto.randomUUID());
@@ -287,7 +289,7 @@ describe("PG fronting schema", () => {
         id: id1,
         systemId,
         startTime: now,
-        endTime: now + 60000,
+        endTime: toUnixMillis(now + 60000),
         memberId,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -297,8 +299,8 @@ describe("PG fronting schema", () => {
       await db.insert(frontingSessions).values({
         id: id2,
         systemId,
-        startTime: now + 30000,
-        endTime: now + 90000,
+        startTime: toUnixMillis(now + 30000),
+        endTime: toUnixMillis(now + 90000),
         memberId,
         encryptedData: testBlob(new Uint8Array([2])),
         createdAt: now,
@@ -318,7 +320,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const cfId = await insertCustomFront(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       const entityTypeId = crypto.randomUUID();
       const entityId = crypto.randomUUID();
@@ -354,7 +356,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const customFrontId = await insertCustomFront(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -377,7 +379,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -395,7 +397,7 @@ describe("PG fronting schema", () => {
     it("rejects nonexistent memberId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(frontingSessions).values({
@@ -415,7 +417,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const customFrontId = await insertCustomFront(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -435,7 +437,7 @@ describe("PG fronting schema", () => {
     it("rejects nonexistent customFrontId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(frontingSessions).values({
@@ -453,7 +455,7 @@ describe("PG fronting schema", () => {
     it("rejects version < 1 via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -466,7 +468,7 @@ describe("PG fronting schema", () => {
     it("rejects fronting session with no subject", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -481,7 +483,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const customFrontId = await insertCustomFront(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -514,7 +516,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id,
@@ -538,7 +540,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const { id, startTime } = await insertFrontingSession(systemId);
 
-      const now = Date.now();
+      const now = fixtureNow();
       await db
         .update(frontingSessions)
         .set({ archived: true, archivedAt: now })
@@ -552,7 +554,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -566,7 +568,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -579,7 +581,7 @@ describe("PG fronting schema", () => {
     it("accepts fronting session with only structureEntityId", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const entityTypeId = crypto.randomUUID();
       const entityId = crypto.randomUUID();
 
@@ -613,7 +615,7 @@ describe("PG fronting schema", () => {
     it("rejects nonexistent structureEntityId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(frontingSessions).values({
@@ -631,7 +633,7 @@ describe("PG fronting schema", () => {
     it("restricts deletion of structure entity with dependent fronting session", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const entityTypeId = crypto.randomUUID();
       const entityId = crypto.randomUUID();
 
@@ -665,7 +667,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(customFronts).values({
@@ -686,7 +688,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(customFronts).values({
         id,
@@ -706,7 +708,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(customFronts).values({
         id,
@@ -725,7 +727,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(customFronts).values({
         id,
@@ -747,7 +749,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const id = await insertCustomFront(systemId);
 
-      const now = Date.now();
+      const now = fixtureNow();
       await db
         .update(customFronts)
         .set({ archived: true, archivedAt: now })
@@ -760,7 +762,7 @@ describe("PG fronting schema", () => {
     it("rejects version < 1 via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -773,7 +775,7 @@ describe("PG fronting schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -786,7 +788,7 @@ describe("PG fronting schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -804,7 +806,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(frontingComments).values({
@@ -831,7 +833,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id,
@@ -854,7 +856,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const commentId = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id: commentId,
@@ -885,7 +887,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const commentId = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id: commentId,
@@ -910,7 +912,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(frontingComments).values({
@@ -931,14 +933,14 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(frontingComments).values({
           id: brandId<FrontingCommentId>(crypto.randomUUID()),
           frontingSessionId: sessionId,
           systemId,
-          sessionStartTime: sessionStartTime + 99999,
+          sessionStartTime: toUnixMillis(sessionStartTime + 99999),
           memberId,
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -953,7 +955,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id,
@@ -976,7 +978,7 @@ describe("PG fronting schema", () => {
       const customFrontId = await insertCustomFront(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id,
@@ -999,7 +1001,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id,
@@ -1019,7 +1021,7 @@ describe("PG fronting schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(frontingComments).values({
@@ -1041,7 +1043,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id,
@@ -1065,7 +1067,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id,
@@ -1091,7 +1093,7 @@ describe("PG fronting schema", () => {
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingComments).values({
         id,
@@ -1104,7 +1106,7 @@ describe("PG fronting schema", () => {
         updatedAt: now,
       });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(frontingComments)
         .set({ archived: true, archivedAt: updateNow })
@@ -1119,7 +1121,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -1134,7 +1136,7 @@ describe("PG fronting schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const { id: sessionId, startTime: sessionStartTime } = await insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(

--- a/packages/db/src/__tests__/schema-pg-groups.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-groups.integration.test.ts
@@ -9,6 +9,7 @@ import { groupMemberships, groups } from "../schema/pg/groups.js";
 import { members } from "../schema/pg/members.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgGroupsTables,
   pgInsertAccount,
@@ -42,7 +43,7 @@ describe("PG groups schema", () => {
     raw = crypto.randomUUID(),
   ): Promise<GroupId> {
     const id = brandId<GroupId>(raw);
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(groups).values({
       id,
       systemId: brandId<SystemId>(systemId),
@@ -63,7 +64,7 @@ describe("PG groups schema", () => {
     memberId: string,
     systemId: string,
   ): Promise<void> {
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(groupMemberships).values({
       groupId,
       memberId,
@@ -94,7 +95,7 @@ describe("PG groups schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<GroupId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(groups).values({
@@ -136,7 +137,7 @@ describe("PG groups schema", () => {
     it("rejects negative sort_order via CHECK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(groups).values({
@@ -154,7 +155,7 @@ describe("PG groups schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<GroupId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(groups).values({
         id,
@@ -175,7 +176,7 @@ describe("PG groups schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<GroupId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(groups).values({
         id,
@@ -197,7 +198,7 @@ describe("PG groups schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<GroupId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(groups).values({
         id,
@@ -208,7 +209,7 @@ describe("PG groups schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(groups)
         .set({ archived: true, archivedAt: archiveTime })
@@ -232,7 +233,7 @@ describe("PG groups schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -245,7 +246,7 @@ describe("PG groups schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -264,7 +265,7 @@ describe("PG groups schema", () => {
       const systemId = await insertSystem(accountId);
       const groupId = await insertGroup(systemId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(groupMemberships).values({
         groupId,
@@ -311,7 +312,7 @@ describe("PG groups schema", () => {
       const systemId = await insertSystem(accountId);
       const groupId = await insertGroup(systemId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(groupMemberships).values({
         groupId,

--- a/packages/db/src/__tests__/schema-pg-import-export.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-import-export.integration.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../schema/pg/import-export.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgImportExportTables,
   pgInsertAccount,
@@ -59,7 +60,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importJobs).values({
         id,
@@ -97,7 +98,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importJobs).values({
         id,
@@ -123,7 +124,7 @@ describe("PG import-export schema", () => {
     it("rejects negative progressPercent", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(importJobs).values({
@@ -142,7 +143,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importJobs).values({
         id,
@@ -162,7 +163,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importJobs).values({
         id,
@@ -181,7 +182,7 @@ describe("PG import-export schema", () => {
     it("rejects progressPercent above 100", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(importJobs).values({
@@ -199,7 +200,7 @@ describe("PG import-export schema", () => {
     it("rejects invalid source value", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(importJobs).values({
@@ -216,7 +217,7 @@ describe("PG import-export schema", () => {
     it("rejects invalid status value", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(importJobs).values({
@@ -235,7 +236,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importJobs).values({
         id,
@@ -254,7 +255,7 @@ describe("PG import-export schema", () => {
     it("rejects chunksCompleted exceeding chunksTotal", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(importJobs).values({
@@ -274,7 +275,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importJobs).values({
         id,
@@ -294,7 +295,7 @@ describe("PG import-export schema", () => {
       const accountA = await insertAccount();
       const accountB = await insertAccount();
       const systemOfB = await insertSystem(accountB);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(importJobs).values({
@@ -312,7 +313,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const errors = [
         {
           entityType: "unknown" as const,
@@ -347,7 +348,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const errors = Array.from({ length: 1000 }, (_, i) => ({
         entityType: "unknown" as const,
         entityId: null,
@@ -372,7 +373,7 @@ describe("PG import-export schema", () => {
     it("rejects errorLog with more than 1000 entries", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const errors = Array.from({ length: 1001 }, (_, i) => ({
         entityType: "unknown" as const,
         entityId: null,
@@ -399,7 +400,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(exportRequests).values({
         id,
@@ -426,7 +427,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(exportRequests).values({
         id,
@@ -447,7 +448,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(exportRequests).values({
         id,
@@ -466,7 +467,7 @@ describe("PG import-export schema", () => {
     it("rejects invalid format value", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(exportRequests).values({
@@ -484,7 +485,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(exportRequests).values({
         id,
@@ -504,7 +505,7 @@ describe("PG import-export schema", () => {
       const accountA = await insertAccount();
       const accountB = await insertAccount();
       const systemOfB = await insertSystem(accountB);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(exportRequests).values({
@@ -522,7 +523,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(exportRequests).values({
         id,
@@ -543,7 +544,7 @@ describe("PG import-export schema", () => {
     it("round-trips all fields including all timestamps", async () => {
       const accountId = await insertAccount();
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(accountPurgeRequests).values({
         id,
@@ -575,7 +576,7 @@ describe("PG import-export schema", () => {
     it("applies default status of pending", async () => {
       const accountId = await insertAccount();
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(accountPurgeRequests).values({
         id,
@@ -594,7 +595,7 @@ describe("PG import-export schema", () => {
 
     it("rejects invalid status value", async () => {
       const accountId = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(accountPurgeRequests).values({
@@ -611,7 +612,7 @@ describe("PG import-export schema", () => {
     it("cascades on account deletion", async () => {
       const accountId = await insertAccount();
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(accountPurgeRequests).values({
         id,
@@ -633,7 +634,7 @@ describe("PG import-export schema", () => {
     it("allows nullable confirmedAt, completedAt, and cancelledAt", async () => {
       const accountId = await insertAccount();
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(accountPurgeRequests).values({
         id,
@@ -656,7 +657,7 @@ describe("PG import-export schema", () => {
 
     it("rejects second active purge request when first is confirmed", async () => {
       const accountId = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       await db.insert(accountPurgeRequests).values({
@@ -686,7 +687,7 @@ describe("PG import-export schema", () => {
 
     it("allows new purge request after previous is completed", async () => {
       const accountId = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       await db.insert(accountPurgeRequests).values({
@@ -722,7 +723,7 @@ describe("PG import-export schema", () => {
 
     it("allows new purge request after previous is cancelled", async () => {
       const accountId = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       await db.insert(accountPurgeRequests).values({
@@ -758,7 +759,7 @@ describe("PG import-export schema", () => {
 
     it("rejects second active purge request when first is processing", async () => {
       const accountId = await insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       await db.insert(accountPurgeRequests).values({
@@ -792,7 +793,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       const state: ImportCheckpointState = {
         schemaVersion: 2,
@@ -841,7 +842,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importJobs).values({
         id,
@@ -869,7 +870,7 @@ describe("PG import-export schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importEntityRefs).values({
         id,
@@ -892,7 +893,7 @@ describe("PG import-export schema", () => {
     it("enforces unique (account, system, source, type, sourceId)", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(importEntityRefs).values({
         id: crypto.randomUUID(),
@@ -932,7 +933,7 @@ describe("PG import-export schema", () => {
           sourceEntityType: "member",
           sourceEntityId: "x",
           pluralscapeEntityId: "y",
-          importedAt: Date.now(),
+          importedAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -949,7 +950,7 @@ describe("PG import-export schema", () => {
         sourceEntityType: "member",
         sourceEntityId: "sys-cascade-check",
         pluralscapeEntityId: "mem_sys_cascade",
-        importedAt: Date.now(),
+        importedAt: fixtureNow(),
       });
 
       await db.delete(systems).where(eq(systems.id, systemId));
@@ -974,7 +975,7 @@ describe("PG import-export schema", () => {
           sourceEntityType: "not-a-real-type" as never,
           sourceEntityId: "x",
           pluralscapeEntityId: "y",
-          importedAt: Date.now(),
+          importedAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -991,7 +992,7 @@ describe("PG import-export schema", () => {
         sourceEntityType: "member",
         sourceEntityId: "abc-cascade",
         pluralscapeEntityId: "mem_cascade_target",
-        importedAt: Date.now(),
+        importedAt: fixtureNow(),
       });
 
       await db.delete(accounts).where(eq(accounts.id, accountId));

--- a/packages/db/src/__tests__/schema-pg-innerworld.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-innerworld.integration.test.ts
@@ -10,6 +10,7 @@ import {
   innerworldRegions,
 } from "../schema/pg/innerworld.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgInnerworldTables,
   pgInsertAccount,
@@ -54,7 +55,7 @@ describe("PG Innerworld Schema", () => {
 
   it("round-trips innerworldRegions with all fields", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     await db.insert(innerworldRegions).values({
@@ -85,7 +86,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_regions defaults archived to false and archivedAt to null", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     await db.insert(innerworldRegions).values({
@@ -106,7 +107,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_regions round-trips archived: true with archivedAt", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     await db.insert(innerworldRegions).values({
@@ -129,7 +130,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_regions updates archived from false to true", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     await db.insert(innerworldRegions).values({
@@ -140,7 +141,7 @@ describe("PG Innerworld Schema", () => {
       updatedAt: now,
     });
 
-    const archiveTime = Date.now();
+    const archiveTime = fixtureNow();
     await db
       .update(innerworldRegions)
       .set({ archived: true, archivedAt: archiveTime })
@@ -156,7 +157,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_regions rejects archived=true with archivedAt=null via CHECK", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       client.query(
@@ -168,7 +169,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_regions rejects archived=false with archivedAt set via CHECK", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       client.query(
@@ -180,7 +181,7 @@ describe("PG Innerworld Schema", () => {
 
   it("round-trips innerworldEntities with all fields", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const entityId = newEntityId();
 
     await db.insert(innerworldEntities).values({
@@ -207,7 +208,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_entities defaults archived to false and archivedAt to null", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const entityId = newEntityId();
 
     await db.insert(innerworldEntities).values({
@@ -228,7 +229,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_entities round-trips archived: true with archivedAt", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const entityId = newEntityId();
 
     await db.insert(innerworldEntities).values({
@@ -251,7 +252,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_entities updates archived from false to true", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const entityId = newEntityId();
 
     await db.insert(innerworldEntities).values({
@@ -262,7 +263,7 @@ describe("PG Innerworld Schema", () => {
       updatedAt: now,
     });
 
-    const archiveTime = Date.now();
+    const archiveTime = fixtureNow();
     await db
       .update(innerworldEntities)
       .set({ archived: true, archivedAt: archiveTime })
@@ -278,7 +279,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_entities rejects archived=true with archivedAt=null via CHECK", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       client.query(
@@ -290,7 +291,7 @@ describe("PG Innerworld Schema", () => {
 
   it("innerworld_entities rejects archived=false with archivedAt set via CHECK", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       client.query(
@@ -302,7 +303,7 @@ describe("PG Innerworld Schema", () => {
 
   it("round-trips innerworldCanvas (1:1 pattern, systemId as PK)", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(innerworldCanvas).values({
       systemId,
@@ -323,7 +324,7 @@ describe("PG Innerworld Schema", () => {
 
   it("restricts parent region deletion when referenced by child region", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const parentId = newRegionId();
 
     await db.insert(innerworldRegions).values({
@@ -350,7 +351,7 @@ describe("PG Innerworld Schema", () => {
 
   it("restricts region deletion when referenced by entity", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     await db.insert(innerworldRegions).values({
@@ -377,7 +378,7 @@ describe("PG Innerworld Schema", () => {
 
   it("cascades system delete to all 3 innerworld tables", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     await db.insert(innerworldRegions).values({
@@ -427,7 +428,7 @@ describe("PG Innerworld Schema", () => {
 
   it("enforces canvas 1:1 pattern (PK violation on duplicate systemId)", async () => {
     const systemId = await setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(innerworldCanvas).values({
       systemId,

--- a/packages/db/src/__tests__/schema-pg-journal.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-journal.integration.test.ts
@@ -9,6 +9,7 @@ import { frontingSessions } from "../schema/pg/fronting.js";
 import { journalEntries, wikiPages } from "../schema/pg/journal.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgJournalTables,
   pgInsertAccount,
@@ -50,7 +51,7 @@ describe("PG journal schema", () => {
       const systemId = await insertSystem(accountId);
       const fsId = brandId<FrontingSessionId>(crypto.randomUUID());
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30]));
 
       const memberId = await pgInsertMember(db, systemId);
@@ -84,7 +85,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(journalEntries).values({
         id,
@@ -102,7 +103,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(journalEntries).values({
         id,
@@ -122,7 +123,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(journalEntries).values({
         id,
@@ -143,7 +144,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(journalEntries).values({
         id,
@@ -153,7 +154,7 @@ describe("PG journal schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(journalEntries)
         .set({ archived: true, archivedAt: archiveTime })
@@ -168,7 +169,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(journalEntries).values({
         id,
@@ -186,7 +187,7 @@ describe("PG journal schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -199,7 +200,7 @@ describe("PG journal schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -215,7 +216,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30]));
       const hash = brandId<SlugHash>("a".repeat(64));
 
@@ -238,7 +239,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(wikiPages).values({
         id,
@@ -259,7 +260,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(wikiPages).values({
         id,
@@ -270,7 +271,7 @@ describe("PG journal schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(wikiPages)
         .set({ archived: true, archivedAt: archiveTime })
@@ -285,7 +286,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const slugHash = brandId<SlugHash>("b".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(wikiPages).values({
         id: brandId<WikiPageId>(crypto.randomUUID()),
@@ -313,7 +314,7 @@ describe("PG journal schema", () => {
       const systemId1 = await insertSystem(accountId);
       const systemId2 = await insertSystem(accountId);
       const slugHash = brandId<SlugHash>("c".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(wikiPages).values({
         id: brandId<WikiPageId>(crypto.randomUUID()),
@@ -343,7 +344,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(wikiPages).values({
         id,
@@ -362,7 +363,7 @@ describe("PG journal schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -375,7 +376,7 @@ describe("PG journal schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -388,7 +389,7 @@ describe("PG journal schema", () => {
     it("rejects slug_hash shorter than 64 chars", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(wikiPages).values({
@@ -406,7 +407,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const slugHash = brandId<SlugHash>("h".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(wikiPages).values({
         id: brandId<WikiPageId>(crypto.randomUUID()),
@@ -438,7 +439,7 @@ describe("PG journal schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const slugHash = brandId<SlugHash>("i".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(wikiPages).values({
         id: brandId<WikiPageId>(crypto.randomUUID()),

--- a/packages/db/src/__tests__/schema-pg-key-rotation.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-key-rotation.integration.test.ts
@@ -8,6 +8,7 @@ import { bucketKeyRotations, bucketRotationItems } from "../schema/pg/key-rotati
 import { buckets } from "../schema/pg/privacy.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgKeyRotationTables,
   pgInsertAccount,
@@ -21,6 +22,7 @@ import type {
   BucketKeyRotationId,
   BucketRotationItemId,
   SystemId,
+  UnixMillis,
 } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
@@ -37,7 +39,7 @@ describe("PG key-rotation schema", () => {
     systemId: SystemId,
     id: BucketId = brandId<BucketId>(crypto.randomUUID()),
   ): Promise<BucketId> {
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(buckets).values({
       id,
       systemId,
@@ -56,7 +58,7 @@ describe("PG key-rotation schema", () => {
       fromKeyVersion: number;
       toKeyVersion: number;
       totalItems: number;
-      initiatedAt: number;
+      initiatedAt: UnixMillis;
     }> = {},
   ): Promise<BucketKeyRotationId> {
     const id = overrides.id ?? brandId<BucketKeyRotationId>(crypto.randomUUID());
@@ -67,7 +69,7 @@ describe("PG key-rotation schema", () => {
       fromKeyVersion: overrides.fromKeyVersion ?? 1,
       toKeyVersion: overrides.toKeyVersion ?? 2,
       totalItems: overrides.totalItems ?? 10,
-      initiatedAt: overrides.initiatedAt ?? Date.now(),
+      initiatedAt: overrides.initiatedAt ?? fixtureNow(),
     });
     return id;
   }
@@ -87,7 +89,7 @@ describe("PG key-rotation schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const bucketId = await insertBucket(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<BucketKeyRotationId>(crypto.randomUUID());
 
       await db.insert(bucketKeyRotations).values({
@@ -126,7 +128,7 @@ describe("PG key-rotation schema", () => {
           toKeyVersion: 2,
           state: "invalid" as "initiated",
           totalItems: 1,
-          initiatedAt: Date.now(),
+          initiatedAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -144,7 +146,7 @@ describe("PG key-rotation schema", () => {
           fromKeyVersion: 3,
           toKeyVersion: 2,
           totalItems: 1,
-          initiatedAt: Date.now(),
+          initiatedAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -162,7 +164,7 @@ describe("PG key-rotation schema", () => {
           fromKeyVersion: 2,
           toKeyVersion: 2,
           totalItems: 1,
-          initiatedAt: Date.now(),
+          initiatedAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -180,7 +182,7 @@ describe("PG key-rotation schema", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         totalItems: 1,
-        initiatedAt: Date.now(),
+        initiatedAt: fixtureNow(),
       });
 
       for (const nextState of ["migrating", "sealing", "completed"] as const) {
@@ -209,7 +211,7 @@ describe("PG key-rotation schema", () => {
         fromKeyVersion: 1,
         toKeyVersion: 2,
         totalItems: 5,
-        initiatedAt: Date.now(),
+        initiatedAt: fixtureNow(),
       });
 
       await expect(
@@ -246,7 +248,7 @@ describe("PG key-rotation schema", () => {
         entityId: crypto.randomUUID(),
         status: "claimed",
         claimedBy: "worker-1",
-        claimedAt: Date.now(),
+        claimedAt: fixtureNow(),
         attempts: 1,
       });
 

--- a/packages/db/src/__tests__/schema-pg-lifecycle-events.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-lifecycle-events.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { lifecycleEvents } from "../schema/pg/lifecycle-events.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow, fixtureNowPlus } from "./fixtures/timestamps.js";
 import {
   createPgLifecycleEventsTables,
   pgInsertAccount,
@@ -39,8 +40,8 @@ describe("PG lifecycle_events schema", () => {
   it("inserts and retrieves with all columns", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const occurredAt = Date.now() - 86400000;
-    const recordedAt = Date.now();
+    const occurredAt = fixtureNowPlus(-86400000);
+    const recordedAt = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
@@ -65,7 +66,7 @@ describe("PG lifecycle_events schema", () => {
   it("round-trips encrypted_data binary correctly", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
@@ -88,16 +89,16 @@ describe("PG lifecycle_events schema", () => {
   it("supports multiple events per system (append-only pattern)", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     for (let i = 0; i < 3; i++) {
       await db.insert(lifecycleEvents).values({
         id: brandId<LifecycleEventId>(crypto.randomUUID()),
         systemId,
         eventType: "discovery",
-        occurredAt: now + i * 1000,
-        recordedAt: now + i * 1000,
-        updatedAt: now + i * 1000,
+        occurredAt: toUnixMillis(now + i * 1000),
+        recordedAt: toUnixMillis(now + i * 1000),
+        updatedAt: toUnixMillis(now + i * 1000),
         encryptedData: testBlob(new Uint8Array([i])),
       });
     }
@@ -112,7 +113,7 @@ describe("PG lifecycle_events schema", () => {
   it("cascades on system deletion", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
     await db.insert(lifecycleEvents).values({
@@ -131,7 +132,7 @@ describe("PG lifecycle_events schema", () => {
   });
 
   it("rejects nonexistent systemId FK", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     await expect(
       db.insert(lifecycleEvents).values({
         id: brandId<LifecycleEventId>(crypto.randomUUID()),
@@ -160,7 +161,7 @@ describe("PG lifecycle_events schema", () => {
   it("rejects duplicate primary key", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
     await db.insert(lifecycleEvents).values({
@@ -189,8 +190,8 @@ describe("PG lifecycle_events schema", () => {
   it("stores separate occurred_at and recorded_at timestamps", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const occurredAt = Date.now() - 604800000; // 1 week ago
-    const recordedAt = Date.now();
+    const occurredAt = fixtureNowPlus(-604800000); // 1 week ago
+    const recordedAt = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
     await db.insert(lifecycleEvents).values({
@@ -213,7 +214,7 @@ describe("PG lifecycle_events schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(lifecycleEvents).values({
       id,
@@ -233,7 +234,7 @@ describe("PG lifecycle_events schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(lifecycleEvents).values({
       id,
@@ -252,7 +253,7 @@ describe("PG lifecycle_events schema", () => {
   it("rejects invalid eventType via CHECK constraint", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await expect(
       db.insert(lifecycleEvents).values({
@@ -271,7 +272,7 @@ describe("PG lifecycle_events schema", () => {
     it("defaults archived to false and archivedAt to null on insert", async () => {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
       const rows = await db
@@ -294,7 +295,7 @@ describe("PG lifecycle_events schema", () => {
     it("defaults version to 1 on insert", async () => {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
       const rows = await db
@@ -316,7 +317,7 @@ describe("PG lifecycle_events schema", () => {
     it("rejects archived=true with archivedAt=null via consistency check", async () => {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(lifecycleEvents).values({
@@ -336,7 +337,7 @@ describe("PG lifecycle_events schema", () => {
     it("rejects archived=false with archivedAt set via consistency check", async () => {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(lifecycleEvents).values({
@@ -356,7 +357,7 @@ describe("PG lifecycle_events schema", () => {
     it("rejects version < 1 via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(

--- a/packages/db/src/__tests__/schema-pg-members.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-members.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { members, memberPhotos } from "../schema/pg/members.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgMemberTables,
   pgInsertAccount,
@@ -29,7 +30,7 @@ describe("PG members schema", () => {
 
   async function insertMember(systemId: string, raw = crypto.randomUUID()): Promise<MemberId> {
     const id = brandId<MemberId>(raw);
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(members).values({
       id,
       systemId,
@@ -60,7 +61,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(members).values({
@@ -81,7 +82,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(members).values({
         id,
@@ -100,7 +101,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(members).values({
         id,
@@ -125,7 +126,7 @@ describe("PG members schema", () => {
     });
 
     it("rejects nonexistent systemId FK", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       await expect(
         db.insert(members).values({
           id: crypto.randomUUID(),
@@ -141,7 +142,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(members).values({
         id,
@@ -159,7 +160,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(members).values({
         id,
@@ -180,7 +181,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(members).values({
         id,
@@ -190,7 +191,7 @@ describe("PG members schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(members)
         .set({ archived: true, archivedAt: archiveTime })
@@ -205,7 +206,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(members).values({
         id,
@@ -215,7 +216,7 @@ describe("PG members schema", () => {
         updatedAt: now,
       });
 
-      const later = now + 1000;
+      const later = toUnixMillis(now + 1000);
       await db
         .update(members)
         .set({ version: sql`${members.version} + 1`, updatedAt: later })
@@ -229,7 +230,7 @@ describe("PG members schema", () => {
     it("rejects version < 1 via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -242,7 +243,7 @@ describe("PG members schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -255,7 +256,7 @@ describe("PG members schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -272,7 +273,7 @@ describe("PG members schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([100, 200]));
 
       await db.insert(memberPhotos).values({
@@ -296,7 +297,7 @@ describe("PG members schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(memberPhotos).values({
         id,
@@ -316,7 +317,7 @@ describe("PG members schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(memberPhotos).values({
         id,
@@ -335,7 +336,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(memberPhotos).values({
         id: brandId<MemberPhotoId>(crypto.randomUUID()),
@@ -354,7 +355,7 @@ describe("PG members schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const photoId = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(memberPhotos).values({
         id: photoId,
@@ -373,7 +374,7 @@ describe("PG members schema", () => {
     it("rejects nonexistent memberId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(memberPhotos).values({
@@ -391,7 +392,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(memberPhotos).values({
@@ -410,7 +411,7 @@ describe("PG members schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(memberPhotos).values({
         id,
@@ -431,7 +432,7 @@ describe("PG members schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(memberPhotos).values({
         id,
@@ -454,7 +455,7 @@ describe("PG members schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(memberPhotos).values({
         id,
@@ -465,7 +466,7 @@ describe("PG members schema", () => {
         updatedAt: now,
       });
 
-      const archiveTime = Date.now();
+      const archiveTime = fixtureNow();
       await db
         .update(memberPhotos)
         .set({ archived: true, archivedAt: archiveTime })
@@ -480,7 +481,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -494,7 +495,7 @@ describe("PG members schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(

--- a/packages/db/src/__tests__/schema-pg-nomenclature-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-nomenclature-settings.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { nomenclatureSettings } from "../schema/pg/nomenclature-settings.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgNomenclatureSettingsTables,
   pgInsertAccount,
@@ -39,7 +40,7 @@ describe("PG nomenclature_settings schema", () => {
   it("inserts and retrieves with all columns", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     await db.insert(nomenclatureSettings).values({
@@ -63,7 +64,7 @@ describe("PG nomenclature_settings schema", () => {
   it("defaults version to 1", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(nomenclatureSettings).values({
       systemId,
@@ -82,7 +83,7 @@ describe("PG nomenclature_settings schema", () => {
   it("round-trips encrypted_data binary correctly", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
     const blob = testBlob(blobCiphertext);
@@ -104,7 +105,7 @@ describe("PG nomenclature_settings schema", () => {
   it("enforces 1:1 with systems (rejects duplicate systemId)", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(nomenclatureSettings).values({
       systemId,
@@ -126,7 +127,7 @@ describe("PG nomenclature_settings schema", () => {
   it("cascades on system deletion", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(nomenclatureSettings).values({
       systemId,
@@ -144,7 +145,7 @@ describe("PG nomenclature_settings schema", () => {
   });
 
   it("rejects nonexistent systemId FK", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     await expect(
       db.insert(nomenclatureSettings).values({
         systemId: brandId<SystemId>("nonexistent"),
@@ -158,7 +159,7 @@ describe("PG nomenclature_settings schema", () => {
   it("supports version increment", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(nomenclatureSettings).values({
       systemId,
@@ -169,7 +170,7 @@ describe("PG nomenclature_settings schema", () => {
 
     await db
       .update(nomenclatureSettings)
-      .set({ version: 2, updatedAt: Date.now() })
+      .set({ version: 2, updatedAt: fixtureNow() })
       .where(eq(nomenclatureSettings.systemId, systemId));
 
     const rows = await db

--- a/packages/db/src/__tests__/schema-pg-notifications.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-notifications.integration.test.ts
@@ -13,6 +13,7 @@ import {
 import { friendConnections } from "../schema/pg/privacy.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgNotificationTables,
   pgInsertAccount,
@@ -64,7 +65,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(deviceTokens).values({
         id,
@@ -89,7 +90,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(deviceTokens).values({
         id,
@@ -108,7 +109,7 @@ describe("PG notifications schema", () => {
     it("rejects invalid platform values", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(deviceTokens).values({
@@ -125,7 +126,7 @@ describe("PG notifications schema", () => {
     it("rejects duplicate tokenHash+platform pair", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const tokenHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd";
 
       await db.insert(deviceTokens).values({
@@ -152,7 +153,7 @@ describe("PG notifications schema", () => {
     it("allows same tokenHash on different platforms", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const tokenHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd";
 
       await db.insert(deviceTokens).values({
@@ -178,7 +179,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(deviceTokens).values({
         id,
@@ -198,7 +199,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(deviceTokens).values({
         id,
@@ -220,7 +221,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id,
@@ -242,7 +243,7 @@ describe("PG notifications schema", () => {
     it("enforces unique (system_id, event_type)", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id: brandId<NotificationConfigId>(crypto.randomUUID()),
@@ -267,7 +268,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id,
@@ -288,7 +289,7 @@ describe("PG notifications schema", () => {
     it("rejects invalid event_type", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(notificationConfigs).values({
@@ -305,7 +306,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id,
@@ -329,7 +330,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id,
@@ -351,7 +352,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id,
@@ -375,7 +376,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id,
@@ -385,7 +386,7 @@ describe("PG notifications schema", () => {
         updatedAt: now,
       });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(notificationConfigs)
         .set({ archived: true, archivedAt: updateNow })
@@ -401,7 +402,7 @@ describe("PG notifications schema", () => {
     it("allows duplicate (systemId, eventType) when both rows are archived", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id: brandId<NotificationConfigId>(crypto.randomUUID()),
@@ -427,7 +428,7 @@ describe("PG notifications schema", () => {
     it("rejects duplicate (systemId, eventType) when both rows are active", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(notificationConfigs).values({
         id: brandId<NotificationConfigId>(crypto.randomUUID()),
@@ -451,7 +452,7 @@ describe("PG notifications schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -464,7 +465,7 @@ describe("PG notifications schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -481,7 +482,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -514,7 +515,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -544,7 +545,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -581,7 +582,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -614,7 +615,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -649,7 +650,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -669,7 +670,7 @@ describe("PG notifications schema", () => {
         updatedAt: now,
       });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(friendNotificationPreferences)
         .set({ archived: true, archivedAt: updateNow })
@@ -687,7 +688,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -726,7 +727,7 @@ describe("PG notifications schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -762,7 +763,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,
@@ -785,7 +786,7 @@ describe("PG notifications schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: fcId,

--- a/packages/db/src/__tests__/schema-pg-pk-bridge.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-pk-bridge.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { pkBridgeConfigs } from "../schema/pg/pk-bridge.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgPkBridgeTables,
   makePkBridgeConfigId,
@@ -45,8 +46,8 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
-    const syncAt = now - 60_000;
+    const now = fixtureNow();
+    const syncAt = toUnixMillis(now - 60_000);
     const tokenCiphertext = new Uint8Array([10, 20, 30, 40]);
     const token = testBlob(tokenCiphertext);
     const mappings = testBlob(new Uint8Array([50, 60, 70]));
@@ -86,7 +87,7 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(pkBridgeConfigs).values({
       id,
@@ -110,7 +111,7 @@ describe("PG pk_bridge_configs schema", () => {
       const accountId = await insertAccount();
       const systemId = await pgInsertSystem(db, accountId);
       const id = makePkBridgeConfigId();
-      const now = Date.now();
+      const now = fixtureNow();
       await db.insert(pkBridgeConfigs).values({
         id,
         systemId,
@@ -144,7 +145,7 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(pkBridgeConfigs).values({
       id,
@@ -166,8 +167,8 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
-    const syncAt = now - 120_000;
+    const now = fixtureNow();
+    const syncAt = toUnixMillis(now - 120_000);
 
     await db.insert(pkBridgeConfigs).values({
       id,
@@ -189,7 +190,7 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
+    const now = fixtureNow();
 
     const tokenCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) tokenCiphertext[i] = i;
@@ -222,7 +223,7 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(pkBridgeConfigs).values({
       id,
@@ -250,7 +251,7 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(pkBridgeConfigs).values({
       id,
@@ -268,7 +269,7 @@ describe("PG pk_bridge_configs schema", () => {
   });
 
   it("rejects nonexistent systemId FK", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     await expect(
       db.insert(pkBridgeConfigs).values({
         id: makePkBridgeConfigId(),
@@ -287,7 +288,7 @@ describe("PG pk_bridge_configs schema", () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
     const id = makePkBridgeConfigId();
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(pkBridgeConfigs).values({
       id,

--- a/packages/db/src/__tests__/schema-pg-privacy.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-privacy.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -15,6 +15,7 @@ import {
 } from "../schema/pg/privacy.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgPrivacyTables,
   pgInsertAccount,
@@ -55,7 +56,7 @@ describe("PG privacy schema", () => {
     systemId: SystemId,
     id: BucketId = brandId<BucketId>(crypto.randomUUID()),
   ): Promise<BucketId> {
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(buckets).values({
       id,
       systemId,
@@ -71,7 +72,7 @@ describe("PG privacy schema", () => {
     friendAccountId: AccountId,
     id: FriendConnectionId = brandId<FriendConnectionId>(crypto.randomUUID()),
   ): Promise<FriendConnectionId> {
-    const now = Date.now();
+    const now = fixtureNow();
     await db.insert(friendConnections).values({
       id,
       accountId,
@@ -106,7 +107,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(buckets).values({
@@ -127,7 +128,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlobT2();
 
       await db.insert(buckets).values({
@@ -147,7 +148,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(buckets).values({
         id,
@@ -172,7 +173,7 @@ describe("PG privacy schema", () => {
     });
 
     it("rejects nonexistent systemId FK", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       await expect(
         db.insert(buckets).values({
           id: brandId<BucketId>(crypto.randomUUID()),
@@ -188,7 +189,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(buckets).values({
         id,
@@ -207,7 +208,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(buckets).values({
         id,
@@ -229,7 +230,7 @@ describe("PG privacy schema", () => {
       const systemId = await insertSystem(accountId);
       const id = await insertBucket(systemId);
 
-      const now = Date.now();
+      const now = fixtureNow();
       await db.update(buckets).set({ archived: true, archivedAt: now }).where(eq(buckets.id, id));
       const rows = await db.select().from(buckets).where(eq(buckets.id, id));
       expect(rows[0]?.archived).toBe(true);
@@ -241,7 +242,7 @@ describe("PG privacy schema", () => {
       const systemId = await insertSystem(accountId);
       const id = await insertBucket(systemId);
 
-      const archiveNow = Date.now();
+      const archiveNow = fixtureNow();
       await db
         .update(buckets)
         .set({ archived: true, archivedAt: archiveNow })
@@ -257,7 +258,7 @@ describe("PG privacy schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -270,7 +271,7 @@ describe("PG privacy schema", () => {
     it("rejects archived=false with archivedAt set via CHECK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -386,7 +387,7 @@ describe("PG privacy schema", () => {
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
       const id = brandId<KeyGrantId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const keyData = new Uint8Array([99, 88, 77]);
 
       await db.insert(keyGrants).values({
@@ -414,7 +415,7 @@ describe("PG privacy schema", () => {
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
       const id = brandId<KeyGrantId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(keyGrants).values({
         id,
@@ -436,7 +437,7 @@ describe("PG privacy schema", () => {
       const bucketId = await insertBucket(systemId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(keyGrants).values({
         id: brandId<KeyGrantId>(crypto.randomUUID()),
@@ -457,7 +458,7 @@ describe("PG privacy schema", () => {
       const bucketId = await insertBucket(systemId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(keyGrants).values({
@@ -478,7 +479,7 @@ describe("PG privacy schema", () => {
       const bucketId = await insertBucket(systemId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(keyGrants).values({
         id: brandId<KeyGrantId>(crypto.randomUUID()),
@@ -507,7 +508,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const bucketId = await insertBucket(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(keyGrants).values({
@@ -530,7 +531,7 @@ describe("PG privacy schema", () => {
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
       const id = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id,
@@ -552,7 +553,7 @@ describe("PG privacy schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.execute(
@@ -579,7 +580,7 @@ describe("PG privacy schema", () => {
     it("rejects self-friendship via CHECK", async () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(friendConnections).values({
@@ -597,7 +598,7 @@ describe("PG privacy schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: brandId<FriendConnectionId>(crypto.randomUUID()),
@@ -624,7 +625,7 @@ describe("PG privacy schema", () => {
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
       const id = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id,
@@ -645,7 +646,7 @@ describe("PG privacy schema", () => {
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
       const id = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id,
@@ -669,7 +670,7 @@ describe("PG privacy schema", () => {
       await insertSystem(friendAccountId);
       const id = await insertFriendConnection(accountId, friendAccountId);
 
-      const now = Date.now();
+      const now = fixtureNow();
       await db
         .update(friendConnections)
         .set({ archived: true, archivedAt: now })
@@ -684,7 +685,7 @@ describe("PG privacy schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: brandId<FriendConnectionId>(crypto.randomUUID()),
@@ -712,7 +713,7 @@ describe("PG privacy schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: brandId<FriendConnectionId>(crypto.randomUUID()),
@@ -738,7 +739,7 @@ describe("PG privacy schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -753,7 +754,7 @@ describe("PG privacy schema", () => {
       await insertSystem(accountId);
       const friendAccountId = await insertAccount();
       await insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -770,7 +771,7 @@ describe("PG privacy schema", () => {
       await insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
       const code = `CODE_${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id,
@@ -789,7 +790,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id,
@@ -806,7 +807,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const code = `CODE_${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id: brandId<FriendCodeId>(crypto.randomUUID()),
@@ -829,7 +830,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const codeId = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id: codeId,
@@ -846,7 +847,7 @@ describe("PG privacy schema", () => {
     it("rejects code shorter than 8 characters via CHECK", async () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(friendCodes).values({
@@ -861,7 +862,7 @@ describe("PG privacy schema", () => {
     it("accepts code exactly 8 characters", async () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id: brandId<FriendCodeId>(crypto.randomUUID()),
@@ -874,7 +875,7 @@ describe("PG privacy schema", () => {
     it("rejects expiresAt <= createdAt via CHECK", async () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(friendCodes).values({
@@ -882,7 +883,7 @@ describe("PG privacy schema", () => {
           accountId,
           code: `CODE_${crypto.randomUUID()}`,
           createdAt: now,
-          expiresAt: now - 1000,
+          expiresAt: toUnixMillis(now - 1000),
         }),
       ).rejects.toThrow();
     });
@@ -890,7 +891,7 @@ describe("PG privacy schema", () => {
     it("rejects expiresAt === createdAt via CHECK", async () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(friendCodes).values({
@@ -907,7 +908,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id,
@@ -925,7 +926,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id,
@@ -945,7 +946,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id,
@@ -954,7 +955,7 @@ describe("PG privacy schema", () => {
         createdAt: now,
       });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(friendCodes)
         .set({ archived: true, archivedAt: updateNow })
@@ -967,7 +968,7 @@ describe("PG privacy schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK", async () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -980,7 +981,7 @@ describe("PG privacy schema", () => {
     it("rejects archived=false with archivedAt set via CHECK", async () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -994,7 +995,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const code = `CODE_${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id: brandId<FriendCodeId>(crypto.randomUUID()),
@@ -1022,7 +1023,7 @@ describe("PG privacy schema", () => {
       const accountId = await insertAccount();
       await insertSystem(accountId);
       const code = `CODE_${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendCodes).values({
         id: brandId<FriendCodeId>(crypto.randomUUID()),

--- a/packages/db/src/__tests__/schema-pg-safe-mode-content.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-safe-mode-content.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { safeModeContent } from "../schema/pg/safe-mode-content.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgSafeModeContentTables,
   makeSafeModeContentId,
@@ -40,7 +41,7 @@ describe("PG safe_mode_content schema", () => {
   it("inserts and retrieves with all columns", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
@@ -65,7 +66,7 @@ describe("PG safe_mode_content schema", () => {
   it("defaults version to 1", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({
@@ -83,7 +84,7 @@ describe("PG safe_mode_content schema", () => {
   it("defaults sort_order to 0", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({
@@ -101,7 +102,7 @@ describe("PG safe_mode_content schema", () => {
   it("supports multiple content items per system with ordering", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     const items = [
       { id: makeSafeModeContentId(), sortOrder: 3 },
@@ -130,7 +131,7 @@ describe("PG safe_mode_content schema", () => {
   it("round-trips encrypted_data binary correctly", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
@@ -151,7 +152,7 @@ describe("PG safe_mode_content schema", () => {
   it("cascades on system deletion", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({
@@ -168,7 +169,7 @@ describe("PG safe_mode_content schema", () => {
   });
 
   it("rejects nonexistent systemId FK", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     await expect(
       db.insert(safeModeContent).values({
         id: makeSafeModeContentId(),
@@ -195,7 +196,7 @@ describe("PG safe_mode_content schema", () => {
   it("rejects duplicate primary key", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     await db.insert(safeModeContent).values({

--- a/packages/db/src/__tests__/schema-pg-snapshots.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-snapshots.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { systemSnapshots } from "../schema/pg/snapshots.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgSnapshotTables,
   pgInsertAccount,
@@ -40,7 +41,7 @@ describe("PG system_snapshots schema", () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
     const id = brandId<SystemSnapshotId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(systemSnapshots).values({
       id,
@@ -66,7 +67,7 @@ describe("PG system_snapshots schema", () => {
       systemId,
       snapshotTrigger: "scheduled-daily",
       encryptedData: testBlob(),
-      createdAt: Date.now(),
+      createdAt: fixtureNow(),
     });
 
     const rows = await db.select().from(systemSnapshots).where(eq(systemSnapshots.id, id));
@@ -83,7 +84,7 @@ describe("PG system_snapshots schema", () => {
       systemId,
       snapshotTrigger: "scheduled-weekly",
       encryptedData: testBlob(),
-      createdAt: Date.now(),
+      createdAt: fixtureNow(),
     });
 
     const rows = await db.select().from(systemSnapshots).where(eq(systemSnapshots.id, id));
@@ -100,7 +101,7 @@ describe("PG system_snapshots schema", () => {
         systemId,
         snapshotTrigger: "invalid" as "manual",
         encryptedData: testBlob(),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       }),
     ).rejects.toThrow();
   });
@@ -115,7 +116,7 @@ describe("PG system_snapshots schema", () => {
       systemId,
       snapshotTrigger: "manual",
       encryptedData: testBlob(),
-      createdAt: Date.now(),
+      createdAt: fixtureNow(),
     });
 
     await db.delete(systems).where(eq(systems.id, systemId));
@@ -126,7 +127,7 @@ describe("PG system_snapshots schema", () => {
   it("supports index query by system_id and created_at", async () => {
     const accountId = await insertAccount();
     const systemId = await insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     for (let i = 0; i < 3; i++) {
       await db.insert(systemSnapshots).values({
@@ -134,7 +135,7 @@ describe("PG system_snapshots schema", () => {
         systemId,
         snapshotTrigger: "manual",
         encryptedData: testBlob(),
-        createdAt: now + i * 1000,
+        createdAt: toUnixMillis(now + i * 1000),
       });
     }
 

--- a/packages/db/src/__tests__/schema-pg-structure.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-structure.integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../schema/pg/structure.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgStructureTables,
   pgInsertAccount,
@@ -98,7 +99,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       await db.insert(relationships).values({
@@ -120,7 +121,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id,
@@ -139,7 +140,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id,
@@ -156,7 +157,7 @@ describe("PG structure schema", () => {
     });
 
     it("rejects nonexistent systemId FK", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       await expect(
         db.insert(relationships).values({
           id: newRelId(),
@@ -175,7 +176,7 @@ describe("PG structure schema", () => {
       const sourceMemberId = await insertMember(systemId);
       const targetMemberId = await insertMember(systemId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id,
@@ -200,7 +201,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id,
@@ -221,7 +222,7 @@ describe("PG structure schema", () => {
     it("rejects invalid type via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(relationships).values({
@@ -239,7 +240,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id: newRelId(),
@@ -257,7 +258,7 @@ describe("PG structure schema", () => {
     it("rejects nonexistent sourceMemberId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(relationships).values({
@@ -276,7 +277,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id: newRelId(),
@@ -294,7 +295,7 @@ describe("PG structure schema", () => {
     it("rejects nonexistent targetMemberId FK", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(relationships).values({
@@ -313,7 +314,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id,
@@ -333,7 +334,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id,
@@ -355,7 +356,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(relationships).values({
         id,
@@ -366,7 +367,7 @@ describe("PG structure schema", () => {
         updatedAt: now,
       });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(relationships)
         .set({ archived: true, archivedAt: updateNow })
@@ -379,7 +380,7 @@ describe("PG structure schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -392,7 +393,7 @@ describe("PG structure schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -410,7 +411,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20]));
 
       await db.insert(systemStructureEntityTypes).values({
@@ -434,7 +435,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id,
@@ -453,7 +454,7 @@ describe("PG structure schema", () => {
     });
 
     it("rejects nonexistent systemId FK", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       await expect(
         db.insert(systemStructureEntityTypes).values({
           id: newTypeId(),
@@ -470,7 +471,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id,
@@ -493,7 +494,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id,
@@ -518,7 +519,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id,
@@ -540,7 +541,7 @@ describe("PG structure schema", () => {
     it("rejects archived=true with null archivedAt", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -553,7 +554,7 @@ describe("PG structure schema", () => {
     it("rejects archived=false with non-null archivedAt", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -566,7 +567,7 @@ describe("PG structure schema", () => {
     it("rejects version 0", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -584,7 +585,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -619,7 +620,7 @@ describe("PG structure schema", () => {
     it("rejects nonexistent entityTypeId FK (RESTRICT)", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(systemStructureEntities).values({
@@ -638,7 +639,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -668,7 +669,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -702,7 +703,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -735,7 +736,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -758,7 +759,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -781,7 +782,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -805,7 +806,7 @@ describe("PG structure schema", () => {
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -842,7 +843,7 @@ describe("PG structure schema", () => {
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -883,7 +884,7 @@ describe("PG structure schema", () => {
     it("rejects nonexistent entityId FK (RESTRICT)", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(systemStructureEntityLinks).values({
@@ -901,7 +902,7 @@ describe("PG structure schema", () => {
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -939,7 +940,7 @@ describe("PG structure schema", () => {
       const typeId = newTypeId();
       const parentEntityId = newEntityId();
       const childEntityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -994,7 +995,7 @@ describe("PG structure schema", () => {
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1032,7 +1033,7 @@ describe("PG structure schema", () => {
       const typeId = newTypeId();
       const parentEntityId = newEntityId();
       const childEntityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1082,7 +1083,7 @@ describe("PG structure schema", () => {
       const typeId = newTypeId();
       const parentEntityId = newEntityId();
       const childEntityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1139,7 +1140,7 @@ describe("PG structure schema", () => {
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1184,7 +1185,7 @@ describe("PG structure schema", () => {
       const typeId = newTypeId();
       const entityId = newEntityId();
       const linkId = newLinkId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1229,7 +1230,7 @@ describe("PG structure schema", () => {
       const memberId = await insertMember(systemId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1271,7 +1272,7 @@ describe("PG structure schema", () => {
     it("rejects nonexistent memberId FK (RESTRICT)", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(systemStructureEntityMemberLinks).values({
@@ -1288,7 +1289,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityMemberLinks).values({
         id: newMemberLinkId(),
@@ -1307,7 +1308,7 @@ describe("PG structure schema", () => {
       const memberId = await insertMember(systemId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1352,7 +1353,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityMemberLinks).values({
         id: newMemberLinkId(),
@@ -1378,7 +1379,7 @@ describe("PG structure schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const linkId = newMemberLinkId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityMemberLinks).values({
         id: linkId,
@@ -1400,7 +1401,7 @@ describe("PG structure schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(systemStructureEntityMemberLinks).values({
@@ -1424,7 +1425,7 @@ describe("PG structure schema", () => {
       const typeId = newTypeId();
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1479,7 +1480,7 @@ describe("PG structure schema", () => {
       const typeId = newTypeId();
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1534,7 +1535,7 @@ describe("PG structure schema", () => {
       const systemId = await insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1568,7 +1569,7 @@ describe("PG structure schema", () => {
       const typeId = newTypeId();
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,
@@ -1618,7 +1619,7 @@ describe("PG structure schema", () => {
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
       const assocId = newAssocId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(systemStructureEntityTypes).values({
         id: typeId,

--- a/packages/db/src/__tests__/schema-pg-sync.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-sync.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { syncChanges, syncDocuments, syncSnapshots } from "../schema/pg/sync.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import { createPgSyncTables, pgInsertAccount, pgInsertSystem } from "./helpers/pg-helpers.js";
 
 import type { NewSyncDocument } from "../schema/pg/sync.js";
@@ -45,8 +46,8 @@ describe("PG sync schema", () => {
       documentId: brandId<SyncDocumentId>(crypto.randomUUID()),
       systemId,
       docType: "system-core",
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
+      createdAt: fixtureNow(),
+      updatedAt: fixtureNow(),
       ...overrides,
     };
   }
@@ -61,7 +62,7 @@ describe("PG sync schema", () => {
       authorPublicKey: new Uint8Array(32).fill(0x01),
       nonce: new Uint8Array(24).fill(seq),
       signature: new Uint8Array(64).fill(0x77),
-      createdAt: Date.now(),
+      createdAt: fixtureNow(),
     };
   }
 
@@ -74,7 +75,7 @@ describe("PG sync schema", () => {
       authorPublicKey: new Uint8Array(32).fill(0x02),
       nonce: new Uint8Array(24).fill(0xaa),
       signature: new Uint8Array(64).fill(0x88),
-      createdAt: Date.now(),
+      createdAt: fixtureNow(),
     };
   }
 
@@ -83,7 +84,7 @@ describe("PG sync schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(syncDocuments).values({
         documentId,
@@ -123,7 +124,7 @@ describe("PG sync schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(syncDocuments).values({
         documentId,
@@ -149,7 +150,7 @@ describe("PG sync schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(syncDocuments).values({
         documentId,
@@ -174,7 +175,7 @@ describe("PG sync schema", () => {
       async (docType) => {
         const accountId = await insertAccount();
         const systemId = await insertSystem(accountId);
-        const now = Date.now();
+        const now = fixtureNow();
 
         await expect(
           db.insert(syncDocuments).values({
@@ -191,7 +192,7 @@ describe("PG sync schema", () => {
     it("rejects invalid doc_type", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(syncDocuments).values({
@@ -207,7 +208,7 @@ describe("PG sync schema", () => {
     it("rejects invalid key_type", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(syncDocuments).values({
@@ -224,7 +225,7 @@ describe("PG sync schema", () => {
     it("rejects sizeBytes < 0", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(syncDocuments).values({
@@ -241,7 +242,7 @@ describe("PG sync schema", () => {
     it("rejects snapshotVersion < 0", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(syncDocuments).values({
@@ -258,7 +259,7 @@ describe("PG sync schema", () => {
     it("rejects lastSeq < 0", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         db.insert(syncDocuments).values({
@@ -276,7 +277,7 @@ describe("PG sync schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(syncDocuments).values({
         documentId,
@@ -300,7 +301,7 @@ describe("PG sync schema", () => {
     it("round-trips all fields including binary columns", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       const [doc] = await db.insert(syncDocuments).values(makeDoc(systemId)).returning();
       const documentId = doc?.documentId ?? brandId<SyncDocumentId>("");
@@ -400,7 +401,7 @@ describe("PG sync schema", () => {
         authorPublicKey,
         nonce,
         signature: new Uint8Array(64).fill(0x77),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       });
 
       await expect(
@@ -412,7 +413,7 @@ describe("PG sync schema", () => {
           authorPublicKey,
           nonce,
           signature: new Uint8Array(64).fill(0x77),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         }),
       ).rejects.toThrow();
     });
@@ -438,7 +439,7 @@ describe("PG sync schema", () => {
     it("round-trips all fields including binary columns", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       const [doc] = await db.insert(syncDocuments).values(makeDoc(systemId)).returning();
       const documentId = doc?.documentId ?? brandId<SyncDocumentId>("");
@@ -498,7 +499,7 @@ describe("PG sync schema", () => {
 
       const newPayload = new Uint8Array([0x11, 0x22, 0x33]);
       const newNonce = new Uint8Array(24).fill(0xbb);
-      const updatedAt = Date.now();
+      const updatedAt = fixtureNow();
 
       const newSignature = new Uint8Array(64).fill(0x99);
       await db

--- a/packages/db/src/__tests__/schema-pg-system-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-system-settings.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { systemSettings } from "../schema/pg/system-settings.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgSystemSettingsTables,
   pgInsertAccount,
@@ -39,7 +40,7 @@ describe("PG system_settings schema", () => {
   it("inserts and retrieves with all columns", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     await db.insert(systemSettings).values({
@@ -68,7 +69,7 @@ describe("PG system_settings schema", () => {
   it("defaults boolean fields to false", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(systemSettings).values({
       id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
@@ -88,7 +89,7 @@ describe("PG system_settings schema", () => {
   it("allows nullable locale and pinHash", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(systemSettings).values({
       id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
@@ -109,7 +110,7 @@ describe("PG system_settings schema", () => {
   it("defaults version to 1", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(systemSettings).values({
       id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
@@ -129,7 +130,7 @@ describe("PG system_settings schema", () => {
   it("enforces 1:1 with systems (rejects duplicate systemId)", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(systemSettings).values({
       id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
@@ -153,7 +154,7 @@ describe("PG system_settings schema", () => {
   it("cascades on system deletion", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     await db.insert(systemSettings).values({
       id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
@@ -172,7 +173,7 @@ describe("PG system_settings schema", () => {
   });
 
   it("rejects nonexistent systemId FK", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     await expect(
       db.insert(systemSettings).values({
         id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
@@ -211,7 +212,7 @@ describe("PG system_settings schema", () => {
   it("round-trips encrypted_data binary correctly", async () => {
     const accountId = await insertAccount();
     const systemId = await pgInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
     const blob = testBlob(blobCiphertext);

--- a/packages/db/src/__tests__/schema-pg-systems.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-systems.integration.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import { createPgSystemTables, pgInsertAccount, testBlob } from "./helpers/pg-helpers.js";
 
 import type { AccountId, SystemId } from "@pluralscape/types";
@@ -32,7 +33,7 @@ describe("PG systems schema", () => {
 
   it("inserts and retrieves with all columns", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
     const data = testBlob(new Uint8Array([1, 2, 3, 4, 5]));
 
@@ -53,7 +54,7 @@ describe("PG systems schema", () => {
 
   it("allows nullable encrypted_data", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({
@@ -69,7 +70,7 @@ describe("PG systems schema", () => {
 
   it("round-trips encrypted_data binary correctly", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
     const blobCiphertext = new Uint8Array(256);
     for (let i = 0; i < 256; i++) blobCiphertext[i] = i;
@@ -89,7 +90,7 @@ describe("PG systems schema", () => {
 
   it("defaults version to 1", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({
@@ -105,7 +106,7 @@ describe("PG systems schema", () => {
 
   it("cascades on account deletion", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({
@@ -121,7 +122,7 @@ describe("PG systems schema", () => {
   });
 
   it("rejects nonexistent accountId FK", async () => {
-    const now = Date.now();
+    const now = fixtureNow();
     await expect(
       db.insert(systems).values({
         id: brandId<SystemId>(crypto.randomUUID()),
@@ -134,7 +135,7 @@ describe("PG systems schema", () => {
 
   it("rejects duplicate primary key", async () => {
     const accountId = await insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     await db.insert(systems).values({

--- a/packages/db/src/__tests__/schema-pg-timers.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-timers.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -9,6 +9,7 @@ import { members } from "../schema/pg/members.js";
 import { systems } from "../schema/pg/systems.js";
 import { checkInRecords, timerConfigs } from "../schema/pg/timers.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createPgTimerTables,
   pgInsertAccount,
@@ -50,7 +51,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30]));
 
       await db.insert(timerConfigs).values({
@@ -72,7 +73,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id,
@@ -91,7 +92,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id,
@@ -110,7 +111,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id,
@@ -141,7 +142,7 @@ describe("PG timers schema", () => {
         ["12:00", "18:45"],
       ]) {
         const id = brandId<TimerId>(crypto.randomUUID());
-        const now = Date.now();
+        const now = fixtureNow();
         await db.insert(timerConfigs).values({
           id,
           systemId,
@@ -168,8 +169,8 @@ describe("PG timers schema", () => {
             systemId,
             wakingStart: bad,
             encryptedData: testBlob(new Uint8Array([1])),
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
+            createdAt: fixtureNow(),
+            updatedAt: fixtureNow(),
           }),
         ).rejects.toThrow();
       }
@@ -186,8 +187,8 @@ describe("PG timers schema", () => {
             systemId,
             wakingEnd: bad,
             encryptedData: testBlob(new Uint8Array([1])),
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
+            createdAt: fixtureNow(),
+            updatedAt: fixtureNow(),
           }),
         ).rejects.toThrow();
       }
@@ -197,7 +198,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id,
@@ -218,7 +219,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id,
@@ -237,7 +238,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id,
@@ -258,7 +259,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id,
@@ -268,7 +269,7 @@ describe("PG timers schema", () => {
         updatedAt: now,
       });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(timerConfigs)
         .set({ archived: true, archivedAt: updateNow })
@@ -281,7 +282,7 @@ describe("PG timers schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -294,7 +295,7 @@ describe("PG timers schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -311,7 +312,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -340,7 +341,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([5, 6, 7]));
 
       await db.insert(timerConfigs).values({
@@ -356,7 +357,7 @@ describe("PG timers schema", () => {
         systemId,
         timerConfigId: timerId,
         scheduledAt: now,
-        respondedAt: now + 1000,
+        respondedAt: toUnixMillis(now + 1000),
         dismissed: true,
         encryptedData: data,
       });
@@ -371,7 +372,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -396,7 +397,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -423,7 +424,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -451,7 +452,7 @@ describe("PG timers schema", () => {
       const memberId = await insertMember(systemId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -478,7 +479,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -504,7 +505,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const memberId = await insertMember(systemId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -529,7 +530,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -554,7 +555,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -574,14 +575,14 @@ describe("PG timers schema", () => {
           id: respondedId,
           systemId,
           timerConfigId: timerId,
-          scheduledAt: now + 1000,
-          respondedAt: now + 2000,
+          scheduledAt: toUnixMillis(now + 1000),
+          respondedAt: toUnixMillis(now + 2000),
         },
         {
           id: dismissedId,
           systemId,
           timerConfigId: timerId,
-          scheduledAt: now + 3000,
+          scheduledAt: toUnixMillis(now + 3000),
           dismissed: true,
         },
       ]);
@@ -599,7 +600,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -623,7 +624,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -652,7 +653,7 @@ describe("PG timers schema", () => {
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -666,7 +667,7 @@ describe("PG timers schema", () => {
         .insert(checkInRecords)
         .values({ id, systemId, timerConfigId: timerId, scheduledAt: now });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(checkInRecords)
         .set({ archived: true, archivedAt: updateNow })
@@ -680,7 +681,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -717,7 +718,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,
@@ -739,7 +740,7 @@ describe("PG timers schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(timerConfigs).values({
         id: timerId,

--- a/packages/db/src/__tests__/schema-pg-views.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-views.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -32,6 +32,7 @@ import {
   getUnconfirmedAcknowledgements,
 } from "../views/pg.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   PG_DDL,
   pgExec,
@@ -162,13 +163,13 @@ describe("PG views / query helpers", () => {
 
   describe("getCurrentFronters", () => {
     it("returns sessions with null end_time", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id: brandId<FrontingSessionId>(crypto.randomUUID()),
         systemId,
         memberId,
-        startTime: now - 60000,
+        startTime: toUnixMillis(now - 60000),
         endTime: null,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -178,8 +179,8 @@ describe("PG views / query helpers", () => {
         id: brandId<FrontingSessionId>(crypto.randomUUID()),
         systemId,
         memberId,
-        startTime: now - 120000,
-        endTime: now - 30000,
+        startTime: toUnixMillis(now - 120000),
+        endTime: toUnixMillis(now - 30000),
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
         updatedAt: now,
@@ -198,13 +199,13 @@ describe("PG views / query helpers", () => {
 
   describe("getCurrentFrontersWithDuration", () => {
     it("returns positive duration for active sessions", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(frontingSessions).values({
         id: brandId<FrontingSessionId>(crypto.randomUUID()),
         systemId,
         memberId,
-        startTime: now - 60000,
+        startTime: toUnixMillis(now - 60000),
         endTime: null,
         encryptedData: testBlob(new Uint8Array([1])),
         createdAt: now,
@@ -224,7 +225,7 @@ describe("PG views / query helpers", () => {
 
   describe("getActiveApiKeys", () => {
     it("returns non-revoked keys", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(apiKeys).values({
         id: brandId<ApiKeyId>(crypto.randomUUID()),
@@ -258,7 +259,7 @@ describe("PG views / query helpers", () => {
     });
 
     it("includes key with encryptedData", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(apiKeys).values({
         id: brandId<ApiKeyId>(crypto.randomUUID()),
@@ -282,7 +283,7 @@ describe("PG views / query helpers", () => {
       await insertSystem(otherAccountId1);
       const otherAccountId2 = await insertAccount();
       await insertSystem(otherAccountId2);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(friendConnections).values({
         id: brandId<FriendConnectionId>(crypto.randomUUID()),
@@ -313,7 +314,7 @@ describe("PG views / query helpers", () => {
 
   describe("getPendingWebhookRetries", () => {
     it("respects max_attempts parameter", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const webhookId = brandId<WebhookId>(crypto.randomUUID());
       const maxAttempts = 3;
 
@@ -334,7 +335,7 @@ describe("PG views / query helpers", () => {
         eventType: "member.created",
         status: "failed",
         attemptCount: 2,
-        nextRetryAt: now - 60000,
+        nextRetryAt: toUnixMillis(now - 60000),
         encryptedData: new Uint8Array([1, 2, 3]),
         createdAt: now,
       });
@@ -346,7 +347,7 @@ describe("PG views / query helpers", () => {
         eventType: "member.created",
         status: "failed",
         attemptCount: 5,
-        nextRetryAt: now - 60000,
+        nextRetryAt: toUnixMillis(now - 60000),
         encryptedData: new Uint8Array([1, 2, 3]),
         createdAt: now,
       });
@@ -358,7 +359,7 @@ describe("PG views / query helpers", () => {
         eventType: "member.created",
         status: "failed",
         attemptCount: 2,
-        nextRetryAt: now + 60000,
+        nextRetryAt: toUnixMillis(now + 60000),
         encryptedData: new Uint8Array([1, 2, 3]),
         createdAt: now,
       });
@@ -376,7 +377,7 @@ describe("PG views / query helpers", () => {
 
   describe("getUnconfirmedAcknowledgements", () => {
     it("returns only unconfirmed", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(acknowledgements).values({
         id: brandId<AcknowledgementId>(crypto.randomUUID()),
@@ -407,7 +408,7 @@ describe("PG views / query helpers", () => {
 
   describe("getMemberGroupSummary", () => {
     it("returns correct member count per group", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const memberId1 = crypto.randomUUID();
       const memberId2 = crypto.randomUUID();
       const groupId = brandId<GroupId>(crypto.randomUUID());
@@ -454,7 +455,7 @@ describe("PG views / query helpers", () => {
 
   describe("getActiveFriendConnections", () => {
     it("returns only accepted connections", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const otherAccountId1 = await insertAccount();
       await insertSystem(otherAccountId1);
       const otherAccountId2 = await insertAccount();
@@ -484,7 +485,7 @@ describe("PG views / query helpers", () => {
 
   describe("getActiveDeviceTokens", () => {
     it("returns non-revoked tokens", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(deviceTokens).values({
         id: brandId<FrontingSessionId>(crypto.randomUUID()),
@@ -512,7 +513,7 @@ describe("PG views / query helpers", () => {
 
   describe("getActiveDeviceTransfers", () => {
     it("returns pending non-expired transfers", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const sourceSession = brandId<SessionId>(crypto.randomUUID());
       const targetSession = brandId<SessionId>(crypto.randomUUID());
 
@@ -530,7 +531,7 @@ describe("PG views / query helpers", () => {
         status: "pending",
         codeSalt: new Uint8Array(16),
         createdAt: now,
-        expiresAt: now + 3600000,
+        expiresAt: toUnixMillis(now + 3600000),
       });
 
       // Pending but expired
@@ -547,8 +548,8 @@ describe("PG views / query helpers", () => {
         targetSessionId: targetSession2,
         status: "pending",
         codeSalt: new Uint8Array(16),
-        createdAt: now - 7200000,
-        expiresAt: now - 3600000,
+        createdAt: toUnixMillis(now - 7200000),
+        expiresAt: toUnixMillis(now - 3600000),
       });
 
       const active = await getActiveDeviceTransfers(db, accountId);
@@ -559,7 +560,7 @@ describe("PG views / query helpers", () => {
 
   describe("getCurrentFrontingComments", () => {
     it("returns comments only for active sessions", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const activeSessionId = brandId<FrontingSessionId>(crypto.randomUUID());
       const endedSessionId = brandId<FrontingSessionId>(crypto.randomUUID());
 
@@ -568,7 +569,7 @@ describe("PG views / query helpers", () => {
           id: activeSessionId,
           systemId,
           memberId,
-          startTime: now - 60000,
+          startTime: toUnixMillis(now - 60000),
           endTime: null,
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -578,8 +579,8 @@ describe("PG views / query helpers", () => {
           id: endedSessionId,
           systemId,
           memberId,
-          startTime: now - 120000,
-          endTime: now - 30000,
+          startTime: toUnixMillis(now - 120000),
+          endTime: toUnixMillis(now - 30000),
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
           updatedAt: now,
@@ -590,7 +591,7 @@ describe("PG views / query helpers", () => {
           id: brandId<FrontingCommentId>(crypto.randomUUID()),
           frontingSessionId: activeSessionId,
           systemId,
-          sessionStartTime: now - 60000,
+          sessionStartTime: toUnixMillis(now - 60000),
           memberId,
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -600,7 +601,7 @@ describe("PG views / query helpers", () => {
           id: brandId<FrontingCommentId>(crypto.randomUUID()),
           frontingSessionId: endedSessionId,
           systemId,
-          sessionStartTime: now - 120000,
+          sessionStartTime: toUnixMillis(now - 120000),
           memberId,
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -619,11 +620,11 @@ describe("PG views / query helpers", () => {
     });
 
     it("excludes comments with matching sessionId but mismatched systemId", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const sessionIdA = brandId<FrontingSessionId>(crypto.randomUUID());
       const sessionIdB = brandId<FrontingSessionId>(crypto.randomUUID());
-      const startTimeA = now - 60000;
-      const startTimeB = now - 90000;
+      const startTimeA = toUnixMillis(now - 60000);
+      const startTimeB = toUnixMillis(now - 90000);
 
       // Create session in system A
       await db.insert(frontingSessions).values({
@@ -691,7 +692,7 @@ describe("PG views / query helpers", () => {
 
   describe("getStructureEntityAssociations", () => {
     it("returns associations for a system", async () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const entityTypeId = brandId<SystemStructureEntityTypeId>(crypto.randomUUID());
       const entityId1 = brandId<SystemStructureEntityId>(crypto.randomUUID());
       const entityId2 = brandId<SystemStructureEntityId>(crypto.randomUUID());

--- a/packages/db/src/__tests__/schema-pg-webhooks.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-webhooks.integration.test.ts
@@ -1,5 +1,5 @@
 import { PGlite } from "@electric-sql/pglite";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -9,6 +9,7 @@ import { accounts } from "../schema/pg/auth.js";
 import { systems } from "../schema/pg/systems.js";
 import { webhookConfigs, webhookDeliveries } from "../schema/pg/webhooks.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   MS_PER_DAY,
   TTL_RETENTION_DAYS,
@@ -54,7 +55,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const s = secret([1, 2, 3]);
 
       await db.insert(webhookConfigs).values({
@@ -81,7 +82,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id,
@@ -101,7 +102,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id,
@@ -122,7 +123,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const keyId = brandId<ApiKeyId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(apiKeys).values({
         id: keyId,
@@ -153,7 +154,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id,
@@ -174,7 +175,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id,
@@ -195,7 +196,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id,
@@ -218,7 +219,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id,
@@ -230,7 +231,7 @@ describe("PG webhooks schema", () => {
         updatedAt: now,
       });
 
-      const updateNow = Date.now();
+      const updateNow = fixtureNow();
       await db
         .update(webhookConfigs)
         .set({ archived: true, archivedAt: updateNow })
@@ -243,7 +244,7 @@ describe("PG webhooks schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -256,7 +257,7 @@ describe("PG webhooks schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", async () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       await expect(
         client.query(
@@ -273,7 +274,7 @@ describe("PG webhooks schema", () => {
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
       const id = brandId<WebhookDeliveryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -305,7 +306,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -333,7 +334,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -362,7 +363,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -392,7 +393,7 @@ describe("PG webhooks schema", () => {
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
       const id = brandId<WebhookDeliveryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -422,7 +423,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -451,8 +452,8 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
-      const thirtyOneDaysAgo = now - (TTL_RETENTION_DAYS + 1) * MS_PER_DAY;
+      const now = fixtureNow();
+      const thirtyOneDaysAgo = toUnixMillis(now - (TTL_RETENTION_DAYS + 1) * MS_PER_DAY);
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -516,7 +517,7 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       await db.insert(webhookConfigs).values({
         id: whId,
@@ -544,8 +545,8 @@ describe("PG webhooks schema", () => {
       const accountId = await insertAccount();
       const systemId = await insertSystem(accountId);
       const whId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
-      const retryAt = now + 60_000;
+      const now = fixtureNow();
+      const retryAt = toUnixMillis(now + 60_000);
 
       await db.insert(webhookConfigs).values({
         id: whId,

--- a/packages/db/src/__tests__/schema-sqlite-analytics.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-analytics.integration.test.ts
@@ -8,6 +8,7 @@ import { frontingReports } from "../schema/sqlite/analytics.js";
 import { accounts } from "../schema/sqlite/auth.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteAnalyticsTables,
   makeFrontingReportId,
@@ -48,7 +49,7 @@ describe("SQLite analytics schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = makeFrontingReportId();
-      const now = Date.now();
+      const now = fixtureNow();
       const blob = testBlob();
 
       db.insert(frontingReports)
@@ -75,7 +76,7 @@ describe("SQLite analytics schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = makeFrontingReportId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingReports)
         .values({
@@ -96,7 +97,7 @@ describe("SQLite analytics schema", () => {
     it("rejects invalid format value", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -118,7 +119,7 @@ describe("SQLite analytics schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = makeFrontingReportId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingReports)
         .values({
@@ -138,7 +139,7 @@ describe("SQLite analytics schema", () => {
     });
 
     it("rejects nonexistent systemId FK", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         db
           .insert(frontingReports)
@@ -159,7 +160,7 @@ describe("SQLite analytics schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = makeFrontingReportId();
-      const now = Date.now();
+      const now = fixtureNow();
       const values = {
         id,
         systemId,
@@ -177,7 +178,7 @@ describe("SQLite analytics schema", () => {
     it("queries multiple reports by systemId", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingReports)
         .values([
@@ -214,7 +215,7 @@ describe("SQLite analytics schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = makeFrontingReportId();
-      const now = Date.now();
+      const now = fixtureNow();
       const blob = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(frontingReports)

--- a/packages/db/src/__tests__/schema-sqlite-api-keys.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-api-keys.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -8,6 +8,7 @@ import { apiKeys } from "../schema/sqlite/api-keys.js";
 import { accounts } from "../schema/sqlite/auth.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteApiKeysTables,
   sqliteInsertAccount,
@@ -40,7 +41,7 @@ describe("SQLite api_keys schema", () => {
   it("inserts and retrieves a metadata API key", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
 
@@ -70,7 +71,7 @@ describe("SQLite api_keys schema", () => {
   it("inserts and retrieves a crypto API key", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
     const keyMaterial = new Uint8Array([1, 2, 3, 4, 5]);
@@ -99,7 +100,7 @@ describe("SQLite api_keys schema", () => {
   it("rejects invalid key_type via CHECK constraint", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -121,7 +122,7 @@ describe("SQLite api_keys schema", () => {
   it("enforces unique token_hash", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const tokenHash = `hash_${crypto.randomUUID()}`;
 
     db.insert(apiKeys)
@@ -157,7 +158,7 @@ describe("SQLite api_keys schema", () => {
   it("allows nullable optional fields", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
@@ -184,8 +185,8 @@ describe("SQLite api_keys schema", () => {
   it("stores and retrieves timestamps", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
-    const later = now + 86400000;
+    const now = fixtureNow();
+    const later = toUnixMillis(now + 86400000);
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
@@ -213,7 +214,7 @@ describe("SQLite api_keys schema", () => {
   it("cascades on account deletion", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
@@ -237,7 +238,7 @@ describe("SQLite api_keys schema", () => {
   it("cascades on system deletion", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
@@ -261,7 +262,7 @@ describe("SQLite api_keys schema", () => {
   it("rejects nonexistent accountId FK", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -282,7 +283,7 @@ describe("SQLite api_keys schema", () => {
 
   it("rejects nonexistent systemId FK", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -304,7 +305,7 @@ describe("SQLite api_keys schema", () => {
   it("rejects metadata key with encrypted_key_material", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -327,7 +328,7 @@ describe("SQLite api_keys schema", () => {
   it("rejects crypto key without encrypted_key_material", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -349,7 +350,7 @@ describe("SQLite api_keys schema", () => {
   it("round-trips empty scopes array", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
 
     db.insert(apiKeys)
@@ -372,7 +373,7 @@ describe("SQLite api_keys schema", () => {
   it("round-trips empty Uint8Array for encrypted_key_material", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const emptyMaterial = new Uint8Array(0);
 
@@ -397,7 +398,7 @@ describe("SQLite api_keys schema", () => {
   it("rejects insert without encryptedData", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -420,7 +421,7 @@ describe("SQLite api_keys schema", () => {
   it("round-trips encryptedData blob", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const blob = testBlob(new Uint8Array([10, 20, 30]));
 

--- a/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-audit-log.integration.test.ts
@@ -7,6 +7,7 @@ import { auditLog } from "../schema/sqlite/audit-log.js";
 import { accounts } from "../schema/sqlite/auth.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteAuditLogTables,
   makeAuditLogEntryId,
@@ -43,7 +44,7 @@ describe("SQLite audit_log schema", () => {
   it("inserts and retrieves with all columns (detail as text)", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
     const actor = testActor("account", accountId);
 
@@ -74,7 +75,7 @@ describe("SQLite audit_log schema", () => {
   });
 
   it("allows nullable fields (accountId, systemId, ipAddress, userAgent, detail)", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
@@ -95,7 +96,7 @@ describe("SQLite audit_log schema", () => {
   });
 
   it("rejects invalid event_type via CHECK constraint", () => {
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -135,7 +136,7 @@ describe("SQLite audit_log schema", () => {
     ] as const;
 
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     for (const eventType of eventTypes) {
       db.insert(auditLog)
         .values({
@@ -156,7 +157,7 @@ describe("SQLite audit_log schema", () => {
   });
 
   it("supports api-key actor type", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
     const actor = testActor("api-key", "key-123");
 
@@ -175,7 +176,7 @@ describe("SQLite audit_log schema", () => {
 
   it("sets account_id to NULL on account deletion (SET NULL)", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
@@ -197,7 +198,7 @@ describe("SQLite audit_log schema", () => {
   it("sets system_id to NULL on system deletion (SET NULL)", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
@@ -218,7 +219,7 @@ describe("SQLite audit_log schema", () => {
   });
 
   it("rejects duplicate primary key", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeAuditLogEntryId();
 
     db.insert(auditLog)
@@ -244,7 +245,7 @@ describe("SQLite audit_log schema", () => {
   });
 
   it("accepts detail at exactly 2048 characters", () => {
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(auditLog)
       .values({
@@ -258,7 +259,7 @@ describe("SQLite audit_log schema", () => {
   });
 
   it("rejects detail exceeding 2048 characters", () => {
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db

--- a/packages/db/src/__tests__/schema-sqlite-auth.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-auth.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -12,6 +12,7 @@ import {
   sessions,
 } from "../schema/sqlite/auth.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import { createSqliteAuthTables, testBlob } from "./helpers/sqlite-helpers.js";
 
 import type {
@@ -20,6 +21,7 @@ import type {
   DeviceTransferRequestId,
   RecoveryKeyId,
   SessionId,
+  UnixMillis,
 } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
@@ -47,8 +49,8 @@ describe("SQLite auth schema", () => {
       emailSalt: string;
       authKeyHash: Uint8Array;
       kdfSalt: string;
-      createdAt: number;
-      updatedAt: number;
+      createdAt: UnixMillis;
+      updatedAt: UnixMillis;
     }> = {},
   ): {
     id: AccountId;
@@ -56,10 +58,10 @@ describe("SQLite auth schema", () => {
     emailSalt: string;
     authKeyHash: Uint8Array;
     kdfSalt: string;
-    createdAt: number;
-    updatedAt: number;
+    createdAt: UnixMillis;
+    updatedAt: UnixMillis;
   } {
-    const now = Date.now();
+    const now = fixtureNow();
     const data = {
       id: brandId<AccountId>(overrides.id ?? crypto.randomUUID()),
       emailHash: overrides.emailHash ?? `hash_${crypto.randomUUID()}`,
@@ -76,13 +78,13 @@ describe("SQLite auth schema", () => {
 
   function insertSession(
     accountId: AccountId,
-    overrides: Partial<{ id: SessionId; tokenHash: string; createdAt: number }> = {},
-  ): { id: SessionId; accountId: AccountId; tokenHash: string; createdAt: number } {
+    overrides: Partial<{ id: SessionId; tokenHash: string; createdAt: UnixMillis }> = {},
+  ): { id: SessionId; accountId: AccountId; tokenHash: string; createdAt: UnixMillis } {
     const data = {
       id: overrides.id ?? newSessionId(),
       accountId,
       tokenHash: overrides.tokenHash ?? `tok_${crypto.randomUUID()}`,
-      createdAt: overrides.createdAt ?? Date.now(),
+      createdAt: overrides.createdAt ?? fixtureNow(),
     };
     db.insert(sessions).values(data).run();
     return data;
@@ -146,7 +148,7 @@ describe("SQLite auth schema", () => {
     });
 
     it("rejects null kdfSalt", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         client
           .prepare(
@@ -178,7 +180,7 @@ describe("SQLite auth schema", () => {
           encryptedPrivateKey: privateKey,
           publicKey,
           keyType: "encryption",
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -200,7 +202,7 @@ describe("SQLite auth schema", () => {
           encryptedPrivateKey: new Uint8Array([1]),
           publicKey: new Uint8Array([2]),
           keyType: "signing",
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -219,7 +221,7 @@ describe("SQLite auth schema", () => {
             encryptedPrivateKey: new Uint8Array([1]),
             publicKey: new Uint8Array([2]),
             keyType: "invalid" as "encryption",
-            createdAt: Date.now(),
+            createdAt: fixtureNow(),
           })
           .run(),
       ).toThrow(/constraint|CHECK/i);
@@ -236,7 +238,7 @@ describe("SQLite auth schema", () => {
           encryptedPrivateKey: new Uint8Array([1]),
           publicKey: new Uint8Array([2]),
           keyType: "encryption",
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -255,7 +257,7 @@ describe("SQLite auth schema", () => {
             encryptedPrivateKey: new Uint8Array([1]),
             publicKey: new Uint8Array([2]),
             keyType: "encryption",
-            createdAt: Date.now(),
+            createdAt: fixtureNow(),
           })
           .run(),
       ).toThrow(/FOREIGN KEY|constraint/i);
@@ -272,7 +274,7 @@ describe("SQLite auth schema", () => {
           encryptedPrivateKey: new Uint8Array(0),
           publicKey: new Uint8Array(0),
           keyType: "encryption",
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -283,7 +285,7 @@ describe("SQLite auth schema", () => {
 
     it("enforces NOT NULL on required columns", () => {
       const account = insertAccount();
-      const now = String(Date.now());
+      const now = String(fixtureNow());
       expect(() =>
         client.exec(
           `INSERT INTO auth_keys (id, account_id, key_type, created_at) VALUES ('${crypto.randomUUID()}', '${account.id}', 'encryption', ${now})`,
@@ -295,10 +297,10 @@ describe("SQLite auth schema", () => {
   describe("sessions", () => {
     it("inserts and retrieves with all fields", () => {
       const account = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newSessionId();
 
-      const expiresAt = now + ONE_DAY_MS;
+      const expiresAt = toUnixMillis(now + ONE_DAY_MS);
       db.insert(sessions)
         .values({
           id,
@@ -329,7 +331,7 @@ describe("SQLite auth schema", () => {
           id,
           accountId: account.id,
           tokenHash: `tok_${crypto.randomUUID()}`,
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -346,7 +348,7 @@ describe("SQLite auth schema", () => {
           id,
           accountId: account.id,
           tokenHash: `tok_${crypto.randomUUID()}`,
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -357,14 +359,14 @@ describe("SQLite auth schema", () => {
     it("round-trips expiresAt when provided", () => {
       const account = insertAccount();
       const id = newSessionId();
-      const expiresAt = Date.now() + ONE_DAY_MS;
+      const expiresAt = toUnixMillis(fixtureNow() + ONE_DAY_MS);
 
       db.insert(sessions)
         .values({
           id,
           accountId: account.id,
           tokenHash: `tok_${crypto.randomUUID()}`,
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
           expiresAt,
         })
         .run();
@@ -382,7 +384,7 @@ describe("SQLite auth schema", () => {
           id,
           accountId: account.id,
           tokenHash: `tok_${crypto.randomUUID()}`,
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -399,7 +401,7 @@ describe("SQLite auth schema", () => {
           id,
           accountId: account.id,
           tokenHash: `tok_${crypto.randomUUID()}`,
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -423,7 +425,7 @@ describe("SQLite auth schema", () => {
             id: newSessionId(),
             accountId: brandId<AccountId>("nonexistent"),
             tokenHash: `tok_${crypto.randomUUID()}`,
-            createdAt: Date.now(),
+            createdAt: fixtureNow(),
           })
           .run(),
       ).toThrow(/FOREIGN KEY|constraint/i);
@@ -431,7 +433,7 @@ describe("SQLite auth schema", () => {
 
     it("rejects expiresAt <= createdAt via CHECK", () => {
       const account = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -441,7 +443,7 @@ describe("SQLite auth schema", () => {
             accountId: account.id,
             tokenHash: `tok_${crypto.randomUUID()}`,
             createdAt: now,
-            expiresAt: now - 1000,
+            expiresAt: toUnixMillis(now - 1000),
           })
           .run(),
       ).toThrow(/constraint|CHECK/i);
@@ -449,7 +451,7 @@ describe("SQLite auth schema", () => {
 
     it("rejects expiresAt === createdAt via CHECK (boundary)", () => {
       const account = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -468,7 +470,7 @@ describe("SQLite auth schema", () => {
     it("updates expiresAt from null to a value", () => {
       const account = insertAccount();
       const id = newSessionId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(sessions)
         .values({
@@ -479,7 +481,7 @@ describe("SQLite auth schema", () => {
         })
         .run();
 
-      const expiresAt = now + ONE_DAY_MS;
+      const expiresAt = toUnixMillis(now + ONE_DAY_MS);
       db.update(sessions).set({ expiresAt }).where(eq(sessions.id, id)).run();
 
       const rows = db.select().from(sessions).where(eq(sessions.id, id)).all();
@@ -495,7 +497,7 @@ describe("SQLite auth schema", () => {
           id,
           accountId: account.id,
           tokenHash: `tok_${crypto.randomUUID()}`,
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -514,7 +516,7 @@ describe("SQLite auth schema", () => {
           accountId: account.id,
           tokenHash: `tok_${crypto.randomUUID()}`,
           encryptedData: blob,
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -535,7 +537,7 @@ describe("SQLite auth schema", () => {
           accountId: account.id,
           encryptedMasterKey: masterKey,
           recoveryKeyHash: new Uint8Array(32),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -554,7 +556,7 @@ describe("SQLite auth schema", () => {
           accountId: account.id,
           encryptedMasterKey: new Uint8Array([1, 2, 3]),
           recoveryKeyHash: new Uint8Array(32),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -565,14 +567,14 @@ describe("SQLite auth schema", () => {
     it("round-trips revokedAt when set", () => {
       const account = insertAccount();
       const id = newRecoveryKeyId();
-      const revokedAt = Date.now();
+      const revokedAt = fixtureNow();
 
       db.insert(recoveryKeys)
         .values({
           id,
           accountId: account.id,
           encryptedMasterKey: new Uint8Array([1, 2, 3]),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
           revokedAt,
         })
         .run();
@@ -591,7 +593,7 @@ describe("SQLite auth schema", () => {
           accountId: account.id,
           encryptedMasterKey: new Uint8Array([1]),
           recoveryKeyHash: new Uint8Array(32),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
@@ -609,7 +611,7 @@ describe("SQLite auth schema", () => {
             accountId: brandId<AccountId>("nonexistent"),
             encryptedMasterKey: new Uint8Array([1]),
             recoveryKeyHash: new Uint8Array(32),
-            createdAt: Date.now(),
+            createdAt: fixtureNow(),
           })
           .run(),
       ).toThrow(/FOREIGN KEY|constraint/i);
@@ -625,11 +627,11 @@ describe("SQLite auth schema", () => {
           accountId: account.id,
           encryptedMasterKey: new Uint8Array([1, 2, 3]),
           recoveryKeyHash: new Uint8Array(32),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run();
 
-      const revokedAt = Date.now();
+      const revokedAt = fixtureNow();
       db.update(recoveryKeys).set({ revokedAt }).where(eq(recoveryKeys.id, id)).run();
 
       const rows = db.select().from(recoveryKeys).where(eq(recoveryKeys.id, id)).all();
@@ -642,7 +644,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -653,7 +655,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -672,7 +674,7 @@ describe("SQLite auth schema", () => {
     it("accepts targetSessionId as null", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -683,7 +685,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: null,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -700,7 +702,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -711,7 +713,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -728,7 +730,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -739,7 +741,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -755,7 +757,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
       const keyMaterial = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]);
 
@@ -768,7 +770,7 @@ describe("SQLite auth schema", () => {
           encryptedKeyMaterial: keyMaterial,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -784,7 +786,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -795,7 +797,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -811,7 +813,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -824,7 +826,7 @@ describe("SQLite auth schema", () => {
           encryptedKeyMaterial: new Uint8Array([1, 2, 3]),
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -840,7 +842,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -852,7 +854,7 @@ describe("SQLite auth schema", () => {
           status: "expired",
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -868,7 +870,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -881,7 +883,7 @@ describe("SQLite auth schema", () => {
             status: "invalid" as "pending",
             codeSalt: TEST_CODE_SALT,
             createdAt: now,
-            expiresAt: now + ONE_HOUR_MS,
+            expiresAt: toUnixMillis(now + ONE_HOUR_MS),
           })
           .run(),
       ).toThrow(/constraint|CHECK/i);
@@ -891,7 +893,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -903,7 +905,7 @@ describe("SQLite auth schema", () => {
             targetSessionId: target.id,
             codeSalt: TEST_CODE_SALT,
             createdAt: now,
-            expiresAt: now - 1000,
+            expiresAt: toUnixMillis(now - 1000),
           })
           .run(),
       ).toThrow(/constraint|CHECK/i);
@@ -913,7 +915,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -935,7 +937,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -946,7 +948,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -963,7 +965,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -974,7 +976,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 
@@ -990,7 +992,7 @@ describe("SQLite auth schema", () => {
     it("validates both source and target session FKs", () => {
       const account = insertAccount();
       const session = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1002,7 +1004,7 @@ describe("SQLite auth schema", () => {
             targetSessionId: session.id,
             codeSalt: TEST_CODE_SALT,
             createdAt: now,
-            expiresAt: now + ONE_HOUR_MS,
+            expiresAt: toUnixMillis(now + ONE_HOUR_MS),
           })
           .run(),
       ).toThrow(/FOREIGN KEY|constraint/i);
@@ -1017,7 +1019,7 @@ describe("SQLite auth schema", () => {
             targetSessionId: brandId<SessionId>("nonexistent"),
             codeSalt: TEST_CODE_SALT,
             createdAt: now,
-            expiresAt: now + ONE_HOUR_MS,
+            expiresAt: toUnixMillis(now + ONE_HOUR_MS),
           })
           .run(),
       ).toThrow(/FOREIGN KEY|constraint/i);
@@ -1027,7 +1029,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1040,7 +1042,7 @@ describe("SQLite auth schema", () => {
             status: "approved",
             codeSalt: TEST_CODE_SALT,
             createdAt: now,
-            expiresAt: now + ONE_HOUR_MS,
+            expiresAt: toUnixMillis(now + ONE_HOUR_MS),
           })
           .run(),
       ).toThrow(/constraint|CHECK/i);
@@ -1050,7 +1052,7 @@ describe("SQLite auth schema", () => {
       const account = insertAccount();
       const source = insertSession(account.id);
       const target = insertSession(account.id);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newDeviceTransferRequestId();
 
       db.insert(deviceTransferRequests)
@@ -1061,7 +1063,7 @@ describe("SQLite auth schema", () => {
           targetSessionId: target.id,
           codeSalt: TEST_CODE_SALT,
           createdAt: now,
-          expiresAt: now + ONE_HOUR_MS,
+          expiresAt: toUnixMillis(now + ONE_HOUR_MS),
         })
         .run();
 

--- a/packages/db/src/__tests__/schema-sqlite-blob-metadata.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-blob-metadata.integration.test.ts
@@ -9,6 +9,7 @@ import { blobMetadata } from "../schema/sqlite/blob-metadata.js";
 import { buckets } from "../schema/sqlite/privacy.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteBlobMetadataTables,
   sqliteInsertAccount,
@@ -47,7 +48,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(blobMetadata)
       .values({
@@ -78,7 +79,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const storageKey = `blobs/${crypto.randomUUID()}`;
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(blobMetadata)
       .values({
@@ -116,7 +117,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(blobMetadata)
       .values({
@@ -141,7 +142,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const bucketId = brandId<BucketId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(buckets)
       .values({
@@ -176,7 +177,7 @@ describe("SQLite blob_metadata schema", () => {
   it("rejects invalid purpose", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -200,7 +201,7 @@ describe("SQLite blob_metadata schema", () => {
   it("rejects sizeBytes <= 0", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -240,7 +241,7 @@ describe("SQLite blob_metadata schema", () => {
   it("rejects invalid encryptionTier", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     // Use raw SQL to bypass TypeScript EncryptionTier type and test DB CHECK constraint
     expect(() =>
@@ -284,7 +285,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     // Use raw SQL to bypass Drizzle's type checking and test the DB constraint
     expect(() =>
@@ -300,7 +301,7 @@ describe("SQLite blob_metadata schema", () => {
   it("rejects checksum not exactly 64 characters", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -340,7 +341,7 @@ describe("SQLite blob_metadata schema", () => {
   it("accepts size_bytes at exactly 10 GB", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -365,7 +366,7 @@ describe("SQLite blob_metadata schema", () => {
   it("rejects size_bytes exceeding 10 GB", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -390,7 +391,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(blobMetadata)
       .values({
@@ -415,7 +416,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(blobMetadata)
       .values({
@@ -441,7 +442,7 @@ describe("SQLite blob_metadata schema", () => {
   it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -465,7 +466,7 @@ describe("SQLite blob_metadata schema", () => {
   it("rejects archived=false with archivedAt set via CHECK constraint", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -491,7 +492,7 @@ describe("SQLite blob_metadata schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const id = brandId<BlobId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(blobMetadata)
       .values({

--- a/packages/db/src/__tests__/schema-sqlite-communication.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-communication.integration.test.ts
@@ -17,6 +17,7 @@ import {
 import { members } from "../schema/sqlite/members.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteCommunicationTables,
   sqliteInsertAccount,
@@ -92,7 +93,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const data = testBlob(new Uint8Array([10, 20, 30]));
       const id = brandId<ChannelId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(channels)
         .values({
@@ -115,7 +116,7 @@ describe("SQLite communication schema", () => {
     it("rejects invalid type via CHECK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -136,7 +137,7 @@ describe("SQLite communication schema", () => {
     it("rejects negative sort_order via CHECK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -189,7 +190,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -203,7 +204,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -218,7 +219,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.update(channels)
         .set({ archived: true, archivedAt: now })
@@ -237,7 +238,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
       const id = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([5, 6, 7]));
 
       db.insert(messages)
@@ -264,7 +265,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
       const msgId = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(messages)
         .values({
@@ -288,7 +289,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
       const msgId = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(messages)
         .values({
@@ -311,7 +312,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -326,7 +327,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -342,7 +343,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
       const id = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(messages)
         .values({
@@ -368,7 +369,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const channelId = insertChannel(systemId);
       const id = brandId<MessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(messages)
         .values({
@@ -394,7 +395,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(boardMessages)
         .values({
@@ -418,7 +419,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(boardMessages)
         .values({
@@ -439,7 +440,7 @@ describe("SQLite communication schema", () => {
     it("rejects negative sort_order via CHECK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -460,7 +461,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(boardMessages)
         .values({
@@ -482,7 +483,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(boardMessages)
         .values({
@@ -504,7 +505,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(boardMessages)
         .values({
@@ -527,7 +528,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -541,7 +542,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -556,7 +557,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BoardMessageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(boardMessages)
         .values({
@@ -585,7 +586,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notes)
         .values({
@@ -608,7 +609,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notes)
         .values({
@@ -631,7 +632,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notes)
         .values({
@@ -652,7 +653,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notes)
         .values({
@@ -675,7 +676,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notes)
         .values({
@@ -695,7 +696,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -709,7 +710,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -724,7 +725,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notes)
         .values({
@@ -749,7 +750,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(polls)
         .values({
@@ -785,7 +786,7 @@ describe("SQLite communication schema", () => {
     it("rejects invalid status via CHECK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -822,7 +823,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(polls)
         .values({
@@ -858,7 +859,7 @@ describe("SQLite communication schema", () => {
     it("rejects invalid kind via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -884,7 +885,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(polls)
         .values({
@@ -910,7 +911,7 @@ describe("SQLite communication schema", () => {
     it("rejects nonexistent createdByMemberId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -946,7 +947,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<PollId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(polls)
         .values({
@@ -973,7 +974,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -987,7 +988,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1002,7 +1003,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.update(polls).set({ archived: true, archivedAt: now }).where(eq(polls.id, pollId)).run();
 
@@ -1018,7 +1019,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20]));
 
       db.insert(pollVotes)
@@ -1043,7 +1044,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1060,7 +1061,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const voteId = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(pollVotes)
         .values({
@@ -1084,7 +1085,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const voteId = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(pollVotes)
         .values({
@@ -1108,8 +1109,8 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
-      const votedAt = Date.now();
+      const now = fixtureNow();
+      const votedAt = fixtureNow();
 
       db.insert(pollVotes)
         .values({
@@ -1138,7 +1139,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(pollVotes)
         .values({
@@ -1163,7 +1164,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(pollVotes)
         .values({
@@ -1187,7 +1188,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(pollVotes)
         .values({
@@ -1212,7 +1213,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1227,7 +1228,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1243,7 +1244,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const pollId = insertPoll(systemId);
       const id = brandId<PollVoteId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(pollVotes)
         .values({
@@ -1273,7 +1274,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1294,7 +1295,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1315,7 +1316,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1337,7 +1338,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1358,7 +1359,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1379,7 +1380,7 @@ describe("SQLite communication schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1400,7 +1401,7 @@ describe("SQLite communication schema", () => {
     it("rejects nonexistent createdByMemberId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1421,7 +1422,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1442,7 +1443,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({
@@ -1464,7 +1465,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1478,7 +1479,7 @@ describe("SQLite communication schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1493,7 +1494,7 @@ describe("SQLite communication schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<AcknowledgementId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(acknowledgements)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-custom-fields.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-custom-fields.integration.test.ts
@@ -16,6 +16,7 @@ import { buckets } from "../schema/sqlite/privacy.js";
 import { systemStructureEntities, systemStructureEntityTypes } from "../schema/sqlite/structure.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteCustomFieldsTables,
   sqliteInsertAccount,
@@ -61,7 +62,7 @@ describe("SQLite custom fields schema", () => {
     systemId: SystemId,
     id: BucketId = brandId<BucketId>(crypto.randomUUID()),
   ): BucketId {
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(buckets)
       .values({
         id,
@@ -78,7 +79,7 @@ describe("SQLite custom fields schema", () => {
     systemId: SystemId,
     id: FieldDefinitionId = brandId<FieldDefinitionId>(crypto.randomUUID()),
   ): FieldDefinitionId {
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(fieldDefinitions)
       .values({
         id,
@@ -114,7 +115,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(fieldDefinitions)
@@ -138,7 +139,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitions)
         .values({
@@ -172,7 +173,7 @@ describe("SQLite custom fields schema", () => {
     });
 
     it("rejects nonexistent systemId FK", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         db
           .insert(fieldDefinitions)
@@ -192,7 +193,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitions)
         .values({
@@ -216,7 +217,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitions)
         .values({
@@ -241,7 +242,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitions)
         .values({
@@ -263,7 +264,7 @@ describe("SQLite custom fields schema", () => {
     it("rejects invalid fieldType via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -283,7 +284,7 @@ describe("SQLite custom fields schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -297,7 +298,7 @@ describe("SQLite custom fields schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -312,7 +313,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<FieldDefinitionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitions)
         .values({
@@ -342,7 +343,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(fieldValues)
@@ -368,7 +369,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -389,7 +390,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -412,7 +413,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -433,7 +434,7 @@ describe("SQLite custom fields schema", () => {
     it("rejects nonexistent fieldDefinitionId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -456,7 +457,7 @@ describe("SQLite custom fields schema", () => {
       const memberId = brandId<MemberId>(sqliteInsertMember(db, systemId));
       const fieldDefId = insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -480,7 +481,7 @@ describe("SQLite custom fields schema", () => {
       const memberId1 = brandId<MemberId>(sqliteInsertMember(db, systemId));
       const memberId2 = brandId<MemberId>(sqliteInsertMember(db, systemId));
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -518,7 +519,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = brandId<MemberId>(sqliteInsertMember(db, systemId));
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -552,7 +553,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -585,7 +586,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = brandId<MemberId>(sqliteInsertMember(db, systemId));
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -622,7 +623,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -789,7 +790,7 @@ describe("SQLite custom fields schema", () => {
       systemId: SystemId,
       id = brandId<SystemStructureEntityTypeId>(crypto.randomUUID()),
     ): SystemStructureEntityTypeId {
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(systemStructureEntityTypes)
         .values({
           id,
@@ -808,7 +809,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const id = brandId<FieldDefinitionScopeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitionScopes)
         .values({
@@ -836,7 +837,7 @@ describe("SQLite custom fields schema", () => {
     it("rejects nonexistent field_definition_id FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -857,7 +858,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -879,7 +880,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -895,7 +896,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const entityTypeId = brandId<SystemStructureEntityTypeId>(insertEntityType(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -910,7 +911,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitionScopes)
         .values({
@@ -942,7 +943,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -958,7 +959,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const id = brandId<FieldDefinitionScopeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitionScopes)
         .values({
@@ -984,7 +985,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldDefinitionScopes)
         .values({
@@ -1008,7 +1009,7 @@ describe("SQLite custom fields schema", () => {
       systemId: SystemId,
       id = brandId<SystemStructureEntityTypeId>(crypto.randomUUID()),
     ): SystemStructureEntityTypeId {
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(systemStructureEntityTypes)
         .values({
           id,
@@ -1027,7 +1028,7 @@ describe("SQLite custom fields schema", () => {
       entityTypeId: SystemStructureEntityTypeId,
       id = brandId<SystemStructureEntityId>(crypto.randomUUID()),
     ): SystemStructureEntityId {
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(systemStructureEntities)
         .values({
           id,
@@ -1044,7 +1045,7 @@ describe("SQLite custom fields schema", () => {
 
     function insertGroup(systemId: string, raw = crypto.randomUUID()): GroupId {
       const id = brandId<GroupId>(raw);
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(groups)
         .values({
           id,
@@ -1065,7 +1066,7 @@ describe("SQLite custom fields schema", () => {
       const entityTypeId = brandId<SystemStructureEntityTypeId>(insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(insertEntity(systemId, entityTypeId));
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -1092,7 +1093,7 @@ describe("SQLite custom fields schema", () => {
       const fieldDefId = insertFieldDefinition(systemId);
       const groupId = brandId<GroupId>(insertGroup(systemId));
       const id = brandId<FieldValueId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -1120,7 +1121,7 @@ describe("SQLite custom fields schema", () => {
       const memberId = brandId<MemberId>(sqliteInsertMember(db, systemId));
       const entityTypeId = brandId<SystemStructureEntityTypeId>(insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(insertEntity(systemId, entityTypeId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1145,7 +1146,7 @@ describe("SQLite custom fields schema", () => {
       const fieldDefId = insertFieldDefinition(systemId);
       const memberId = brandId<MemberId>(sqliteInsertMember(db, systemId));
       const groupId = brandId<GroupId>(insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1171,7 +1172,7 @@ describe("SQLite custom fields schema", () => {
       const entityTypeId = brandId<SystemStructureEntityTypeId>(insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(insertEntity(systemId, entityTypeId));
       const groupId = brandId<GroupId>(insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1198,7 +1199,7 @@ describe("SQLite custom fields schema", () => {
       const entityTypeId = brandId<SystemStructureEntityTypeId>(insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(insertEntity(systemId, entityTypeId));
       const groupId = brandId<GroupId>(insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1224,7 +1225,7 @@ describe("SQLite custom fields schema", () => {
       const fieldDefId = insertFieldDefinition(systemId);
       const entityTypeId = brandId<SystemStructureEntityTypeId>(insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(insertEntity(systemId, entityTypeId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -1248,7 +1249,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const groupId = brandId<GroupId>(insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -1271,7 +1272,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1293,7 +1294,7 @@ describe("SQLite custom fields schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1317,7 +1318,7 @@ describe("SQLite custom fields schema", () => {
       const fieldDefId = insertFieldDefinition(systemId);
       const entityTypeId = brandId<SystemStructureEntityTypeId>(insertEntityType(systemId));
       const entityId = brandId<SystemStructureEntityId>(insertEntity(systemId, entityTypeId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({
@@ -1352,7 +1353,7 @@ describe("SQLite custom fields schema", () => {
       const systemId = insertSystem(accountId);
       const fieldDefId = insertFieldDefinition(systemId);
       const groupId = brandId<GroupId>(insertGroup(systemId));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(fieldValues)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-fronting.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-fronting.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -9,6 +9,7 @@ import { customFronts, frontingComments, frontingSessions } from "../schema/sqli
 import { members } from "../schema/sqlite/members.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteFrontingTables,
   sqliteInsertAccount,
@@ -45,7 +46,7 @@ describe("SQLite fronting schema", () => {
 
   function insertCustomFront(systemId: string, raw = crypto.randomUUID()): CustomFrontId {
     const id = brandId<CustomFrontId>(raw);
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(customFronts)
       .values({
         id,
@@ -64,7 +65,7 @@ describe("SQLite fronting schema", () => {
     memberId?: string,
   ): FrontingSessionId {
     const sessionId = brandId<FrontingSessionId>(id);
-    const now = Date.now();
+    const now = fixtureNow();
     const resolvedMemberId = memberId ?? insertMember(systemId);
     db.insert(frontingSessions)
       .values({
@@ -103,7 +104,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(frontingSessions)
@@ -112,7 +113,7 @@ describe("SQLite fronting schema", () => {
           systemId,
           memberId,
           startTime: now,
-          endTime: now + 1000,
+          endTime: toUnixMillis(now + 1000),
           encryptedData: data,
           createdAt: now,
           updatedAt: now,
@@ -132,7 +133,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingSessions)
         .values({
@@ -155,7 +156,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingSessions)
         .values({
@@ -188,7 +189,7 @@ describe("SQLite fronting schema", () => {
     });
 
     it("rejects nonexistent systemId FK", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         db
           .insert(frontingSessions)
@@ -209,7 +210,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -235,7 +236,7 @@ describe("SQLite fronting schema", () => {
             systemId,
             memberId,
             startTime: now,
-            endTime: now - 1,
+            endTime: toUnixMillis(now - 1),
             encryptedData: testBlob(new Uint8Array([1])),
             createdAt: now,
             updatedAt: now,
@@ -249,7 +250,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId1 = insertMember(systemId);
       const memberId2 = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       const id1 = brandId<FrontingSessionId>(crypto.randomUUID());
       const id2 = brandId<FrontingSessionId>(crypto.randomUUID());
@@ -260,7 +261,7 @@ describe("SQLite fronting schema", () => {
           systemId,
           memberId: memberId1,
           startTime: now,
-          endTime: now + 2000,
+          endTime: toUnixMillis(now + 2000),
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
           updatedAt: now,
@@ -272,8 +273,8 @@ describe("SQLite fronting schema", () => {
           id: id2,
           systemId,
           memberId: memberId2,
-          startTime: now + 1000,
-          endTime: now + 3000,
+          startTime: toUnixMillis(now + 1000),
+          endTime: toUnixMillis(now + 3000),
           encryptedData: testBlob(new Uint8Array([2])),
           createdAt: now,
           updatedAt: now,
@@ -293,7 +294,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const cfId = insertCustomFront(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       const entityTypeId = crypto.randomUUID();
       const entityId = crypto.randomUUID();
@@ -330,7 +331,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const customFrontId = insertCustomFront(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingSessions)
         .values({
@@ -353,7 +354,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingSessions)
         .values({
@@ -375,7 +376,7 @@ describe("SQLite fronting schema", () => {
     it("rejects nonexistent memberId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -397,7 +398,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const customFrontId = insertCustomFront(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingSessions)
         .values({
@@ -419,7 +420,7 @@ describe("SQLite fronting schema", () => {
     it("rejects nonexistent customFrontId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -441,7 +442,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -455,7 +456,7 @@ describe("SQLite fronting schema", () => {
     it("rejects fronting session with no subject", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -471,7 +472,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const customFrontId = insertCustomFront(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingSessions)
         .values({
@@ -506,7 +507,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<FrontingSessionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingSessions)
         .values({
@@ -531,7 +532,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -546,7 +547,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -561,7 +562,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.update(frontingSessions)
         .set({ archived: true, archivedAt: now, updatedAt: now })
@@ -576,7 +577,7 @@ describe("SQLite fronting schema", () => {
     it("accepts fronting session with only structureEntityId", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const entityTypeId = crypto.randomUUID();
       const entityId = crypto.randomUUID();
 
@@ -614,7 +615,7 @@ describe("SQLite fronting schema", () => {
     it("rejects nonexistent structureEntityId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -635,7 +636,7 @@ describe("SQLite fronting schema", () => {
     it("restricts deletion of structure entity with dependent fronting session", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const entityTypeId = crypto.randomUUID();
       const entityId = crypto.randomUUID();
 
@@ -673,7 +674,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(customFronts)
@@ -696,7 +697,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(customFronts)
         .values({
@@ -718,7 +719,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(customFronts)
         .values({
@@ -739,7 +740,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<CustomFrontId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(customFronts)
         .values({
@@ -761,7 +762,7 @@ describe("SQLite fronting schema", () => {
     it("rejects version < 1 via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -775,7 +776,7 @@ describe("SQLite fronting schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -789,7 +790,7 @@ describe("SQLite fronting schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -804,7 +805,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = insertCustomFront(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.update(customFronts)
         .set({ archived: true, archivedAt: now, updatedAt: now })
@@ -824,7 +825,7 @@ describe("SQLite fronting schema", () => {
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(frontingComments)
@@ -852,7 +853,7 @@ describe("SQLite fronting schema", () => {
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -875,7 +876,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -900,7 +901,7 @@ describe("SQLite fronting schema", () => {
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
       const commentId = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -927,7 +928,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -951,7 +952,7 @@ describe("SQLite fronting schema", () => {
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -975,7 +976,7 @@ describe("SQLite fronting schema", () => {
       const customFrontId = insertCustomFront(systemId);
       const sessionId = insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -998,7 +999,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -1021,7 +1022,7 @@ describe("SQLite fronting schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const sessionId = insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1045,7 +1046,7 @@ describe("SQLite fronting schema", () => {
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -1070,7 +1071,7 @@ describe("SQLite fronting schema", () => {
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({
@@ -1096,7 +1097,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1112,7 +1113,7 @@ describe("SQLite fronting schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1129,7 +1130,7 @@ describe("SQLite fronting schema", () => {
       const memberId = insertMember(systemId);
       const sessionId = insertFrontingSession(systemId);
       const id = brandId<FrontingCommentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(frontingComments)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-groups.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-groups.integration.test.ts
@@ -9,6 +9,7 @@ import { groupMemberships, groups } from "../schema/sqlite/groups.js";
 import { members } from "../schema/sqlite/members.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteGroupsTables,
   sqliteInsertAccount,
@@ -46,7 +47,7 @@ describe("SQLite groups schema", () => {
     } = {},
   ): GroupId {
     const id = brandId<GroupId>(opts.id ?? crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(groups)
       .values({
         id,
@@ -85,7 +86,7 @@ describe("SQLite groups schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<GroupId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(groups)
@@ -118,7 +119,7 @@ describe("SQLite groups schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<GroupId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(groups)
         .values({
@@ -157,7 +158,7 @@ describe("SQLite groups schema", () => {
     it("rejects negative sort_order via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -178,7 +179,7 @@ describe("SQLite groups schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<GroupId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(groups)
         .values({
@@ -197,7 +198,7 @@ describe("SQLite groups schema", () => {
       expect(before[0]?.archivedAt).toBeNull();
 
       // Update to archived
-      const archivedAt = Date.now();
+      const archivedAt = fixtureNow();
       db.update(groups).set({ archived: true, archivedAt }).where(eq(groups.id, id)).run();
 
       const after = db.select().from(groups).where(eq(groups.id, id)).all();
@@ -218,7 +219,7 @@ describe("SQLite groups schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -232,7 +233,7 @@ describe("SQLite groups schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -250,7 +251,7 @@ describe("SQLite groups schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const groupId = insertGroup(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(groupMemberships)
         .values({
@@ -278,7 +279,7 @@ describe("SQLite groups schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const groupId = insertGroup(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(groupMemberships)
         .values({
@@ -304,7 +305,7 @@ describe("SQLite groups schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const groupId = insertGroup(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(groupMemberships)
         .values({
@@ -330,7 +331,7 @@ describe("SQLite groups schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const groupId = insertGroup(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(groupMemberships)
         .values({
@@ -359,7 +360,7 @@ describe("SQLite groups schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const groupId = insertGroup(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(groupMemberships)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-import-export.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-import-export.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -14,6 +14,7 @@ import {
 import { buckets } from "../schema/sqlite/privacy.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteImportExportTables,
   sqliteInsertAccount,
@@ -63,7 +64,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(importJobs)
         .values({
@@ -85,8 +86,8 @@ describe("SQLite import-export schema", () => {
           chunksTotal: 10,
           chunksCompleted: 4,
           createdAt: now,
-          updatedAt: now + 1000,
-          completedAt: now + 5000,
+          updatedAt: toUnixMillis(now + 1000),
+          completedAt: toUnixMillis(now + 5000),
         })
         .run();
 
@@ -109,7 +110,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(importJobs)
         .values({
@@ -138,7 +139,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const errors = [
         {
           entityType: "unknown" as const,
@@ -173,7 +174,7 @@ describe("SQLite import-export schema", () => {
     it("rejects invalid source value", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -193,7 +194,7 @@ describe("SQLite import-export schema", () => {
     it("rejects invalid status value", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -214,7 +215,7 @@ describe("SQLite import-export schema", () => {
     it("rejects negative progressPercent", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -236,7 +237,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(importJobs)
         .values({
@@ -258,7 +259,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(importJobs)
         .values({
@@ -279,7 +280,7 @@ describe("SQLite import-export schema", () => {
     it("rejects progressPercent above 100", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -301,7 +302,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(importJobs)
         .values({
@@ -322,7 +323,7 @@ describe("SQLite import-export schema", () => {
     it("rejects chunksCompleted exceeding chunksTotal", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -345,7 +346,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(importJobs)
         .values({
@@ -367,7 +368,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const errors = Array.from({ length: 1000 }, (_, i) => ({
         entityType: "unknown" as const,
         entityId: null,
@@ -394,7 +395,7 @@ describe("SQLite import-export schema", () => {
     it("rejects errorLog with more than 1000 entries", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const errors = Array.from({ length: 1001 }, (_, i) => ({
         entityType: "unknown" as const,
         entityId: null,
@@ -425,7 +426,7 @@ describe("SQLite import-export schema", () => {
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
       const blobId = brandId<BlobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(buckets)
         .values({
@@ -461,7 +462,7 @@ describe("SQLite import-export schema", () => {
           blobId,
           createdAt: now,
           updatedAt: now,
-          completedAt: now + 3000,
+          completedAt: toUnixMillis(now + 3000),
         })
         .run();
 
@@ -480,7 +481,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(exportRequests)
         .values({
@@ -504,7 +505,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(exportRequests)
         .values({
@@ -525,7 +526,7 @@ describe("SQLite import-export schema", () => {
     it("rejects invalid format value", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -545,7 +546,7 @@ describe("SQLite import-export schema", () => {
     it("rejects invalid status value", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -567,7 +568,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(exportRequests)
         .values({ id, accountId, systemId, format: "json", status, createdAt: now, updatedAt: now })
@@ -582,7 +583,7 @@ describe("SQLite import-export schema", () => {
       const systemId = insertSystem(accountId);
       const blobId = brandId<BlobId>(crypto.randomUUID());
       const exportId = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(buckets)
         .values({
@@ -632,7 +633,7 @@ describe("SQLite import-export schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(exportRequests)
         .values({
@@ -656,7 +657,7 @@ describe("SQLite import-export schema", () => {
     it("round-trips with all fields", () => {
       const accountId = insertAccount();
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(accountPurgeRequests)
         .values({
@@ -664,10 +665,10 @@ describe("SQLite import-export schema", () => {
           accountId,
           status: "confirmed",
           confirmationPhrase: "DELETE MY ACCOUNT",
-          scheduledPurgeAt: now + 86400000,
+          scheduledPurgeAt: toUnixMillis(now + 86400000),
           requestedAt: now,
-          confirmedAt: now + 1000,
-          completedAt: now + 86400000,
+          confirmedAt: toUnixMillis(now + 1000),
+          completedAt: toUnixMillis(now + 86400000),
           cancelledAt: null,
         })
         .run();
@@ -690,7 +691,7 @@ describe("SQLite import-export schema", () => {
 
     it("rejects invalid status value", () => {
       const accountId = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -700,7 +701,7 @@ describe("SQLite import-export schema", () => {
             accountId,
             status: "invalid-status" as "pending",
             confirmationPhrase: "DELETE MY ACCOUNT",
-            scheduledPurgeAt: now + 86400000,
+            scheduledPurgeAt: toUnixMillis(now + 86400000),
             requestedAt: now,
           })
           .run(),
@@ -710,7 +711,7 @@ describe("SQLite import-export schema", () => {
     it("applies default status of pending", () => {
       const accountId = insertAccount();
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(accountPurgeRequests)
         .values({
@@ -733,7 +734,7 @@ describe("SQLite import-export schema", () => {
     it("cascades on account deletion", () => {
       const accountId = insertAccount();
       const id = brandId<ImportJobId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(accountPurgeRequests)
         .values({
@@ -741,7 +742,7 @@ describe("SQLite import-export schema", () => {
           accountId,
           status: "pending",
           confirmationPhrase: "CONFIRM DELETE",
-          scheduledPurgeAt: now + 86400000,
+          scheduledPurgeAt: toUnixMillis(now + 86400000),
           requestedAt: now,
         })
         .run();
@@ -757,7 +758,7 @@ describe("SQLite import-export schema", () => {
 
     it("rejects second active purge request when first is confirmed", () => {
       const accountId = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       db.insert(accountPurgeRequests)
@@ -792,7 +793,7 @@ describe("SQLite import-export schema", () => {
 
     it("allows new purge request after previous is completed", () => {
       const accountId = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       db.insert(accountPurgeRequests)
@@ -833,7 +834,7 @@ describe("SQLite import-export schema", () => {
 
     it("allows new purge request after previous is cancelled", () => {
       const accountId = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       db.insert(accountPurgeRequests)
@@ -874,7 +875,7 @@ describe("SQLite import-export schema", () => {
 
     it("rejects second active purge request when first is processing", () => {
       const accountId = insertAccount();
-      const now = Date.now();
+      const now = fixtureNow();
       const firstId = crypto.randomUUID();
 
       db.insert(accountPurgeRequests)

--- a/packages/db/src/__tests__/schema-sqlite-innerworld.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-innerworld.integration.test.ts
@@ -10,6 +10,7 @@ import {
   innerworldRegions,
 } from "../schema/sqlite/innerworld.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteInnerworldTables,
   sqliteInsertAccount,
@@ -56,7 +57,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("round-trips innerworldRegions with all fields", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     db.insert(innerworldRegions)
@@ -90,7 +91,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_regions defaults archived to false and archivedAt to null", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     db.insert(innerworldRegions)
@@ -114,7 +115,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_regions round-trips archived: true with archivedAt", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     db.insert(innerworldRegions)
@@ -140,7 +141,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_regions rejects archived=true with archivedAt=null via CHECK", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -153,7 +154,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_regions rejects archived=false with archivedAt set via CHECK", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -166,7 +167,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_regions updates archived from false to true", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     db.insert(innerworldRegions)
@@ -195,7 +196,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("round-trips innerworldEntities with all fields", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     db.insert(innerworldRegions)
@@ -236,7 +237,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_entities defaults archived to false and archivedAt to null", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const entityId = newEntityId();
 
     db.insert(innerworldEntities)
@@ -260,7 +261,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_entities round-trips archived: true with archivedAt", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const entityId = newEntityId();
 
     db.insert(innerworldEntities)
@@ -286,7 +287,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_entities rejects archived=true with archivedAt=null via CHECK", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -299,7 +300,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_entities rejects archived=false with archivedAt set via CHECK", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -312,7 +313,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("innerworld_entities updates archived from false to true", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const entityId = newEntityId();
 
     db.insert(innerworldEntities)
@@ -341,7 +342,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("round-trips innerworldCanvas (1:1 pattern, systemId as PK)", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(innerworldCanvas)
       .values({
@@ -365,7 +366,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("sets parentRegionId to null when parent region is deleted (SET NULL)", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const parentId = newRegionId();
     const childId = newRegionId();
 
@@ -399,7 +400,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("sets entity regionId to null when region is deleted (SET NULL)", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
     const entityId = newEntityId();
 
@@ -437,7 +438,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("cascades system delete to all 3 innerworld tables", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
     const regionId = newRegionId();
 
     db.insert(innerworldRegions)
@@ -485,7 +486,7 @@ describe("SQLite Innerworld Schema", () => {
 
   it("enforces canvas 1:1 pattern (PK violation on duplicate systemId)", () => {
     const systemId = setupSystem();
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(innerworldCanvas)
       .values({

--- a/packages/db/src/__tests__/schema-sqlite-jobs.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-jobs.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { jobs } from "../schema/sqlite/jobs.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteJobsTables,
   sqliteInsertAccount,
@@ -45,7 +46,7 @@ describe("SQLite jobs schema", () => {
 
   describe("text primary key", () => {
     it("stores and retrieves a prefixed UUID as the primary key", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newJobId();
 
       db.insert(jobs)
@@ -63,7 +64,7 @@ describe("SQLite jobs schema", () => {
     });
 
     it("rejects duplicate primary keys", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const id = newJobId();
 
       db.insert(jobs).values({ id, type: "sync-push", payload: {}, createdAt: now }).run();
@@ -78,7 +79,7 @@ describe("SQLite jobs schema", () => {
     it("stores and retrieves all fields including JSON payload", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const payload = { key: "value", nested: { count: 42 } };
 
       db.insert(jobs)
@@ -90,10 +91,10 @@ describe("SQLite jobs schema", () => {
           status: "running",
           attempts: 2,
           maxAttempts: 10,
-          nextRetryAt: now + 60000,
+          nextRetryAt: toUnixMillis(now + 60000),
           error: "Previous attempt failed",
           createdAt: now,
-          startedAt: now + 1000,
+          startedAt: toUnixMillis(now + 1000),
           completedAt: null,
           idempotencyKey: `idem-${crypto.randomUUID()}`,
         })
@@ -117,7 +118,7 @@ describe("SQLite jobs schema", () => {
 
   describe("defaults", () => {
     it("defaults status to pending, attempts to 0, maxAttempts to 5", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       const result = db
         .insert(jobs)
@@ -138,7 +139,7 @@ describe("SQLite jobs schema", () => {
 
   describe("nullable systemId", () => {
     it("allows null systemId for system-wide jobs", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       const result = db
         .insert(jobs)
@@ -159,7 +160,7 @@ describe("SQLite jobs schema", () => {
 
   describe("status CHECK constraint", () => {
     it("rejects invalid status values", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db.run(
@@ -171,7 +172,7 @@ describe("SQLite jobs schema", () => {
 
   describe("type CHECK constraint", () => {
     it("rejects invalid job type", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db.run(
@@ -183,7 +184,7 @@ describe("SQLite jobs schema", () => {
 
   describe("attempts CHECK constraint", () => {
     it("rejects attempts exceeding max_attempts", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db.run(
@@ -195,7 +196,7 @@ describe("SQLite jobs schema", () => {
 
   describe("idempotency key unique constraint", () => {
     it("rejects duplicate idempotency keys", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const key = `unique-key-${crypto.randomUUID()}`;
 
       db.insert(jobs)
@@ -223,7 +224,7 @@ describe("SQLite jobs schema", () => {
     });
 
     it("allows multiple null idempotency keys", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() => {
         db.insert(jobs)
@@ -252,7 +253,7 @@ describe("SQLite jobs schema", () => {
     it("cascades delete when system is deleted", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(jobs)
         .values({
@@ -276,7 +277,7 @@ describe("SQLite jobs schema", () => {
 
   describe("job lifecycle", () => {
     it("transitions through pending -> running -> completed", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       const inserted = db
         .insert(jobs)
@@ -292,7 +293,7 @@ describe("SQLite jobs schema", () => {
       expect(inserted.status).toBe("pending");
 
       db.update(jobs)
-        .set({ status: "running", startedAt: now + 1000, attempts: 1 })
+        .set({ status: "running", startedAt: toUnixMillis(now + 1000), attempts: 1 })
         .where(eq(jobs.id, inserted.id))
         .run();
 
@@ -301,7 +302,7 @@ describe("SQLite jobs schema", () => {
       expect(running?.attempts).toBe(1);
 
       db.update(jobs)
-        .set({ status: "completed", completedAt: now + 5000 })
+        .set({ status: "completed", completedAt: toUnixMillis(now + 5000) })
         .where(eq(jobs.id, inserted.id))
         .run();
 
@@ -311,7 +312,7 @@ describe("SQLite jobs schema", () => {
     });
 
     it("transitions through pending -> running -> dead-letter with error", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       const inserted = db
         .insert(jobs)
@@ -327,7 +328,7 @@ describe("SQLite jobs schema", () => {
       db.update(jobs)
         .set({
           status: "running",
-          startedAt: now + 1000,
+          startedAt: toUnixMillis(now + 1000),
           attempts: 1,
         })
         .where(eq(jobs.id, inserted.id))
@@ -338,7 +339,7 @@ describe("SQLite jobs schema", () => {
           status: "dead-letter",
           attempts: 5,
           error: "Connection timeout after 5 attempts",
-          completedAt: now + 30000,
+          completedAt: toUnixMillis(now + 30000),
         })
         .where(eq(jobs.id, inserted.id))
         .run();
@@ -352,7 +353,7 @@ describe("SQLite jobs schema", () => {
 
   describe("new columns (ADR 010)", () => {
     it("round-trips heartbeat, timeout, result, scheduledFor, priority", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const result: JobResult = {
         success: true,
         message: "done",
@@ -366,10 +367,10 @@ describe("SQLite jobs schema", () => {
           type: "sync-push",
           payload: { test: true },
           createdAt: now,
-          lastHeartbeatAt: now + 1000,
+          lastHeartbeatAt: toUnixMillis(now + 1000),
           timeoutMs: 60000,
           result,
-          scheduledFor: now + 10000,
+          scheduledFor: toUnixMillis(now + 10000),
           priority: 5,
         })
         .returning()
@@ -383,7 +384,7 @@ describe("SQLite jobs schema", () => {
     });
 
     it("defaults timeoutMs to 30000 and priority to 0", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       const inserted = db
         .insert(jobs)
@@ -406,7 +407,7 @@ describe("SQLite jobs schema", () => {
 
   describe("dead-letter status", () => {
     it("accepts attempts equal to maxAttempts for terminal states", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       const inserted = db
         .insert(jobs)
@@ -429,7 +430,7 @@ describe("SQLite jobs schema", () => {
     });
 
     it("replays dead-letter -> pending with reset", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       const inserted = db
         .insert(jobs)
@@ -459,7 +460,7 @@ describe("SQLite jobs schema", () => {
 
   describe("timeoutMs CHECK constraint", () => {
     it("rejects non-positive timeoutMs", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db.run(
@@ -477,7 +478,7 @@ describe("SQLite jobs schema", () => {
 
   describe("priority ordering", () => {
     it("orders jobs by priority ascending", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(jobs)
         .values([

--- a/packages/db/src/__tests__/schema-sqlite-journal.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-journal.integration.test.ts
@@ -10,6 +10,7 @@ import { journalEntries, wikiPages } from "../schema/sqlite/journal.js";
 import { members } from "../schema/sqlite/members.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteJournalTables,
   sqliteInsertAccount,
@@ -55,7 +56,7 @@ describe("SQLite journal schema", () => {
       const memberId = insertMember(systemId);
       const fsId = brandId<FrontingSessionId>(crypto.randomUUID());
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30]));
 
       db.insert(frontingSessions)
@@ -92,7 +93,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(journalEntries)
         .values({
@@ -112,7 +113,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(journalEntries)
         .values({
@@ -134,7 +135,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(journalEntries)
         .values({
@@ -157,7 +158,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(journalEntries)
         .values({
@@ -177,7 +178,7 @@ describe("SQLite journal schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -191,7 +192,7 @@ describe("SQLite journal schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -206,7 +207,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<JournalEntryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(journalEntries)
         .values({
@@ -234,7 +235,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30]));
       const hash = brandId<SlugHash>("a".repeat(64));
 
@@ -259,7 +260,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(wikiPages)
         .values({
@@ -282,7 +283,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const slugHash = brandId<SlugHash>("b".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(wikiPages)
         .values({
@@ -315,7 +316,7 @@ describe("SQLite journal schema", () => {
       const systemId1 = insertSystem(accountId);
       const systemId2 = insertSystem(accountId);
       const slugHash = brandId<SlugHash>("c".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(wikiPages)
         .values({
@@ -349,7 +350,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(wikiPages)
         .values({
@@ -370,7 +371,7 @@ describe("SQLite journal schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -384,7 +385,7 @@ describe("SQLite journal schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -399,7 +400,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WikiPageId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(wikiPages)
         .values({
@@ -425,7 +426,7 @@ describe("SQLite journal schema", () => {
     it("rejects slug_hash shorter than 64 chars", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -446,7 +447,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const slugHash = brandId<SlugHash>("h".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(wikiPages)
         .values({
@@ -482,7 +483,7 @@ describe("SQLite journal schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const slugHash = brandId<SlugHash>("i".repeat(64));
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(wikiPages)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-key-rotation.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-key-rotation.integration.test.ts
@@ -8,6 +8,7 @@ import { bucketKeyRotations, bucketRotationItems } from "../schema/sqlite/key-ro
 import { buckets } from "../schema/sqlite/privacy.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteKeyRotationTables,
   sqliteInsertAccount,
@@ -21,6 +22,7 @@ import type {
   BucketKeyRotationId,
   BucketRotationItemId,
   SystemId,
+  UnixMillis,
 } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
@@ -37,7 +39,7 @@ describe("SQLite key-rotation schema", () => {
     systemId: SystemId,
     id: BucketId = brandId<BucketId>(crypto.randomUUID()),
   ): BucketId {
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(buckets)
       .values({
         id,
@@ -58,7 +60,7 @@ describe("SQLite key-rotation schema", () => {
       fromKeyVersion: number;
       toKeyVersion: number;
       totalItems: number;
-      initiatedAt: number;
+      initiatedAt: UnixMillis;
     }> = {},
   ): BucketKeyRotationId {
     const id = overrides.id ?? brandId<BucketKeyRotationId>(crypto.randomUUID());
@@ -70,7 +72,7 @@ describe("SQLite key-rotation schema", () => {
         fromKeyVersion: overrides.fromKeyVersion ?? 1,
         toKeyVersion: overrides.toKeyVersion ?? 2,
         totalItems: overrides.totalItems ?? 10,
-        initiatedAt: overrides.initiatedAt ?? Date.now(),
+        initiatedAt: overrides.initiatedAt ?? fixtureNow(),
       })
       .run();
     return id;
@@ -92,7 +94,7 @@ describe("SQLite key-rotation schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const bucketId = insertBucket(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<BucketKeyRotationId>(crypto.randomUUID());
 
       db.insert(bucketKeyRotations)
@@ -135,7 +137,7 @@ describe("SQLite key-rotation schema", () => {
             toKeyVersion: 2,
             state: "invalid" as "initiated",
             totalItems: 1,
-            initiatedAt: Date.now(),
+            initiatedAt: fixtureNow(),
           })
           .run(),
       ).toThrow();
@@ -156,7 +158,7 @@ describe("SQLite key-rotation schema", () => {
             fromKeyVersion: 3,
             toKeyVersion: 2,
             totalItems: 1,
-            initiatedAt: Date.now(),
+            initiatedAt: fixtureNow(),
           })
           .run(),
       ).toThrow();
@@ -177,7 +179,7 @@ describe("SQLite key-rotation schema", () => {
             fromKeyVersion: 2,
             toKeyVersion: 2,
             totalItems: 1,
-            initiatedAt: Date.now(),
+            initiatedAt: fixtureNow(),
           })
           .run(),
       ).toThrow();
@@ -197,7 +199,7 @@ describe("SQLite key-rotation schema", () => {
           fromKeyVersion: 1,
           toKeyVersion: 2,
           totalItems: 1,
-          initiatedAt: Date.now(),
+          initiatedAt: fixtureNow(),
         })
         .run();
 
@@ -229,7 +231,7 @@ describe("SQLite key-rotation schema", () => {
           fromKeyVersion: 1,
           toKeyVersion: 2,
           totalItems: 5,
-          initiatedAt: Date.now(),
+          initiatedAt: fixtureNow(),
         })
         .run();
 
@@ -276,7 +278,7 @@ describe("SQLite key-rotation schema", () => {
           entityId: crypto.randomUUID(),
           status: "claimed",
           claimedBy: "worker-1",
-          claimedAt: Date.now(),
+          claimedAt: fixtureNow(),
           attempts: 1,
         })
         .run();

--- a/packages/db/src/__tests__/schema-sqlite-lifecycle-events.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-lifecycle-events.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -8,6 +8,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { lifecycleEvents } from "../schema/sqlite/lifecycle-events.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow, fixtureNowPlus } from "./fixtures/timestamps.js";
 import {
   createSqliteLifecycleEventsTables,
   sqliteInsertAccount,
@@ -40,8 +41,8 @@ describe("SQLite lifecycle_events schema", () => {
   it("inserts and retrieves with all columns", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const occurred = Date.now() - 86400000;
-    const recorded = Date.now();
+    const occurred = fixtureNowPlus(-86400000);
+    const recorded = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
@@ -68,7 +69,7 @@ describe("SQLite lifecycle_events schema", () => {
   it("round-trips encrypted_data binary correctly", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
@@ -93,7 +94,7 @@ describe("SQLite lifecycle_events schema", () => {
   it("allows multiple events per system", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(lifecycleEvents)
       .values({
@@ -112,9 +113,9 @@ describe("SQLite lifecycle_events schema", () => {
         id: brandId<LifecycleEventId>(crypto.randomUUID()),
         systemId,
         eventType: "discovery",
-        occurredAt: now + 1000,
-        recordedAt: now + 1000,
-        updatedAt: now + 1000,
+        occurredAt: toUnixMillis(now + 1000),
+        recordedAt: toUnixMillis(now + 1000),
+        updatedAt: toUnixMillis(now + 1000),
         encryptedData: testBlob(new Uint8Array([2])),
       })
       .run();
@@ -130,8 +131,8 @@ describe("SQLite lifecycle_events schema", () => {
   it("supports separate occurred_at and recorded_at", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const occurred = Date.now() - 3600000;
-    const recorded = Date.now();
+    const occurred = fixtureNowPlus(-3600000);
+    const recorded = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
     db.insert(lifecycleEvents)
@@ -155,7 +156,7 @@ describe("SQLite lifecycle_events schema", () => {
   it("cascades on system deletion", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
     db.insert(lifecycleEvents)
@@ -176,7 +177,7 @@ describe("SQLite lifecycle_events schema", () => {
   });
 
   it("rejects nonexistent systemId FK", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     expect(() =>
       db
         .insert(lifecycleEvents)
@@ -196,7 +197,7 @@ describe("SQLite lifecycle_events schema", () => {
   it("rejects duplicate primary key", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
     db.insert(lifecycleEvents)
@@ -231,7 +232,7 @@ describe("SQLite lifecycle_events schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(lifecycleEvents)
       .values({
@@ -253,7 +254,7 @@ describe("SQLite lifecycle_events schema", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
     const id = brandId<LifecycleEventId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(lifecycleEvents)
       .values({
@@ -274,7 +275,7 @@ describe("SQLite lifecycle_events schema", () => {
   it("rejects invalid eventType via CHECK constraint", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -296,7 +297,7 @@ describe("SQLite lifecycle_events schema", () => {
     it("defaults archived to false and archivedAt to null on insert", () => {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
       db.insert(lifecycleEvents)
@@ -319,7 +320,7 @@ describe("SQLite lifecycle_events schema", () => {
     it("defaults version to 1 on insert", () => {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = brandId<LifecycleEventId>(crypto.randomUUID());
 
       db.insert(lifecycleEvents)
@@ -341,7 +342,7 @@ describe("SQLite lifecycle_events schema", () => {
     it("rejects archived=true with archivedAt=null via consistency check", () => {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -364,7 +365,7 @@ describe("SQLite lifecycle_events schema", () => {
     it("rejects archived=false with archivedAt set via consistency check", () => {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -387,7 +388,7 @@ describe("SQLite lifecycle_events schema", () => {
     it("rejects version < 1 via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client

--- a/packages/db/src/__tests__/schema-sqlite-members.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-members.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -8,6 +8,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { members, memberPhotos } from "../schema/sqlite/members.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteMemberTables,
   sqliteInsertAccount,
@@ -29,7 +30,7 @@ describe("SQLite members schema", () => {
 
   function insertMember(systemId: string, raw = crypto.randomUUID()): MemberId {
     const id = brandId<MemberId>(raw);
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(members)
       .values({
         id,
@@ -63,7 +64,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(members)
@@ -86,7 +87,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(members)
         .values({
@@ -107,7 +108,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(members)
         .values({
@@ -134,7 +135,7 @@ describe("SQLite members schema", () => {
     });
 
     it("rejects nonexistent systemId FK", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         db
           .insert(members)
@@ -153,7 +154,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(members)
         .values({
@@ -173,7 +174,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(members)
         .values({
@@ -196,7 +197,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(members)
         .values({
@@ -208,7 +209,7 @@ describe("SQLite members schema", () => {
         })
         .run();
 
-      const later = now + 1000;
+      const later = toUnixMillis(now + 1000);
       db.update(members)
         .set({ version: sql`${members.version} + 1`, updatedAt: later })
         .where(eq(members.id, id))
@@ -222,7 +223,7 @@ describe("SQLite members schema", () => {
     it("rejects version < 1 via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -236,7 +237,7 @@ describe("SQLite members schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -250,7 +251,7 @@ describe("SQLite members schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -265,7 +266,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(members)
         .values({
@@ -291,7 +292,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([100, 200]));
 
       db.insert(memberPhotos)
@@ -317,7 +318,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(memberPhotos)
         .values({
@@ -339,7 +340,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(memberPhotos)
         .values({
@@ -361,7 +362,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const photoId = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(memberPhotos)
         .values({
@@ -384,7 +385,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const photoId = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(memberPhotos)
         .values({
@@ -405,7 +406,7 @@ describe("SQLite members schema", () => {
     it("rejects nonexistent memberId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -426,7 +427,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -448,7 +449,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(memberPhotos)
         .values({
@@ -471,7 +472,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(memberPhotos)
         .values({
@@ -495,7 +496,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -510,7 +511,7 @@ describe("SQLite members schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -526,7 +527,7 @@ describe("SQLite members schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = brandId<MemberPhotoId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(memberPhotos)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-nomenclature-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-nomenclature-settings.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { nomenclatureSettings } from "../schema/sqlite/nomenclature-settings.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteNomenclatureSettingsTables,
   sqliteInsertAccount,
@@ -40,7 +41,7 @@ describe("SQLite nomenclature_settings schema", () => {
   it("inserts and retrieves with all columns", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     db.insert(nomenclatureSettings)
@@ -67,7 +68,7 @@ describe("SQLite nomenclature_settings schema", () => {
   it("defaults version to 1", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(nomenclatureSettings)
       .values({
@@ -89,7 +90,7 @@ describe("SQLite nomenclature_settings schema", () => {
   it("round-trips encrypted_data binary correctly", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
     const blob = testBlob(bigArray);
@@ -114,7 +115,7 @@ describe("SQLite nomenclature_settings schema", () => {
   it("enforces 1:1 with systems (rejects duplicate systemId)", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(nomenclatureSettings)
       .values({
@@ -141,7 +142,7 @@ describe("SQLite nomenclature_settings schema", () => {
   it("cascades on system deletion", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(nomenclatureSettings)
       .values({
@@ -162,7 +163,7 @@ describe("SQLite nomenclature_settings schema", () => {
   });
 
   it("rejects nonexistent systemId FK", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     expect(() =>
       db
         .insert(nomenclatureSettings)
@@ -179,7 +180,7 @@ describe("SQLite nomenclature_settings schema", () => {
   it("supports version increment", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(nomenclatureSettings)
       .values({
@@ -191,7 +192,7 @@ describe("SQLite nomenclature_settings schema", () => {
       .run();
 
     db.update(nomenclatureSettings)
-      .set({ version: 2, updatedAt: Date.now() })
+      .set({ version: 2, updatedAt: fixtureNow() })
       .where(eq(nomenclatureSettings.systemId, systemId))
       .run();
 

--- a/packages/db/src/__tests__/schema-sqlite-notifications.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-notifications.integration.test.ts
@@ -13,6 +13,7 @@ import {
 import { friendConnections } from "../schema/sqlite/privacy.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteNotificationTables,
   sqliteInsertAccount,
@@ -66,7 +67,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(deviceTokens)
         .values({
@@ -93,7 +94,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(deviceTokens)
         .values({
@@ -114,7 +115,7 @@ describe("SQLite notifications schema", () => {
     it("rejects invalid platform", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -129,7 +130,7 @@ describe("SQLite notifications schema", () => {
     it("rejects duplicate tokenHash+platform pair", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const tokenHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd";
 
       db.insert(deviceTokens)
@@ -161,7 +162,7 @@ describe("SQLite notifications schema", () => {
     it("allows same tokenHash on different platforms", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const tokenHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd";
 
       db.insert(deviceTokens)
@@ -191,7 +192,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(deviceTokens)
         .values({
@@ -213,7 +214,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(deviceTokens)
         .values({
@@ -237,7 +238,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -262,7 +263,7 @@ describe("SQLite notifications schema", () => {
     it("enforces unique (system_id, event_type)", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -291,7 +292,7 @@ describe("SQLite notifications schema", () => {
     it("rejects invalid event_type", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -307,7 +308,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -332,7 +333,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -359,7 +360,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({ id, systemId, eventType: "switch-reminder", createdAt: now, updatedAt: now })
@@ -378,7 +379,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -404,7 +405,7 @@ describe("SQLite notifications schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -418,7 +419,7 @@ describe("SQLite notifications schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -433,7 +434,7 @@ describe("SQLite notifications schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<NotificationConfigId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -462,7 +463,7 @@ describe("SQLite notifications schema", () => {
     it("allows duplicate (systemId, eventType) when both rows are archived", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -492,7 +493,7 @@ describe("SQLite notifications schema", () => {
     it("rejects duplicate (systemId, eventType) when both rows are active", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(notificationConfigs)
         .values({
@@ -526,7 +527,7 @@ describe("SQLite notifications schema", () => {
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -565,7 +566,7 @@ describe("SQLite notifications schema", () => {
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -603,7 +604,7 @@ describe("SQLite notifications schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -648,7 +649,7 @@ describe("SQLite notifications schema", () => {
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -687,7 +688,7 @@ describe("SQLite notifications schema", () => {
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -727,7 +728,7 @@ describe("SQLite notifications schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -754,7 +755,7 @@ describe("SQLite notifications schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -782,7 +783,7 @@ describe("SQLite notifications schema", () => {
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
       const id = brandId<FriendNotificationPreferenceId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -825,7 +826,7 @@ describe("SQLite notifications schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -870,7 +871,7 @@ describe("SQLite notifications schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       const fcId = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-pk-bridge.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { pkBridgeConfigs } from "../schema/sqlite/pk-bridge.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqlitePkBridgeTables,
   makePkBridgeConfigId,
@@ -41,7 +42,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("round-trips all fields including binary columns and timestamps", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makePkBridgeConfigId();
     const pkTokenCiphertext = new Uint8Array([10, 20, 30]);
     const pkToken = testBlob(pkTokenCiphertext);
@@ -81,7 +82,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("defaults enabled to true when not explicitly set", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
@@ -108,7 +109,7 @@ describe("SQLite PK Bridge Schema", () => {
     for (const direction of validDirections) {
       const accountId = insertAccount();
       const systemId = sqliteInsertSystem(db, accountId);
-      const now = Date.now();
+      const now = fixtureNow();
       const id = makePkBridgeConfigId();
 
       db.insert(pkBridgeConfigs)
@@ -132,7 +133,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("rejects invalid syncDirection via CHECK constraint", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -154,7 +155,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("allows null lastSyncAt", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
@@ -178,8 +179,8 @@ describe("SQLite PK Bridge Schema", () => {
   it("stores non-null lastSyncAt timestamp", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
-    const syncTime = now - 60000;
+    const now = fixtureNow();
+    const syncTime = toUnixMillis(now - 60000);
     const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
@@ -203,7 +204,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("round-trips larger Uint8Array data for all binary columns", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makePkBridgeConfigId();
 
     const largePkTokenCiphertext = new Uint8Array(256);
@@ -238,7 +239,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("cascades delete when parent system is deleted", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
@@ -268,7 +269,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("defaults version to 1", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)
@@ -289,7 +290,7 @@ describe("SQLite PK Bridge Schema", () => {
   });
 
   it("rejects nonexistent systemId FK", () => {
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       db
@@ -311,7 +312,7 @@ describe("SQLite PK Bridge Schema", () => {
   it("stores enabled as false and retrieves it correctly", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makePkBridgeConfigId();
 
     db.insert(pkBridgeConfigs)

--- a/packages/db/src/__tests__/schema-sqlite-privacy.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-privacy.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -15,6 +15,7 @@ import {
 } from "../schema/sqlite/privacy.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqlitePrivacyTables,
   sqliteInsertAccount,
@@ -55,7 +56,7 @@ describe("SQLite privacy schema", () => {
     systemId: SystemId,
     id: BucketId = brandId<BucketId>(crypto.randomUUID()),
   ): BucketId {
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(buckets)
       .values({
         id,
@@ -73,7 +74,7 @@ describe("SQLite privacy schema", () => {
     friendAccountId: AccountId,
     id: FriendConnectionId = brandId<FriendConnectionId>(crypto.randomUUID()),
   ): FriendConnectionId {
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(friendConnections)
       .values({
         id,
@@ -111,7 +112,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(buckets)
@@ -134,7 +135,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlobT2();
 
       db.insert(buckets)
@@ -156,7 +157,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(buckets)
         .values({
@@ -183,7 +184,7 @@ describe("SQLite privacy schema", () => {
     });
 
     it("rejects nonexistent systemId FK", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         db
           .insert(buckets)
@@ -202,7 +203,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(buckets)
         .values({
@@ -223,7 +224,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<BucketId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(buckets)
         .values({
@@ -245,7 +246,7 @@ describe("SQLite privacy schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -259,7 +260,7 @@ describe("SQLite privacy schema", () => {
     it("rejects archived=false with archivedAt set via CHECK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -274,7 +275,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = insertBucket(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.update(buckets)
         .set({ archived: true, archivedAt: now, updatedAt: now })
@@ -290,14 +291,14 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = insertBucket(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.update(buckets)
         .set({ archived: true, archivedAt: now, updatedAt: now })
         .where(eq(buckets.id, id))
         .run();
 
-      const unarchiveNow = Date.now();
+      const unarchiveNow = fixtureNow();
       db.update(buckets)
         .set({ archived: false, archivedAt: null, updatedAt: unarchiveNow })
         .where(eq(buckets.id, id))
@@ -446,7 +447,7 @@ describe("SQLite privacy schema", () => {
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
       const id = brandId<KeyGrantId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const keyData = new Uint8Array([99, 88, 77, 66]);
 
       db.insert(keyGrants)
@@ -476,7 +477,7 @@ describe("SQLite privacy schema", () => {
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
       const id = brandId<KeyGrantId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(keyGrants)
         .values({
@@ -501,7 +502,7 @@ describe("SQLite privacy schema", () => {
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
       const grantId = brandId<KeyGrantId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(keyGrants)
         .values({
@@ -526,7 +527,7 @@ describe("SQLite privacy schema", () => {
       const bucketId = insertBucket(systemId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -550,7 +551,7 @@ describe("SQLite privacy schema", () => {
       const bucketId = insertBucket(systemId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(keyGrants)
         .values({
@@ -584,7 +585,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const bucketId = insertBucket(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -610,7 +611,7 @@ describe("SQLite privacy schema", () => {
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
       const id = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -634,7 +635,7 @@ describe("SQLite privacy schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -670,7 +671,7 @@ describe("SQLite privacy schema", () => {
     it("rejects self-friendship via CHECK", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -691,7 +692,7 @@ describe("SQLite privacy schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       insertFriendConnection(accountId, friendAccountId);
 
@@ -715,7 +716,7 @@ describe("SQLite privacy schema", () => {
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
       const id = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -738,7 +739,7 @@ describe("SQLite privacy schema", () => {
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
       const id = brandId<FriendConnectionId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -762,7 +763,7 @@ describe("SQLite privacy schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -778,7 +779,7 @@ describe("SQLite privacy schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -795,7 +796,7 @@ describe("SQLite privacy schema", () => {
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
       const id = insertFriendConnection(accountId, friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.update(friendConnections)
         .set({ archived: true, archivedAt: now, updatedAt: now })
@@ -812,7 +813,7 @@ describe("SQLite privacy schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -844,7 +845,7 @@ describe("SQLite privacy schema", () => {
       insertSystem(accountId);
       const friendAccountId = insertAccount();
       insertSystem(friendAccountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendConnections)
         .values({
@@ -877,7 +878,7 @@ describe("SQLite privacy schema", () => {
       insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
       const code = `FC-${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -898,7 +899,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -917,7 +918,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const code = `FC-${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -945,7 +946,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -964,7 +965,7 @@ describe("SQLite privacy schema", () => {
     it("rejects code shorter than 8 characters via CHECK", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -982,7 +983,7 @@ describe("SQLite privacy schema", () => {
     it("accepts code exactly 8 characters", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -997,7 +998,7 @@ describe("SQLite privacy schema", () => {
     it("rejects expiresAt === createdAt via CHECK", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1016,7 +1017,7 @@ describe("SQLite privacy schema", () => {
     it("rejects expiresAt <= createdAt via CHECK", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1026,7 +1027,7 @@ describe("SQLite privacy schema", () => {
             accountId,
             code: `FC-${crypto.randomUUID()}`,
             createdAt: now,
-            expiresAt: now - 1000,
+            expiresAt: toUnixMillis(now - 1000),
           })
           .run(),
       ).toThrow();
@@ -1036,7 +1037,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -1056,7 +1057,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -1077,7 +1078,7 @@ describe("SQLite privacy schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1091,7 +1092,7 @@ describe("SQLite privacy schema", () => {
     it("rejects archived=false with archivedAt set via CHECK", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -1106,7 +1107,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const id = brandId<FriendCodeId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -1131,7 +1132,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const code = `FC-${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({
@@ -1163,7 +1164,7 @@ describe("SQLite privacy schema", () => {
       const accountId = insertAccount();
       insertSystem(accountId);
       const code = `FC-${crypto.randomUUID()}`;
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(friendCodes)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-safe-mode-content.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { safeModeContent } from "../schema/sqlite/safe-mode-content.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteSafeModeContentTables,
   makeSafeModeContentId,
@@ -41,7 +42,7 @@ describe("SQLite safe_mode_content schema", () => {
   it("inserts and retrieves with all columns", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
@@ -68,7 +69,7 @@ describe("SQLite safe_mode_content schema", () => {
   it("defaults version to 1", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)
@@ -88,7 +89,7 @@ describe("SQLite safe_mode_content schema", () => {
   it("defaults sort_order to 0", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)
@@ -108,7 +109,7 @@ describe("SQLite safe_mode_content schema", () => {
   it("supports multiple items with ordering", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     for (let i = 0; i < 3; i++) {
       db.insert(safeModeContent)
@@ -136,7 +137,7 @@ describe("SQLite safe_mode_content schema", () => {
   it("round-trips encrypted_data binary correctly", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
@@ -159,7 +160,7 @@ describe("SQLite safe_mode_content schema", () => {
   it("cascades on system deletion", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)
@@ -178,7 +179,7 @@ describe("SQLite safe_mode_content schema", () => {
   });
 
   it("rejects nonexistent systemId FK", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     expect(() =>
       db
         .insert(safeModeContent)
@@ -196,7 +197,7 @@ describe("SQLite safe_mode_content schema", () => {
   it("rejects duplicate primary key", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const id = makeSafeModeContentId();
 
     db.insert(safeModeContent)

--- a/packages/db/src/__tests__/schema-sqlite-snapshots.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-snapshots.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -7,6 +7,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { systemSnapshots } from "../schema/sqlite/snapshots.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteSnapshotTables,
   sqliteInsertAccount,
@@ -47,7 +48,7 @@ describe("SQLite system_snapshots schema", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
     const id = brandId<SystemSnapshotId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(systemSnapshots)
       .values({
@@ -76,7 +77,7 @@ describe("SQLite system_snapshots schema", () => {
         systemId,
         snapshotTrigger: "scheduled-daily",
         encryptedData: testBlob(),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       })
       .run();
 
@@ -95,7 +96,7 @@ describe("SQLite system_snapshots schema", () => {
         systemId,
         snapshotTrigger: "scheduled-weekly",
         encryptedData: testBlob(),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       })
       .run();
 
@@ -115,7 +116,7 @@ describe("SQLite system_snapshots schema", () => {
           systemId,
           snapshotTrigger: "invalid" as "manual",
           encryptedData: testBlob(),
-          createdAt: Date.now(),
+          createdAt: fixtureNow(),
         })
         .run(),
     ).toThrow();
@@ -132,7 +133,7 @@ describe("SQLite system_snapshots schema", () => {
         systemId,
         snapshotTrigger: "manual",
         encryptedData: testBlob(),
-        createdAt: Date.now(),
+        createdAt: fixtureNow(),
       })
       .run();
 
@@ -144,7 +145,7 @@ describe("SQLite system_snapshots schema", () => {
   it("supports multiple snapshots per system", () => {
     const accountId = insertAccount();
     const systemId = insertSystem(accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     for (let i = 0; i < 3; i++) {
       db.insert(systemSnapshots)
@@ -153,7 +154,7 @@ describe("SQLite system_snapshots schema", () => {
           systemId,
           snapshotTrigger: "manual",
           encryptedData: testBlob(),
-          createdAt: now + i * 1000,
+          createdAt: toUnixMillis(now + i * 1000),
         })
         .run();
     }

--- a/packages/db/src/__tests__/schema-sqlite-structure.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-structure.integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../schema/sqlite/structure.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteStructureTables,
   sqliteInsertAccount,
@@ -96,7 +97,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30, 40, 50]));
 
       db.insert(relationships)
@@ -120,7 +121,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -141,7 +142,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -160,7 +161,7 @@ describe("SQLite structure schema", () => {
     });
 
     it("rejects nonexistent systemId FK", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         db
           .insert(relationships)
@@ -182,7 +183,7 @@ describe("SQLite structure schema", () => {
       const sourceMemberId = insertMember(systemId);
       const targetMemberId = insertMember(systemId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -209,7 +210,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -231,7 +232,7 @@ describe("SQLite structure schema", () => {
     it("rejects invalid type via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -253,7 +254,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -275,7 +276,7 @@ describe("SQLite structure schema", () => {
     it("rejects nonexistent sourceMemberId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -298,7 +299,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -320,7 +321,7 @@ describe("SQLite structure schema", () => {
     it("rejects nonexistent targetMemberId FK", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -342,7 +343,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -364,7 +365,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -387,7 +388,7 @@ describe("SQLite structure schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -402,7 +403,7 @@ describe("SQLite structure schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -418,7 +419,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newRelId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(relationships)
         .values({
@@ -449,7 +450,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20]));
 
       db.insert(systemStructureEntityTypes)
@@ -469,7 +470,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -491,7 +492,7 @@ describe("SQLite structure schema", () => {
     });
 
     it("rejects nonexistent systemId FK", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       expect(() =>
         db
           .insert(systemStructureEntityTypes)
@@ -511,7 +512,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -537,7 +538,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -562,7 +563,7 @@ describe("SQLite structure schema", () => {
     it("rejects archived=true with null archivedAt", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -577,7 +578,7 @@ describe("SQLite structure schema", () => {
     it("rejects archived=false with non-null archivedAt", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -592,7 +593,7 @@ describe("SQLite structure schema", () => {
     it("rejects version 0", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -612,7 +613,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -652,7 +653,7 @@ describe("SQLite structure schema", () => {
     it("rejects nonexistent entityTypeId FK (RESTRICT)", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -674,7 +675,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -711,7 +712,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -749,7 +750,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -776,7 +777,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -803,7 +804,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -831,7 +832,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -873,7 +874,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -915,7 +916,7 @@ describe("SQLite structure schema", () => {
     it("rejects nonexistent entityId FK (RESTRICT)", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -936,7 +937,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -974,7 +975,7 @@ describe("SQLite structure schema", () => {
       const typeId = newTypeId();
       const parentEntityId = newEntityId();
       const childEntityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1035,7 +1036,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1080,7 +1081,7 @@ describe("SQLite structure schema", () => {
       const typeId = newTypeId();
       const parentEntityId = newEntityId();
       const childEntityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1139,7 +1140,7 @@ describe("SQLite structure schema", () => {
       const typeId = newTypeId();
       const parentEntityId = newEntityId();
       const childEntityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1205,7 +1206,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1247,7 +1248,7 @@ describe("SQLite structure schema", () => {
       const typeId = newTypeId();
       const entityId = newEntityId();
       const linkId = newLinkId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1291,7 +1292,7 @@ describe("SQLite structure schema", () => {
       const memberId = insertMember(systemId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1340,7 +1341,7 @@ describe("SQLite structure schema", () => {
     it("rejects nonexistent memberId FK (RESTRICT)", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1360,7 +1361,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityMemberLinks)
         .values({
@@ -1383,7 +1384,7 @@ describe("SQLite structure schema", () => {
       const memberId = insertMember(systemId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1437,7 +1438,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityMemberLinks)
         .values({
@@ -1468,7 +1469,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const linkId = newMemberLinkId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityMemberLinks)
         .values({
@@ -1491,7 +1492,7 @@ describe("SQLite structure schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -1518,7 +1519,7 @@ describe("SQLite structure schema", () => {
       const typeId = newTypeId();
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1580,7 +1581,7 @@ describe("SQLite structure schema", () => {
       const typeId = newTypeId();
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1645,7 +1646,7 @@ describe("SQLite structure schema", () => {
       const typeId = newTypeId();
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1701,7 +1702,7 @@ describe("SQLite structure schema", () => {
       const entityId1 = newEntityId();
       const entityId2 = newEntityId();
       const assocId = newAssocId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({
@@ -1757,7 +1758,7 @@ describe("SQLite structure schema", () => {
       const systemId = insertSystem(accountId);
       const typeId = newTypeId();
       const entityId = newEntityId();
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(systemStructureEntityTypes)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-sync.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-sync.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -8,6 +8,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { syncChanges, syncDocuments, syncSnapshots } from "../schema/sqlite/sync.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteSyncTables,
   sqliteInsertAccount,
@@ -38,7 +39,7 @@ describe("SQLite sync schema", () => {
     docType: SyncDocumentType = "system-core",
   ): SyncDocumentId => {
     const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-    const now = Date.now();
+    const now = fixtureNow();
     db.insert(syncDocuments)
       .values({ documentId, systemId, docType, createdAt: now, updatedAt: now })
       .run();
@@ -71,7 +72,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(syncDocuments)
         .values({
@@ -87,7 +88,7 @@ describe("SQLite sync schema", () => {
           bucketId: brandId<BucketId>(crypto.randomUUID()),
           channelId: brandId<ChannelId>(crypto.randomUUID()),
           createdAt: now,
-          updatedAt: now + 1000,
+          updatedAt: toUnixMillis(now + 1000),
         })
         .run();
 
@@ -117,7 +118,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(syncDocuments)
         .values({ documentId, systemId, docType: "chat", createdAt: now, updatedAt: now })
@@ -140,7 +141,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = brandId<SyncDocumentId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(syncDocuments)
         .values({ documentId, systemId, docType: "journal", createdAt: now, updatedAt: now })
@@ -160,7 +161,7 @@ describe("SQLite sync schema", () => {
     it("rejects invalid doc_type", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -179,7 +180,7 @@ describe("SQLite sync schema", () => {
     it("rejects invalid key_type", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -194,7 +195,7 @@ describe("SQLite sync schema", () => {
     it("rejects negative sizeBytes", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -214,7 +215,7 @@ describe("SQLite sync schema", () => {
     it("rejects negative snapshotVersion", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -234,7 +235,7 @@ describe("SQLite sync schema", () => {
     it("rejects negative lastSeq", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         db
@@ -277,7 +278,7 @@ describe("SQLite sync schema", () => {
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
       const payload = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05]);
       const authorKey = Buffer.from([0xaa, 0xbb, 0xcc]);
       const nonce = Buffer.from([0x11, 0x22, 0x33]);
@@ -312,7 +313,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const makeChange = () =>
         Buffer.from(crypto.randomUUID().replace(/-/g, ""), "hex").subarray(0, 8);
       const makeSig = () => Buffer.alloc(64, 0x77);
@@ -352,7 +353,7 @@ describe("SQLite sync schema", () => {
       const systemId = insertSystem(accountId);
       const docId1 = insertDocument(systemId, "chat");
       const docId2 = insertDocument(systemId, "journal");
-      const now = Date.now();
+      const now = fixtureNow();
       const makeChange = () =>
         Buffer.from(crypto.randomUUID().replace(/-/g, ""), "hex").subarray(0, 8);
       const makeSig = () => Buffer.alloc(64, 0x77);
@@ -393,7 +394,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const authorKey = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
       const nonce = Buffer.from([0xca, 0xfe, 0xba, 0xbe]);
 
@@ -432,7 +433,7 @@ describe("SQLite sync schema", () => {
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
       const id = crypto.randomUUID();
-      const now = Date.now();
+      const now = fixtureNow();
       const buf = Buffer.from([0x01, 0x02]);
 
       db.insert(syncChanges)
@@ -464,7 +465,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const payload = Buffer.from([0xf0, 0xe1, 0xd2, 0xc3]);
       const authorKey = Buffer.from([0x10, 0x20, 0x30]);
       const nonce = Buffer.from([0xa1, 0xb2, 0xc3]);
@@ -502,7 +503,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const buf = Buffer.from([0x01]);
       const sig = Buffer.alloc(64, 0x88);
 
@@ -547,7 +548,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const buf = Buffer.from([0x01]);
       const sig = Buffer.alloc(64, 0x88);
 
@@ -583,7 +584,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const buf = Buffer.from([0x01]);
       const sig = Buffer.alloc(64, 0x88);
 
@@ -607,7 +608,7 @@ describe("SQLite sync schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const documentId = insertDocument(systemId);
-      const now = Date.now();
+      const now = fixtureNow();
       const buf = Buffer.from([0x01]);
       const sig = Buffer.alloc(64, 0x88);
 

--- a/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
@@ -8,6 +8,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { systemSettings } from "../schema/sqlite/system-settings.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteSystemSettingsTables,
   sqliteInsertAccount,
@@ -40,7 +41,7 @@ describe("SQLite system_settings schema", () => {
   it("inserts and retrieves with all columns", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const data = testBlob(new Uint8Array([10, 20, 30]));
 
     db.insert(systemSettings)
@@ -72,7 +73,7 @@ describe("SQLite system_settings schema", () => {
   it("defaults boolean fields to false", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(systemSettings)
       .values({
@@ -95,7 +96,7 @@ describe("SQLite system_settings schema", () => {
   it("allows nullable locale and pinHash", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(systemSettings)
       .values({
@@ -119,7 +120,7 @@ describe("SQLite system_settings schema", () => {
   it("defaults version to 1", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(systemSettings)
       .values({
@@ -142,7 +143,7 @@ describe("SQLite system_settings schema", () => {
   it("enforces 1:1 with systems (rejects duplicate systemId)", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(systemSettings)
       .values({
@@ -171,7 +172,7 @@ describe("SQLite system_settings schema", () => {
   it("cascades on system deletion", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     db.insert(systemSettings)
       .values({
@@ -195,7 +196,7 @@ describe("SQLite system_settings schema", () => {
   it("rejects pinHash that does not start with $argon2id$", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
 
     expect(() =>
       client
@@ -207,7 +208,7 @@ describe("SQLite system_settings schema", () => {
   });
 
   it("rejects nonexistent systemId FK", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     expect(() =>
       db
         .insert(systemSettings)
@@ -225,7 +226,7 @@ describe("SQLite system_settings schema", () => {
   it("round-trips encrypted_data binary correctly", () => {
     const accountId = insertAccount();
     const systemId = sqliteInsertSystem(db, accountId);
-    const now = Date.now();
+    const now = fixtureNow();
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
     const blob = testBlob(bigArray);

--- a/packages/db/src/__tests__/schema-sqlite-systems.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-systems.integration.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { accounts } from "../schema/sqlite/auth.js";
 import { systems } from "../schema/sqlite/systems.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteSystemTables,
   sqliteInsertAccount,
@@ -37,7 +38,7 @@ describe("SQLite systems schema", () => {
 
   it("inserts and retrieves with all columns", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
     const data = testBlob(new Uint8Array([1, 2, 3, 4, 5]));
 
@@ -60,7 +61,7 @@ describe("SQLite systems schema", () => {
 
   it("allows nullable encrypted_data", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)
@@ -78,7 +79,7 @@ describe("SQLite systems schema", () => {
 
   it("round-trips encrypted_data binary correctly", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
     const bigArray = new Uint8Array(256);
     for (let i = 0; i < 256; i++) bigArray[i] = i;
@@ -100,7 +101,7 @@ describe("SQLite systems schema", () => {
 
   it("defaults version to 1", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)
@@ -118,7 +119,7 @@ describe("SQLite systems schema", () => {
 
   it("cascades on account deletion", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)
@@ -136,7 +137,7 @@ describe("SQLite systems schema", () => {
   });
 
   it("rejects nonexistent accountId FK", () => {
-    const now = Date.now();
+    const now = fixtureNow();
     expect(() =>
       db
         .insert(systems)
@@ -152,7 +153,7 @@ describe("SQLite systems schema", () => {
 
   it("rejects duplicate primary key", () => {
     const accountId = insertAccount();
-    const now = Date.now();
+    const now = fixtureNow();
     const id = brandId<SystemId>(crypto.randomUUID());
 
     db.insert(systems)

--- a/packages/db/src/__tests__/schema-sqlite-timers.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-timers.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -9,6 +9,7 @@ import { members } from "../schema/sqlite/members.js";
 import { systems } from "../schema/sqlite/systems.js";
 import { checkInRecords, timerConfigs } from "../schema/sqlite/timers.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   createSqliteTimerTables,
   sqliteInsertAccount,
@@ -52,7 +53,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([10, 20, 30]));
 
       db.insert(timerConfigs)
@@ -76,7 +77,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -97,7 +98,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -118,7 +119,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -151,7 +152,7 @@ describe("SQLite timers schema", () => {
         ["12:00", "18:45"],
       ]) {
         const id = brandId<TimerId>(crypto.randomUUID());
-        const now = Date.now();
+        const now = fixtureNow();
         db.insert(timerConfigs)
           .values({
             id,
@@ -182,8 +183,8 @@ describe("SQLite timers schema", () => {
               systemId,
               wakingStart: bad,
               encryptedData: testBlob(new Uint8Array([1])),
-              createdAt: Date.now(),
-              updatedAt: Date.now(),
+              createdAt: fixtureNow(),
+              updatedAt: fixtureNow(),
             })
             .run(),
         ).toThrow();
@@ -203,8 +204,8 @@ describe("SQLite timers schema", () => {
               systemId,
               wakingEnd: bad,
               encryptedData: testBlob(new Uint8Array([1])),
-              createdAt: Date.now(),
-              updatedAt: Date.now(),
+              createdAt: fixtureNow(),
+              updatedAt: fixtureNow(),
             })
             .run(),
         ).toThrow();
@@ -215,7 +216,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -238,7 +239,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -259,7 +260,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -281,7 +282,7 @@ describe("SQLite timers schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -295,7 +296,7 @@ describe("SQLite timers schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -310,7 +311,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -339,7 +340,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -372,7 +373,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const data = testBlob(new Uint8Array([5, 6, 7]));
 
       db.insert(timerConfigs)
@@ -391,7 +392,7 @@ describe("SQLite timers schema", () => {
           systemId,
           timerConfigId: timerId,
           scheduledAt: now,
-          respondedAt: now + 1000,
+          respondedAt: toUnixMillis(now + 1000),
           dismissed: true,
           encryptedData: data,
         })
@@ -407,7 +408,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -438,7 +439,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -469,7 +470,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -501,7 +502,7 @@ describe("SQLite timers schema", () => {
       const memberId = insertMember(systemId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -532,7 +533,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -562,7 +563,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const memberId = insertMember(systemId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -593,7 +594,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -623,7 +624,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -646,14 +647,14 @@ describe("SQLite timers schema", () => {
             id: respondedId,
             systemId,
             timerConfigId: timerId,
-            scheduledAt: now + 1000,
-            respondedAt: now + 2000,
+            scheduledAt: toUnixMillis(now + 1000),
+            respondedAt: toUnixMillis(now + 2000),
           },
           {
             id: dismissedId,
             systemId,
             timerConfigId: timerId,
-            scheduledAt: now + 3000,
+            scheduledAt: toUnixMillis(now + 3000),
             dismissed: true,
           },
         ])
@@ -673,7 +674,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -699,7 +700,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -731,7 +732,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -773,7 +774,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -798,7 +799,7 @@ describe("SQLite timers schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({
@@ -824,7 +825,7 @@ describe("SQLite timers schema", () => {
       const systemId = insertSystem(accountId);
       const timerId = brandId<TimerId>(crypto.randomUUID());
       const id = brandId<CheckInRecordId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(timerConfigs)
         .values({

--- a/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-views.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -32,6 +32,7 @@ import {
   getUnconfirmedAcknowledgements,
 } from "../views/sqlite.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   SQLITE_DDL,
   sqliteInsertAccount,
@@ -160,13 +161,13 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns sessions with null end_time", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(frontingSessions)
         .values({
           id: brandId<FrontingSessionId>(crypto.randomUUID()),
           systemId,
           memberId,
-          startTime: now - 60000,
+          startTime: toUnixMillis(now - 60000),
           endTime: null,
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -178,8 +179,8 @@ describe("SQLite views / query helpers", () => {
           id: brandId<FrontingSessionId>(crypto.randomUUID()),
           systemId,
           memberId,
-          startTime: now - 120000,
-          endTime: now - 30000,
+          startTime: toUnixMillis(now - 120000),
+          endTime: toUnixMillis(now - 30000),
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
           updatedAt: now,
@@ -199,13 +200,13 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns positive duration for active sessions", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(frontingSessions)
         .values({
           id: brandId<FrontingSessionId>(crypto.randomUUID()),
           systemId,
           memberId,
-          startTime: now - 60000,
+          startTime: toUnixMillis(now - 60000),
           endTime: null,
           encryptedData: testBlob(new Uint8Array([1])),
           createdAt: now,
@@ -226,7 +227,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns non-revoked keys and excludes revoked", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(apiKeys)
         .values({
           id: brandId<ApiKeyId>(crypto.randomUUID()),
@@ -265,7 +266,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns only pending connections", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const otherAccountId1 = insertAccount();
       insertSystem(otherAccountId1);
       const otherAccountId2 = insertAccount();
@@ -304,7 +305,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns failed deliveries under max attempts and respects limit", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const webhookId = brandedWebhookId();
       const maxAttempts = 3;
       db.insert(webhookConfigs)
@@ -327,7 +328,7 @@ describe("SQLite views / query helpers", () => {
           eventType: "member.created",
           status: "failed",
           attemptCount: 2,
-          nextRetryAt: now - 60000,
+          nextRetryAt: toUnixMillis(now - 60000),
           encryptedData: new Uint8Array([1, 2, 3]),
           createdAt: now,
         })
@@ -341,7 +342,7 @@ describe("SQLite views / query helpers", () => {
           eventType: "member.created",
           status: "failed",
           attemptCount: 5,
-          nextRetryAt: now - 60000,
+          nextRetryAt: toUnixMillis(now - 60000),
           encryptedData: new Uint8Array([1, 2, 3]),
           createdAt: now,
         })
@@ -355,7 +356,7 @@ describe("SQLite views / query helpers", () => {
           eventType: "member.created",
           status: "failed",
           attemptCount: 2,
-          nextRetryAt: now + 60000,
+          nextRetryAt: toUnixMillis(now + 60000),
           encryptedData: new Uint8Array([1, 2, 3]),
           createdAt: now,
         })
@@ -374,7 +375,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns only unconfirmed acknowledgements", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       db.insert(acknowledgements)
         .values({
           id: brandId<AcknowledgementId>(crypto.randomUUID()),
@@ -408,7 +409,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns groups with correct member counts", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const memberId1 = crypto.randomUUID();
       const memberId2 = crypto.randomUUID();
       const groupId = brandId<GroupId>(crypto.randomUUID());
@@ -461,7 +462,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns only accepted connections", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const otherAccountId = insertAccount();
       insertSystem(otherAccountId);
 
@@ -488,7 +489,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns non-revoked tokens with tokenHash field", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const tokenHashValue = `tokenHash_${crypto.randomUUID()}`.slice(0, 64);
       db.insert(deviceTokens)
         .values({
@@ -525,7 +526,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns comments only for active sessions", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const activeSessionId = brandId<FrontingSessionId>(crypto.randomUUID());
       const endedSessionId = brandId<FrontingSessionId>(crypto.randomUUID());
 
@@ -535,7 +536,7 @@ describe("SQLite views / query helpers", () => {
             id: activeSessionId,
             systemId,
             memberId,
-            startTime: now - 60000,
+            startTime: toUnixMillis(now - 60000),
             endTime: null,
             encryptedData: testBlob(new Uint8Array([1])),
             createdAt: now,
@@ -545,8 +546,8 @@ describe("SQLite views / query helpers", () => {
             id: endedSessionId,
             systemId,
             memberId,
-            startTime: now - 120000,
-            endTime: now - 30000,
+            startTime: toUnixMillis(now - 120000),
+            endTime: toUnixMillis(now - 30000),
             encryptedData: testBlob(new Uint8Array([1])),
             createdAt: now,
             updatedAt: now,
@@ -589,7 +590,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns pending non-expired transfers", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const sourceSession = brandId<SessionId>(crypto.randomUUID());
       const targetSession = brandId<SessionId>(crypto.randomUUID());
 
@@ -610,7 +611,7 @@ describe("SQLite views / query helpers", () => {
           status: "pending",
           codeSalt: new Uint8Array(16),
           createdAt: now,
-          expiresAt: now + 3600000,
+          expiresAt: toUnixMillis(now + 3600000),
         })
         .run();
 
@@ -641,8 +642,8 @@ describe("SQLite views / query helpers", () => {
           targetSessionId: targetSession2,
           status: "pending",
           codeSalt: new Uint8Array(16),
-          createdAt: now - 7200000,
-          expiresAt: now - 3600000,
+          createdAt: toUnixMillis(now - 7200000),
+          expiresAt: toUnixMillis(now - 3600000),
         })
         .run();
 
@@ -659,7 +660,7 @@ describe("SQLite views / query helpers", () => {
     });
 
     it("returns associations for a system", () => {
-      const now = Date.now();
+      const now = fixtureNow();
       const entityTypeId = brandId<SystemStructureEntityTypeId>(crypto.randomUUID());
       const entityId1 = brandId<SystemStructureEntityId>(crypto.randomUUID());
       const entityId2 = brandId<SystemStructureEntityId>(crypto.randomUUID());

--- a/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-webhooks.integration.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import Database from "better-sqlite3-multiple-ciphers";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -9,6 +9,7 @@ import { accounts } from "../schema/sqlite/auth.js";
 import { systems } from "../schema/sqlite/systems.js";
 import { webhookConfigs, webhookDeliveries } from "../schema/sqlite/webhooks.js";
 
+import { fixtureNow } from "./fixtures/timestamps.js";
 import {
   MS_PER_DAY,
   TTL_RETENTION_DAYS,
@@ -61,7 +62,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
       const s = secret([1, 2, 3]);
 
       db.insert(webhookConfigs)
@@ -90,7 +91,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookConfigs)
         .values({
@@ -112,7 +113,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookConfigs)
         .values({
@@ -135,7 +136,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const keyId = brandId<ApiKeyId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(apiKeys)
         .values({
@@ -172,7 +173,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookConfigs)
         .values({
@@ -195,7 +196,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookConfigs)
         .values({
@@ -218,7 +219,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookConfigs)
         .values({
@@ -242,7 +243,7 @@ describe("SQLite webhooks schema", () => {
     it("rejects archived=true with archivedAt=null via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -256,7 +257,7 @@ describe("SQLite webhooks schema", () => {
     it("rejects archived=false with archivedAt set via CHECK constraint", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -271,7 +272,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       const systemId = insertSystem(accountId);
       const id = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookConfigs)
         .values({
@@ -304,7 +305,7 @@ describe("SQLite webhooks schema", () => {
       const accountId = insertAccount();
       deliverySystemId = insertSystem(accountId);
       deliveryWhId = brandId<WebhookId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookConfigs)
         .values({
@@ -321,7 +322,7 @@ describe("SQLite webhooks schema", () => {
 
     it("round-trips with defaults", () => {
       const id = brandId<WebhookDeliveryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookDeliveries)
         .values({
@@ -342,7 +343,7 @@ describe("SQLite webhooks schema", () => {
     });
 
     it("rejects invalid event_type", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -355,7 +356,7 @@ describe("SQLite webhooks schema", () => {
     });
 
     it("rejects invalid status", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -375,7 +376,7 @@ describe("SQLite webhooks schema", () => {
     });
 
     it("rejects negative attempt_count", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -388,7 +389,7 @@ describe("SQLite webhooks schema", () => {
     });
 
     it("rejects http_status outside 100-599", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       expect(() =>
         client
@@ -411,7 +412,7 @@ describe("SQLite webhooks schema", () => {
 
     it("cascades on system deletion", () => {
       const id = brandId<WebhookDeliveryId>(crypto.randomUUID());
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookDeliveries)
         .values({
@@ -430,8 +431,8 @@ describe("SQLite webhooks schema", () => {
     });
 
     it("supports TTL cleanup query on terminal states", () => {
-      const now = Date.now();
-      const thirtyOneDaysAgo = now - (TTL_RETENTION_DAYS + 1) * MS_PER_DAY;
+      const now = fixtureNow();
+      const thirtyOneDaysAgo = toUnixMillis(now - (TTL_RETENTION_DAYS + 1) * MS_PER_DAY);
       const whId = brandId<WebhookId>(crypto.randomUUID());
 
       db.insert(webhookConfigs)
@@ -499,7 +500,7 @@ describe("SQLite webhooks schema", () => {
     });
 
     it("restricts webhook config deletion when referenced by delivery", () => {
-      const now = Date.now();
+      const now = fixtureNow();
 
       db.insert(webhookDeliveries)
         .values({
@@ -518,8 +519,8 @@ describe("SQLite webhooks schema", () => {
     });
 
     it("queries retryable deliveries by system_id", () => {
-      const now = Date.now();
-      const retryAt = now + 60_000;
+      const now = fixtureNow();
+      const retryAt = toUnixMillis(now + 60_000);
 
       const pendingId = brandId<WebhookDeliveryId>(crypto.randomUUID());
       const successId = brandId<WebhookDeliveryId>(crypto.randomUUID());

--- a/packages/db/src/__tests__/schema-type-parity.test.ts
+++ b/packages/db/src/__tests__/schema-type-parity.test.ts
@@ -32,6 +32,7 @@ import type {
   MemberFrontingBreakdown,
   SystemId,
   SystemSettingsId,
+  UnixMillis,
 } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
@@ -686,25 +687,25 @@ describe("Type-level assertions", () => {
     expectTypeOf<Row["systemId"]>().toEqualTypeOf<SystemId>();
   });
 
-  // Fix 7 — importJobs.updatedAt is number (non-nullable, custom pgTimestamp returns UnixMillis)
-  it("PG importJobs.updatedAt infers as number (non-nullable)", () => {
+  // Fix 7 — importJobs.updatedAt is UnixMillis (non-nullable, custom pgTimestamp returns UnixMillis)
+  it("PG importJobs.updatedAt infers as UnixMillis (non-nullable)", () => {
     type Row = InferSelectModel<typeof pg.importJobs>;
-    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<number>();
+    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<UnixMillis>();
   });
 
-  it("SQLite importJobs.updatedAt infers as number (non-nullable)", () => {
+  it("SQLite importJobs.updatedAt infers as UnixMillis (non-nullable)", () => {
     type Row = InferSelectModel<typeof sqlite.importJobs>;
-    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<number>();
+    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<UnixMillis>();
   });
 
-  it("PG exportRequests.updatedAt infers as number (non-nullable)", () => {
+  it("PG exportRequests.updatedAt infers as UnixMillis (non-nullable)", () => {
     type Row = InferSelectModel<typeof pg.exportRequests>;
-    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<number>();
+    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<UnixMillis>();
   });
 
-  it("SQLite exportRequests.updatedAt infers as number (non-nullable)", () => {
+  it("SQLite exportRequests.updatedAt infers as UnixMillis (non-nullable)", () => {
     type Row = InferSelectModel<typeof sqlite.exportRequests>;
-    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<number>();
+    expectTypeOf<Row["updatedAt"]>().toEqualTypeOf<UnixMillis>();
   });
 
   // Fix 8 — frontingReports has expected field types
@@ -718,30 +719,30 @@ describe("Type-level assertions", () => {
     expectTypeOf<Row["format"]>().toEqualTypeOf<"html" | "pdf">();
   });
 
-  it("PG frontingReports.generatedAt infers as number", () => {
+  it("PG frontingReports.generatedAt infers as UnixMillis", () => {
     type Row = InferSelectModel<typeof pg.frontingReports>;
-    expectTypeOf<Row["generatedAt"]>().toEqualTypeOf<number>();
+    expectTypeOf<Row["generatedAt"]>().toEqualTypeOf<UnixMillis>();
   });
 
   // Auth session security — new nullable columns
-  it("PG sessions.expiresAt infers as number | null", () => {
+  it("PG sessions.expiresAt infers as UnixMillis | null", () => {
     type Row = InferSelectModel<typeof pg.sessions>;
-    expectTypeOf<Row["expiresAt"]>().toEqualTypeOf<number | null>();
+    expectTypeOf<Row["expiresAt"]>().toEqualTypeOf<UnixMillis | null>();
   });
 
-  it("SQLite sessions.expiresAt infers as number | null", () => {
+  it("SQLite sessions.expiresAt infers as UnixMillis | null", () => {
     type Row = InferSelectModel<typeof sqlite.sessions>;
-    expectTypeOf<Row["expiresAt"]>().toEqualTypeOf<number | null>();
+    expectTypeOf<Row["expiresAt"]>().toEqualTypeOf<UnixMillis | null>();
   });
 
-  it("PG recoveryKeys.revokedAt infers as number | null", () => {
+  it("PG recoveryKeys.revokedAt infers as UnixMillis | null", () => {
     type Row = InferSelectModel<typeof pg.recoveryKeys>;
-    expectTypeOf<Row["revokedAt"]>().toEqualTypeOf<number | null>();
+    expectTypeOf<Row["revokedAt"]>().toEqualTypeOf<UnixMillis | null>();
   });
 
-  it("SQLite recoveryKeys.revokedAt infers as number | null", () => {
+  it("SQLite recoveryKeys.revokedAt infers as UnixMillis | null", () => {
     type Row = InferSelectModel<typeof sqlite.recoveryKeys>;
-    expectTypeOf<Row["revokedAt"]>().toEqualTypeOf<number | null>();
+    expectTypeOf<Row["revokedAt"]>().toEqualTypeOf<UnixMillis | null>();
   });
 });
 

--- a/packages/db/src/columns/pg.ts
+++ b/packages/db/src/columns/pg.ts
@@ -3,14 +3,14 @@ import { customType, varchar } from "drizzle-orm/pg-core";
 
 import { ID_MAX_LENGTH } from "../helpers/db.constants.js";
 
-import type { AnyBrandedId, EncryptedBlob } from "@pluralscape/types";
+import type { AnyBrandedId, EncryptedBlob, UnixMillis } from "@pluralscape/types";
 
 const JSON_PREVIEW_LENGTH = 100;
 
 // ── Mapping functions (exported for independent testing) ───────
 
 /** Converts UnixMillis to ISO string for PG timestamptz storage. */
-export function timestampToDriver(ms: number): string {
+export function timestampToDriver(ms: UnixMillis): string {
   if (!Number.isFinite(ms)) {
     throw new Error(`Invalid timestamp: ${String(ms)} is not a finite number`);
   }
@@ -18,12 +18,12 @@ export function timestampToDriver(ms: number): string {
 }
 
 /** Converts PG timestamptz string back to UnixMillis. */
-export function timestampFromDriver(val: string): number {
+export function timestampFromDriver(val: string): UnixMillis {
   const ms = Date.parse(val);
   if (Number.isNaN(ms)) {
     throw new Error(`Invalid timestamp string: "${val}" could not be parsed`);
   }
-  return ms;
+  return ms as UnixMillis;
 }
 
 /** Converts Uint8Array to Buffer for PG bytea storage. */
@@ -58,7 +58,7 @@ export function jsonFromDriver(val: unknown): unknown {
 // ── Custom column types ────────────────────────────────────────
 
 /** PG timestamptz column that maps to/from UnixMillis (number). */
-export const pgTimestamp = customType<{ data: number; driverData: string }>({
+export const pgTimestamp = customType<{ data: UnixMillis; driverData: string }>({
   dataType() {
     return "timestamptz";
   },

--- a/packages/db/src/columns/sqlite.ts
+++ b/packages/db/src/columns/sqlite.ts
@@ -1,26 +1,26 @@
 import { deserializeEncryptedBlob, serializeEncryptedBlob } from "@pluralscape/crypto";
 import { customType, text } from "drizzle-orm/sqlite-core";
 
-import type { AnyBrandedId, EncryptedBlob } from "@pluralscape/types";
+import type { AnyBrandedId, EncryptedBlob, UnixMillis } from "@pluralscape/types";
 
 const JSON_PREVIEW_LENGTH = 100;
 
 // ── Mapping functions (exported for independent testing) ───────
 
-/** SQLite timestamp: passthrough (integer to integer). */
-export function timestampToDriver(ms: number): number {
+/** SQLite timestamp: passthrough (UnixMillis in, raw number out to driver). */
+export function timestampToDriver(ms: UnixMillis): number {
   if (!Number.isFinite(ms)) {
     throw new Error(`Invalid timestamp: ${String(ms)} is not a finite number`);
   }
   return ms;
 }
 
-/** SQLite timestamp: passthrough (integer to integer). */
-export function timestampFromDriver(val: number): number {
+/** SQLite timestamp: passthrough (raw number from driver, branded out). */
+export function timestampFromDriver(val: number): UnixMillis {
   if (!Number.isFinite(val)) {
     throw new Error(`Invalid timestamp: ${String(val)} is not a finite number`);
   }
-  return val;
+  return val as UnixMillis;
 }
 
 /** SQLite JSON: stringify for text storage. */
@@ -42,7 +42,7 @@ export function jsonFromDriver(val: string): unknown {
 // ── Custom column types ────────────────────────────────────────
 
 /** SQLite integer column that stores UnixMillis (passthrough). */
-export const sqliteTimestamp = customType<{ data: number; driverData: number }>({
+export const sqliteTimestamp = customType<{ data: UnixMillis; driverData: number }>({
   dataType() {
     return "integer";
   },

--- a/packages/db/src/queries/audit-log-cleanup.ts
+++ b/packages/db/src/queries/audit-log-cleanup.ts
@@ -1,3 +1,4 @@
+import { toUnixMillis } from "@pluralscape/types";
 import { lt, sql } from "drizzle-orm";
 
 import { auditLog as pgAuditLog } from "../schema/pg/audit-log.js";
@@ -52,7 +53,7 @@ export function sqliteCleanupAuditLog<
   options: { olderThanDays: number; batchSize?: number },
 ): CleanupResult {
   validateOlderThanDays(options.olderThanDays);
-  const cutoffMs = Date.now() - options.olderThanDays * MS_PER_DAY;
+  const cutoffMs = toUnixMillis(Date.now() - options.olderThanDays * MS_PER_DAY);
 
   if (options.batchSize !== undefined && options.batchSize > 0) {
     // Batch delete: delete up to batchSize rows per invocation

--- a/packages/db/src/queries/device-transfer-cleanup.ts
+++ b/packages/db/src/queries/device-transfer-cleanup.ts
@@ -1,3 +1,4 @@
+import { toUnixMillis } from "@pluralscape/types";
 import { and, eq, lte, sql } from "drizzle-orm";
 
 import { deviceTransferRequests as pgDeviceTransferRequests } from "../schema/pg/auth.js";
@@ -44,7 +45,7 @@ export async function pgCleanupDeviceTransfers<
 export function sqliteCleanupDeviceTransfers<
   TSchema extends Record<string, unknown> = Record<string, never>,
 >(db: BetterSQLite3Database<TSchema>): CleanupResult {
-  const cutoffMs = Date.now();
+  const cutoffMs = toUnixMillis(Date.now());
 
   const result = db
     .update(sqliteDeviceTransferRequests)

--- a/packages/db/src/queries/recovery-key.ts
+++ b/packages/db/src/queries/recovery-key.ts
@@ -4,7 +4,7 @@ import { recoveryKeys as pgRecoveryKeys } from "../schema/pg/auth.js";
 import { recoveryKeys as sqliteRecoveryKeys } from "../schema/sqlite/auth.js";
 
 import type { NewRecoveryKey, RecoveryKeyRow } from "../schema/pg/auth.js";
-import type { AccountId, RecoveryKeyId } from "@pluralscape/types";
+import type { AccountId, RecoveryKeyId, UnixMillis } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -16,13 +16,13 @@ export interface StoreRecoveryKeyInput {
   readonly id: RecoveryKeyId;
   readonly accountId: AccountId;
   readonly encryptedMasterKey: Uint8Array;
-  readonly createdAt: number;
+  readonly createdAt: UnixMillis;
 }
 
 /** Input for atomically replacing a recovery key backup. */
 export interface ReplaceRecoveryKeyInput {
   readonly revokeId: RecoveryKeyId;
-  readonly revokedAt: number;
+  readonly revokedAt: UnixMillis;
   readonly newRow: StoreRecoveryKeyInput;
 }
 
@@ -65,7 +65,7 @@ export async function pgRevokeRecoveryKey<
 >(
   db: PostgresJsDatabase<TSchema> | PgliteDatabase<TSchema>,
   id: RecoveryKeyId,
-  revokedAt: number,
+  revokedAt: UnixMillis,
 ): Promise<void> {
   const rows = await db
     .update(pgRecoveryKeys)
@@ -138,7 +138,7 @@ export function sqliteGetActiveRecoveryKey<
 /** Set revokedAt on a recovery key row. Throws if no matching row exists. */
 export function sqliteRevokeRecoveryKey<
   TSchema extends Record<string, unknown> = Record<string, never>,
->(db: BetterSQLite3Database<TSchema>, id: RecoveryKeyId, revokedAt: number): void {
+>(db: BetterSQLite3Database<TSchema>, id: RecoveryKeyId, revokedAt: UnixMillis): void {
   const result = db
     .update(sqliteRecoveryKeys)
     .set({ revokedAt })

--- a/packages/queue/src/adapters/sqlite/__tests__/row-mapper.test.ts
+++ b/packages/queue/src/adapters/sqlite/__tests__/row-mapper.test.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { describe, expect, it } from "vitest";
 
 import { QueueCorruptionError } from "../../../errors.js";
@@ -7,7 +7,7 @@ import { rowToJob } from "../row-mapper.js";
 import type { JobRow } from "@pluralscape/db/sqlite";
 import type { JobId, JobPayload, JobType } from "@pluralscape/types";
 
-const BASE_CREATED_AT = 1_700_000_000_000;
+const BASE_CREATED_AT = toUnixMillis(1_700_000_000_000);
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 function baseRow(overrides: Partial<JobRow>): JobRow {


### PR DESCRIPTION
## Summary

- Flip `pgTimestamp`/`sqliteTimestamp` customType generics from `{ data: number }` to `{ data: UnixMillis }`
- Add `fixtureNow()` / `fixtureNowPlus()` test helpers at `packages/db/src/__tests__/fixtures/timestamps.ts`
- Migrate every `Date.now()` fixture-insert site across PG + sqlite integration tests
- Narrow production timestamp call-sites in `packages/db/src/queries/` + `apps/api/` + `packages/queue/` to `UnixMillis` via `toUnixMillis(...)` at Drizzle boundaries

## Scope expansion vs design

The design anticipated zero production write-site changes. In practice the customType flip surfaced 3 additional production surfaces that needed narrowing:

1. `packages/db/src/columns/{pg,sqlite}.ts` mapper fn signatures
2. `packages/db/src/queries/{audit-log-cleanup,device-transfer-cleanup,recovery-key}.ts`
3. `apps/api/src/` (~67 files) + `packages/queue/src/adapters/sqlite/__tests__/row-mapper.test.ts`

All are boundary conversions; no logic changes. Parity tests untouched (C11c tightens them).

## Test plan

- [x] `pnpm turbo typecheck --force` green (21/21 packages)
- [x] `/verify` full suite green:
  - Unit: PASS
  - Integration: PASS
  - E2E: PASS (507/507 + 2 skipped)
  - SP Import: PASS
  - PK Import: PASS

## References

- Design: `docs/superpowers/specs/2026-04-24-types-ltel-c11-cleanup-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-types-ltel-c11b-timestamp-lift.md`
- Bean: ps-ava1 (completed)
- Unblocks: ps-z7j6 (C11c — parity tightening + StripBrands deletion, epic closeout)