### PR TITLE
fix(validation): ps-q8vs — quick wins (S4 snapshotId brand, S5 helper docs, S1/S2 bean closure)

### DIFF
--- a/.beans/ps-q8vs--branded-id-drift-cleanup-across-5-surfaces.md
+++ b/.beans/ps-q8vs--branded-id-drift-cleanup-across-5-surfaces.md
@@ -5,10 +5,10 @@ status: in-progress
 type: task
 priority: normal
 created_at: 2026-04-21T14:00:15Z
-updated_at: 2026-04-25T05:03:15Z
+updated_at: 2026-04-25T05:06:06Z
 parent: ps-cd6x
 blocked_by:
-    - types-f62m
+  - types-f62m
 ---
 
 Replace bare string / string | null with branded ID types at the 5 surfaces the 2026-04-20 audit flagged in its recurring "Branded-type drift at API/DB boundaries" pattern. Consumes the <Entity> / <Entity>ServerMetadata pairs published by types-f62m.
@@ -22,7 +22,7 @@ The 2026-04-20 audit SUMMARY enumerated 5 specific drift sites. Each uses a raw 
 - [x] Surface 1 — fixed in cbf22ac2 (api-hgd2, 2026-04-20). cryptoKeyId now ApiKeyId | null.
 - [x] Surface 2 — fixed in 59ef63d5 (types-ltel C9, 2026-04-24). bucketId/channelId now BucketId/ChannelId | null.
 - [ ] Surface 3 — packages/types: BucketContentTag.entityId typed as plain string. Replace with the union of entity-ID brands it can validly hold (MemberId | GroupId | …) or a dedicated TaggedEntityId brand.
-- [ ] Surface 4 — packages/validation: DuplicateSystemBodySchema.snapshotId uses bare string. Replace with the branded SystemSnapshotId.
+- [x] Surface 4 — DuplicateSystemBodySchema.snapshotId now uses brandedIdQueryParam('snap\_'). Redundant brandId calls removed from system-duplicate.service.ts.
 - [ ] Surface 5 — packages/validation: brandedString base helper redefines the branding pattern rather than re-exporting from packages/types/src/ids.ts. Replace with a re-export.
 - [ ] Run pnpm typecheck; fix any downstream callers that receive narrower types
 

--- a/.beans/ps-q8vs--branded-id-drift-cleanup-across-5-surfaces.md
+++ b/.beans/ps-q8vs--branded-id-drift-cleanup-across-5-surfaces.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: normal
 created_at: 2026-04-21T14:00:15Z
-updated_at: 2026-04-25T05:06:06Z
+updated_at: 2026-04-25T05:06:51Z
 parent: ps-cd6x
 blocked_by:
   - types-f62m
@@ -23,7 +23,7 @@ The 2026-04-20 audit SUMMARY enumerated 5 specific drift sites. Each uses a raw 
 - [x] Surface 2 — fixed in 59ef63d5 (types-ltel C9, 2026-04-24). bucketId/channelId now BucketId/ChannelId | null.
 - [ ] Surface 3 — packages/types: BucketContentTag.entityId typed as plain string. Replace with the union of entity-ID brands it can validly hold (MemberId | GroupId | …) or a dedicated TaggedEntityId brand.
 - [x] Surface 4 — DuplicateSystemBodySchema.snapshotId now uses brandedIdQueryParam('snap\_'). Redundant brandId calls removed from system-duplicate.service.ts.
-- [ ] Surface 5 — packages/validation: brandedString base helper redefines the branding pattern rather than re-exporting from packages/types/src/ids.ts. Replace with a re-export.
+- [x] Surface 5 — verified Brand is already imported from @pluralscape/types (not redefined). Added JSDoc documenting intentional purpose split between brandedString (generic) and brandedIdQueryParam (ID-prefix-strict).
 - [ ] Run pnpm typecheck; fix any downstream callers that receive narrower types
 
 ## Out of scope

--- a/.beans/ps-q8vs--branded-id-drift-cleanup-across-5-surfaces.md
+++ b/.beans/ps-q8vs--branded-id-drift-cleanup-across-5-surfaces.md
@@ -1,14 +1,14 @@
 ---
 # ps-q8vs
 title: Branded-ID drift cleanup across 5 surfaces
-status: todo
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-04-21T14:00:15Z
-updated_at: 2026-04-21T14:00:39Z
+updated_at: 2026-04-25T05:03:15Z
 parent: ps-cd6x
 blocked_by:
-  - types-f62m
+    - types-f62m
 ---
 
 Replace bare string / string | null with branded ID types at the 5 surfaces the 2026-04-20 audit flagged in its recurring "Branded-type drift at API/DB boundaries" pattern. Consumes the <Entity> / <Entity>ServerMetadata pairs published by types-f62m.
@@ -19,8 +19,8 @@ The 2026-04-20 audit SUMMARY enumerated 5 specific drift sites. Each uses a raw 
 
 ## Scope
 
-- [ ] Surface 1 — apps/api: WebhookConfigResult uses `string | null` for IDs where branded IDs exist. Replace with WebhookConfigId / SystemId / etc.
-- [ ] Surface 2 — packages/types: SyncDocument.bucketId and SyncDocument.channelId typed as plain strings. Replace with BucketId and ChannelId (or define them if missing in ids.ts).
+- [x] Surface 1 — fixed in cbf22ac2 (api-hgd2, 2026-04-20). cryptoKeyId now ApiKeyId | null.
+- [x] Surface 2 — fixed in 59ef63d5 (types-ltel C9, 2026-04-24). bucketId/channelId now BucketId/ChannelId | null.
 - [ ] Surface 3 — packages/types: BucketContentTag.entityId typed as plain string. Replace with the union of entity-ID brands it can validly hold (MemberId | GroupId | …) or a dedicated TaggedEntityId brand.
 - [ ] Surface 4 — packages/validation: DuplicateSystemBodySchema.snapshotId uses bare string. Replace with the branded SystemSnapshotId.
 - [ ] Surface 5 — packages/validation: brandedString base helper redefines the branding pattern rather than re-exporting from packages/types/src/ids.ts. Replace with a re-export.

--- a/apps/api/src/services/system-duplicate.service.ts
+++ b/apps/api/src/services/system-duplicate.service.ts
@@ -61,12 +61,7 @@ export async function duplicateSystem(
     const [snapshot] = await tx
       .select({ id: systemSnapshots.id, encryptedData: systemSnapshots.encryptedData })
       .from(systemSnapshots)
-      .where(
-        and(
-          eq(systemSnapshots.id, brandId<SystemSnapshotId>(snapshotId)),
-          eq(systemSnapshots.systemId, sourceSystemId),
-        ),
-      )
+      .where(and(eq(systemSnapshots.id, snapshotId), eq(systemSnapshots.systemId, sourceSystemId)))
       .limit(1);
 
     if (!snapshot) {
@@ -91,7 +86,7 @@ export async function duplicateSystem(
 
     return {
       id: newSystemId,
-      sourceSnapshotId: brandId<SystemSnapshotId>(snapshot.id),
+      sourceSnapshotId: snapshot.id,
     };
   });
 }

--- a/packages/validation/src/branded.ts
+++ b/packages/validation/src/branded.ts
@@ -3,10 +3,19 @@ import { z } from "zod/v4";
 import type { Brand } from "@pluralscape/types";
 
 /**
- * Zod schema for a branded string type.
+ * Generic Zod custom validator for any brand on a non-empty string.
+ *
+ * For ID brands with a fixed prefix (e.g. `mem_<uuid>`), use
+ * {@link brandedIdQueryParam} instead — it enforces the prefix pattern
+ * and is the canonical helper for branded IDs from `packages/types/src/ids.ts`.
+ *
+ * This generic helper exists for non-ID brands (e.g. opaque tags) where
+ * only non-emptiness is checked. Callers should prefer the prefix-strict
+ * helper when an ID brand is being validated.
+ *
  * Uses z.custom to produce the correct Brand<string, B> output type without
  * type assertions — the phantom __brand tag cannot be expressed by z.string().
- * Contract tests in contract.test.ts verify correctness at both compile-time and runtime.
+ * Contract tests in contract.test.ts verify correctness at compile-time and runtime.
  */
 export function brandedString<B extends string>(): z.ZodType<Brand<string, B>> {
   return z.custom<Brand<string, B>>((val) => typeof val === "string" && val.length > 0);

--- a/packages/validation/src/snapshot.ts
+++ b/packages/validation/src/snapshot.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 
+import { brandedIdQueryParam } from "./branded-id.js";
 import { MAX_ENCRYPTED_DATA_SIZE } from "./validation.constants.js";
 
 export const CreateSnapshotBodySchema = z
@@ -11,6 +12,6 @@ export const CreateSnapshotBodySchema = z
 
 export const DuplicateSystemBodySchema = z
   .object({
-    snapshotId: z.string().min(1),
+    snapshotId: brandedIdQueryParam("snap_"),
   })
   .readonly();


### PR DESCRIPTION
## Summary
- Reality-sync ps-q8vs bean: S1 (cbf22ac2) and S2 (59ef63d5) already fixed by C1-C10 — closed in bean
- S4: DuplicateSystemBodySchema.snapshotId now uses brandedIdQueryParam('snap_') — removed redundant brandId calls from system-duplicate.service.ts
- S5: documented intentional purpose split between brandedString (generic) and brandedIdQueryParam (ID-prefix-strict)

PR2 follow-up will cover S3 (BucketContentTag.entityId discriminated union — larger refactor).

## Test plan
- [x] pnpm types:check-sot passes
- [x] pnpm test:unit passes
- [ ] CI green