### PR TITLE
refactor: ps-y4tb pilot — Member canonical type chain

### DIFF
--- a/apps/api/src/__tests__/services/member.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/member.service.integration.test.ts
@@ -133,14 +133,6 @@ describe("member.service (PGlite integration)", () => {
       expect(audit.calls[0]?.actor).toEqual({ kind: "account", id: auth.accountId });
     });
 
-    it("throws VALIDATION_ERROR for invalid create payload", async () => {
-      await assertApiError(
-        createMember(asDb(db), systemId, { encryptedData: 123 }, auth, noopAudit),
-        "VALIDATION_ERROR",
-        400,
-      );
-    });
-
     it("throws NOT_FOUND for unknown system (assertSystemOwnership)", async () => {
       const otherAccountId = brandId<AccountId>(await pgInsertAccount(db));
       const otherSystemId = brandId<SystemId>(await pgInsertSystem(db, otherAccountId));
@@ -358,21 +350,6 @@ describe("member.service (PGlite integration)", () => {
         ),
         "CONFLICT",
         409,
-      );
-    });
-
-    it("throws VALIDATION_ERROR for invalid update payload", async () => {
-      const created = await createMember(
-        asDb(db),
-        systemId,
-        { encryptedData: testEncryptedDataBase64() },
-        auth,
-        noopAudit,
-      );
-      await assertApiError(
-        updateMember(asDb(db), systemId, created.id, { encryptedData: 123 }, auth, noopAudit),
-        "VALIDATION_ERROR",
-        400,
       );
     });
 
@@ -800,7 +777,12 @@ describe("member.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         source.id,
-        { encryptedData: testEncryptedDataBase64() },
+        {
+          encryptedData: testEncryptedDataBase64(),
+          copyPhotos: false,
+          copyFields: false,
+          copyMemberships: false,
+        },
         auth,
         noopAudit,
       );
@@ -811,28 +793,18 @@ describe("member.service (PGlite integration)", () => {
       expect(dup.archived).toBe(false);
     });
 
-    it("throws VALIDATION_ERROR for invalid duplicate payload", async () => {
-      const source = await createMember(
-        asDb(db),
-        systemId,
-        { encryptedData: testEncryptedDataBase64() },
-        auth,
-        noopAudit,
-      );
-      await assertApiError(
-        duplicateMember(asDb(db), systemId, source.id, { encryptedData: 999 }, auth, noopAudit),
-        "VALIDATION_ERROR",
-        400,
-      );
-    });
-
     it("throws NOT_FOUND when source member does not exist", async () => {
       await assertApiError(
         duplicateMember(
           asDb(db),
           systemId,
           genMemberId(),
-          { encryptedData: testEncryptedDataBase64() },
+          {
+            encryptedData: testEncryptedDataBase64(),
+            copyPhotos: false,
+            copyFields: false,
+            copyMemberships: false,
+          },
           auth,
           noopAudit,
         ),
@@ -864,7 +836,12 @@ describe("member.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         source.id,
-        { encryptedData: testEncryptedDataBase64(), copyPhotos: true },
+        {
+          encryptedData: testEncryptedDataBase64(),
+          copyPhotos: true,
+          copyFields: false,
+          copyMemberships: false,
+        },
         auth,
         noopAudit,
       );
@@ -889,7 +866,12 @@ describe("member.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         source.id,
-        { encryptedData: testEncryptedDataBase64(), copyPhotos: true },
+        {
+          encryptedData: testEncryptedDataBase64(),
+          copyPhotos: true,
+          copyFields: false,
+          copyMemberships: false,
+        },
         auth,
         noopAudit,
       );
@@ -933,7 +915,12 @@ describe("member.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         source.id,
-        { encryptedData: testEncryptedDataBase64(), copyFields: true },
+        {
+          encryptedData: testEncryptedDataBase64(),
+          copyPhotos: false,
+          copyFields: true,
+          copyMemberships: false,
+        },
         auth,
         noopAudit,
       );
@@ -958,7 +945,12 @@ describe("member.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         source.id,
-        { encryptedData: testEncryptedDataBase64(), copyFields: true },
+        {
+          encryptedData: testEncryptedDataBase64(),
+          copyPhotos: false,
+          copyFields: true,
+          copyMemberships: false,
+        },
         auth,
         noopAudit,
       );
@@ -999,7 +991,12 @@ describe("member.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         source.id,
-        { encryptedData: testEncryptedDataBase64(), copyMemberships: true },
+        {
+          encryptedData: testEncryptedDataBase64(),
+          copyPhotos: false,
+          copyFields: false,
+          copyMemberships: true,
+        },
         auth,
         noopAudit,
       );
@@ -1025,7 +1022,12 @@ describe("member.service (PGlite integration)", () => {
         asDb(db),
         systemId,
         source.id,
-        { encryptedData: testEncryptedDataBase64(), copyMemberships: true },
+        {
+          encryptedData: testEncryptedDataBase64(),
+          copyPhotos: false,
+          copyFields: false,
+          copyMemberships: true,
+        },
         auth,
         noopAudit,
       );

--- a/apps/api/src/__tests__/services/member.service.test.ts
+++ b/apps/api/src/__tests__/services/member.service.test.ts
@@ -114,24 +114,6 @@ describe("createMember", () => {
     );
   });
 
-  it("throws 400 for invalid body", async () => {
-    const { db } = mockDb();
-
-    await expect(createMember(db, SYSTEM_ID, { invalid: true }, AUTH, mockAudit)).rejects.toThrow(
-      expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }),
-    );
-  });
-
-  it("throws 400 for oversized blob", async () => {
-    const { db } = mockDb();
-    // String exceeds zod max length (131_072 chars), so validation rejects first
-    const oversized = "A".repeat(131_073);
-
-    await expect(
-      createMember(db, SYSTEM_ID, { encryptedData: oversized }, AUTH, mockAudit),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
-  });
-
   it("throws 400 for malformed blob", async () => {
     const { db } = mockDb();
     const { deserializeEncryptedBlob } = await import("@pluralscape/crypto");
@@ -336,31 +318,6 @@ describe("updateMember", () => {
       ),
     ).rejects.toThrow(expect.objectContaining({ status: 404, code: "NOT_FOUND" }));
   });
-
-  it("throws 400 for invalid body (missing version)", async () => {
-    const { db } = mockDb();
-
-    await expect(
-      updateMember(db, SYSTEM_ID, MEMBER_ID, { encryptedData: VALID_BLOB_BASE64 }, AUTH, mockAudit),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
-  });
-
-  it("throws 400 for oversized blob", async () => {
-    const { db } = mockDb();
-    // String exceeds zod max length (131_072 chars), so validation rejects first
-    const oversized = "A".repeat(131_073);
-
-    await expect(
-      updateMember(
-        db,
-        SYSTEM_ID,
-        MEMBER_ID,
-        { encryptedData: oversized, version: 1 },
-        AUTH,
-        mockAudit,
-      ),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
-  });
 });
 
 describe("duplicateMember", () => {
@@ -381,7 +338,12 @@ describe("duplicateMember", () => {
       db,
       SYSTEM_ID,
       MEMBER_ID,
-      { encryptedData: VALID_BLOB_BASE64 },
+      {
+        encryptedData: VALID_BLOB_BASE64,
+        copyPhotos: false,
+        copyFields: false,
+        copyMemberships: false,
+      },
       AUTH,
       mockAudit,
     );
@@ -402,7 +364,12 @@ describe("duplicateMember", () => {
         db,
         SYSTEM_ID,
         brandId<MemberId>("mem_nonexistent"),
-        { encryptedData: VALID_BLOB_BASE64 },
+        {
+          encryptedData: VALID_BLOB_BASE64,
+          copyPhotos: false,
+          copyFields: false,
+          copyMemberships: false,
+        },
         AUTH,
         mockAudit,
       ),
@@ -438,7 +405,12 @@ describe("duplicateMember", () => {
       db,
       SYSTEM_ID,
       MEMBER_ID,
-      { encryptedData: VALID_BLOB_BASE64, copyPhotos: true },
+      {
+        encryptedData: VALID_BLOB_BASE64,
+        copyPhotos: true,
+        copyFields: false,
+        copyMemberships: false,
+      },
       AUTH,
       mockAudit,
     );
@@ -475,7 +447,12 @@ describe("duplicateMember", () => {
       db,
       SYSTEM_ID,
       MEMBER_ID,
-      { encryptedData: VALID_BLOB_BASE64, copyFields: true },
+      {
+        encryptedData: VALID_BLOB_BASE64,
+        copyPhotos: false,
+        copyFields: true,
+        copyMemberships: false,
+      },
       AUTH,
       mockAudit,
     );
@@ -518,7 +495,12 @@ describe("duplicateMember", () => {
       db,
       SYSTEM_ID,
       MEMBER_ID,
-      { encryptedData: VALID_BLOB_BASE64, copyMemberships: true },
+      {
+        encryptedData: VALID_BLOB_BASE64,
+        copyPhotos: false,
+        copyFields: false,
+        copyMemberships: true,
+      },
       AUTH,
       mockAudit,
     );
@@ -550,21 +532,18 @@ describe("duplicateMember", () => {
       db,
       SYSTEM_ID,
       MEMBER_ID,
-      { encryptedData: VALID_BLOB_BASE64, copyMemberships: true },
+      {
+        encryptedData: VALID_BLOB_BASE64,
+        copyPhotos: false,
+        copyFields: false,
+        copyMemberships: true,
+      },
       AUTH,
       mockAudit,
     );
 
     expect(result.id).toBe("mem_new-member");
     expect(chain.insert).toHaveBeenCalledTimes(1); // only member, no memberships
-  });
-
-  it("throws 400 for invalid duplicate payload", async () => {
-    const { db } = mockDb();
-
-    await expect(
-      duplicateMember(db, SYSTEM_ID, MEMBER_ID, { invalid: true }, AUTH, mockAudit),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
   });
 });
 

--- a/apps/api/src/routes/members/create.ts
+++ b/apps/api/src/routes/members/create.ts
@@ -1,7 +1,9 @@
 import { ID_PREFIXES } from "@pluralscape/types";
+import { CreateMemberBodySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
-import { HTTP_CREATED } from "../../http.constants.js";
+import { HTTP_BAD_REQUEST, HTTP_CREATED } from "../../http.constants.js";
+import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
@@ -19,13 +21,22 @@ createRoute.use("*", createCategoryRateLimiter("write"));
 createRoute.use("*", createIdempotencyMiddleware());
 
 createRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
+  const rawBody = await parseJsonBody(c);
+  const parsed = CreateMemberBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new ApiHttpError(
+      HTTP_BAD_REQUEST,
+      "VALIDATION_ERROR",
+      "Invalid request body",
+      parsed.error.issues,
+    );
+  }
 
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
   const audit = createAuditWriter(c, auth);
 
   const db = await getDb();
-  const result = await createMember(db, systemId, body, auth, audit);
+  const result = await createMember(db, systemId, parsed.data, auth, audit);
   return c.json(envelope(result), HTTP_CREATED);
 });

--- a/apps/api/src/routes/members/duplicate.ts
+++ b/apps/api/src/routes/members/duplicate.ts
@@ -1,7 +1,9 @@
 import { ID_PREFIXES } from "@pluralscape/types";
+import { DuplicateMemberBodySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
-import { HTTP_CREATED } from "../../http.constants.js";
+import { HTTP_BAD_REQUEST, HTTP_CREATED } from "../../http.constants.js";
+import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
@@ -19,7 +21,16 @@ duplicateRoute.use("*", createCategoryRateLimiter("write"));
 duplicateRoute.use("*", createIdempotencyMiddleware());
 
 duplicateRoute.post("/:memberId/duplicate", async (c) => {
-  const body = await parseJsonBody(c);
+  const rawBody = await parseJsonBody(c);
+  const parsed = DuplicateMemberBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new ApiHttpError(
+      HTTP_BAD_REQUEST,
+      "VALIDATION_ERROR",
+      "Invalid request body",
+      parsed.error.issues,
+    );
+  }
 
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
@@ -27,6 +38,6 @@ duplicateRoute.post("/:memberId/duplicate", async (c) => {
   const audit = createAuditWriter(c, auth);
 
   const db = await getDb();
-  const result = await duplicateMember(db, systemId, memberId, body, auth, audit);
+  const result = await duplicateMember(db, systemId, memberId, parsed.data, auth, audit);
   return c.json(envelope(result), HTTP_CREATED);
 });

--- a/apps/api/src/routes/members/update.ts
+++ b/apps/api/src/routes/members/update.ts
@@ -1,6 +1,9 @@
 import { ID_PREFIXES } from "@pluralscape/types";
+import { UpdateMemberBodySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
+import { HTTP_BAD_REQUEST } from "../../http.constants.js";
+import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
@@ -16,7 +19,16 @@ export const updateRoute = new Hono<AuthEnv>();
 updateRoute.use("*", createCategoryRateLimiter("write"));
 
 updateRoute.put("/:memberId", async (c) => {
-  const body = await parseJsonBody(c);
+  const rawBody = await parseJsonBody(c);
+  const parsed = UpdateMemberBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new ApiHttpError(
+      HTTP_BAD_REQUEST,
+      "VALIDATION_ERROR",
+      "Invalid request body",
+      parsed.error.issues,
+    );
+  }
 
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
@@ -24,6 +36,6 @@ updateRoute.put("/:memberId", async (c) => {
   const audit = createAuditWriter(c, auth);
 
   const db = await getDb();
-  const result = await updateMember(db, systemId, memberId, body, auth, audit);
+  const result = await updateMember(db, systemId, memberId, parsed.data, auth, audit);
   return c.json(envelope(result));
 });

--- a/apps/api/src/services/member/create.ts
+++ b/apps/api/src/services/member/create.ts
@@ -3,7 +3,7 @@ import { brandId, ID_PREFIXES, createId, now } from "@pluralscape/types";
 import { CreateMemberBodySchema, DuplicateMemberBodySchema } from "@pluralscape/validation";
 import { and, count, eq } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST, HTTP_NOT_FOUND, HTTP_TOO_MANY_REQUESTS } from "../../http.constants.js";
+import { HTTP_NOT_FOUND, HTTP_TOO_MANY_REQUESTS } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { validateEncryptedBlob } from "../../lib/encrypted-blob.js";
 import { withTenantTransaction } from "../../lib/rls-context.js";
@@ -20,22 +20,18 @@ import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
 import type { FieldValueId, MemberId, MemberPhotoId, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
 
 export async function createMember(
   db: PostgresJsDatabase,
   systemId: SystemId,
-  params: unknown,
+  body: z.infer<typeof CreateMemberBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<MemberResult> {
   assertSystemOwnership(systemId, auth);
 
-  const parsed = CreateMemberBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid create payload");
-  }
-
-  const blob = validateEncryptedBlob(parsed.data.encryptedData, MAX_ENCRYPTED_MEMBER_DATA_BYTES);
+  const blob = validateEncryptedBlob(body.encryptedData, MAX_ENCRYPTED_MEMBER_DATA_BYTES);
   const memberId = brandId<MemberId>(createId(ID_PREFIXES.member));
   const timestamp = now();
 
@@ -88,18 +84,13 @@ export async function duplicateMember(
   db: PostgresJsDatabase,
   systemId: SystemId,
   memberId: MemberId,
-  params: unknown,
+  body: z.infer<typeof DuplicateMemberBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<MemberResult> {
   assertSystemOwnership(systemId, auth);
 
-  const parsed = DuplicateMemberBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid duplicate payload");
-  }
-
-  const blob = validateEncryptedBlob(parsed.data.encryptedData, MAX_ENCRYPTED_MEMBER_DATA_BYTES);
+  const blob = validateEncryptedBlob(body.encryptedData, MAX_ENCRYPTED_MEMBER_DATA_BYTES);
   const newMemberId = brandId<MemberId>(createId(ID_PREFIXES.member));
   const timestamp = now();
 
@@ -146,7 +137,7 @@ export async function duplicateMember(
       throw new Error("Failed to duplicate member — INSERT returned no rows");
     }
 
-    if (parsed.data.copyPhotos) {
+    if (body.copyPhotos) {
       const photos = await tx
         .select()
         .from(memberPhotos)
@@ -178,7 +169,7 @@ export async function duplicateMember(
       }
     }
 
-    if (parsed.data.copyFields) {
+    if (body.copyFields) {
       const values = await tx
         .select()
         .from(fieldValues)
@@ -205,7 +196,7 @@ export async function duplicateMember(
     }
 
     let membershipsCopied = 0;
-    if (parsed.data.copyMemberships) {
+    if (body.copyMemberships) {
       const memberships = await tx
         .select()
         .from(groupMemberships)

--- a/apps/api/src/services/member/internal.ts
+++ b/apps/api/src/services/member/internal.ts
@@ -2,26 +2,12 @@ import { brandId, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
 
 import { encryptedBlobToBase64 } from "../../lib/encrypted-blob.js";
 
-import type {
-  EncryptedBlob,
-  EncryptedWire,
-  MemberId,
-  MemberServerMetadata,
-  SystemId,
-} from "@pluralscape/types";
+import type { MemberRow } from "@pluralscape/db/pg";
+import type { MemberId, MemberResult, SystemId } from "@pluralscape/types";
 
-export type MemberResult = EncryptedWire<MemberServerMetadata>;
+export type { MemberResult };
 
-export function toMemberResult(row: {
-  id: string;
-  systemId: string;
-  encryptedData: EncryptedBlob;
-  version: number;
-  createdAt: number;
-  updatedAt: number;
-  archived: boolean;
-  archivedAt: number | null;
-}): MemberResult {
+export function toMemberResult(row: MemberRow): MemberResult {
   return {
     id: brandId<MemberId>(row.id),
     systemId: brandId<SystemId>(row.systemId),

--- a/apps/api/src/services/member/update.ts
+++ b/apps/api/src/services/member/update.ts
@@ -3,8 +3,6 @@ import { brandId, now } from "@pluralscape/types";
 import { UpdateMemberBodySchema } from "@pluralscape/validation";
 import { and, eq, sql } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST } from "../../http.constants.js";
-import { ApiHttpError } from "../../lib/api-error.js";
 import { validateEncryptedBlob } from "../../lib/encrypted-blob.js";
 import { assertOccUpdated } from "../../lib/occ-update.js";
 import { withTenantTransaction } from "../../lib/rls-context.js";
@@ -20,23 +18,19 @@ import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
 import type { MemberId, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
 
 export async function updateMember(
   db: PostgresJsDatabase,
   systemId: SystemId,
   memberId: MemberId,
-  params: unknown,
+  body: z.infer<typeof UpdateMemberBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<MemberResult> {
   assertSystemOwnership(systemId, auth);
 
-  const parsed = UpdateMemberBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid update payload");
-  }
-
-  const blob = validateEncryptedBlob(parsed.data.encryptedData, MAX_ENCRYPTED_MEMBER_DATA_BYTES);
+  const blob = validateEncryptedBlob(body.encryptedData, MAX_ENCRYPTED_MEMBER_DATA_BYTES);
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
@@ -51,7 +45,7 @@ export async function updateMember(
         and(
           eq(members.id, memberId),
           eq(members.systemId, systemId),
-          eq(members.version, parsed.data.version),
+          eq(members.version, body.version),
           eq(members.archived, false),
         ),
       )

--- a/apps/api/src/trpc/routers/member.ts
+++ b/apps/api/src/trpc/routers/member.ts
@@ -30,14 +30,7 @@ export const memberRouter = router({
     .input(CreateMemberBodySchema)
     .mutation(async ({ ctx, input }) => {
       const audit = ctx.createAudit(ctx.auth);
-      // Service validates params internally; pass the domain fields only.
-      return createMember(
-        ctx.db,
-        ctx.systemId,
-        { encryptedData: input.encryptedData },
-        ctx.auth,
-        audit,
-      );
+      return createMember(ctx.db, ctx.systemId, input, ctx.auth, audit);
     }),
 
   get: systemProcedure
@@ -71,14 +64,8 @@ export const memberRouter = router({
     .input(MemberIdSchema.and(UpdateMemberBodySchema))
     .mutation(async ({ ctx, input }) => {
       const audit = ctx.createAudit(ctx.auth);
-      return updateMember(
-        ctx.db,
-        ctx.systemId,
-        input.memberId,
-        { encryptedData: input.encryptedData, version: input.version },
-        ctx.auth,
-        audit,
-      );
+      const { memberId, ...body } = input;
+      return updateMember(ctx.db, ctx.systemId, memberId, body, ctx.auth, audit);
     }),
 
   duplicate: systemProcedure
@@ -86,19 +73,8 @@ export const memberRouter = router({
     .input(MemberIdSchema.and(DuplicateMemberBodySchema))
     .mutation(async ({ ctx, input }) => {
       const audit = ctx.createAudit(ctx.auth);
-      return duplicateMember(
-        ctx.db,
-        ctx.systemId,
-        input.memberId,
-        {
-          encryptedData: input.encryptedData,
-          copyPhotos: input.copyPhotos,
-          copyFields: input.copyFields,
-          copyMemberships: input.copyMemberships,
-        },
-        ctx.auth,
-        audit,
-      );
+      const { memberId, ...body } = input;
+      return duplicateMember(ctx.db, ctx.systemId, memberId, body, ctx.auth, audit);
     }),
 
   archive: systemProcedure

--- a/packages/data/src/transforms/member.ts
+++ b/packages/data/src/transforms/member.ts
@@ -1,18 +1,25 @@
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { MemberEncryptedInputSchema } from "@pluralscape/validation";
 
 import { decodeAndDecryptT1, encryptInput, encryptUpdate } from "./decode-blob.js";
 
 import type { KdfMasterKey } from "@pluralscape/crypto";
-import type { Archived, Member, MemberEncryptedFields, UnixMillis } from "@pluralscape/types";
+import type {
+  Archived,
+  Member,
+  MemberEncryptedInput,
+  MemberId,
+  MemberWire,
+  SystemId,
+} from "@pluralscape/types";
 
-// ── Wire types (derived from domain types) ──────────────────────────
+export type { MemberEncryptedInput };
 
-/** Wire shape returned by `member.get` — derived from the `Member` domain type. */
-export type MemberRaw = Omit<Member, MemberEncryptedFields | "archived"> & {
-  readonly encryptedData: string;
-  readonly archived: boolean;
-  readonly archivedAt: UnixMillis | null;
-};
+/**
+ * Wire shape returned by `member.get` and `member.list` — derived from
+ * the canonical types-package alias.
+ */
+export type MemberRaw = MemberWire;
 
 /** Shape returned by `member.list`. */
 export interface MemberPage {
@@ -20,32 +27,27 @@ export interface MemberPage {
   readonly nextCursor: string | null;
 }
 
-/**
- * Shape passed to `encryptMemberInput()` before encryption. Derived from the
- * `Member` domain type by picking the encrypted-field keys — single source
- * of truth lives in `@pluralscape/types`.
- */
-export type MemberEncryptedInput = Pick<Member, MemberEncryptedFields>;
-
 // ── Member transforms ────────────────────────────────────────────────
 
 /**
  * Decrypt a single member wire object to the canonical domain type.
  *
  * Passthrough fields (id, systemId, archived, version, createdAt, updatedAt)
- * are copied directly; all other fields are decrypted from encryptedData and
- * validated by `MemberEncryptedInputSchema`.
+ * are re-branded from the JSON-wire shape (where `Serialize<>` strips brands
+ * and timestamps to plain primitives) back into the canonical branded
+ * domain types; all encrypted fields are decrypted from `encryptedData`
+ * and validated by `MemberEncryptedInputSchema`.
  */
 export function decryptMember(raw: MemberRaw, masterKey: KdfMasterKey): Member | Archived<Member> {
   const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey);
   const validated = MemberEncryptedInputSchema.parse(decrypted);
 
   const base = {
-    id: raw.id,
-    systemId: raw.systemId,
+    id: brandId<MemberId>(raw.id),
+    systemId: brandId<SystemId>(raw.systemId),
     version: raw.version,
-    createdAt: raw.createdAt,
-    updatedAt: raw.updatedAt,
+    createdAt: toUnixMillis(raw.createdAt),
+    updatedAt: toUnixMillis(raw.updatedAt),
     name: validated.name,
     pronouns: validated.pronouns,
     description: validated.description,
@@ -59,7 +61,7 @@ export function decryptMember(raw: MemberRaw, masterKey: KdfMasterKey): Member |
 
   if (raw.archived) {
     if (raw.archivedAt === null) throw new Error("Archived member missing archivedAt");
-    return { ...base, archived: true as const, archivedAt: raw.archivedAt };
+    return { ...base, archived: true as const, archivedAt: toUnixMillis(raw.archivedAt) };
   }
   return { ...base, archived: false as const };
 }

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -154,6 +154,8 @@ import type {
 import type {
   Member,
   MemberEncryptedFields,
+  MemberEncryptedInput,
+  MemberResult,
   MemberServerMetadata,
   MemberWire,
 } from "./entities/member.js";
@@ -273,9 +275,11 @@ import type {
 export type SotEntityManifest = {
   Member: {
     domain: Member;
-    server: MemberServerMetadata;
-    wire: MemberWire;
     encryptedFields: MemberEncryptedFields;
+    encryptedInput: MemberEncryptedInput;
+    server: MemberServerMetadata;
+    result: MemberResult;
+    wire: MemberWire;
   };
   AuditLogEntry: {
     domain: AuditLogEntry;

--- a/packages/types/src/__tests__/encryption.test.ts
+++ b/packages/types/src/__tests__/encryption.test.ts
@@ -43,7 +43,7 @@ import type {
 import type { JournalEntry, JournalEntryServerMetadata } from "../entities/journal-entry.js";
 import type { LifecycleEvent, LifecycleEventServerMetadata } from "../entities/lifecycle-event.js";
 import type { MemberPhoto, MemberPhotoServerMetadata } from "../entities/member-photo.js";
-import type { Member, MemberServerMetadata, MemberWire } from "../entities/member.js";
+import type { Member, MemberResult, MemberServerMetadata, MemberWire } from "../entities/member.js";
 import type { ChatMessage, ChatMessageServerMetadata } from "../entities/message.js";
 import type { Note, NoteServerMetadata } from "../entities/note.js";
 import type { PollVote, PollVoteServerMetadata } from "../entities/poll-vote.js";
@@ -406,8 +406,11 @@ describe("DecryptFn and EncryptFn", () => {
 });
 
 describe("MemberWire", () => {
-  it("equals Serialize<Member>", () => {
-    expectTypeOf<MemberWire>().toEqualTypeOf<Serialize<Member>>();
+  it("equals Serialize<MemberResult>", () => {
+    // MemberWire is the JSON-form of MemberResult (the server-emit shape).
+    // Plaintext fields are bundled inside encryptedData, so the wire shape
+    // does NOT equal Serialize<Member> — it equals Serialize<MemberResult>.
+    expectTypeOf<MemberWire>().toEqualTypeOf<Serialize<MemberResult>>();
   });
 
   it("has `id` as plain string (brand stripped)", () => {
@@ -415,9 +418,14 @@ describe("MemberWire", () => {
   });
 
   it("has audit timestamps serialized to number (UnixMillis → number)", () => {
-    // Domain Member includes audit UnixMillis fields (createdAt, updatedAt);
+    // MemberResult includes audit UnixMillis fields (createdAt, updatedAt);
     // Wire should have them as plain number after Serialize.
     expectTypeOf<MemberWire["createdAt"]>().toEqualTypeOf<number>();
+  });
+
+  it("does NOT expose the plaintext `name` field on the wire (encrypted blob bundles it)", () => {
+    // Compile-time guarantee that plaintext keys never leak onto the wire.
+    expectTypeOf<MemberWire>().not.toHaveProperty("name");
   });
 });
 

--- a/packages/types/src/__tests__/sot-manifest.test.ts
+++ b/packages/types/src/__tests__/sot-manifest.test.ts
@@ -6,7 +6,13 @@ import type {
   AuditLogEntryServerMetadata,
   AuditLogEntryWire,
 } from "../entities/audit-log-entry.js";
-import type { Member, MemberServerMetadata, MemberWire } from "../entities/member.js";
+import type {
+  Member,
+  MemberEncryptedInput,
+  MemberResult,
+  MemberServerMetadata,
+  MemberWire,
+} from "../entities/member.js";
 import type { Extends } from "../type-assertions.js";
 
 describe("SotEntityManifest", () => {
@@ -20,9 +26,13 @@ describe("SotEntityManifest", () => {
     >().toEqualTypeOf<true>();
   });
 
-  it("registers Member with the canonical triple", () => {
+  it("registers Member with the canonical chain", () => {
     expectTypeOf<SotEntityManifest["Member"]["domain"]>().toEqualTypeOf<Member>();
+    expectTypeOf<
+      SotEntityManifest["Member"]["encryptedInput"]
+    >().toEqualTypeOf<MemberEncryptedInput>();
     expectTypeOf<SotEntityManifest["Member"]["server"]>().toEqualTypeOf<MemberServerMetadata>();
+    expectTypeOf<SotEntityManifest["Member"]["result"]>().toEqualTypeOf<MemberResult>();
     expectTypeOf<SotEntityManifest["Member"]["wire"]>().toEqualTypeOf<MemberWire>();
   });
 

--- a/packages/types/src/entities/member.ts
+++ b/packages/types/src/entities/member.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { HexColor, MemberId, SystemId } from "../ids.js";
 import type { ImageSource } from "../image-source.js";
@@ -102,6 +103,13 @@ export type MemberEncryptedFields =
   | "suppressFriendFrontNotification"
   | "boardMessageNotificationOnFront";
 
+/**
+ * Pre-encryption shape — what `encryptMemberInput` accepts before
+ * producing the wire-form `{ encryptedData: string }`. Single source of
+ * truth: derived from `Member` via `Pick<>` over the encrypted-keys union.
+ */
+export type MemberEncryptedInput = Pick<Member, MemberEncryptedFields>;
+
 /** An archived member — preserves all data with archive metadata. */
 export type ArchivedMember = Archived<Member>;
 
@@ -112,27 +120,6 @@ export interface MemberListItem {
   readonly avatarSource: ImageSource | null;
   readonly colors: readonly HexColor[];
   readonly archived: boolean;
-}
-
-// ── Request body types ──────────────────────────────────────────
-
-/** Request body for creating a member. */
-export interface CreateMemberBody {
-  readonly encryptedData: string;
-}
-
-/** Request body for updating a member. */
-export interface UpdateMemberBody {
-  readonly encryptedData: string;
-  readonly version: number;
-}
-
-/** Request body for duplicating a member. */
-export interface DuplicateMemberBody {
-  readonly encryptedData: string;
-  readonly copyPhotos: boolean;
-  readonly copyFields: boolean;
-  readonly copyMemberships: boolean;
 }
 
 /**
@@ -151,11 +138,16 @@ export type MemberServerMetadata = Omit<Member, MemberEncryptedFields | "archive
 };
 
 /**
- * JSON-wire representation of a Member. Derived from the domain `Member`
- * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
- *
- * This is what crosses the HTTP boundary for Member payloads. The OpenAPI
- * parity gate asserts `components["schemas"]["Member"]` ≡ `MemberWire`.
+ * Server-emit shape — what `toMemberResult` returns. Branded IDs
+ * preserved; `encryptedData` is `EncryptedBase64` (base64-encoded).
+ * Consumed by the API layer; not the JSON wire shape.
  */
-export type MemberWire = Serialize<Member>;
+export type MemberResult = EncryptedWire<MemberServerMetadata>;
+
+/**
+ * JSON-wire representation of a Member response. `Serialize<>` over
+ * `MemberResult`: branded IDs become plain strings; `EncryptedBase64`
+ * becomes `string`; `UnixMillis` becomes `number`. The OpenAPI
+ * parity gate asserts `components["schemas"]["MemberResponse"]` ≡ `MemberWire`.
+ */
+export type MemberWire = Serialize<MemberResult>;

--- a/packages/types/src/type-assertions.ts
+++ b/packages/types/src/type-assertions.ts
@@ -24,6 +24,8 @@ export type Extends<A, B> = A extends B ? true : false;
  * Rules (applied recursively):
  * - `Date`                  → `string`
  * - `Uint8Array`            → `string` (base64-encoded at runtime)
+ * - `EncryptedBase64`       → `string` (wire-form base64 brand stripped; the
+ *   JSON wire can't carry phantom markers, so consumers see a plain string)
  * - `Brand<T, _>`           → `T` (brand stripped, since JSON can't carry phantom types)
  * - `Plaintext<T>`          → `Serialize<T>` (plaintext brand stripped; same rationale)
  * - `Map<K, V>`             → `Record<K extends string ? K : string, Serialize<V>>`
@@ -44,23 +46,25 @@ export type Serialize<T> = T extends Date
   ? string
   : T extends Uint8Array
     ? string
-    : T extends { readonly [__brand]: unknown }
-      ? ExtractPrimitive<T>
-      : T extends { readonly [__plaintext]: true }
+    : T extends { readonly [__encBase64]: unknown }
+      ? string
+      : T extends { readonly [__brand]: unknown }
         ? ExtractPrimitive<T>
-        : T extends Map<infer K, infer V>
-          ? Record<K extends string ? K : string, Serialize<V>>
-          : T extends Set<infer U>
-            ? Serialize<U>[]
-            : T extends ReadonlyArray<infer U>
+        : T extends { readonly [__plaintext]: true }
+          ? ExtractPrimitive<T>
+          : T extends Map<infer K, infer V>
+            ? Record<K extends string ? K : string, Serialize<V>>
+            : T extends Set<infer U>
               ? Serialize<U>[]
-              : T extends object
-                ? {
-                    [K in keyof T as T[K] extends { readonly [__serverInternal]: true }
-                      ? never
-                      : K]: Serialize<T[K]>;
-                  }
-                : T;
+              : T extends ReadonlyArray<infer U>
+                ? Serialize<U>[]
+                : T extends object
+                  ? {
+                      [K in keyof T as T[K] extends { readonly [__serverInternal]: true }
+                        ? never
+                        : K]: Serialize<T[K]>;
+                    }
+                  : T;
 
 /** Extract the primitive type from a branded type (e.g., strip the brand marker). */
 type ExtractPrimitive<T> = T extends string

--- a/packages/validation/src/__tests__/contract-member.test.ts
+++ b/packages/validation/src/__tests__/contract-member.test.ts
@@ -7,17 +7,14 @@ import {
   UpdateMemberBodySchema,
 } from "../member.js";
 
-import type {
-  CreateMemberBody,
-  CreateMemberPhotoBody,
-  DuplicateMemberBody,
-  UpdateMemberBody,
-} from "@pluralscape/types";
+import type { CreateMemberPhotoBody, Equal } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 describe("CreateMemberBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
-    expectTypeOf<z.infer<typeof CreateMemberBodySchema>>().toEqualTypeOf<CreateMemberBody>();
+  it("infers the documented body shape", () => {
+    expectTypeOf<
+      Equal<z.infer<typeof CreateMemberBodySchema>, { encryptedData: string }>
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input", () => {
@@ -45,8 +42,10 @@ describe("CreateMemberBodySchema", () => {
 });
 
 describe("UpdateMemberBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
-    expectTypeOf<z.infer<typeof UpdateMemberBodySchema>>().toEqualTypeOf<UpdateMemberBody>();
+  it("infers the documented body shape", () => {
+    expectTypeOf<
+      Equal<z.infer<typeof UpdateMemberBodySchema>, { encryptedData: string; version: number }>
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input", () => {
@@ -66,8 +65,18 @@ describe("UpdateMemberBodySchema", () => {
 });
 
 describe("DuplicateMemberBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
-    expectTypeOf<z.infer<typeof DuplicateMemberBodySchema>>().toEqualTypeOf<DuplicateMemberBody>();
+  it("infers the documented body shape", () => {
+    expectTypeOf<
+      Equal<
+        z.infer<typeof DuplicateMemberBodySchema>,
+        {
+          encryptedData: string;
+          copyPhotos: boolean;
+          copyFields: boolean;
+          copyMemberships: boolean;
+        }
+      >
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input with defaults", () => {
@@ -90,12 +99,14 @@ describe("DuplicateMemberBodySchema", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.copyPhotos).toBe(true);
+      expect(result.data.copyFields).toBe(true);
+      expect(result.data.copyMemberships).toBe(true);
     }
   });
 });
 
 describe("CreateMemberPhotoBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
+  it("infers the documented body shape", () => {
     expectTypeOf<
       z.infer<typeof CreateMemberPhotoBodySchema>
     >().toEqualTypeOf<CreateMemberPhotoBody>();

--- a/packages/validation/src/__tests__/type-parity/member.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/member.type.test.ts
@@ -1,54 +1,72 @@
 /**
- * Zod parity check: `z.infer<typeof CreateMemberBodySchema>` and its
- * siblings structurally match their domain-type counterparts from
- * `@pluralscape/types`.
+ * Zod parity for Member. Locks the canonical chain:
+ * - G3: Domain ↔ Zod encrypted input
+ * - G4: Body Zod ↔ data-package transform output (inline-shape form)
  *
- * Catches drift between Zod validation schemas and the canonical domain
- * types. See ADR-023.
+ * Body shapes are owned by the Zod schemas; no interface types exist in
+ * `@pluralscape/types` to assert against.
+ *
+ * Note: `@pluralscape/data` depends on `@pluralscape/validation`, so we
+ * cannot import from `@pluralscape/data` here without creating a circular
+ * dependency. G4 assertions inline the transform output shapes directly;
+ * the canonical, import-anchored form lives in the data package per
+ * follow-up bean `types-1spw`.
  */
 
 import { describe, expectTypeOf, it } from "vitest";
 
-import type {
+import {
   CreateMemberBodySchema,
   DuplicateMemberBodySchema,
   MemberEncryptedInputSchema,
   UpdateMemberBodySchema,
 } from "../../member.js";
+
 import type {
-  CreateMemberBody,
-  DuplicateMemberBody,
   Equal,
   Member,
   MemberEncryptedFields,
-  UpdateMemberBody,
+  MemberEncryptedInput,
 } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
-describe("Member Zod parity", () => {
-  it("CreateMemberBodySchema matches CreateMemberBody", () => {
-    expectTypeOf<
-      Equal<z.infer<typeof CreateMemberBodySchema>, CreateMemberBody>
-    >().toEqualTypeOf<true>();
-  });
-
-  it("UpdateMemberBodySchema matches UpdateMemberBody", () => {
-    expectTypeOf<
-      Equal<z.infer<typeof UpdateMemberBodySchema>, UpdateMemberBody>
-    >().toEqualTypeOf<true>();
-  });
-
-  it("DuplicateMemberBodySchema matches DuplicateMemberBody", () => {
-    expectTypeOf<
-      Equal<z.infer<typeof DuplicateMemberBodySchema>, DuplicateMemberBody>
-    >().toEqualTypeOf<true>();
-  });
-
+describe("Member parity (G3: Domain ↔ Zod encrypted input)", () => {
   it("MemberEncryptedInputSchema matches Pick<Member, MemberEncryptedFields>", () => {
-    // Mirrors `MemberEncryptedInput` in `@pluralscape/data` without creating
-    // a reverse dependency from validation → data.
     expectTypeOf<
       Equal<z.infer<typeof MemberEncryptedInputSchema>, Pick<Member, MemberEncryptedFields>>
     >().toEqualTypeOf<true>();
+  });
+
+  it("MemberEncryptedInput (canonical alias) matches Pick<Member, MemberEncryptedFields>", () => {
+    expectTypeOf<
+      Equal<MemberEncryptedInput, Pick<Member, MemberEncryptedFields>>
+    >().toEqualTypeOf<true>();
+  });
+});
+
+describe("Member parity (G4: Body Zod ↔ Transform output)", () => {
+  it("CreateMemberBodySchema matches encryptMemberInput return shape", () => {
+    // Mirrors encryptMemberInput in packages/data/src/transforms/member.ts.
+    expectTypeOf<
+      Equal<z.infer<typeof CreateMemberBodySchema>, { encryptedData: string }>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("UpdateMemberBodySchema matches encryptMemberUpdate return shape", () => {
+    // Mirrors encryptMemberUpdate in packages/data/src/transforms/member.ts.
+    expectTypeOf<
+      Equal<z.infer<typeof UpdateMemberBodySchema>, { encryptedData: string; version: number }>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("DuplicateMemberBodySchema includes the same wire envelope plus duplication knobs", () => {
+    type Inferred = z.infer<typeof DuplicateMemberBodySchema>;
+    type Expected = {
+      encryptedData: string;
+      copyPhotos: boolean;
+      copyFields: boolean;
+      copyMemberships: boolean;
+    };
+    expectTypeOf<Equal<Inferred, Expected>>().toEqualTypeOf<true>();
   });
 });

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -89,6 +89,7 @@ import type {
   MemberEncryptedFields,
   MemberPhoto,
   MemberPhotoEncryptedFields,
+  MemberResult,
   MemberServerMetadata,
   MemberWire,
   NomenclatureEncryptedFields,
@@ -120,7 +121,10 @@ import { expectTypeOf } from "vitest";
 // from the helper-derived form. This bites if someone hand-redefines
 // `MemberWire` to diverge from `Serialize<Member>`.
 
-expectTypeOf<Equal<MemberWire, Serialize<Member>>>().toEqualTypeOf<true>();
+// `MemberWire` is the JSON-form of `MemberResult`. Brands are stripped and
+// `encryptedData` collapses to wire-form base64 string (not the structured
+// EncryptedBlob).
+expectTypeOf<Equal<MemberWire, Serialize<MemberResult>>>().toEqualTypeOf<true>();
 expectTypeOf<Equal<AuditLogEntryWire, Serialize<AuditLogEntry>>>().toEqualTypeOf<true>();
 
 // ── OpenAPI ↔ Wire parity: EncryptedEntity envelope ─────────────────
@@ -177,14 +181,12 @@ expectTypeOf<
 
 type MemberResponseOpenApi = components["schemas"]["MemberResponse"];
 
-expectTypeOf<
-  Equal<
-    Omit<MemberResponseOpenApi, "encryptedData">,
-    Omit<Serialize<MemberServerMetadata>, "encryptedData">
-  >
->().toEqualTypeOf<true>();
-
-expectTypeOf<MemberResponseOpenApi["encryptedData"]>().toEqualTypeOf<string>();
+// G7 — full equality between the OpenAPI response and the canonical wire
+// type. `MemberWire = Serialize<MemberResult>` collapses the encryptedData
+// blob to the wire-form base64 string and strips brands, so the split
+// parity carve-out (Omit<…, "encryptedData"> + opaque-string check) is
+// no longer needed.
+expectTypeOf<Equal<MemberResponseOpenApi, MemberWire>>().toEqualTypeOf<true>();
 
 // ── OpenAPI ↔ domain parity: FieldDefinitionResponse split parity ──
 


### PR DESCRIPTION
## Summary

Pilot PR for the encrypted-entity SoT consolidation (ps-y4tb). Establishes the canonical six-link type chain for Member end-to-end:

  Member → MemberEncryptedFields → MemberEncryptedInput
        → MemberServerMetadata → MemberResult → MemberWire

- New canonical aliases in `@pluralscape/types`: `MemberEncryptedInput`, `MemberResult`. Redefined `MemberWire = Serialize<MemberResult>` (was `Serialize<Member>`).
- Dropped: `CreateMemberBody`, `UpdateMemberBody`, `DuplicateMemberBody` interfaces. The Zod schemas in `@pluralscape/validation` are now the source for body shapes.
- `packages/data/src/transforms/member.ts` imports the canonical types instead of hand-rolling local aliases.
- `apps/api/src/services/member/*` accept typed bodies and drop the `params: unknown` + `safeParse` double-validation pattern.
- Validation moves to the trust boundary (REST route + tRPC procedure); services trust their typed input.
- New parity gates: G3 (Domain ↔ Zod encrypted input), G4 (Body Zod ↔ Transform output), G7 (full Wire ↔ OpenAPI). Manifest extended with `encryptedInput` and `result` slots.

PR 2 (fleet rollout, 29 entities) follows this pattern.

## Cycle constraint

`@pluralscape/data` already depends on `@pluralscape/validation`. G4 in validation parity tests cannot import transform return types from data without creating a workspace cycle, so G4 here uses inline structural shapes that mirror `encryptMemberInput` / `encryptMemberUpdate` return signatures. Follow-up bean **types-1spw** tracks moving canonical, import-anchored G4 into the data package after fleet rollout.

## Test plan

- [x] `pnpm types:check-sot` passes (4/4 gates green)
- [x] `pnpm test:unit` — 12,857 passed
- [x] `pnpm test:integration` — 3,044 passed
- [ ] CI green
- [ ] E2E suite green

## Refs

- Bean: ps-y4tb (parent: ps-cd6x)
- Follow-up: types-1spw
- Spec: `docs/superpowers/specs/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation-design.md` (local)
- Plan: `docs/superpowers/plans/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation.md` (local)