### PR TITLE
refactor: ps-y4tb fleet — canonical type chain for 28 encrypted entities

### DIFF
--- a/.beans/ps-6phh--plaintextspecial-entity-type-sot-consolidation.md
+++ b/.beans/ps-6phh--plaintextspecial-entity-type-sot-consolidation.md
@@ -8,7 +8,7 @@ created_at: 2026-04-25T08:02:48Z
 updated_at: 2026-04-25T08:02:52Z
 parent: ps-cd6x
 blocked_by:
-    - ps-y4tb
+  - ps-y4tb
 ---
 
 Consolidate the type chain for plaintext and special entities — sibling to ps-y4tb (which covers encrypted entities). Tackled after the encrypted-entity work proves the pattern.
@@ -31,7 +31,7 @@ Per the 2026-04-25 audit:
 
 ## Goals
 
-- Drop redundant *Body interfaces in @pluralscape/types where they duplicate z.infer<XBodySchema>
+- Drop redundant \*Body interfaces in @pluralscape/types where they duplicate z.infer<XBodySchema>
 - Drop hand-rolled XRaw types in packages/data where applicable (some plaintext entities don't have transforms)
 - Service signature cleanup: drop params: unknown, accept z.infer<XBodySchema>
 - Add Zod-to-types parity tests for any hand-rolled request input types

--- a/.beans/ps-6phh--plaintextspecial-entity-type-sot-consolidation.md
+++ b/.beans/ps-6phh--plaintextspecial-entity-type-sot-consolidation.md
@@ -1,0 +1,42 @@
+---
+# ps-6phh
+title: Plaintext/special entity type SoT consolidation
+status: draft
+type: epic
+priority: normal
+created_at: 2026-04-25T08:02:48Z
+updated_at: 2026-04-25T08:02:52Z
+parent: ps-cd6x
+blocked_by:
+    - ps-y4tb
+---
+
+Consolidate the type chain for plaintext and special entities — sibling to ps-y4tb (which covers encrypted entities). Tackled after the encrypted-entity work proves the pattern.
+
+## Scope: PLAINTEXT/SPECIAL ENTITIES (23 entities)
+
+Per the 2026-04-25 audit:
+
+- Plaintext with standard ServerMetadata (19 entities): account, account-purge-request, audit-log-entry, auth-key, blob, bucket-key-rotation, bucket-rotation-item, device-token, device-transfer-request, export-request, field-definition-scope, friend-code, friend-notification-preference, import-job, key-grant, notification-config, recovery-key, sync-document, webhook-config
+- Plaintext junction tables with EncryptedFields = never (3 entities): structure-entity-association, structure-entity-link, structure-entity-member-link
+- Request-only batch operation type (1 entity): import-entity-ref
+
+## Differences from the encrypted bean
+
+- No XEncryptedFields keys-union to lift (some have it set to never)
+- No data-package transform (no encryption to apply)
+- No XEncryptedInput type
+- No XResult / EncryptedWire wrapping (XServerMetadata IS the wire shape)
+- Some entities have hand-rolled request input types in @pluralscape/types (LoginCredentials, RegistrationInitiateInput, etc.) that need case-by-case judgment about whether to keep, redefine via z.infer, or drop
+
+## Goals
+
+- Drop redundant *Body interfaces in @pluralscape/types where they duplicate z.infer<XBodySchema>
+- Drop hand-rolled XRaw types in packages/data where applicable (some plaintext entities don't have transforms)
+- Service signature cleanup: drop params: unknown, accept z.infer<XBodySchema>
+- Add Zod-to-types parity tests for any hand-rolled request input types
+- Audit and document handling for request-only types (import-entity-ref) and aggregated/computed result types
+
+## Spec
+
+To be written after ps-y4tb (encrypted entities) lands and the consolidation pattern is proven.

--- a/.beans/ps-etbc--ps-y4tb-fleet-completion-data-transforms-services.md
+++ b/.beans/ps-etbc--ps-y4tb-fleet-completion-data-transforms-services.md
@@ -1,6 +1,6 @@
 ---
 # ps-etbc
-title: 'ps-y4tb fleet completion: data transforms, services, routes, tRPC, parity tests, manifest'
+title: "ps-y4tb fleet completion: data transforms, services, routes, tRPC, parity tests, manifest"
 status: todo
 type: task
 priority: high
@@ -34,11 +34,12 @@ For each of the 14 services/routes/routers consuming the deprecated `*Body` inte
 - tRPC routers: pass input directly (no manual rebuild)
 
 Affected files (from grep on 2026-04-25):
+
 - apps/api/src/services/member/photos/create.ts
 - apps/api/src/services/field-definition/{create,update}.ts
 - apps/api/src/services/field-value/{set,update}.ts
 - apps/api/src/trpc/routers/{member-photo,field}.ts
-- apps/api/src/routes/.../* (all corresponding routes)
+- apps/api/src/routes/.../\* (all corresponding routes)
 - packages/import-sp/src/mappers/field-definition.mapper.ts (uses CreateFieldDefinitionBody — switch to z.infer)
 - packages/data/src/transforms/custom-field.ts
 

--- a/.beans/ps-etbc--ps-y4tb-fleet-completion-data-transforms-services.md
+++ b/.beans/ps-etbc--ps-y4tb-fleet-completion-data-transforms-services.md
@@ -1,0 +1,86 @@
+---
+# ps-etbc
+title: 'ps-y4tb fleet completion: data transforms, services, routes, tRPC, parity tests, manifest'
+status: todo
+type: task
+priority: high
+created_at: 2026-04-25T19:49:40Z
+updated_at: 2026-04-25T19:49:44Z
+parent: ps-y4tb
+---
+
+## Background
+
+PR 2 of ps-y4tb (encrypted-entity SoT consolidation, fleet rollout) landed the canonical type chain in `@pluralscape/types` for 28 of the 29 in-scope encrypted entities (17 Class A, 10 Class B, friend-connection). CheckInRecord is tracked separately in `types-600s`.
+
+This bean covers the remaining fleet rollout tasks deferred from PR 2 to keep its diff additive and reviewable:
+
+## In scope
+
+### A. Data transforms cleanup (Task 4.4 of original plan)
+
+Per file in `packages/data/src/transforms/`: drop hand-rolled `XRaw = Omit<XDecrypted, XEncryptedFields> & { encryptedData: string }`, replace with `XRaw = XWire` from `@pluralscape/types`. Drop local `XEncryptedInput` declarations and re-export the canonical alias. Drop `AssertXFieldsSubset` types. Update `decryptX` to re-brand IDs/timestamps via `brandId<XId>(raw.id)` etc. (per Member-pilot pattern).
+
+Files: acknowledgement, board-message, channel, custom-field (FieldDefinition + FieldValue), custom-front, friend-connection, fronting-comment, fronting-session, group, innerworld-canvas, innerworld-entity, innerworld-region, lifecycle-event, message, note, poll (Poll + PollVote), privacy-bucket, relationship, structure-entity, structure-entity-type, system-settings, timer-check-in (TimerConfig only — CheckInRecord deferred to types-600s).
+
+A prior subagent attempt on this work went rogue, edited test files outside scope, and broke signatures (system-settings.ts, poll.ts encryptedData null handling, multiple test fixtures). Approach this in smaller batches with strict scope (explicitly forbid test file edits — those are Task 4.9). Verify each batch with typecheck before continuing.
+
+### B. Service / route / tRPC migration (Tasks 4.5-4.8)
+
+For each of the 14 services/routes/routers consuming the deprecated `*Body` interfaces (FieldDefinition ×2, FieldValue ×2, MemberPhoto ×1):
+
+- Service create/update files: change signature from `params: unknown` + `safeParse` to `body: z.infer<typeof XBodySchema>`
+- Route files: parse body at boundary with `XBodySchema.safeParse`, throw `ApiHttpError(VALIDATION_ERROR)` on failure
+- tRPC routers: pass input directly (no manual rebuild)
+
+Affected files (from grep on 2026-04-25):
+- apps/api/src/services/member/photos/create.ts
+- apps/api/src/services/field-definition/{create,update}.ts
+- apps/api/src/services/field-value/{set,update}.ts
+- apps/api/src/trpc/routers/{member-photo,field}.ts
+- apps/api/src/routes/.../* (all corresponding routes)
+- packages/import-sp/src/mappers/field-definition.mapper.ts (uses CreateFieldDefinitionBody — switch to z.infer)
+- packages/data/src/transforms/custom-field.ts
+
+After consumers are migrated, delete the deprecated `*Body` interfaces from `field-definition.ts`, `field-value.ts`, `member-photo.ts`. Update `packages/validation/src/__tests__/contract-{custom-fields,member}.test.ts` to use inline shapes (per Member pilot pattern).
+
+### C. Parity tests (Task 4.9)
+
+Add `packages/validation/src/__tests__/type-parity/<entity>.type.test.ts` for the 19 previously-uncovered entities, using the Member pilot G3 + G4 inline-shape pattern. Update existing 11 parity tests if their assertions reference any retired type.
+
+### D. SoT manifest (Task 4.11)
+
+For each of the 29 in-scope entities (Class A, B, D), extend the manifest entry in `packages/types/src/__sot-manifest__.ts` with `encryptedInput` and `result` slots. Add corresponding assertions in `packages/types/src/__tests__/sot-manifest.test.ts`.
+
+### E. OpenAPI parity (Task 4.10)
+
+For each of the 29 in-scope entities, replace the carve-out form (Omit<…, "encryptedData"> + opaque-string check) in `scripts/openapi-wire-parity.type-test.ts` with the G7 full-equality form: `Equal<XResponseOpenApi, XWire>`. Update `Equal<XWire, Serialize<X>>` self-consistency assertions to `Equal<XWire, Serialize<XResult>>`.
+
+### F. Documentation refresh (Task 5)
+
+Update CLAUDE.md, packages/types/README.md, packages/data/README.md, ADR-023, architecture.md, CONTRIBUTING.md to reflect the canonical chain + drift gates.
+
+## Out of scope
+
+- CheckInRecord canonical chain — see `types-600s`
+- Class C entities (api-key, session, system-snapshot) — see `ps-qmyt`
+- Class E webhook-delivery server-side encryption — see `ps-f3ox`
+- Plaintext / special entity SoT — see `ps-6phh`
+
+## Acceptance
+
+- [ ] All `decryptX` functions in `packages/data/src/transforms/` consume `XWire` (the canonical wire type) and re-brand IDs/timestamps
+- [ ] All `*Body` deprecated interfaces removed from `@pluralscape/types`
+- [ ] All 14 consumers migrated to `z.infer<typeof XBodySchema>`
+- [ ] Per-entity parity tests for 29 entities (G3 + G4 inline-shape form)
+- [ ] SoT manifest extended; manifest test passes
+- [ ] OpenAPI parity in G7 form for all 29 entities
+- [ ] `pnpm types:check-sot` clean
+- [ ] CI green (unit / integration / E2E)
+- [ ] Documentation refreshed (Task 5)
+
+## Cross-references
+
+- Parent: ps-y4tb
+- Sibling: types-600s (CheckInRecord), types-1spw (G4 anchor in data)
+- Plan: `docs/superpowers/plans/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation.md` Tasks 4.4–4.11 + Task 5

--- a/.beans/ps-etbc--ps-y4tb-fleet-completion-data-transforms-services.md
+++ b/.beans/ps-etbc--ps-y4tb-fleet-completion-data-transforms-services.md
@@ -5,7 +5,7 @@ status: todo
 type: task
 priority: high
 created_at: 2026-04-25T19:49:40Z
-updated_at: 2026-04-25T19:49:44Z
+updated_at: 2026-04-25T22:27:49Z
 parent: ps-y4tb
 ---
 
@@ -43,7 +43,7 @@ Affected files (from grep on 2026-04-25):
 - packages/import-sp/src/mappers/field-definition.mapper.ts (uses CreateFieldDefinitionBody — switch to z.infer)
 - packages/data/src/transforms/custom-field.ts
 
-After consumers are migrated, delete the deprecated `*Body` interfaces from `field-definition.ts`, `field-value.ts`, `member-photo.ts`. Update `packages/validation/src/__tests__/contract-{custom-fields,member}.test.ts` to use inline shapes (per Member pilot pattern).
+Note: FieldDefinition, FieldValue, and MemberPhoto are already migrated end-to-end in PR #561 (alongside the Member pilot from #560). Their Body interfaces have been deleted and consumers are no longer in this bean's scope.
 
 ### C. Parity tests (Task 4.9)
 
@@ -85,3 +85,9 @@ Update CLAUDE.md, packages/types/README.md, packages/data/README.md, ADR-023, ar
 - Parent: ps-y4tb
 - Sibling: types-600s (CheckInRecord), types-1spw (G4 anchor in data)
 - Plan: `docs/superpowers/plans/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation.md` Tasks 4.4–4.11 + Task 5
+
+## Update — out-of-scope clarification (2026-04-25)
+
+Do not add net-new inline-shape G4 assertions in `packages/validation/src/__tests__/type-parity/`. Those will be superseded by `types-1spw` (canonical, import-anchored G4 in the data package) once the data-package transforms cleanup lands.
+
+If existing inline-shape G4 assertions are found during ps-etbc work (e.g., from Member pilot or PR #561 migrations), leave them in place — `types-1spw` will sweep them later.

--- a/.beans/ps-f3ox--class-e-server-side-t3-encryption-webhook-delivery.md
+++ b/.beans/ps-f3ox--class-e-server-side-t3-encryption-webhook-delivery.md
@@ -1,0 +1,42 @@
+---
+# ps-f3ox
+title: 'Class E server-side T3 encryption: webhook-delivery'
+status: draft
+type: task
+priority: normal
+created_at: 2026-04-25T08:07:36Z
+updated_at: 2026-04-25T08:07:49Z
+parent: ps-cd6x
+blocked_by:
+    - ps-y4tb
+---
+
+webhook-delivery is the lone encrypted entity using server-side T3 encryption (Uint8Array signed with server-held key) instead of E2E EncryptedBlob.
+
+## Why it doesn't fit the canonical chain
+
+- WebhookDeliveryServerMetadata.encryptedData is Uint8Array (not EncryptedBlob)
+- Encryption is server-side only — not E2E from the client
+- No client-side decryption transform exists in packages/data
+- EncryptedWire<T> assumes EncryptedBlob; doesn't apply here
+- The wire shape (what crosses HTTP) for webhook-delivery is server-internal — clients don't normally see deliveries; they're admin/audit views
+
+## Question for design
+
+Does webhook-delivery benefit from the canonical chain at all, or is it appropriate to leave it as a documented exception?
+
+Options:
+- (a) Define a sibling chain for T3 server-encrypted entities: XServerMetadata + XResult + XWire, where Result/Wire convert Uint8Array to base64 string
+- (b) Leave webhook-delivery alone; document why it's an exception in ADR-023
+- (c) Standardize the parts that do apply (Drizzle parity, Wire shape) but keep the encryption layer bespoke
+
+## Acceptance
+
+- A design call resolves the option above
+- ADR-023 includes a section on T3 server-side encrypted entities (whether webhook-delivery is the only one or not)
+- If (a) is chosen: parity tests + types-package additions match
+- If (b) is chosen: a comment in webhook-delivery.ts explains why it diverges
+
+## Blocked-by
+
+ps-y4tb (so the canonical chain is settled before we decide how webhook-delivery relates to it).

--- a/.beans/ps-f3ox--class-e-server-side-t3-encryption-webhook-delivery.md
+++ b/.beans/ps-f3ox--class-e-server-side-t3-encryption-webhook-delivery.md
@@ -1,6 +1,6 @@
 ---
 # ps-f3ox
-title: 'Class E server-side T3 encryption: webhook-delivery'
+title: "Class E server-side T3 encryption: webhook-delivery"
 status: draft
 type: task
 priority: normal
@@ -8,7 +8,7 @@ created_at: 2026-04-25T08:07:36Z
 updated_at: 2026-04-25T08:07:49Z
 parent: ps-cd6x
 blocked_by:
-    - ps-y4tb
+  - ps-y4tb
 ---
 
 webhook-delivery is the lone encrypted entity using server-side T3 encryption (Uint8Array signed with server-held key) instead of E2E EncryptedBlob.
@@ -26,6 +26,7 @@ webhook-delivery is the lone encrypted entity using server-side T3 encryption (U
 Does webhook-delivery benefit from the canonical chain at all, or is it appropriate to leave it as a documented exception?
 
 Options:
+
 - (a) Define a sibling chain for T3 server-encrypted entities: XServerMetadata + XResult + XWire, where Result/Wire convert Uint8Array to base64 string
 - (b) Leave webhook-delivery alone; document why it's an exception in ADR-023
 - (c) Standardize the parts that do apply (Drizzle parity, Wire shape) but keep the encryption layer bespoke

--- a/.beans/ps-qmyt--class-c-structurally-divergent-encryption-api-key.md
+++ b/.beans/ps-qmyt--class-c-structurally-divergent-encryption-api-key.md
@@ -1,0 +1,56 @@
+---
+# ps-qmyt
+title: 'Class C structurally-divergent encryption: api-key, session, system-snapshot'
+status: draft
+type: feature
+priority: normal
+created_at: 2026-04-25T08:07:36Z
+updated_at: 2026-04-25T08:07:49Z
+parent: ps-cd6x
+blocked_by:
+    - ps-y4tb
+---
+
+Three encrypted entities whose encrypted payload is NOT a Pick<X, K> subset of their domain type — they carry auxiliary side-data with its own type. The Class A canonical chain (lifted into ps-y4tb) doesn't apply directly; each needs bespoke design.
+
+## Background — what makes them divergent
+
+### api-key (apps/api/src/services/api-key/, packages/types/src/entities/api-key.ts)
+- Domain ApiKey is a discriminated union (MetadataApiKey vs CryptoApiKey) — already complex
+- Server row bundles 'name' and 'publicKey' inside encryptedData blob
+- ApiKeyServerMetadata.encryptedKeyMaterial is a separate Uint8Array column (not in EncryptedBlob)
+- Full chain has TWO encrypted payloads (the main blob + key material)
+
+### session (packages/types/src/entities/session.ts)
+- Domain Session has NO encrypted fields — it's metadata about the auth session
+- DeviceInfo (separate exported interface) is what's encrypted in the blob
+- DeviceInfo includes: platform, appVersion, deviceName
+- SessionServerMetadata extends Session with tokenHash + encryptedData (nullable)
+- Comment in session.ts:29 explicitly says 'Session is a plaintext entity (the domain type has no client-encrypted field union)'
+
+### system-snapshot (packages/types/src/entities/system-snapshot.ts)
+- Domain SystemSnapshot has plaintext metadata (id, systemId, createdAt, snapshotTrigger)
+- SnapshotContent (separate type) is what's encrypted
+- Comment at line 42: 'stores the T1-encrypted SnapshotContent — which lives in its own type (not as a keys-subset of SystemSnapshot)'
+
+## Per-entity design questions (one design call each)
+
+For each entity:
+
+1. What is the canonical name for the encrypted-payload type? (DeviceInfo for session, SnapshotContent for system-snapshot, ?ApiKeyEncryptedPayload? for api-key)
+2. Where does that type live? (already in @pluralscape/types per session.ts:20 and system-snapshot — verify api-key)
+3. What's the equivalent of XEncryptedInput? (For Class A it's Pick<X, XEncryptedFields>; here it's the auxiliary type itself)
+4. How is parity expressed? (z.infer<XEncryptedInputSchema> ≡ DeviceInfo, etc.)
+5. What's XResult / XWire? (Same as Class A — EncryptedWire<XServerMetadata> works because the encrypted blob is in ServerMetadata)
+6. Hand-rolled XRaw type in data/transforms — same cleanup as Class A?
+
+## Acceptance
+
+- Each of the 3 entities has a documented canonical chain in packages/types
+- Parity tests cover the encrypted-payload ↔ Zod schema relationship
+- packages/data/transforms/<entity>.ts (where applicable) imports canonical types
+- Any service-layer cleanup (params: unknown → typed) applied consistently with the encrypted-entity epic
+
+## Blocked-by
+
+ps-y4tb (encrypted-entity SoT consolidation) — proves the pattern; this work extends it to bespoke cases.

--- a/.beans/ps-qmyt--class-c-structurally-divergent-encryption-api-key.md
+++ b/.beans/ps-qmyt--class-c-structurally-divergent-encryption-api-key.md
@@ -1,6 +1,6 @@
 ---
 # ps-qmyt
-title: 'Class C structurally-divergent encryption: api-key, session, system-snapshot'
+title: "Class C structurally-divergent encryption: api-key, session, system-snapshot"
 status: draft
 type: feature
 priority: normal
@@ -8,7 +8,7 @@ created_at: 2026-04-25T08:07:36Z
 updated_at: 2026-04-25T08:07:49Z
 parent: ps-cd6x
 blocked_by:
-    - ps-y4tb
+  - ps-y4tb
 ---
 
 Three encrypted entities whose encrypted payload is NOT a Pick<X, K> subset of their domain type — they carry auxiliary side-data with its own type. The Class A canonical chain (lifted into ps-y4tb) doesn't apply directly; each needs bespoke design.
@@ -16,12 +16,14 @@ Three encrypted entities whose encrypted payload is NOT a Pick<X, K> subset of t
 ## Background — what makes them divergent
 
 ### api-key (apps/api/src/services/api-key/, packages/types/src/entities/api-key.ts)
+
 - Domain ApiKey is a discriminated union (MetadataApiKey vs CryptoApiKey) — already complex
 - Server row bundles 'name' and 'publicKey' inside encryptedData blob
 - ApiKeyServerMetadata.encryptedKeyMaterial is a separate Uint8Array column (not in EncryptedBlob)
 - Full chain has TWO encrypted payloads (the main blob + key material)
 
 ### session (packages/types/src/entities/session.ts)
+
 - Domain Session has NO encrypted fields — it's metadata about the auth session
 - DeviceInfo (separate exported interface) is what's encrypted in the blob
 - DeviceInfo includes: platform, appVersion, deviceName
@@ -29,6 +31,7 @@ Three encrypted entities whose encrypted payload is NOT a Pick<X, K> subset of t
 - Comment in session.ts:29 explicitly says 'Session is a plaintext entity (the domain type has no client-encrypted field union)'
 
 ### system-snapshot (packages/types/src/entities/system-snapshot.ts)
+
 - Domain SystemSnapshot has plaintext metadata (id, systemId, createdAt, snapshotTrigger)
 - SnapshotContent (separate type) is what's encrypted
 - Comment at line 42: 'stores the T1-encrypted SnapshotContent — which lives in its own type (not as a keys-subset of SystemSnapshot)'

--- a/.beans/ps-y4tb--fleet-wide-type-sot-consolidation.md
+++ b/.beans/ps-y4tb--fleet-wide-type-sot-consolidation.md
@@ -41,8 +41,6 @@ The 2026-04-25 type-drift audit revealed structural gaps in the existing type ch
 
 To be written via brainstorming skill (2026-04-25).
 
-
-
 ## PR 1 Pilot Progress (2026-04-25)
 
 Member canonical chain implemented in worktree `refactor/ps-y4tb-pilot-member`. All 10 PR-1 tasks complete:
@@ -56,8 +54,6 @@ Member canonical chain implemented in worktree `refactor/ps-y4tb-pilot-member`. 
 Cycle constraint discovered: `@pluralscape/data` already depends on `@pluralscape/validation`, so G4 in validation parity tests cannot import from data. Inline-shape G4 used instead (mirrors existing pattern in `packages/validation/src/__tests__/contract-member.test.ts`). Follow-up bean **types-1spw** tracks moving canonical G4 anchoring to the data package after fleet rollout.
 
 Plan reference: `docs/superpowers/plans/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation.md` Task 3.7 (cycle-constraint note above Step 1).
-
-
 
 ## PR 1 Merged — 2026-04-25 09:33 UTC
 

--- a/.beans/ps-y4tb--fleet-wide-type-sot-consolidation.md
+++ b/.beans/ps-y4tb--fleet-wide-type-sot-consolidation.md
@@ -1,0 +1,88 @@
+---
+# ps-y4tb
+title: Encrypted-entity type SoT consolidation
+status: in-progress
+type: epic
+priority: normal
+created_at: 2026-04-25T07:48:01Z
+updated_at: 2026-04-25T09:34:38Z
+parent: ps-cd6x
+---
+
+Consolidate the entity type chain so that @pluralscape/types is the single source of truth, eliminating hand-rolled drift surfaces across packages/data, apps/api/services, and packages/types itself.
+
+## Scope: ENCRYPTED ENTITIES ONLY (34 entities)
+
+This bean covers the 34 entities with encrypted data. Plaintext consolidation is tracked separately in a sibling bean. Per the 2026-04-25 audit:
+
+- Class A (canonical pattern, 18 entities): bucket, custom-front, field-definition, field-value, fronting-comment, fronting-session, group, innerworld-canvas, innerworld-entity, innerworld-region, lifecycle-event, member, member-photo, relationship, structure-entity, structure-entity-type, system, system-settings
+- Class B (EncryptedFields not yet exported, 10 entities): acknowledgement, board-message, channel, journal-entry, message, note, poll, poll-vote, timer-config, wiki-page
+- Class C (structurally divergent encryption, 3 entities): api-key, session, system-snapshot
+- Class D (optional/nullable encryption, 2 entities): check-in-record, friend-connection
+- Class E (server-side T3 encryption, 1 entity): webhook-delivery
+
+## Background
+
+The 2026-04-25 type-drift audit revealed structural gaps in the existing type chain (using Member as the reference case):
+
+1. `MemberWire = Serialize<Member>` describes a fictional wire shape that never crosses HTTP. The actual canonical wire-response type is `Serialize<MemberServerMetadata>` (asserted in `scripts/openapi-wire-parity.type-test.ts:178`). Two definitions disagree.
+2. `MemberRaw` in `packages/data/src/transforms/member.ts:11` is hand-rolled; should be derived from `MemberServerMetadata` via canonical aliases in @pluralscape/types.
+3. `MemberEncryptedInput` in `packages/data/src/transforms/member.ts:28` is a derivation that should live in @pluralscape/types.
+4. `MemberResult` in `apps/api/src/services/member/internal.ts:13` is an EncryptedWire projection; should be re-exported from @pluralscape/types so all entities have a discoverable canonical name.
+5. `toMemberResult` (services internal.ts:15-24) hand-rolls the row arg type instead of importing `MemberRow` from @pluralscape/db.
+6. `CreateMemberBody`, `UpdateMemberBody`, `DuplicateMemberBody` (interfaces in @pluralscape/types) are redundant duplicates of `z.infer<typeof XBodySchema>` from the validation package.
+7. Service signatures use `params: unknown` then revalidate via `safeParse` — double validation; tRPC routers manually rebuild objects to feed the unknown-typed services.
+
+## Outcome
+
+@pluralscape/types defines the canonical chain per entity: `X` → `XEncryptedFields` → `XEncryptedInput` → `XServerMetadata` → `XResult` → `XWire`. Other packages derive from those. Validation lives at the boundary (REST route + tRPC); services accept typed input and trust it.
+
+## Spec
+
+To be written via brainstorming skill (2026-04-25).
+
+
+
+## PR 1 Pilot Progress (2026-04-25)
+
+Member canonical chain implemented in worktree `refactor/ps-y4tb-pilot-member`. All 10 PR-1 tasks complete:
+
+- [x] Tasks 3.1–3.6: Member entity types, data transforms, services, routes, tRPC, service test cleanup
+- [x] Task 3.7: Validation parity tests (G3 + G4 inline-shape form, cycle constraint discovered)
+- [x] Task 3.8: SoT manifest + manifest test extended with encryptedInput + result slots
+- [x] Task 3.9: OpenAPI parity converted from carve-out split to G7 full-equality (`MemberResponseOpenApi ≡ MemberWire`)
+- [x] Task 3.10: integration tests + 7-commit push + PR #560 opened
+
+Cycle constraint discovered: `@pluralscape/data` already depends on `@pluralscape/validation`, so G4 in validation parity tests cannot import from data. Inline-shape G4 used instead (mirrors existing pattern in `packages/validation/src/__tests__/contract-member.test.ts`). Follow-up bean **types-1spw** tracks moving canonical G4 anchoring to the data package after fleet rollout.
+
+Plan reference: `docs/superpowers/plans/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation.md` Task 3.7 (cycle-constraint note above Step 1).
+
+
+
+## PR 1 Merged — 2026-04-25 09:33 UTC
+
+PR #560 squash-merged as commit `e32d3a97` on main. All 13 CI checks passed (typecheck, lint, unit coverage, integration, e2e, migration freshness, OpenAPI reconciliation, tRPC parity, scope coverage, security audit, semgrep, CodeQL).
+
+### Member canonical chain (live on main)
+
+```
+Member → MemberEncryptedFields → MemberEncryptedInput
+      → MemberServerMetadata → MemberResult → MemberWire
+```
+
+### Pattern locked in for fleet rollout
+
+- New canonical types in `@pluralscape/types`: `MemberEncryptedInput = Pick<Member, MemberEncryptedFields>`, `MemberResult = EncryptedWire<MemberServerMetadata>`, `MemberWire = Serialize<MemberResult>`
+- `Serialize<T>` extended in `packages/types/src/type-assertions.ts` to also strip `__encBase64` brand
+- `*Body` interfaces dropped — Zod owns body shapes
+- Services: `params: unknown` + `safeParse` removed; signatures take `z.infer<typeof XBodySchema>`
+- Routes: validate at boundary with `safeParse` + `ApiHttpError(VALIDATION_ERROR)`
+- tRPC: pass `input` directly (or destructure URL params)
+- Manifest: `encryptedInput` and `result` slots added
+- OpenAPI parity in G7 form (full equality `MemberResponseOpenApi ≡ MemberWire`, no carve-out)
+
+### Next: PR 2 (Task 4 in plan) — fleet rollout to 29 entities
+
+11 commits across Class A (18), Class B (10), Class D (2) per plan. Class C (api-key, session, system-snapshot) tracked separately in `ps-qmyt`. Class E (webhook-delivery) tracked in `ps-f3ox`. Plaintext entities tracked in `ps-6phh`.
+
+Worktree to use: `/home/theprismsystem/git/ps-y4tb-fleet` from `origin/main` (post-merge).

--- a/.beans/types-1spw--anchor-g4-parity-assertions-to-data-transform-retu.md
+++ b/.beans/types-1spw--anchor-g4-parity-assertions-to-data-transform-retu.md
@@ -1,0 +1,45 @@
+---
+# types-1spw
+title: Anchor G4 parity assertions to data transform return types
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-25T09:05:46Z
+updated_at: 2026-04-25T09:05:51Z
+parent: ps-y4tb
+---
+
+## Background
+
+Task 3.7 of ps-y4tb (Encrypted-entity SoT consolidation, Member pilot) discovered a circular dependency that prevents the planned G4 (Body Zod ↔ Transform output) parity from being mechanically anchored to the actual transform return types in `packages/validation` parity tests.
+
+`@pluralscape/data` depends on `@pluralscape/validation`, so importing `encryptMemberInput` / `encryptMemberUpdate` from `@pluralscape/data/transforms/member` into `packages/validation/src/__tests__/type-parity/member.type.test.ts` would create a workspace cycle. Both 3.7 and the existing `packages/validation/src/__tests__/contract-member.test.ts` therefore inline the structural shape (`{ encryptedData: string }`, `{ encryptedData: string; version: number }`, `{ encryptedData: string; copyPhotos: boolean; copyFields: boolean; copyMemberships: boolean }`) instead of `ReturnType<typeof encryptMemberInput>`.
+
+## Drift risk
+
+If a transform return signature changes (e.g. adds a `meta: string` field), the inline shape in the parity test will not auto-update — the test passes silently while the wire breaks.
+
+## Options
+
+A. **Move the G4 parity tests into `packages/data`.** Data already imports both validation and types, so `ReturnType<typeof encryptXInput>` and `z.infer<typeof CreateXBodySchema>` can sit in the same file. Per-entity test files mirror the structure currently in `packages/validation/src/__tests__/type-parity/`. (Recommended.)
+
+B. **Introduce a `packages/parity-tests` (or similar) test-only workspace that depends on both.** Heavier; only worth it if multiple cross-package parity gates need a home.
+
+C. **Invert the data ↔ validation dependency** so validation depends on data instead. Likely impractical — schemas drive transform input shapes, not the other way around.
+
+## Scope
+
+Apply to the full encrypted-entity fleet *after* PR 2 of ps-y4tb lands the inline-shape pattern uniformly. Doing this per-entity during the fleet migration would amplify the per-PR diff for marginal benefit; a single follow-up sweep is cleaner.
+
+## Acceptance
+
+- [ ] G4 parity assertions for each in-scope encrypted entity live in a file that imports both the Zod schema and the transform return type as values, without breaking the dep graph
+- [ ] The inline-shape G4 assertions in `packages/validation/src/__tests__/type-parity/<entity>.type.test.ts` and `packages/validation/src/__tests__/contract-<entity>.test.ts` are removed (or kept as belt-and-suspenders, decided per-entity)
+- [ ] `pnpm types:check-sot` passes
+- [ ] CI typecheck/lint clean
+
+## Cross-references
+
+- Parent: ps-y4tb (Encrypted-entity type SoT consolidation)
+- Related: ADR-023 (Zod ↔ types alignment)
+- Plan reference: `docs/superpowers/plans/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation.md` Task 3.7 (cycle constraint note)

--- a/.beans/types-1spw--anchor-g4-parity-assertions-to-data-transform-retu.md
+++ b/.beans/types-1spw--anchor-g4-parity-assertions-to-data-transform-retu.md
@@ -29,7 +29,7 @@ C. **Invert the data ↔ validation dependency** so validation depends on data i
 
 ## Scope
 
-Apply to the full encrypted-entity fleet *after* PR 2 of ps-y4tb lands the inline-shape pattern uniformly. Doing this per-entity during the fleet migration would amplify the per-PR diff for marginal benefit; a single follow-up sweep is cleaner.
+Apply to the full encrypted-entity fleet _after_ PR 2 of ps-y4tb lands the inline-shape pattern uniformly. Doing this per-entity during the fleet migration would amplify the per-PR diff for marginal benefit; a single follow-up sweep is cleaner.
 
 ## Acceptance
 

--- a/.beans/types-600s--apply-canonical-chain-to-checkinrecord-server-only.md
+++ b/.beans/types-600s--apply-canonical-chain-to-checkinrecord-server-only.md
@@ -1,0 +1,45 @@
+---
+# types-600s
+title: Apply canonical chain to CheckInRecord (server-only encrypted payload)
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-25T19:17:08Z
+updated_at: 2026-04-25T19:17:11Z
+parent: ps-y4tb
+---
+
+## Background
+
+Discovered during ps-y4tb fleet rollout (PR 2, Task 4.3). The plan classified `CheckInRecord` as Class D (nullable encryption), but its structure is divergent: the domain has NO encrypted fields (all properties are server-visible plaintext), while the server row carries an OPTIONAL `encryptedData: EncryptedBlob | null` payload that is recorded with check-in responses (e.g., mood/note attached to a response).
+
+`CheckInRecordServerMetadata` also carries `idempotencyKey: string | null` with a JSDoc comment "never leaked to clients". Today this field is plain `string | null` rather than `ServerInternal<string | null>`, so applying `EncryptedWire<T>` directly would leak it into the wire type.
+
+## Required work
+
+1. Annotate `idempotencyKey` on `CheckInRecordServerMetadata` as `ServerInternal<string | null>` so `EncryptedWire<T>`'s `StripServerInternal<T>` mapped type strips it correctly.
+2. Add `CheckInRecordResult = EncryptedWire<CheckInRecordServerMetadata>` (no `EncryptedFields` / `EncryptedInput` aliases — the domain has none).
+3. Replace `CheckInRecordWire = Serialize<CheckInRecord>` with `CheckInRecordWire = Serialize<CheckInRecordResult>` so the wire type includes `encryptedData: string | null`.
+4. Update `__sot-manifest__` entry: domain + server + result + wire (no encryptedFields / encryptedInput).
+5. Update `__tests__/sot-manifest.test.ts` to assert the new slots.
+6. Update `scripts/openapi-wire-parity.type-test.ts` to use `Equal<CheckInRecordResponseOpenApi, CheckInRecordWire>` (G7 form).
+7. Verify `pnpm types:check-sot` and unit / integration tests still pass.
+
+## Why deferred from PR 2
+
+Class A/B entities follow a uniform pattern (`Pick<X, XEncryptedFields>` for `EncryptedInput`, `EncryptedWire<XServerMetadata>` for `Result`). CheckInRecord requires a separate `ServerInternal` annotation and a manifest variant without `encryptedInput` / `encryptedFields` slots. Deferring keeps PR 2's diff focused on the canonical pattern.
+
+## Cross-references
+
+- Parent: ps-y4tb (Encrypted-entity SoT consolidation)
+- Related: ADR-023 (Zod-types alignment), `packages/types/src/server-internal.ts`, `packages/types/src/encrypted-wire.ts`
+- File: `packages/types/src/entities/check-in-record.ts`
+
+## Acceptance
+
+- [ ] `idempotencyKey` annotated `ServerInternal<string | null>`
+- [ ] `CheckInRecordResult` and `CheckInRecordWire` defined per the new pattern
+- [ ] `__sot-manifest__` extended; manifest test updated
+- [ ] OpenAPI parity uses G7 `Equal<MemberResponseOpenApi, MemberWire>` form
+- [ ] `pnpm types:check-sot` passes
+- [ ] CI green

--- a/.beans/types-kk7a--ps-y4tb-followup-jsdoc-adr-cross-reference-cleanup.md
+++ b/.beans/types-kk7a--ps-y4tb-followup-jsdoc-adr-cross-reference-cleanup.md
@@ -1,0 +1,52 @@
+---
+# types-kk7a
+title: "ps-y4tb followup: JSDoc + ADR cross-reference cleanup (system, friend-connection, member-photo, ADR-023)"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-25T23:18:05Z
+updated_at: 2026-04-25T23:18:05Z
+parent: ps-y4tb
+---
+
+## Background
+
+PR #561 review (4-agent ultrareview, 2026-04-25) flagged JSDoc and cross-reference gaps in the canonical type chain rollout. They are non-blocking — the chain integrity is intact — but worth tightening so future readers can rely on the JSDoc as authoritative documentation.
+
+## In scope
+
+### A. JSDoc tightening (3 entities)
+
+1. **`packages/types/src/entities/system.ts:53-59`** — `SystemServerMetadata` adds `archived: boolean` on the server row, but `System` (domain) has no `archived` field. Current JSDoc says "archivable metadata"; understates that this is a server-only field with no domain counterpart. Rewrite the divergence note to call this out explicitly.
+
+2. **`packages/types/src/entities/friend-connection.ts:53-60`** — `FriendConnectionAuxOmitFields` JSDoc only documents reason #2 (junction table). The three-reasons enumeration lives on `FriendConnectionServerMetadata` JSDoc. Move the three-reasons block to the alias JSDoc (or cross-link), since the alias names reason #2 and a hover-reader needs to see all three reasons to understand it.
+
+3. **`packages/types/src/entities/member-photo.ts:26`** — `MemberPhotoEncryptedFields` lists `sortOrder` as encrypted, but `MemberPhotoServerMetadata` re-adds it as plaintext for indexing and `CreateMemberPhotoBodySchema` accepts it top-level. Either drop `sortOrder` from `MemberPhotoEncryptedFields` (and document the divergence) or add a divergence note alongside `MemberPhotoEncryptedInput` explaining one listed field is plaintext server-side.
+
+### B. ADR cross-reference fix (28 entity files)
+
+Anchor-block comment `// ── Canonical chain (see ADR-023) ────` was added across 28 entity files in commit `678d2326`. The repo has `docs/adr/023-zod-type-alignment.md` but no `023-server-internal-and-encrypted-base64-conventions.md`. Either:
+
+- Confirm `023-zod-type-alignment.md` is the right anchor and update no docs.
+- Write the proper canonical-chain ADR and renumber/cross-link.
+
+Decide and either fix the comments or write the ADR.
+
+## Out of scope
+
+- Class C entities (api-key, session, system-snapshot) — see ps-qmyt
+- The structural drift catch on `LifecycleEventServerMetadata` — separate types-level test, not a JSDoc fix
+- Branding suggestions (\`pinHash\`, \`Relationship.label\`) — separate bean (TBD)
+
+## Acceptance
+
+- [ ] `system.ts` JSDoc explicitly notes the domain has no \`archived\` field
+- [ ] `friend-connection.ts` alias JSDoc captures all three orthogonal Omit reasons
+- [ ] `member-photo.ts` resolves the \`sortOrder\` encrypted-vs-plaintext mismatch (either by removing it from \`MemberPhotoEncryptedFields\` or documenting the divergence)
+- [ ] ADR-023 cross-reference is correct in all 28 entity files
+- [ ] \`pnpm types:check-sot\` clean
+
+## Cross-references
+
+- Parent: ps-y4tb
+- Triggered by: PR #561 review (2026-04-25)

--- a/.beans/types-vmk9--ps-y4tb-followup-brand-pinhash-tighten-relationshi.md
+++ b/.beans/types-vmk9--ps-y4tb-followup-brand-pinhash-tighten-relationshi.md
@@ -1,0 +1,78 @@
+---
+# types-vmk9
+title: "ps-y4tb followup: brand pinHash + tighten Relationship.label invariant"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-25T23:18:23Z
+updated_at: 2026-04-25T23:18:23Z
+parent: ps-y4tb
+---
+
+## Background
+
+PR #561 type-design review (2026-04-25) flagged two stringly-typed escapes that carry runtime invariants the type system doesn't express:
+
+1. **\`SystemSettings.pinHash: string | null\`** — this is a hashed app-lock PIN. Should be a brand (\`PinHash\`) so an unhashed PIN can't be assigned by mistake.
+
+2. **\`Relationship.label: string | null\`** — only meaningful when \`type === "custom"\`. The current interface lets you set \`label\` on every \`type\`, including non-custom ones (where the label is silently ignored). A discriminated \`Relationship\` union (custom variant carries \`label: string\`, others omit) would express the invariant in the type system instead of leaving it to runtime checks.
+
+## In scope
+
+### A. Brand \`PinHash\`
+
+In \`packages/types/src/entities/system-settings.ts\`:
+
+\`\`\`typescript
+export type PinHash = Brand<string, "PinHash">;
+\`\`\`
+
+Update \`SystemSettingsServerMetadata.pinHash\` to use the brand. Migrate the one or two call sites that hash the PIN to brand the result with \`brandId<PinHash>(hashed)\` (or \`brand<PinHash>\` for a non-id brand).
+
+### B. Discriminate \`Relationship.label\`
+
+In \`packages/types/src/entities/relationship.ts\`, replace:
+
+\`\`\`typescript
+export interface Relationship extends AuditMetadata {
+readonly type: RelationshipType;
+readonly label: string | null;
+// ...
+}
+\`\`\`
+
+with a discriminated union:
+
+\`\`\`typescript
+export type Relationship = AuditMetadata & ({
+readonly type: "custom";
+readonly label: string;
+// ...
+} | {
+readonly type: Exclude<RelationshipType, "custom">;
+// no label
+// ...
+});
+\`\`\`
+
+Migrate consumers (data transforms, validation schemas, openapi parity types) to handle the union.
+
+## Out of scope
+
+- Other free-text fields documented as "user-supplied display label" (e.g., \`fronting-session.comment\`, \`note.title\`) — those are intentionally free-text per ADR-023 and acceptable.
+- \`note.authorEntityId: AnyBrandedId\` — already JSDoc-documented as polymorphic; the discriminator carries the brand. Leave as-is.
+
+## Acceptance
+
+- [ ] \`PinHash\` brand defined and applied to \`SystemSettingsServerMetadata.pinHash\`
+- [ ] PIN-hashing call sites brand the result
+- [ ] \`Relationship\` is a discriminated union with \`label\` only on the custom variant
+- [ ] Validation schemas (\`packages/validation/src/...\`) reflect the discriminated shape
+- [ ] OpenAPI parity remains green
+- [ ] \`pnpm types:check-sot\` clean
+- [ ] \`pnpm test\` green
+
+## Cross-references
+
+- Parent: ps-y4tb
+- Triggered by: PR #561 review (2026-04-25)

--- a/.beans/types-x61u--ps-y4tb-followup-harden-encrypted-keys-union-with.md
+++ b/.beans/types-x61u--ps-y4tb-followup-harden-encrypted-keys-union-with.md
@@ -1,0 +1,102 @@
+---
+# types-x61u
+title: "ps-y4tb followup: harden encrypted-keys union with Exclude<> (journal-entry, note) + defensive distributive Pick (lifecycle-event)"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-25T23:18:43Z
+updated_at: 2026-04-25T23:18:43Z
+parent: ps-y4tb
+---
+
+## Background
+
+PR #561 type-design review (2026-04-25) suggested two type-system hardening follow-ups in the canonical chain:
+
+### A. \`Exclude<>\` derivation for "encrypt by default"
+
+\`packages/types/src/entities/wiki-page.ts\` already uses:
+
+\`\`\`typescript
+export type WikiPageEncryptedFields = Exclude<
+keyof WikiPage,
+"id" | "systemId" | "archived" | keyof AuditMetadata
+
+> ;
+> \`\`\`
+
+This encodes "encrypt every domain field except this allowlist" — adding a new domain field to \`WikiPage\` will silently land in \`encryptedData\` (which is the safer default).
+
+Two more entities have the same shape (every domain field except id/systemId/audit/archived/restructured-plaintext is encrypted) and currently use literal unions:
+
+- \`packages/types/src/entities/journal-entry.ts\` — encrypted: 6 keys; literal union duplicates \`JournalEntry\` keys
+- \`packages/types/src/entities/note.ts\` — same shape, with \`author\` carved as restructured plaintext
+
+Adding a new domain field like \`mood\` would silently land in plaintext today.
+
+### B. Defensive distributive Pick on \`LifecycleEventEncryptedInput\`
+
+\`packages/types/src/entities/lifecycle-event.ts:165\` declares:
+
+\`\`\`typescript
+export type LifecycleEventEncryptedInput = Pick<LifecycleEvent, "notes">;
+\`\`\`
+
+This works only because \`notes\` is on \`LifecycleEventBase\` (present on every variant). If a future variant overrides \`notes\` with a tighter type (e.g. \`NonEmptyString\`), the non-distributive \`Pick\` will produce an intersection rather than a union, breaking variants.
+
+Make it defensively distributive:
+
+\`\`\`typescript
+export type LifecycleEventEncryptedInput = LifecycleEvent extends unknown
+? Pick<LifecycleEvent, "notes">
+: never;
+\`\`\`
+
+## In scope
+
+### A.1. \`journal-entry.ts\`
+
+Replace:
+\`\`\`typescript
+export type JournalEntryEncryptedFields = "title" | "body" | "moodScore" | "tags" | "linkedMemberIds" | "linkedGroupIds";
+\`\`\`
+
+with:
+\`\`\`typescript
+export type JournalEntryEncryptedFields = Exclude<
+keyof JournalEntry,
+"id" | "systemId" | "frontingSessionId" | "archived" | keyof AuditMetadata
+
+> ;
+> \`\`\`
+
+Verify the resulting union matches the literal one (use a parity assertion).
+
+### A.2. \`note.ts\`
+
+Same pattern with the \`author\` key carved out as restructured plaintext.
+
+### B. \`lifecycle-event.ts:165\`
+
+Apply defensive distributive Pick.
+
+### C. Add type-level guard
+
+In \`packages/types/src/**tests**/encrypted-fields-policy.test.ts\` (new), assert the union derivation matches expectations using \`expectTypeOf\`. The goal is to catch a future contributor who renames a key in \`X\` and breaks the \`Exclude\` allowlist.
+
+## Out of scope
+
+- Other entities that intentionally use literal unions where only a subset is encrypted (e.g., \`fronting-session.ts\` keeps \`comment\` plaintext on the server). Those need targeted Pick/Omit, not Exclude.
+
+## Acceptance
+
+- [ ] \`journal-entry.ts\` and \`note.ts\` use \`Exclude<>\` derivation
+- [ ] \`LifecycleEventEncryptedInput\` is defensively distributive
+- [ ] Parity assertions confirm the new derivations match the previous literal unions
+- [ ] \`pnpm types:check-sot\` clean
+- [ ] \`pnpm test\` green
+
+## Cross-references
+
+- Parent: ps-y4tb
+- Triggered by: PR #561 review (2026-04-25)

--- a/.beans/types-yxgc--branded-value-types-for-non-id-free-text-labels-me.md
+++ b/.beans/types-yxgc--branded-value-types-for-non-id-free-text-labels-me.md
@@ -1,0 +1,68 @@
+---
+# types-yxgc
+title: Branded value types for non-ID free-text labels (member form / display name)
+status: todo
+type: task
+priority: high
+created_at: 2026-04-25T20:28:59Z
+updated_at: 2026-04-25T21:39:52Z
+parent: ps-y4tb
+---
+
+## Background
+
+Discovered during PR #561 (ps-y4tb fleet rollout) review. The type-design reviewer flagged `previousForm` / `newForm` on `FormChangeEvent` and `previousName` / `newName` on `NameChangeEvent` (both in `packages/types/src/entities/lifecycle-event.ts`) as `string | null` fields where cross-field assignment can't be prevented at the type level. After reading the file, these are not identifier references — they are free-text user-supplied display labels (e.g. "child age 8", "human male", "Alex").
+
+The same pattern exists elsewhere in the domain (e.g. member display names, pronouns, group names — anywhere we accept user-supplied display text). Today every such field is a bare `string` (or `string | null`).
+
+A branded string type would prevent accidental cross-field assignment (e.g. assigning a member name into a form-label field) without imposing a runtime cost.
+
+## Proposed scope
+
+Define branded value types in `packages/types/src/value-types.ts` (or extend `ids.ts`):
+
+```typescript
+export type MemberFormLabel = Brand<string, "MemberFormLabel">;
+export type MemberDisplayName = Brand<string, "MemberDisplayName">;
+// … other domain-meaningful display strings as discovered
+```
+
+Audit affected entities:
+
+- `lifecycle-event.ts` — `previousForm`, `newForm`, `previousName`, `newName`
+- `member.ts` — `name`, `pronouns`, `description` (verify each)
+- Any other entity with display text fields
+
+Update callers (services, transforms, tests) to brand values via the existing `brandValue<T>(raw)` helper (or define one if missing — `brandId<T>` only handles ID strings).
+
+`Serialize<T>` already strips brands at the wire boundary (the `__brand` symbol case in `type-assertions.ts`), so wire types are unaffected.
+
+## Out of scope
+
+- Encrypted free-text fields (e.g. notes inside `encryptedData`) — branded value types apply to the post-decrypt domain shape, not to the opaque blob.
+- Stringly-typed identifiers — those use `Brand<string, "XId">` via `brandId<T>` already.
+
+## Design questions to resolve before implementation
+
+1. Is `value-types.ts` the right home? Or per-entity additions to existing entity files?
+2. Should branding be applied retroactively to all string fields, or only where cross-field assignment risk is concrete?
+3. How does this interact with `ps-q8vs` (branded-ID drift cleanup)? Different concern (value vs ID), but similar mechanism.
+4. Does the Zod `z.string().brand<T>()` pattern align with the domain definitions, or do we use plain `z.string()` and brand at the data-package transform layer?
+
+## Acceptance
+
+- [ ] Branded value types defined for in-scope display fields
+- [ ] Domain entity types updated to use branded types
+- [ ] All callers/transforms/tests updated to brand at construction
+- [ ] `pnpm types:check-sot` clean
+- [ ] CI green
+
+## Cross-references
+
+- Parent: `ps-y4tb` (Encrypted-entity SoT consolidation)
+- Related: `ps-q8vs` (Branded-ID drift cleanup) — similar phantom-brand mechanism
+- Triggered by: PR #561 review feedback (type-design-analyzer)
+
+## Note on cross-reference cleanup
+
+The lifecycle-event JSDoc on `previousForm`/`newForm`/`previousName`/`newName` references this bean by ID. When this bean is completed, those JSDoc cross-references must be removed (the fields will then carry branded types, making the comment obsolete). Track as part of this bean's acceptance.

--- a/apps/api/src/__tests__/routes/fields/create.test.ts
+++ b/apps/api/src/__tests__/routes/fields/create.test.ts
@@ -113,6 +113,16 @@ describe("POST /systems/:systemId/fields", () => {
     expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 with issues details when schema validation fails", async () => {
+    const app = createApp();
+    const res = await postJSON(app, `/systems/${SYS_ID}/fields`, { fieldType: "bogus" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(body.error.details)).toBe(true);
+  });
+
   it("returns 404 when system not found", async () => {
     const { ApiHttpError } = await import("../../../lib/api-error.js");
     vi.mocked(createFieldDefinition).mockRejectedValueOnce(

--- a/apps/api/src/__tests__/routes/fields/update.test.ts
+++ b/apps/api/src/__tests__/routes/fields/update.test.ts
@@ -109,6 +109,16 @@ describe("PUT /systems/:systemId/fields/:fieldId", () => {
     expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 with issues details when schema validation fails", async () => {
+    const app = createApp();
+    const res = await putJSON(app, `/systems/${SYS_ID}/fields/${FLD_ID}`, { encryptedData: "x" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(body.error.details)).toBe(true);
+  });
+
   it("returns 409 on conflict", async () => {
     const { ApiHttpError } = await import("../../../lib/api-error.js");
     vi.mocked(updateFieldDefinition).mockRejectedValueOnce(

--- a/apps/api/src/__tests__/routes/groups/fields/set.test.ts
+++ b/apps/api/src/__tests__/routes/groups/fields/set.test.ts
@@ -124,6 +124,16 @@ describe("POST /systems/:systemId/groups/:groupId/fields/:fieldDefId", () => {
     expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 with issues details when schema validation fails", async () => {
+    const app = createApp();
+    const res = await postJSON(app, FIELD_PATH, { wrong: "shape" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(body.error.details)).toBe(true);
+  });
+
   it("returns 404 when group not found", async () => {
     const { ApiHttpError } = await import("../../../../lib/api-error.js");
     vi.mocked(setFieldValueForOwner).mockRejectedValueOnce(

--- a/apps/api/src/__tests__/routes/members/fields/set.test.ts
+++ b/apps/api/src/__tests__/routes/members/fields/set.test.ts
@@ -112,6 +112,16 @@ describe("POST /systems/:systemId/members/:memberId/fields/:fieldDefId", () => {
     expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 with issues details when schema validation fails", async () => {
+    const app = createApp();
+    const res = await postJSON(app, FIELD_PATH, { wrong: "shape" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(body.error.details)).toBe(true);
+  });
+
   it("returns 404 when member not found", async () => {
     const { ApiHttpError } = await import("../../../../lib/api-error.js");
     vi.mocked(setFieldValueForOwner).mockRejectedValueOnce(

--- a/apps/api/src/__tests__/routes/members/fields/update.test.ts
+++ b/apps/api/src/__tests__/routes/members/fields/update.test.ts
@@ -40,7 +40,7 @@ const FLD_DEF_ID = "fld_550e8400-e29b-41d4-a716-446655440000";
 
 const createApp = () => createRouteApp("/systems", systemRoutes);
 
-const VALID_BODY = { encryptedData: "dGVzdA==" as EncryptedBase64 };
+const VALID_BODY = { encryptedData: "dGVzdA==" as EncryptedBase64, version: 1 };
 
 const FIELD_VALUE_RESULT = {
   id: "fv_550e8400-e29b-41d4-a716-446655440000" as never,

--- a/apps/api/src/__tests__/routes/members/fields/update.test.ts
+++ b/apps/api/src/__tests__/routes/members/fields/update.test.ts
@@ -112,6 +112,16 @@ describe("PUT /systems/:systemId/members/:memberId/fields/:fieldDefId", () => {
     expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 with issues details when schema validation fails", async () => {
+    const app = createApp();
+    const res = await putJSON(app, FIELD_PATH, { encryptedData: "x" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(body.error.details)).toBe(true);
+  });
+
   it("returns 404 when field value not found", async () => {
     const { ApiHttpError } = await import("../../../../lib/api-error.js");
     vi.mocked(updateFieldValueForOwner).mockRejectedValueOnce(

--- a/apps/api/src/__tests__/routes/members/photos/create.test.ts
+++ b/apps/api/src/__tests__/routes/members/photos/create.test.ts
@@ -110,6 +110,16 @@ describe("POST /systems/:systemId/members/:memberId/photos", () => {
     expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 with issues details when schema validation fails", async () => {
+    const app = createApp();
+    const res = await postJSON(app, PHOTOS_PATH, { wrong: "shape" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(body.error.details)).toBe(true);
+  });
+
   it("returns 404 when member not found", async () => {
     const { ApiHttpError } = await import("../../../../lib/api-error.js");
     vi.mocked(createMemberPhoto).mockRejectedValueOnce(

--- a/apps/api/src/__tests__/routes/structure/entities/fields/set.test.ts
+++ b/apps/api/src/__tests__/routes/structure/entities/fields/set.test.ts
@@ -130,6 +130,16 @@ describe("POST /systems/:systemId/structure/entities/:entityId/fields/:fieldDefI
     expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
+  it("returns 400 with issues details when schema validation fails", async () => {
+    const app = createApp();
+    const res = await postJSON(app, FIELD_PATH, { wrong: "shape" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiErrorResponse;
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(Array.isArray(body.error.details)).toBe(true);
+  });
+
   it("returns 404 when structure entity not found", async () => {
     const { ApiHttpError } = await import("../../../../../lib/api-error.js");
     vi.mocked(setFieldValueForOwner).mockRejectedValueOnce(

--- a/apps/api/src/__tests__/services/field-definition.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/field-definition.service.integration.test.ts
@@ -121,7 +121,7 @@ describe("field-definition.service (PGlite integration)", () => {
       const result = await createFieldDefinition(
         asDb(db),
         systemId,
-        { fieldType: "text", encryptedData: validBlobBase64() },
+        { fieldType: "text", required: false, sortOrder: 0, encryptedData: validBlobBase64() },
         auth,
         noopAudit,
       );
@@ -137,7 +137,7 @@ describe("field-definition.service (PGlite integration)", () => {
         createFieldDefinition(
           asDb(db),
           systemId,
-          { fieldType: "text", encryptedData: invalidBlobBase64() },
+          { fieldType: "text", required: false, sortOrder: 0, encryptedData: invalidBlobBase64() },
           auth,
           noopAudit,
         ),

--- a/apps/api/src/__tests__/services/field-definition.service.test.ts
+++ b/apps/api/src/__tests__/services/field-definition.service.test.ts
@@ -94,7 +94,7 @@ describe("createFieldDefinition", () => {
     const result = await createFieldDefinition(
       db,
       SYSTEM_ID,
-      { fieldType: "text", encryptedData: VALID_BLOB_BASE64 },
+      { fieldType: "text", required: false, sortOrder: 0, encryptedData: VALID_BLOB_BASE64 },
       AUTH,
       mockAudit,
     );
@@ -109,14 +109,6 @@ describe("createFieldDefinition", () => {
     );
   });
 
-  it("throws validation error for invalid payload", async () => {
-    const { db } = mockDb();
-
-    await expect(
-      createFieldDefinition(db, SYSTEM_ID, { fieldType: "invalid-type" }, AUTH, mockAudit),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
-  });
-
   it("throws quota exceeded when at max field definitions", async () => {
     const { db, chain } = mockDb();
     // count query returns max
@@ -126,26 +118,11 @@ describe("createFieldDefinition", () => {
       createFieldDefinition(
         db,
         SYSTEM_ID,
-        { fieldType: "text", encryptedData: VALID_BLOB_BASE64 },
+        { fieldType: "text", required: false, sortOrder: 0, encryptedData: VALID_BLOB_BASE64 },
         AUTH,
         mockAudit,
       ),
     ).rejects.toThrow(expect.objectContaining({ status: 409, code: "QUOTA_EXCEEDED" }));
-  });
-
-  it("throws 400 for oversized blob (rejected by schema)", async () => {
-    const { db } = mockDb();
-    const oversized = Buffer.from(new Uint8Array(70_000)).toString("base64");
-
-    await expect(
-      createFieldDefinition(
-        db,
-        SYSTEM_ID,
-        { fieldType: "text", encryptedData: oversized },
-        AUTH,
-        mockAudit,
-      ),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
   });
 
   it("rejects cross-system access", async () => {
@@ -155,7 +132,7 @@ describe("createFieldDefinition", () => {
       createFieldDefinition(
         db,
         SYSTEM_ID,
-        { fieldType: "text", encryptedData: VALID_BLOB_BASE64 },
+        { fieldType: "text", required: false, sortOrder: 0, encryptedData: VALID_BLOB_BASE64 },
         AUTH,
         mockAudit,
       ),
@@ -305,14 +282,6 @@ describe("updateFieldDefinition", () => {
         mockAudit,
       ),
     ).rejects.toThrow(expect.objectContaining({ status: 404, code: "NOT_FOUND" }));
-  });
-
-  it("throws validation error for invalid payload", async () => {
-    const { db } = mockDb();
-
-    await expect(
-      updateFieldDefinition(db, SYSTEM_ID, FIELD_ID, { version: 1 }, AUTH, mockAudit),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
   });
 
   it("updates with optional required and sortOrder fields", async () => {
@@ -634,7 +603,7 @@ describe("field definition cache lifecycle", () => {
     await createFieldDefinition(
       db,
       SYSTEM_ID,
-      { fieldType: "text", encryptedData: VALID_BLOB_BASE64 },
+      { fieldType: "text", required: false, sortOrder: 0, encryptedData: VALID_BLOB_BASE64 },
       AUTH,
       mockAudit,
     );

--- a/apps/api/src/__tests__/services/field-value.service.test.ts
+++ b/apps/api/src/__tests__/services/field-value.service.test.ts
@@ -142,18 +142,6 @@ describe("setFieldValueForOwner (member path)", () => {
     ).rejects.toThrow(expect.objectContaining({ status: 409, code: "CONFLICT" }));
   });
 
-  it("throws 400 for invalid payload", async () => {
-    const { db, chain } = mockDb();
-    // assertMemberActive → member found
-    chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
-    // assertFieldDefinitionActive → field def found
-    chain.limit.mockResolvedValueOnce([{ id: FIELD_DEF_ID }]);
-
-    await expect(
-      setFieldValueForOwner(db, SYSTEM_ID, MEMBER_OWNER, FIELD_DEF_ID, {}, AUTH, mockAudit),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
-  });
-
   it("throws 404 when member not found", async () => {
     const { db, chain } = mockDb();
     // assertMemberActive → empty (not found)
@@ -384,26 +372,6 @@ describe("updateFieldValueForOwner (member path)", () => {
       ),
     ).rejects.toThrow(expect.objectContaining({ status: 404, code: "NOT_FOUND" }));
   });
-
-  it("throws 400 for invalid payload", async () => {
-    const { db, chain } = mockDb();
-    // assertMemberActive → member found
-    chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
-    // assertFieldDefinitionActive → field def found
-    chain.limit.mockResolvedValueOnce([{ id: FIELD_DEF_ID }]);
-
-    await expect(
-      updateFieldValueForOwner(
-        db,
-        SYSTEM_ID,
-        MEMBER_OWNER,
-        FIELD_DEF_ID,
-        { encryptedData: VALID_BLOB_BASE64 },
-        AUTH,
-        mockAudit,
-      ),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
-  });
 });
 
 describe("deleteFieldValueForOwner (member path)", () => {
@@ -532,22 +500,6 @@ describe("setFieldValueForOwner", () => {
         mockAudit,
       ),
     ).rejects.toThrow(expect.objectContaining({ status: 409, code: "CONFLICT" }));
-  });
-
-  it("throws VALIDATION_ERROR when payload is invalid for owner path", async () => {
-    const { db } = mockDb();
-
-    await expect(
-      setFieldValueForOwner(
-        db,
-        SYSTEM_ID,
-        { kind: "group", id: GROUP_ID },
-        FIELD_DEF_ID,
-        {},
-        AUTH,
-        mockAudit,
-      ),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
   });
 
   it("wraps InvalidInputError from deserialization as VALIDATION_ERROR", async () => {

--- a/apps/api/src/__tests__/services/member-photo.service.test.ts
+++ b/apps/api/src/__tests__/services/member-photo.service.test.ts
@@ -157,28 +157,6 @@ describe("createMemberPhoto", () => {
     ).rejects.toThrow(expect.objectContaining({ status: 409, code: "QUOTA_EXCEEDED" }));
   });
 
-  it("throws VALIDATION_ERROR for invalid body", async () => {
-    const { db, chain } = mockDb();
-    chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
-    chain.where.mockReturnValueOnce(chain); // assertMemberActive → chains to .limit()
-
-    await expect(createMemberPhoto(db, SYSTEM_ID, MEMBER_ID, {}, AUTH, mockAudit)).rejects.toThrow(
-      expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }),
-    );
-  });
-
-  it("throws 400 for oversized blob (rejected by schema validation)", async () => {
-    const { db, chain } = mockDb();
-    chain.limit.mockResolvedValueOnce([{ id: MEMBER_ID }]);
-    chain.where.mockReturnValueOnce(chain); // assertMemberActive → chains to .limit()
-
-    const oversized = Buffer.from(new Uint8Array(140_000)).toString("base64");
-
-    await expect(
-      createMemberPhoto(db, SYSTEM_ID, MEMBER_ID, { encryptedData: oversized }, AUTH, mockAudit),
-    ).rejects.toThrow(expect.objectContaining({ status: 400, code: "VALIDATION_ERROR" }));
-  });
-
   it("throws NOT_FOUND when member does not exist", async () => {
     const { db, chain } = mockDb();
     // assertMemberActive returns empty → member not found

--- a/apps/api/src/routes/fields/create-field-value-routes.ts
+++ b/apps/api/src/routes/fields/create-field-value-routes.ts
@@ -1,7 +1,9 @@
 import { ID_PREFIXES, brandId } from "@pluralscape/types";
+import { SetFieldValueBodySchema, UpdateFieldValueBodySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
-import { HTTP_CREATED, HTTP_NO_CONTENT } from "../../http.constants.js";
+import { HTTP_BAD_REQUEST, HTTP_CREATED, HTTP_NO_CONTENT } from "../../http.constants.js";
+import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
@@ -70,7 +72,17 @@ export function createFieldValueRoutes(config: FieldValueRouteConfig): FieldValu
   const setRoute = new Hono<AuthEnv>();
   setRoute.use("*", createCategoryRateLimiter("write"));
   setRoute.post("/:fieldDefId", async (c) => {
-    const body = await parseJsonBody(c);
+    const rawBody = await parseJsonBody(c);
+    const parsed = SetFieldValueBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      throw new ApiHttpError(
+        HTTP_BAD_REQUEST,
+        "VALIDATION_ERROR",
+        "Invalid request body",
+        parsed.error.issues,
+      );
+    }
+
     const auth = c.get("auth");
     const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
     const owner = resolveOwner(c.req.param(ownerParamName));
@@ -78,7 +90,15 @@ export function createFieldValueRoutes(config: FieldValueRouteConfig): FieldValu
     const audit = createAuditWriter(c, auth);
 
     const db = await getDb();
-    const result = await setFieldValueForOwner(db, systemId, owner, fieldDefId, body, auth, audit);
+    const result = await setFieldValueForOwner(
+      db,
+      systemId,
+      owner,
+      fieldDefId,
+      parsed.data,
+      auth,
+      audit,
+    );
     return c.json(envelope(result), HTTP_CREATED);
   });
 
@@ -99,7 +119,17 @@ export function createFieldValueRoutes(config: FieldValueRouteConfig): FieldValu
   const updateRoute = new Hono<AuthEnv>();
   updateRoute.use("*", createCategoryRateLimiter("write"));
   updateRoute.put("/:fieldDefId", async (c) => {
-    const body = await parseJsonBody(c);
+    const rawBody = await parseJsonBody(c);
+    const parsed = UpdateFieldValueBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      throw new ApiHttpError(
+        HTTP_BAD_REQUEST,
+        "VALIDATION_ERROR",
+        "Invalid request body",
+        parsed.error.issues,
+      );
+    }
+
     const auth = c.get("auth");
     const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
     const owner = resolveOwner(c.req.param(ownerParamName));
@@ -112,7 +142,7 @@ export function createFieldValueRoutes(config: FieldValueRouteConfig): FieldValu
       systemId,
       owner,
       fieldDefId,
-      body,
+      parsed.data,
       auth,
       audit,
     );

--- a/apps/api/src/routes/fields/create.ts
+++ b/apps/api/src/routes/fields/create.ts
@@ -1,7 +1,9 @@
 import { ID_PREFIXES } from "@pluralscape/types";
+import { CreateFieldDefinitionBodySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
-import { HTTP_CREATED } from "../../http.constants.js";
+import { HTTP_BAD_REQUEST, HTTP_CREATED } from "../../http.constants.js";
+import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
 import { requireIdParam } from "../../lib/id-param.js";
@@ -19,13 +21,22 @@ createRoute.use("*", createCategoryRateLimiter("write"));
 createRoute.use("*", createIdempotencyMiddleware());
 
 createRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
+  const rawBody = await parseJsonBody(c);
+  const parsed = CreateFieldDefinitionBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new ApiHttpError(
+      HTTP_BAD_REQUEST,
+      "VALIDATION_ERROR",
+      "Invalid request body",
+      parsed.error.issues,
+    );
+  }
 
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
   const audit = createAuditWriter(c, auth);
 
   const db = await getDb();
-  const result = await createFieldDefinition(db, systemId, body, auth, audit);
+  const result = await createFieldDefinition(db, systemId, parsed.data, auth, audit);
   return c.json(envelope(result), HTTP_CREATED);
 });

--- a/apps/api/src/routes/fields/update.ts
+++ b/apps/api/src/routes/fields/update.ts
@@ -1,6 +1,9 @@
 import { ID_PREFIXES } from "@pluralscape/types";
+import { UpdateFieldDefinitionBodySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
+import { HTTP_BAD_REQUEST } from "../../http.constants.js";
+import { ApiHttpError } from "../../lib/api-error.js";
 import { createAuditWriter } from "../../lib/audit-writer.js";
 import { getDb } from "../../lib/db.js";
 import { parseIdParam, requireIdParam } from "../../lib/id-param.js";
@@ -16,7 +19,16 @@ export const updateRoute = new Hono<AuthEnv>();
 updateRoute.use("*", createCategoryRateLimiter("write"));
 
 updateRoute.put("/:fieldId", async (c) => {
-  const body = await parseJsonBody(c);
+  const rawBody = await parseJsonBody(c);
+  const parsed = UpdateFieldDefinitionBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new ApiHttpError(
+      HTTP_BAD_REQUEST,
+      "VALIDATION_ERROR",
+      "Invalid request body",
+      parsed.error.issues,
+    );
+  }
 
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
@@ -24,6 +36,6 @@ updateRoute.put("/:fieldId", async (c) => {
   const audit = createAuditWriter(c, auth);
 
   const db = await getDb();
-  const result = await updateFieldDefinition(db, systemId, fieldId, body, auth, audit);
+  const result = await updateFieldDefinition(db, systemId, fieldId, parsed.data, auth, audit);
   return c.json(envelope(result));
 });

--- a/apps/api/src/routes/members/photos/create.ts
+++ b/apps/api/src/routes/members/photos/create.ts
@@ -1,7 +1,9 @@
 import { ID_PREFIXES } from "@pluralscape/types";
+import { CreateMemberPhotoBodySchema } from "@pluralscape/validation";
 import { Hono } from "hono";
 
-import { HTTP_CREATED } from "../../../http.constants.js";
+import { HTTP_BAD_REQUEST, HTTP_CREATED } from "../../../http.constants.js";
+import { ApiHttpError } from "../../../lib/api-error.js";
 import { createAuditWriter } from "../../../lib/audit-writer.js";
 import { getDb } from "../../../lib/db.js";
 import { requireIdParam } from "../../../lib/id-param.js";
@@ -19,7 +21,16 @@ createRoute.use("*", createCategoryRateLimiter("write"));
 createRoute.use("*", createIdempotencyMiddleware());
 
 createRoute.post("/", async (c) => {
-  const body = await parseJsonBody(c);
+  const rawBody = await parseJsonBody(c);
+  const parsed = CreateMemberPhotoBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    throw new ApiHttpError(
+      HTTP_BAD_REQUEST,
+      "VALIDATION_ERROR",
+      "Invalid request body",
+      parsed.error.issues,
+    );
+  }
 
   const auth = c.get("auth");
   const systemId = requireIdParam(c.req.param("systemId"), "systemId", ID_PREFIXES.system);
@@ -27,6 +38,6 @@ createRoute.post("/", async (c) => {
   const audit = createAuditWriter(c, auth);
 
   const db = await getDb();
-  const result = await createMemberPhoto(db, systemId, memberId, body, auth, audit);
+  const result = await createMemberPhoto(db, systemId, memberId, parsed.data, auth, audit);
   return c.json(envelope(result), HTTP_CREATED);
 });

--- a/apps/api/src/services/field-definition/create.ts
+++ b/apps/api/src/services/field-definition/create.ts
@@ -1,9 +1,8 @@
 import { fieldDefinitions } from "@pluralscape/db/pg";
 import { ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
-import { CreateFieldDefinitionBodySchema } from "@pluralscape/validation";
 import { and, count, eq } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST, HTTP_CONFLICT } from "../../http.constants.js";
+import { HTTP_CONFLICT } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { withTenantTransaction } from "../../lib/rls-context.js";
 import { assertSystemOwnership } from "../../lib/system-ownership.js";
@@ -20,23 +19,20 @@ import type { FieldDefinitionResult } from "./internal.js";
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
 import type { FieldDefinitionId, SystemId } from "@pluralscape/types";
+import type { CreateFieldDefinitionBodySchema } from "@pluralscape/validation";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
 
 export async function createFieldDefinition(
   db: PostgresJsDatabase,
   systemId: SystemId,
-  params: unknown,
+  body: z.infer<typeof CreateFieldDefinitionBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<FieldDefinitionResult> {
   assertSystemOwnership(systemId, auth);
 
-  const parsed = CreateFieldDefinitionBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid create payload");
-  }
-
-  const blob = parseAndValidateFieldBlob(parsed.data.encryptedData);
+  const blob = parseAndValidateFieldBlob(body.encryptedData);
   const fieldId = brandId<FieldDefinitionId>(createId(ID_PREFIXES.fieldDefinition));
   const timestamp = now();
 
@@ -60,9 +56,9 @@ export async function createFieldDefinition(
       .values({
         id: fieldId,
         systemId,
-        fieldType: parsed.data.fieldType,
-        required: parsed.data.required,
-        sortOrder: parsed.data.sortOrder,
+        fieldType: body.fieldType,
+        required: body.required,
+        sortOrder: body.sortOrder,
         encryptedData: blob,
         createdAt: timestamp,
         updatedAt: timestamp,
@@ -76,7 +72,7 @@ export async function createFieldDefinition(
     await audit(tx, {
       eventType: "field-definition.created",
       actor: { kind: "account", id: auth.accountId },
-      detail: `Field definition created (type: ${parsed.data.fieldType})`,
+      detail: `Field definition created (type: ${body.fieldType})`,
       systemId,
     });
 

--- a/apps/api/src/services/field-definition/update.ts
+++ b/apps/api/src/services/field-definition/update.ts
@@ -1,10 +1,7 @@
 import { fieldDefinitions } from "@pluralscape/db/pg";
 import { now } from "@pluralscape/types";
-import { UpdateFieldDefinitionBodySchema } from "@pluralscape/validation";
 import { and, eq, sql } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST } from "../../http.constants.js";
-import { ApiHttpError } from "../../lib/api-error.js";
 import { assertOccUpdated } from "../../lib/occ-update.js";
 import { withTenantTransaction } from "../../lib/rls-context.js";
 import { assertSystemOwnership } from "../../lib/system-ownership.js";
@@ -20,24 +17,21 @@ import type { FieldDefinitionResult } from "./internal.js";
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
 import type { FieldDefinitionId, SystemId } from "@pluralscape/types";
+import type { UpdateFieldDefinitionBodySchema } from "@pluralscape/validation";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
 
 export async function updateFieldDefinition(
   db: PostgresJsDatabase,
   systemId: SystemId,
   fieldId: FieldDefinitionId,
-  params: unknown,
+  body: z.infer<typeof UpdateFieldDefinitionBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<FieldDefinitionResult> {
   assertSystemOwnership(systemId, auth);
 
-  const parsed = UpdateFieldDefinitionBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid update payload");
-  }
-
-  const blob = parseAndValidateFieldBlob(parsed.data.encryptedData);
+  const blob = parseAndValidateFieldBlob(body.encryptedData);
   const timestamp = now();
 
   const setClause: Partial<typeof fieldDefinitions.$inferInsert> = {
@@ -45,11 +39,11 @@ export async function updateFieldDefinition(
     updatedAt: timestamp,
   };
 
-  if (parsed.data.required !== undefined) {
-    setClause.required = parsed.data.required;
+  if (body.required !== undefined) {
+    setClause.required = body.required;
   }
-  if (parsed.data.sortOrder !== undefined) {
-    setClause.sortOrder = parsed.data.sortOrder;
+  if (body.sortOrder !== undefined) {
+    setClause.sortOrder = body.sortOrder;
   }
 
   const result = await withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
@@ -63,7 +57,7 @@ export async function updateFieldDefinition(
         and(
           eq(fieldDefinitions.id, fieldId),
           eq(fieldDefinitions.systemId, systemId),
-          eq(fieldDefinitions.version, parsed.data.version),
+          eq(fieldDefinitions.version, body.version),
           eq(fieldDefinitions.archived, false),
         ),
       )

--- a/apps/api/src/services/field-value/set.ts
+++ b/apps/api/src/services/field-value/set.ts
@@ -1,9 +1,8 @@
 import { fieldValues } from "@pluralscape/db/pg";
 import { ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
-import { SetFieldValueBodySchema } from "@pluralscape/validation";
 import { and, eq } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST, HTTP_CONFLICT } from "../../http.constants.js";
+import { HTTP_CONFLICT } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { assertFieldDefinitionActive } from "../../lib/member-helpers.js";
 import { withTenantTransaction } from "../../lib/rls-context.js";
@@ -21,7 +20,9 @@ import type { FieldValueOwner, FieldValueResult } from "./internal.js";
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
 import type { FieldDefinitionId, FieldValueId, SystemId } from "@pluralscape/types";
+import type { SetFieldValueBodySchema } from "@pluralscape/validation";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
 
 function ownerLabel(owner: FieldValueOwner): string {
   switch (owner.kind) {
@@ -43,18 +44,13 @@ export async function setFieldValueForOwner(
   systemId: SystemId,
   owner: FieldValueOwner,
   fieldDefId: FieldDefinitionId,
-  params: unknown,
+  body: z.infer<typeof SetFieldValueBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<FieldValueResult> {
   assertSystemOwnership(systemId, auth);
 
-  const parsed = SetFieldValueBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid set payload");
-  }
-
-  const blob = parseAndValidateValueBlob(parsed.data.encryptedData);
+  const blob = parseAndValidateValueBlob(body.encryptedData);
   const valueId = brandId<FieldValueId>(createId(ID_PREFIXES.fieldValue));
   const timestamp = now();
 

--- a/apps/api/src/services/field-value/update.ts
+++ b/apps/api/src/services/field-value/update.ts
@@ -1,9 +1,8 @@
 import { fieldValues } from "@pluralscape/db/pg";
 import { now } from "@pluralscape/types";
-import { UpdateFieldValueBodySchema } from "@pluralscape/validation";
 import { and, eq, sql } from "drizzle-orm";
 
-import { HTTP_BAD_REQUEST, HTTP_CONFLICT, HTTP_NOT_FOUND } from "../../http.constants.js";
+import { HTTP_CONFLICT, HTTP_NOT_FOUND } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
 import { assertFieldDefinitionActive } from "../../lib/member-helpers.js";
 import { withTenantTransaction } from "../../lib/rls-context.js";
@@ -21,25 +20,22 @@ import type { FieldValueOwner, FieldValueResult } from "./internal.js";
 import type { AuditWriter } from "../../lib/audit-writer.js";
 import type { AuthContext } from "../../lib/auth-context.js";
 import type { FieldDefinitionId, SystemId } from "@pluralscape/types";
+import type { UpdateFieldValueBodySchema } from "@pluralscape/validation";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
 
 export async function updateFieldValueForOwner(
   db: PostgresJsDatabase,
   systemId: SystemId,
   owner: FieldValueOwner,
   fieldDefId: FieldDefinitionId,
-  params: unknown,
+  body: z.infer<typeof UpdateFieldValueBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<FieldValueResult> {
   assertSystemOwnership(systemId, auth);
 
-  const parsed = UpdateFieldValueBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid update payload");
-  }
-
-  const blob = parseAndValidateValueBlob(parsed.data.encryptedData);
+  const blob = parseAndValidateValueBlob(body.encryptedData);
   const timestamp = now();
 
   return withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
@@ -58,7 +54,7 @@ export async function updateFieldValueForOwner(
           eq(fieldValues.fieldDefinitionId, fieldDefId),
           ownerWhereColumn(owner),
           eq(fieldValues.systemId, systemId),
-          eq(fieldValues.version, parsed.data.version),
+          eq(fieldValues.version, body.version),
         ),
       )
       .returning();

--- a/apps/api/src/services/member/photos/create.ts
+++ b/apps/api/src/services/member/photos/create.ts
@@ -1,7 +1,6 @@
 import { deserializeEncryptedBlob, InvalidInputError } from "@pluralscape/crypto";
 import { memberPhotos, systems } from "@pluralscape/db/pg";
 import { ID_PREFIXES, brandId, createId, now } from "@pluralscape/types";
-import { CreateMemberPhotoBodySchema } from "@pluralscape/validation";
 import { and, count, eq, max } from "drizzle-orm";
 
 import { HTTP_BAD_REQUEST, HTTP_CONFLICT } from "../../../http.constants.js";
@@ -18,7 +17,9 @@ import type { MemberPhotoResult } from "./internal.js";
 import type { AuditWriter } from "../../../lib/audit-writer.js";
 import type { AuthContext } from "../../../lib/auth-context.js";
 import type { EncryptedBlob, MemberId, MemberPhotoId, SystemId } from "@pluralscape/types";
+import type { CreateMemberPhotoBodySchema } from "@pluralscape/validation";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { z } from "zod/v4";
 
 const MAX_ENCRYPTED_PHOTO_DATA_BYTES = 131_072;
 
@@ -47,19 +48,14 @@ export async function createMemberPhoto(
   db: PostgresJsDatabase,
   systemId: SystemId,
   memberId: MemberId,
-  params: unknown,
+  body: z.infer<typeof CreateMemberPhotoBodySchema>,
   auth: AuthContext,
   audit: AuditWriter,
 ): Promise<MemberPhotoResult> {
   assertSystemOwnership(systemId, auth);
   await assertMemberActive(db, systemId, memberId);
 
-  const parsed = CreateMemberPhotoBodySchema.safeParse(params);
-  if (!parsed.success) {
-    throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid create payload");
-  }
-
-  const blob = parseAndValidatePhotoBlob(parsed.data.encryptedData);
+  const blob = parseAndValidatePhotoBlob(body.encryptedData);
   const photoId = brandId<MemberPhotoId>(createId(ID_PREFIXES.memberPhoto));
   const timestamp = now();
 
@@ -102,7 +98,7 @@ export async function createMemberPhoto(
     }
 
     // Determine sort order
-    let sortOrder = parsed.data.sortOrder;
+    let sortOrder = body.sortOrder;
     if (sortOrder === undefined) {
       const [maxResult] = await tx
         .select({ maxSort: max(memberPhotos.sortOrder) })

--- a/apps/api/src/trpc/routers/member-photo.ts
+++ b/apps/api/src/trpc/routers/member-photo.ts
@@ -40,14 +40,7 @@ export const memberPhotoRouter = router({
     .input(MemberIdSchema.and(CreateMemberPhotoBodySchema))
     .mutation(async ({ ctx, input }) => {
       const audit = ctx.createAudit(ctx.auth);
-      return createMemberPhoto(
-        ctx.db,
-        ctx.systemId,
-        input.memberId,
-        { encryptedData: input.encryptedData, sortOrder: input.sortOrder },
-        ctx.auth,
-        audit,
-      );
+      return createMemberPhoto(ctx.db, ctx.systemId, input.memberId, input, ctx.auth, audit);
     }),
 
   get: systemProcedure

--- a/packages/types/src/entities/acknowledgement.ts
+++ b/packages/types/src/entities/acknowledgement.ts
@@ -33,6 +33,18 @@ export type ArchivedAcknowledgementRequest = Archived<AcknowledgementRequest>;
 export type AcknowledgementRequestEncryptedFields = "message" | "targetMemberId" | "confirmedAt";
 
 /**
+ * Domain field that is plaintext on the server row but stored with a
+ * different shape than the domain implies. `createdByMemberId` is a
+ * non-nullable `MemberId` on the domain (every acknowledgement has a
+ * creator); on the server row it is nullable to support imported
+ * acknowledgements where the creator member is not yet known.
+ *
+ * Distinguished from `AcknowledgementRequestEncryptedFields` (which lists
+ * keys whose values ride inside the encryptedData blob).
+ */
+export type AcknowledgementRequestRestructuredPlaintextFields = "createdByMemberId";
+
+/**
  * Server-visible AcknowledgementRequest metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the `message`, `targetMemberId`, and `confirmedAt` fields
@@ -46,7 +58,9 @@ export type AcknowledgementRequestEncryptedFields = "message" | "targetMemberId"
  */
 export type AcknowledgementRequestServerMetadata = Omit<
   AcknowledgementRequest,
-  AcknowledgementRequestEncryptedFields | "createdByMemberId" | "archived"
+  | AcknowledgementRequestEncryptedFields
+  | AcknowledgementRequestRestructuredPlaintextFields
+  | "archived"
 > & {
   readonly createdByMemberId: MemberId | null;
   readonly archived: boolean;

--- a/packages/types/src/entities/acknowledgement.ts
+++ b/packages/types/src/entities/acknowledgement.ts
@@ -68,25 +68,18 @@ export type AcknowledgementRequestServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptAcknowledgementInput` accepts.
- * Single source of truth: derived from `AcknowledgementRequest` via `Pick<>`
- * over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// AcknowledgementRequestEncryptedInput → AcknowledgementRequestServerMetadata
+//                                     → AcknowledgementRequestResult → AcknowledgementRequestWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type AcknowledgementRequestEncryptedInput = Pick<
   AcknowledgementRequest,
   AcknowledgementRequestEncryptedFields
 >;
 
-/**
- * Server-emit shape — what `toAcknowledgementRequestResult` returns. Branded
- * IDs and timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type AcknowledgementRequestResult = EncryptedWire<AcknowledgementRequestServerMetadata>;
 
-/**
- * JSON-serialized wire form of `AcknowledgementRequestResult`: branded IDs
- * become plain strings; `EncryptedBase64` becomes plain `string`; timestamps
- * become numbers.
- */
 export type AcknowledgementRequestWire = Serialize<AcknowledgementRequestResult>;

--- a/packages/types/src/entities/acknowledgement.ts
+++ b/packages/types/src/entities/acknowledgement.ts
@@ -23,7 +23,8 @@ export type ArchivedAcknowledgementRequest = Archived<AcknowledgementRequest>;
 /**
  * Keys of `AcknowledgementRequest` that are encrypted client-side before the
  * server sees them. The server stores ciphertext in `encryptedData`; the
- * plaintext columns are `confirmed` and `createdByMemberId` (nullable FK).
+ * plaintext columns on the server row are `confirmed` and `createdByMemberId`
+ * (nullable on the server row to support imported acknowledgements).
  * Consumed by:
  * - `AcknowledgementRequestServerMetadata` (derived via `Omit`)
  * - `AcknowledgementRequestEncryptedInput = Pick<AcknowledgementRequest, AcknowledgementRequestEncryptedFields>`
@@ -54,7 +55,7 @@ export type AcknowledgementRequestServerMetadata = Omit<
 };
 
 /**
- * Pre-encryption shape — what `encryptAcknowledgementRequestInput` accepts.
+ * Pre-encryption shape — what `encryptAcknowledgementInput` accepts.
  * Single source of truth: derived from `AcknowledgementRequest` via `Pick<>`
  * over the encrypted-keys union.
  */

--- a/packages/types/src/entities/acknowledgement.ts
+++ b/packages/types/src/entities/acknowledgement.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { AcknowledgementId, MemberId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -20,6 +21,17 @@ export interface AcknowledgementRequest extends AuditMetadata {
 export type ArchivedAcknowledgementRequest = Archived<AcknowledgementRequest>;
 
 /**
+ * Keys of `AcknowledgementRequest` that are encrypted client-side before the
+ * server sees them. The server stores ciphertext in `encryptedData`; the
+ * plaintext columns are `confirmed` and `createdByMemberId` (nullable FK).
+ * Consumed by:
+ * - `AcknowledgementRequestServerMetadata` (derived via `Omit`)
+ * - `AcknowledgementRequestEncryptedInput = Pick<AcknowledgementRequest, AcknowledgementRequestEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextAcknowledgementRequest parity)
+ */
+export type AcknowledgementRequestEncryptedFields = "message" | "targetMemberId" | "confirmedAt";
+
+/**
  * Server-visible AcknowledgementRequest metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the `message`, `targetMemberId`, and `confirmedAt` fields
@@ -33,7 +45,7 @@ export type ArchivedAcknowledgementRequest = Archived<AcknowledgementRequest>;
  */
 export type AcknowledgementRequestServerMetadata = Omit<
   AcknowledgementRequest,
-  "createdByMemberId" | "targetMemberId" | "message" | "confirmedAt" | "archived"
+  AcknowledgementRequestEncryptedFields | "createdByMemberId" | "archived"
 > & {
   readonly createdByMemberId: MemberId | null;
   readonly archived: boolean;
@@ -42,8 +54,24 @@ export type AcknowledgementRequestServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of an AcknowledgementRequest. Derived from the
- * domain `AcknowledgementRequest` type via `Serialize<T>`; branded IDs
- * become plain strings, `UnixMillis` becomes `number`.
+ * Pre-encryption shape — what `encryptAcknowledgementRequestInput` accepts.
+ * Single source of truth: derived from `AcknowledgementRequest` via `Pick<>`
+ * over the encrypted-keys union.
  */
-export type AcknowledgementRequestWire = Serialize<AcknowledgementRequest>;
+export type AcknowledgementRequestEncryptedInput = Pick<
+  AcknowledgementRequest,
+  AcknowledgementRequestEncryptedFields
+>;
+
+/**
+ * Server-emit shape — what `toAcknowledgementRequestResult` returns. Branded
+ * IDs and timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type AcknowledgementRequestResult = EncryptedWire<AcknowledgementRequestServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `AcknowledgementRequestResult`: branded IDs
+ * become plain strings; `EncryptedBase64` becomes plain `string`; timestamps
+ * become numbers.
+ */
+export type AcknowledgementRequestWire = Serialize<AcknowledgementRequestResult>;

--- a/packages/types/src/entities/board-message.ts
+++ b/packages/types/src/entities/board-message.ts
@@ -47,21 +47,15 @@ export type BoardMessageServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptBoardMessageInput` accepts. Single
- * source of truth: derived from `BoardMessage` via `Pick<>` over the
- * encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// BoardMessageEncryptedInput → BoardMessageServerMetadata
+//                           → BoardMessageResult → BoardMessageWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type BoardMessageEncryptedInput = Pick<BoardMessage, BoardMessageEncryptedFields>;
 
-/**
- * Server-emit shape — what `toBoardMessageResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type BoardMessageResult = EncryptedWire<BoardMessageServerMetadata>;
 
-/**
- * JSON-serialized wire form of `BoardMessageResult`: branded IDs become plain
- * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type BoardMessageWire = Serialize<BoardMessageResult>;

--- a/packages/types/src/entities/board-message.ts
+++ b/packages/types/src/entities/board-message.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { BoardMessageId, MemberId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -19,6 +20,17 @@ export interface BoardMessage extends AuditMetadata {
 export type ArchivedBoardMessage = Archived<BoardMessage>;
 
 /**
+ * Keys of `BoardMessage` that are encrypted client-side before the server
+ * sees them. The server stores ciphertext in `encryptedData`; the plaintext
+ * columns are `pinned` and `sortOrder`.
+ * Consumed by:
+ * - `BoardMessageServerMetadata` (derived via `Omit`)
+ * - `BoardMessageEncryptedInput = Pick<BoardMessage, BoardMessageEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextBoardMessage parity)
+ */
+export type BoardMessageEncryptedFields = "senderId" | "content";
+
+/**
  * Server-visible BoardMessage metadata — raw Drizzle row shape.
  *
  * Hybrid entity: plaintext columns (`pinned`, `sortOrder`) alongside the
@@ -26,15 +38,30 @@ export type ArchivedBoardMessage = Archived<BoardMessage>;
  * `content`. `archived: false` on the domain flips to a mutable boolean
  * here, with a companion `archivedAt` timestamp.
  */
-export type BoardMessageServerMetadata = Omit<BoardMessage, "senderId" | "content" | "archived"> & {
+export type BoardMessageServerMetadata = Omit<
+  BoardMessage,
+  BoardMessageEncryptedFields | "archived"
+> & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
   readonly encryptedData: EncryptedBlob;
 };
 
 /**
- * JSON-wire representation of a BoardMessage. Derived from the domain
- * `BoardMessage` type via `Serialize<T>`; branded IDs become plain strings,
- * `UnixMillis` becomes `number`.
+ * Pre-encryption shape — what `encryptBoardMessageInput` accepts. Single
+ * source of truth: derived from `BoardMessage` via `Pick<>` over the
+ * encrypted-keys union.
  */
-export type BoardMessageWire = Serialize<BoardMessage>;
+export type BoardMessageEncryptedInput = Pick<BoardMessage, BoardMessageEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toBoardMessageResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type BoardMessageResult = EncryptedWire<BoardMessageServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `BoardMessageResult`: branded IDs become plain
+ * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type BoardMessageWire = Serialize<BoardMessageResult>;

--- a/packages/types/src/entities/bucket.ts
+++ b/packages/types/src/entities/bucket.ts
@@ -26,10 +26,13 @@ export type ArchivedPrivacyBucket = Archived<PrivacyBucket>;
  */
 export type PrivacyBucketEncryptedFields = "name" | "description";
 
-/**
- * Pre-encryption shape — what `encryptBucketInput` accepts. Single source
- * of truth: derived from `PrivacyBucket` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// PrivacyBucketEncryptedInput → PrivacyBucketServerMetadata
+//                            → PrivacyBucketResult → PrivacyBucketWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type PrivacyBucketEncryptedInput = Pick<PrivacyBucket, PrivacyBucketEncryptedFields>;
 
 /**
@@ -49,16 +52,8 @@ export type PrivacyBucketServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toPrivacyBucketResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type PrivacyBucketResult = EncryptedWire<PrivacyBucketServerMetadata>;
 
-/**
- * JSON-serialized wire form of `PrivacyBucketResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type PrivacyBucketWire = Serialize<PrivacyBucketResult>;
 
 /**

--- a/packages/types/src/entities/bucket.ts
+++ b/packages/types/src/entities/bucket.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { BucketId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -26,6 +27,12 @@ export type ArchivedPrivacyBucket = Archived<PrivacyBucket>;
 export type PrivacyBucketEncryptedFields = "name" | "description";
 
 /**
+ * Pre-encryption shape — what `encryptPrivacyBucketInput` accepts. Single source
+ * of truth: derived from `PrivacyBucket` via `Pick<>` over the encrypted-keys union.
+ */
+export type PrivacyBucketEncryptedInput = Pick<PrivacyBucket, PrivacyBucketEncryptedFields>;
+
+/**
  * Server-visible PrivacyBucket metadata — raw Drizzle row shape.
  *
  * Derived from `PrivacyBucket` by stripping the encrypted field keys
@@ -43,11 +50,16 @@ export type PrivacyBucketServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a PrivacyBucket. Derived from the domain
- * `PrivacyBucket` type via `Serialize<T>`; branded IDs become plain
- * strings, `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toPrivacyBucketResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type PrivacyBucketWire = Serialize<PrivacyBucket>;
+export type PrivacyBucketResult = EncryptedWire<PrivacyBucketServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `PrivacyBucketResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type PrivacyBucketWire = Serialize<PrivacyBucketResult>;
 
 /**
  * Entity types that can be tagged in privacy buckets.

--- a/packages/types/src/entities/bucket.ts
+++ b/packages/types/src/entities/bucket.ts
@@ -27,7 +27,7 @@ export type ArchivedPrivacyBucket = Archived<PrivacyBucket>;
 export type PrivacyBucketEncryptedFields = "name" | "description";
 
 /**
- * Pre-encryption shape — what `encryptPrivacyBucketInput` accepts. Single source
+ * Pre-encryption shape — what `encryptBucketInput` accepts. Single source
  * of truth: derived from `PrivacyBucket` via `Pick<>` over the encrypted-keys union.
  */
 export type PrivacyBucketEncryptedInput = Pick<PrivacyBucket, PrivacyBucketEncryptedFields>;

--- a/packages/types/src/entities/channel.ts
+++ b/packages/types/src/entities/channel.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { ChannelId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -20,6 +21,17 @@ export interface Channel extends AuditMetadata {
 export type ArchivedChannel = Archived<Channel>;
 
 /**
+ * Keys of `Channel` that are encrypted client-side before the server sees
+ * them. The server stores ciphertext in `encryptedData`; the plaintext
+ * columns are `type`, `parentId`, and `sortOrder`.
+ * Consumed by:
+ * - `ChannelServerMetadata` (derived via `Omit`)
+ * - `ChannelEncryptedInput = Pick<Channel, ChannelEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextChannel parity)
+ */
+export type ChannelEncryptedFields = "name";
+
+/**
  * Server-visible Channel metadata — raw Drizzle row shape.
  *
  * Hybrid entity: plaintext columns (`type`, `parentId`, `sortOrder`) alongside
@@ -28,15 +40,26 @@ export type ArchivedChannel = Archived<Channel>;
  * names. `archived: false` on the domain flips to a mutable boolean here, with
  * a companion `archivedAt` timestamp.
  */
-export type ChannelServerMetadata = Omit<Channel, "name" | "archived"> & {
+export type ChannelServerMetadata = Omit<Channel, ChannelEncryptedFields | "archived"> & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
   readonly encryptedData: EncryptedBlob;
 };
 
 /**
- * JSON-wire representation of a Channel. Derived from the domain `Channel`
- * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
+ * Pre-encryption shape — what `encryptChannelInput` accepts. Single source of
+ * truth: derived from `Channel` via `Pick<>` over the encrypted-keys union.
  */
-export type ChannelWire = Serialize<Channel>;
+export type ChannelEncryptedInput = Pick<Channel, ChannelEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toChannelResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type ChannelResult = EncryptedWire<ChannelServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `ChannelResult`: branded IDs become plain
+ * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type ChannelWire = Serialize<ChannelResult>;

--- a/packages/types/src/entities/channel.ts
+++ b/packages/types/src/entities/channel.ts
@@ -46,20 +46,15 @@ export type ChannelServerMetadata = Omit<Channel, ChannelEncryptedFields | "arch
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptChannelInput` accepts. Single source of
- * truth: derived from `Channel` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// ChannelEncryptedInput → ChannelServerMetadata
+//                      → ChannelResult → ChannelWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type ChannelEncryptedInput = Pick<Channel, ChannelEncryptedFields>;
 
-/**
- * Server-emit shape — what `toChannelResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type ChannelResult = EncryptedWire<ChannelServerMetadata>;
 
-/**
- * JSON-serialized wire form of `ChannelResult`: branded IDs become plain
- * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type ChannelWire = Serialize<ChannelResult>;

--- a/packages/types/src/entities/custom-front.ts
+++ b/packages/types/src/entities/custom-front.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { CustomFrontId, HexColor, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -24,6 +25,12 @@ export interface CustomFront extends AuditMetadata {
  */
 export type CustomFrontEncryptedFields = "name" | "description" | "color" | "emoji";
 
+/**
+ * Pre-encryption shape — what `encryptCustomFrontInput` accepts. Single source
+ * of truth: derived from `CustomFront` via `Pick<>` over the encrypted-keys union.
+ */
+export type CustomFrontEncryptedInput = Pick<CustomFront, CustomFrontEncryptedFields>;
+
 /** An archived custom front — preserves all data with archive metadata. */
 export type ArchivedCustomFront = Archived<CustomFront>;
 
@@ -46,7 +53,13 @@ export type CustomFrontServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a CustomFront. Derived from the domain
- * `CustomFront` type via `Serialize<T>`; branded IDs become plain strings.
+ * Server-emit shape — what `toCustomFrontResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type CustomFrontWire = Serialize<CustomFront>;
+export type CustomFrontResult = EncryptedWire<CustomFrontServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `CustomFrontResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type CustomFrontWire = Serialize<CustomFrontResult>;

--- a/packages/types/src/entities/custom-front.ts
+++ b/packages/types/src/entities/custom-front.ts
@@ -25,10 +25,13 @@ export interface CustomFront extends AuditMetadata {
  */
 export type CustomFrontEncryptedFields = "name" | "description" | "color" | "emoji";
 
-/**
- * Pre-encryption shape — what `encryptCustomFrontInput` accepts. Single source
- * of truth: derived from `CustomFront` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// CustomFrontEncryptedInput → CustomFrontServerMetadata
+//                          → CustomFrontResult → CustomFrontWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type CustomFrontEncryptedInput = Pick<CustomFront, CustomFrontEncryptedFields>;
 
 /** An archived custom front — preserves all data with archive metadata. */
@@ -52,14 +55,6 @@ export type CustomFrontServerMetadata = Omit<
   readonly archivedAt: UnixMillis | null;
 };
 
-/**
- * Server-emit shape — what `toCustomFrontResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type CustomFrontResult = EncryptedWire<CustomFrontServerMetadata>;
 
-/**
- * JSON-serialized wire form of `CustomFrontResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type CustomFrontWire = Serialize<CustomFrontResult>;

--- a/packages/types/src/entities/field-definition.ts
+++ b/packages/types/src/entities/field-definition.ts
@@ -59,32 +59,6 @@ export type FieldDefinitionEncryptedInput = Pick<FieldDefinition, FieldDefinitio
 export type ArchivedFieldDefinition = Archived<FieldDefinition>;
 
 /**
- * Request body for creating a field definition.
- *
- * @deprecated Use `z.infer<typeof CreateFieldDefinitionBodySchema>` from
- * `@pluralscape/validation`. Kept until consumers in services / routes /
- * tRPC routers are migrated; tracked by ps-y4tb fleet rollout (Tasks 4.6+).
- */
-export interface CreateFieldDefinitionBody {
-  readonly fieldType: FieldType;
-  readonly required: boolean;
-  readonly sortOrder: number;
-  readonly encryptedData: string;
-}
-
-/**
- * Request body for updating a field definition.
- *
- * @deprecated Use `z.infer<typeof UpdateFieldDefinitionBodySchema>`.
- */
-export interface UpdateFieldDefinitionBody {
-  readonly required?: boolean;
-  readonly sortOrder?: number;
-  readonly encryptedData: string;
-  readonly version: number;
-}
-
-/**
  * Server-visible FieldDefinition metadata — raw Drizzle row shape.
  *
  * Derived from `FieldDefinition` by stripping the encrypted field keys

--- a/packages/types/src/entities/field-definition.ts
+++ b/packages/types/src/entities/field-definition.ts
@@ -49,10 +49,13 @@ export interface FieldDefinition extends AuditMetadata {
  */
 export type FieldDefinitionEncryptedFields = "name" | "description" | "options";
 
-/**
- * Pre-encryption shape — what `encryptFieldDefinitionInput` accepts. Single source
- * of truth: derived from `FieldDefinition` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// FieldDefinitionEncryptedInput → FieldDefinitionServerMetadata
+//                              → FieldDefinitionResult → FieldDefinitionWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type FieldDefinitionEncryptedInput = Pick<FieldDefinition, FieldDefinitionEncryptedFields>;
 
 /** An archived field definition. */
@@ -76,14 +79,6 @@ export type FieldDefinitionServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toFieldDefinitionResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type FieldDefinitionResult = EncryptedWire<FieldDefinitionServerMetadata>;
 
-/**
- * JSON-serialized wire form of `FieldDefinitionResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type FieldDefinitionWire = Serialize<FieldDefinitionResult>;

--- a/packages/types/src/entities/field-definition.ts
+++ b/packages/types/src/entities/field-definition.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { BucketId, FieldDefinitionId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -48,6 +49,12 @@ export interface FieldDefinition extends AuditMetadata {
  */
 export type FieldDefinitionEncryptedFields = "name" | "description" | "options";
 
+/**
+ * Pre-encryption shape — what `encryptFieldDefinitionInput` accepts. Single source
+ * of truth: derived from `FieldDefinition` via `Pick<>` over the encrypted-keys union.
+ */
+export type FieldDefinitionEncryptedInput = Pick<FieldDefinition, FieldDefinitionEncryptedFields>;
+
 /** An archived field definition. */
 export type ArchivedFieldDefinition = Archived<FieldDefinition>;
 
@@ -70,26 +77,13 @@ export type FieldDefinitionServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a FieldDefinition. Derived from the domain
- * `FieldDefinition` type via `Serialize<T>`; branded IDs become plain
- * strings, `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toFieldDefinitionResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type FieldDefinitionWire = Serialize<FieldDefinition>;
+export type FieldDefinitionResult = EncryptedWire<FieldDefinitionServerMetadata>;
 
-// ── Request body types ──────────────────────────────────────────
-
-/** Request body for creating a field definition. */
-export interface CreateFieldDefinitionBody {
-  readonly fieldType: FieldType;
-  readonly required: boolean;
-  readonly sortOrder: number;
-  readonly encryptedData: string;
-}
-
-/** Request body for updating a field definition. */
-export interface UpdateFieldDefinitionBody {
-  readonly required?: boolean;
-  readonly sortOrder?: number;
-  readonly encryptedData: string;
-  readonly version: number;
-}
+/**
+ * JSON-serialized wire form of `FieldDefinitionResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type FieldDefinitionWire = Serialize<FieldDefinitionResult>;

--- a/packages/types/src/entities/field-definition.ts
+++ b/packages/types/src/entities/field-definition.ts
@@ -59,6 +59,32 @@ export type FieldDefinitionEncryptedInput = Pick<FieldDefinition, FieldDefinitio
 export type ArchivedFieldDefinition = Archived<FieldDefinition>;
 
 /**
+ * Request body for creating a field definition.
+ *
+ * @deprecated Use `z.infer<typeof CreateFieldDefinitionBodySchema>` from
+ * `@pluralscape/validation`. Kept until consumers in services / routes /
+ * tRPC routers are migrated; tracked by ps-y4tb fleet rollout (Tasks 4.6+).
+ */
+export interface CreateFieldDefinitionBody {
+  readonly fieldType: FieldType;
+  readonly required: boolean;
+  readonly sortOrder: number;
+  readonly encryptedData: string;
+}
+
+/**
+ * Request body for updating a field definition.
+ *
+ * @deprecated Use `z.infer<typeof UpdateFieldDefinitionBodySchema>`.
+ */
+export interface UpdateFieldDefinitionBody {
+  readonly required?: boolean;
+  readonly sortOrder?: number;
+  readonly encryptedData: string;
+  readonly version: number;
+}
+
+/**
  * Server-visible FieldDefinition metadata — raw Drizzle row shape.
  *
  * Derived from `FieldDefinition` by stripping the encrypted field keys

--- a/packages/types/src/entities/field-value.ts
+++ b/packages/types/src/entities/field-value.ts
@@ -44,10 +44,13 @@ export interface FieldValue extends AuditMetadata {
  */
 export type FieldValueEncryptedFields = "value";
 
-/**
- * Pre-encryption shape — what `encryptFieldValueInput` accepts. Single source
- * of truth: derived from `FieldValue` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// FieldValueEncryptedInput → FieldValueServerMetadata
+//                         → FieldValueResult → FieldValueWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type FieldValueEncryptedInput = Pick<FieldValue, FieldValueEncryptedFields>;
 
 /**
@@ -64,14 +67,6 @@ export type FieldValueServerMetadata = Omit<FieldValue, FieldValueEncryptedField
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toFieldValueResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type FieldValueResult = EncryptedWire<FieldValueServerMetadata>;
 
-/**
- * JSON-serialized wire form of `FieldValueResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type FieldValueWire = Serialize<FieldValueResult>;

--- a/packages/types/src/entities/field-value.ts
+++ b/packages/types/src/entities/field-value.ts
@@ -75,3 +75,22 @@ export type FieldValueResult = EncryptedWire<FieldValueServerMetadata>;
  * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
  */
 export type FieldValueWire = Serialize<FieldValueResult>;
+
+/**
+ * Request body for setting a field value.
+ *
+ * @deprecated Use `z.infer<typeof SetFieldValueBodySchema>`.
+ */
+export interface SetFieldValueBody {
+  readonly encryptedData: string;
+}
+
+/**
+ * Request body for updating a field value.
+ *
+ * @deprecated Use `z.infer<typeof UpdateFieldValueBodySchema>`.
+ */
+export interface UpdateFieldValueBody {
+  readonly encryptedData: string;
+  readonly version: number;
+}

--- a/packages/types/src/entities/field-value.ts
+++ b/packages/types/src/entities/field-value.ts
@@ -75,22 +75,3 @@ export type FieldValueResult = EncryptedWire<FieldValueServerMetadata>;
  * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
  */
 export type FieldValueWire = Serialize<FieldValueResult>;
-
-/**
- * Request body for setting a field value.
- *
- * @deprecated Use `z.infer<typeof SetFieldValueBodySchema>`.
- */
-export interface SetFieldValueBody {
-  readonly encryptedData: string;
-}
-
-/**
- * Request body for updating a field value.
- *
- * @deprecated Use `z.infer<typeof UpdateFieldValueBodySchema>`.
- */
-export interface UpdateFieldValueBody {
-  readonly encryptedData: string;
-  readonly version: number;
-}

--- a/packages/types/src/entities/field-value.ts
+++ b/packages/types/src/entities/field-value.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   FieldDefinitionId,
@@ -44,6 +45,12 @@ export interface FieldValue extends AuditMetadata {
 export type FieldValueEncryptedFields = "value";
 
 /**
+ * Pre-encryption shape — what `encryptFieldValueInput` accepts. Single source
+ * of truth: derived from `FieldValue` via `Pick<>` over the encrypted-keys union.
+ */
+export type FieldValueEncryptedInput = Pick<FieldValue, FieldValueEncryptedFields>;
+
+/**
  * Server-visible FieldValue metadata — raw Drizzle row shape.
  *
  * Derived from `FieldValue` by stripping the encrypted `value` discriminated
@@ -58,19 +65,13 @@ export type FieldValueServerMetadata = Omit<FieldValue, FieldValueEncryptedField
 };
 
 /**
- * JSON-wire representation of a FieldValue. Derived from the domain
- * `FieldValue` type via `Serialize<T>`; branded IDs become plain strings,
- * `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toFieldValueResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type FieldValueWire = Serialize<FieldValue>;
+export type FieldValueResult = EncryptedWire<FieldValueServerMetadata>;
 
-/** Request body for setting a field value. */
-export interface SetFieldValueBody {
-  readonly encryptedData: string;
-}
-
-/** Request body for updating a field value. */
-export interface UpdateFieldValueBody {
-  readonly encryptedData: string;
-  readonly version: number;
-}
+/**
+ * JSON-serialized wire form of `FieldValueResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type FieldValueWire = Serialize<FieldValueResult>;

--- a/packages/types/src/entities/friend-connection.ts
+++ b/packages/types/src/entities/friend-connection.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { AccountId, BucketId, FriendConnectionId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -30,6 +31,24 @@ export interface FriendConnection extends AuditMetadata {
 export type ArchivedFriendConnection = Archived<FriendConnection>;
 
 /**
+ * Keys of `FriendConnection` that are encrypted client-side before the
+ * server sees them. The `visibility` blob is the only domain field that
+ * lives inside `encryptedData`; `assignedBucketIds` is plaintext but
+ * derived from a junction table, not a column on this entity.
+ */
+export type FriendConnectionEncryptedFields = "visibility";
+
+/**
+ * Pre-encryption shape — what `encryptFriendConnectionInput` accepts.
+ * Single source of truth: derived from `FriendConnection` via `Pick<>`
+ * over the encrypted-keys union.
+ */
+export type FriendConnectionEncryptedInput = Pick<
+  FriendConnection,
+  FriendConnectionEncryptedFields
+>;
+
+/**
  * Server-visible FriendConnection metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the domain carries derived fields (`assignedBucketIds`
@@ -43,7 +62,7 @@ export type ArchivedFriendConnection = Archived<FriendConnection>;
  */
 export type FriendConnectionServerMetadata = Omit<
   FriendConnection,
-  "assignedBucketIds" | "visibility" | "archived"
+  FriendConnectionEncryptedFields | "assignedBucketIds" | "archived"
 > & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
@@ -51,11 +70,19 @@ export type FriendConnectionServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a FriendConnection. Derived from the domain
- * `FriendConnection` type via `Serialize<T>`; branded IDs become plain
- * strings, `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toFriendConnectionResult` returns. Branded
+ * IDs and timestamps preserved; `encryptedData` is wire-form
+ * `EncryptedBase64 | null` (nullable because pending connections have
+ * no visibility blob yet).
  */
-export type FriendConnectionWire = Serialize<FriendConnection>;
+export type FriendConnectionResult = EncryptedWire<FriendConnectionServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `FriendConnectionResult`: branded IDs
+ * become plain strings; `EncryptedBase64 | null` becomes `string | null`;
+ * timestamps become numbers.
+ */
+export type FriendConnectionWire = Serialize<FriendConnectionResult>;
 
 /** A junction mapping a friend connection to a privacy bucket. */
 export interface FriendBucketAssignment {

--- a/packages/types/src/entities/friend-connection.ts
+++ b/packages/types/src/entities/friend-connection.ts
@@ -38,11 +38,13 @@ export type ArchivedFriendConnection = Archived<FriendConnection>;
  */
 export type FriendConnectionEncryptedFields = "visibility";
 
-/**
- * Pre-encryption shape — what `encryptFriendConnectionInput` accepts.
- * Single source of truth: derived from `FriendConnection` via `Pick<>`
- * over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// FriendConnectionEncryptedInput → FriendConnectionServerMetadata
+//                               → FriendConnectionResult → FriendConnectionWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type FriendConnectionEncryptedInput = Pick<
   FriendConnection,
   FriendConnectionEncryptedFields
@@ -79,18 +81,11 @@ export type FriendConnectionServerMetadata = Omit<
 };
 
 /**
- * Server-emit shape — what `toFriendConnectionResult` returns. Branded
- * IDs and timestamps preserved; `encryptedData` is wire-form
- * `EncryptedBase64 | null` (nullable because pending connections have
- * no visibility blob yet).
+ * `encryptedData` is `EncryptedBase64 | null` (nullable because pending
+ * connections have no visibility blob yet).
  */
 export type FriendConnectionResult = EncryptedWire<FriendConnectionServerMetadata>;
 
-/**
- * JSON-serialized wire form of `FriendConnectionResult`: branded IDs
- * become plain strings; `EncryptedBase64 | null` becomes `string | null`;
- * timestamps become numbers.
- */
 export type FriendConnectionWire = Serialize<FriendConnectionResult>;
 
 /** A junction mapping a friend connection to a privacy bucket. */

--- a/packages/types/src/entities/friend-connection.ts
+++ b/packages/types/src/entities/friend-connection.ts
@@ -49,20 +49,29 @@ export type FriendConnectionEncryptedInput = Pick<
 >;
 
 /**
+ * Domain field absent from the server row for STRUCTURAL reasons (the
+ * value lives in a junction table — `friend_bucket_assignments`), not
+ * because it is encrypted. Distinguished from
+ * `FriendConnectionEncryptedFields` (encrypted blob) and `archived`
+ * (literal-to-boolean flip).
+ */
+export type FriendConnectionAuxOmitFields = "assignedBucketIds";
+
+/**
  * Server-visible FriendConnection metadata — raw Drizzle row shape.
  *
- * Hybrid entity: the domain carries derived fields (`assignedBucketIds`
- * comes from the `friend_bucket_assignments` junction table, `visibility`
- * comes from the decrypted `encryptedData` T1 blob) that do not exist as
- * columns on `friend_connections`. The server row strips those derived
- * keys and replaces them with the nullable `encryptedData` column — nullable
- * because a connection can exist in `pending` status before the grantor
- * writes a visibility blob. `archived` relaxes to the raw boolean column
- * plus its `archivedAt` companion.
+ * The Omit clause names three orthogonal reasons a domain key is absent
+ * from the server row:
+ *   1. `FriendConnectionEncryptedFields` — value lives in `encryptedData`
+ *   2. `FriendConnectionAuxOmitFields` — value lives in a junction table
+ *   3. `"archived"` — domain literal `false` flips to mutable boolean below
+ *
+ * Adds the nullable `encryptedData` column (nullable because pending
+ * connections have no visibility blob yet) and `archivedAt`.
  */
 export type FriendConnectionServerMetadata = Omit<
   FriendConnection,
-  FriendConnectionEncryptedFields | "assignedBucketIds" | "archived"
+  FriendConnectionEncryptedFields | FriendConnectionAuxOmitFields | "archived"
 > & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;

--- a/packages/types/src/entities/fronting-comment.ts
+++ b/packages/types/src/entities/fronting-comment.ts
@@ -36,10 +36,13 @@ export interface FrontingComment extends AuditMetadata {
  */
 export type FrontingCommentEncryptedFields = "content";
 
-/**
- * Pre-encryption shape — what `encryptFrontingCommentInput` accepts. Single source
- * of truth: derived from `FrontingComment` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// FrontingCommentEncryptedInput → FrontingCommentServerMetadata
+//                              → FrontingCommentResult → FrontingCommentWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type FrontingCommentEncryptedInput = Pick<FrontingComment, FrontingCommentEncryptedFields>;
 
 /** An archived fronting comment. */
@@ -70,14 +73,6 @@ export type FrontingCommentServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toFrontingCommentResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type FrontingCommentResult = EncryptedWire<FrontingCommentServerMetadata>;
 
-/**
- * JSON-serialized wire form of `FrontingCommentResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type FrontingCommentWire = Serialize<FrontingCommentResult>;

--- a/packages/types/src/entities/fronting-comment.ts
+++ b/packages/types/src/entities/fronting-comment.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   CustomFrontId,
@@ -35,6 +36,12 @@ export interface FrontingComment extends AuditMetadata {
  */
 export type FrontingCommentEncryptedFields = "content";
 
+/**
+ * Pre-encryption shape — what `encryptFrontingCommentInput` accepts. Single source
+ * of truth: derived from `FrontingComment` via `Pick<>` over the encrypted-keys union.
+ */
+export type FrontingCommentEncryptedInput = Pick<FrontingComment, FrontingCommentEncryptedFields>;
+
 /** An archived fronting comment. */
 export type ArchivedFrontingComment = Archived<FrontingComment>;
 
@@ -64,8 +71,13 @@ export type FrontingCommentServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of FrontingComment. Derived from the domain
- * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
+ * Server-emit shape — what `toFrontingCommentResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type FrontingCommentWire = Serialize<FrontingComment>;
+export type FrontingCommentResult = EncryptedWire<FrontingCommentServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `FrontingCommentResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type FrontingCommentWire = Serialize<FrontingCommentResult>;

--- a/packages/types/src/entities/fronting-session.ts
+++ b/packages/types/src/entities/fronting-session.ts
@@ -63,10 +63,13 @@ export type FrontingSessionEncryptedFields =
   | "outtrigger"
   | "outtriggerSentiment";
 
-/**
- * Pre-encryption shape — what `encryptFrontingSessionInput` accepts. Single source
- * of truth: derived from `FrontingSession` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// FrontingSessionEncryptedInput → FrontingSessionServerMetadata
+//                              → FrontingSessionResult → FrontingSessionWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type FrontingSessionEncryptedInput = Pick<FrontingSession, FrontingSessionEncryptedFields>;
 
 /** An archived fronting session. */
@@ -102,14 +105,6 @@ export type FrontingSessionServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toFrontingSessionResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type FrontingSessionResult = EncryptedWire<FrontingSessionServerMetadata>;
 
-/**
- * JSON-serialized wire form of `FrontingSessionResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type FrontingSessionWire = Serialize<FrontingSessionResult>;

--- a/packages/types/src/entities/fronting-session.ts
+++ b/packages/types/src/entities/fronting-session.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   CustomFrontId,
@@ -62,6 +63,12 @@ export type FrontingSessionEncryptedFields =
   | "outtrigger"
   | "outtriggerSentiment";
 
+/**
+ * Pre-encryption shape — what `encryptFrontingSessionInput` accepts. Single source
+ * of truth: derived from `FrontingSession` via `Pick<>` over the encrypted-keys union.
+ */
+export type FrontingSessionEncryptedInput = Pick<FrontingSession, FrontingSessionEncryptedFields>;
+
 /** An archived fronting session. */
 export type ArchivedFrontingSession = Archived<FrontingSession>;
 
@@ -96,8 +103,13 @@ export type FrontingSessionServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of FrontingSession. Derived from the domain
- * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
+ * Server-emit shape — what `toFrontingSessionResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type FrontingSessionWire = Serialize<FrontingSession>;
+export type FrontingSessionResult = EncryptedWire<FrontingSessionServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `FrontingSessionResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type FrontingSessionWire = Serialize<FrontingSessionResult>;

--- a/packages/types/src/entities/group.ts
+++ b/packages/types/src/entities/group.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { GroupId, HexColor, MemberId, SystemId } from "../ids.js";
 import type { ImageSource } from "../image-source.js";
@@ -27,6 +28,12 @@ export interface Group extends AuditMetadata {
  * - `GroupServerMetadata` (derived via `Omit`)
  */
 export type GroupEncryptedFields = "name" | "description" | "imageSource" | "color" | "emoji";
+
+/**
+ * Pre-encryption shape — what `encryptGroupInput` accepts. Single source
+ * of truth: derived from `Group` via `Pick<>` over the encrypted-keys union.
+ */
+export type GroupEncryptedInput = Pick<Group, GroupEncryptedFields>;
 
 /** An archived group — preserves all data with archive metadata. */
 export type ArchivedGroup = Archived<Group>;
@@ -64,7 +71,13 @@ export type GroupServerMetadata = Omit<Group, GroupEncryptedFields | "archived">
 };
 
 /**
- * JSON-wire representation of a Group. Derived from the domain `Group`
- * type via `Serialize<T>`; branded IDs become plain strings.
+ * Server-emit shape — what `toGroupResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type GroupWire = Serialize<Group>;
+export type GroupResult = EncryptedWire<GroupServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `GroupResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type GroupWire = Serialize<GroupResult>;

--- a/packages/types/src/entities/group.ts
+++ b/packages/types/src/entities/group.ts
@@ -29,10 +29,13 @@ export interface Group extends AuditMetadata {
  */
 export type GroupEncryptedFields = "name" | "description" | "imageSource" | "color" | "emoji";
 
-/**
- * Pre-encryption shape — what `encryptGroupInput` accepts. Single source
- * of truth: derived from `Group` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// GroupEncryptedInput → GroupServerMetadata
+//                    → GroupResult → GroupWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type GroupEncryptedInput = Pick<Group, GroupEncryptedFields>;
 
 /** An archived group — preserves all data with archive metadata. */
@@ -70,14 +73,6 @@ export type GroupServerMetadata = Omit<Group, GroupEncryptedFields | "archived">
   readonly archivedAt: UnixMillis | null;
 };
 
-/**
- * Server-emit shape — what `toGroupResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type GroupResult = EncryptedWire<GroupServerMetadata>;
 
-/**
- * JSON-serialized wire form of `GroupResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type GroupWire = Serialize<GroupResult>;

--- a/packages/types/src/entities/innerworld-canvas.ts
+++ b/packages/types/src/entities/innerworld-canvas.ts
@@ -23,11 +23,13 @@ export interface InnerWorldCanvas {
  */
 export type InnerWorldCanvasEncryptedFields = "viewportX" | "viewportY" | "zoom" | "dimensions";
 
-/**
- * Pre-encryption shape — the projection of `InnerWorldCanvas` over its
- * encrypted-keys union. The transform layer (when added) will accept
- * this shape and produce the encrypted wire body.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// InnerWorldCanvasEncryptedInput → InnerWorldCanvasServerMetadata
+//                               → InnerWorldCanvasResult → InnerWorldCanvasWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type InnerWorldCanvasEncryptedInput = Pick<
   InnerWorldCanvas,
   InnerWorldCanvasEncryptedFields
@@ -53,14 +55,6 @@ export type InnerWorldCanvasServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape for `InnerWorldCanvas`: branded IDs and timestamps
- * preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type InnerWorldCanvasResult = EncryptedWire<InnerWorldCanvasServerMetadata>;
 
-/**
- * JSON-serialized wire form of `InnerWorldCanvasResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type InnerWorldCanvasWire = Serialize<InnerWorldCanvasResult>;

--- a/packages/types/src/entities/innerworld-canvas.ts
+++ b/packages/types/src/entities/innerworld-canvas.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -23,6 +24,15 @@ export interface InnerWorldCanvas {
 export type InnerWorldCanvasEncryptedFields = "viewportX" | "viewportY" | "zoom" | "dimensions";
 
 /**
+ * Pre-encryption shape — what `encryptInnerWorldCanvasInput` accepts. Single source
+ * of truth: derived from `InnerWorldCanvas` via `Pick<>` over the encrypted-keys union.
+ */
+export type InnerWorldCanvasEncryptedInput = Pick<
+  InnerWorldCanvas,
+  InnerWorldCanvasEncryptedFields
+>;
+
+/**
  * Server-visible InnerWorldCanvas metadata — raw Drizzle row shape.
  *
  * Derived from `InnerWorldCanvas` by stripping the encrypted field keys
@@ -43,8 +53,13 @@ export type InnerWorldCanvasServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of an InnerWorldCanvas. Derived from the
- * domain `InnerWorldCanvas` type via `Serialize<T>`; branded IDs become
- * plain strings.
+ * Server-emit shape — what `toInnerWorldCanvasResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type InnerWorldCanvasWire = Serialize<InnerWorldCanvas>;
+export type InnerWorldCanvasResult = EncryptedWire<InnerWorldCanvasServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `InnerWorldCanvasResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type InnerWorldCanvasWire = Serialize<InnerWorldCanvasResult>;

--- a/packages/types/src/entities/innerworld-canvas.ts
+++ b/packages/types/src/entities/innerworld-canvas.ts
@@ -24,8 +24,9 @@ export interface InnerWorldCanvas {
 export type InnerWorldCanvasEncryptedFields = "viewportX" | "viewportY" | "zoom" | "dimensions";
 
 /**
- * Pre-encryption shape — what `encryptInnerWorldCanvasInput` accepts. Single source
- * of truth: derived from `InnerWorldCanvas` via `Pick<>` over the encrypted-keys union.
+ * Pre-encryption shape — the projection of `InnerWorldCanvas` over its
+ * encrypted-keys union. The transform layer (when added) will accept
+ * this shape and produce the encrypted wire body.
  */
 export type InnerWorldCanvasEncryptedInput = Pick<
   InnerWorldCanvas,
@@ -53,8 +54,8 @@ export type InnerWorldCanvasServerMetadata = Omit<
 };
 
 /**
- * Server-emit shape — what `toInnerWorldCanvasResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ * Server-emit shape for `InnerWorldCanvas`: branded IDs and timestamps
+ * preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type InnerWorldCanvasResult = EncryptedWire<InnerWorldCanvasServerMetadata>;
 

--- a/packages/types/src/entities/innerworld-entity.ts
+++ b/packages/types/src/entities/innerworld-entity.ts
@@ -86,10 +86,14 @@ export type InnerWorldEntityEncryptedFields =
   | "linkedMemberId"
   | "linkedStructureEntityId";
 
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// InnerWorldEntityEncryptedInput → InnerWorldEntityServerMetadata
+//                               → InnerWorldEntityResult → InnerWorldEntityWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 /**
- * Pre-encryption shape — what `encryptInnerWorldEntityInput` accepts. Single source
- * of truth: derived from `InnerWorldEntity` via distributive `Pick<>` over the
- * encrypted-keys union (each variant independently contributes its subset of keys).
  * Distributive `Pick`: result is a union of per-variant projections (one `Pick<...>`
  * per discriminated variant — `MemberEntity`, `LandmarkEntity`, `StructureEntityEntity`),
  * not a single intersected object type.
@@ -127,14 +131,6 @@ export type InnerWorldEntityServerMetadata = DistributiveOmit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toEntityResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type InnerWorldEntityResult = EncryptedWire<InnerWorldEntityServerMetadata>;
 
-/**
- * JSON-serialized wire form of `InnerWorldEntityResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type InnerWorldEntityWire = Serialize<InnerWorldEntityResult>;

--- a/packages/types/src/entities/innerworld-entity.ts
+++ b/packages/types/src/entities/innerworld-entity.ts
@@ -90,6 +90,9 @@ export type InnerWorldEntityEncryptedFields =
  * Pre-encryption shape — what `encryptInnerWorldEntityInput` accepts. Single source
  * of truth: derived from `InnerWorldEntity` via distributive `Pick<>` over the
  * encrypted-keys union (each variant independently contributes its subset of keys).
+ * Distributive `Pick`: result is a union of per-variant projections (one `Pick<...>`
+ * per discriminated variant — `MemberEntity`, `LandmarkEntity`, `StructureEntityEntity`),
+ * not a single intersected object type.
  */
 export type InnerWorldEntityEncryptedInput = InnerWorldEntity extends unknown
   ? Pick<InnerWorldEntity, InnerWorldEntityEncryptedFields & keyof InnerWorldEntity>
@@ -125,7 +128,7 @@ export type InnerWorldEntityServerMetadata = DistributiveOmit<
 };
 
 /**
- * Server-emit shape — what `toInnerWorldEntityResult` returns. Branded IDs and
+ * Server-emit shape — what `toEntityResult` returns. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type InnerWorldEntityResult = EncryptedWire<InnerWorldEntityServerMetadata>;

--- a/packages/types/src/entities/innerworld-entity.ts
+++ b/packages/types/src/entities/innerworld-entity.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   HexColor,
@@ -86,6 +87,15 @@ export type InnerWorldEntityEncryptedFields =
   | "linkedStructureEntityId";
 
 /**
+ * Pre-encryption shape — what `encryptInnerWorldEntityInput` accepts. Single source
+ * of truth: derived from `InnerWorldEntity` via distributive `Pick<>` over the
+ * encrypted-keys union (each variant independently contributes its subset of keys).
+ */
+export type InnerWorldEntityEncryptedInput = InnerWorldEntity extends unknown
+  ? Pick<InnerWorldEntity, InnerWorldEntityEncryptedFields & keyof InnerWorldEntity>
+  : never;
+
+/**
  * Distributes `Omit<T, K>` over a discriminated union so each variant
  * independently drops its own subset of `K`. The naïve `Omit<Union, K>`
  * would only strip keys present on every variant; this helper flattens
@@ -115,9 +125,13 @@ export type InnerWorldEntityServerMetadata = DistributiveOmit<
 };
 
 /**
- * JSON-wire representation of an InnerWorldEntity. Derived from the
- * domain `InnerWorldEntity` union via `Serialize<T>`; branded IDs become
- * plain strings, `UnixMillis` becomes `number`. The wire form preserves
- * the discriminated-union shape.
+ * Server-emit shape — what `toInnerWorldEntityResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type InnerWorldEntityWire = Serialize<InnerWorldEntity>;
+export type InnerWorldEntityResult = EncryptedWire<InnerWorldEntityServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `InnerWorldEntityResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type InnerWorldEntityWire = Serialize<InnerWorldEntityResult>;

--- a/packages/types/src/entities/innerworld-region.ts
+++ b/packages/types/src/entities/innerworld-region.ts
@@ -36,10 +36,13 @@ export type InnerWorldRegionEncryptedFields =
   | "accessType"
   | "gatekeeperMemberIds";
 
-/**
- * Pre-encryption shape — what `encryptInnerWorldRegionInput` accepts. Single source
- * of truth: derived from `InnerWorldRegion` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// InnerWorldRegionEncryptedInput → InnerWorldRegionServerMetadata
+//                               → InnerWorldRegionResult → InnerWorldRegionWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type InnerWorldRegionEncryptedInput = Pick<
   InnerWorldRegion,
   InnerWorldRegionEncryptedFields
@@ -65,14 +68,6 @@ export type InnerWorldRegionServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toRegionResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type InnerWorldRegionResult = EncryptedWire<InnerWorldRegionServerMetadata>;
 
-/**
- * JSON-serialized wire form of `InnerWorldRegionResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type InnerWorldRegionWire = Serialize<InnerWorldRegionResult>;

--- a/packages/types/src/entities/innerworld-region.ts
+++ b/packages/types/src/entities/innerworld-region.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { InnerWorldRegionId, MemberId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -35,6 +36,15 @@ export type InnerWorldRegionEncryptedFields =
   | "accessType"
   | "gatekeeperMemberIds";
 
+/**
+ * Pre-encryption shape — what `encryptInnerWorldRegionInput` accepts. Single source
+ * of truth: derived from `InnerWorldRegion` via `Pick<>` over the encrypted-keys union.
+ */
+export type InnerWorldRegionEncryptedInput = Pick<
+  InnerWorldRegion,
+  InnerWorldRegionEncryptedFields
+>;
+
 /** An archived innerworld region. */
 export type ArchivedInnerWorldRegion = Archived<InnerWorldRegion>;
 
@@ -56,8 +66,13 @@ export type InnerWorldRegionServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of an InnerWorldRegion. Derived from the domain
- * `InnerWorldRegion` type via `Serialize<T>`; branded IDs become plain
- * strings, `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toInnerWorldRegionResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type InnerWorldRegionWire = Serialize<InnerWorldRegion>;
+export type InnerWorldRegionResult = EncryptedWire<InnerWorldRegionServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `InnerWorldRegionResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type InnerWorldRegionWire = Serialize<InnerWorldRegionResult>;

--- a/packages/types/src/entities/innerworld-region.ts
+++ b/packages/types/src/entities/innerworld-region.ts
@@ -66,7 +66,7 @@ export type InnerWorldRegionServerMetadata = Omit<
 };
 
 /**
- * Server-emit shape — what `toInnerWorldRegionResult` returns. Branded IDs and
+ * Server-emit shape — what `toRegionResult` returns. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type InnerWorldRegionResult = EncryptedWire<InnerWorldRegionServerMetadata>;

--- a/packages/types/src/entities/journal-entry.ts
+++ b/packages/types/src/entities/journal-entry.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   BlobId,
@@ -159,6 +160,24 @@ export interface JournalEntry extends AuditMetadata {
 export type ArchivedJournalEntry = Archived<JournalEntry>;
 
 /**
+ * Keys of `JournalEntry` that are encrypted client-side before the server
+ * sees them. The server stores ciphertext in `encryptedData`; the only
+ * plaintext column (besides the audit triple and `systemId`/`id`) is
+ * `frontingSessionId`, kept in the clear as a FK for efficient joins.
+ * Consumed by:
+ * - `JournalEntryServerMetadata` (derived via `Omit`)
+ * - `JournalEntryEncryptedInput = Pick<JournalEntry, JournalEntryEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextJournalEntry parity)
+ */
+export type JournalEntryEncryptedFields =
+  | "title"
+  | "author"
+  | "blocks"
+  | "tags"
+  | "linkedEntities"
+  | "frontingSnapshots";
+
+/**
  * Server-visible JournalEntry metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the only plaintext column (besides the audit triple and
@@ -171,7 +190,7 @@ export type ArchivedJournalEntry = Archived<JournalEntry>;
  */
 export type JournalEntryServerMetadata = Omit<
   JournalEntry,
-  "author" | "title" | "blocks" | "tags" | "linkedEntities" | "frontingSnapshots" | "archived"
+  JournalEntryEncryptedFields | "archived"
 > & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
@@ -179,8 +198,20 @@ export type JournalEntryServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a JournalEntry. Derived from the domain
- * `JournalEntry` type via `Serialize<T>`; branded IDs become plain strings,
- * `UnixMillis` becomes `number`.
+ * Pre-encryption shape — what `encryptJournalEntryInput` accepts. Single
+ * source of truth: derived from `JournalEntry` via `Pick<>` over the
+ * encrypted-keys union.
  */
-export type JournalEntryWire = Serialize<JournalEntry>;
+export type JournalEntryEncryptedInput = Pick<JournalEntry, JournalEntryEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toJournalEntryResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type JournalEntryResult = EncryptedWire<JournalEntryServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `JournalEntryResult`: branded IDs become plain
+ * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type JournalEntryWire = Serialize<JournalEntryResult>;

--- a/packages/types/src/entities/journal-entry.ts
+++ b/packages/types/src/entities/journal-entry.ts
@@ -198,15 +198,15 @@ export type JournalEntryServerMetadata = Omit<
 };
 
 /**
- * Pre-encryption shape — what `encryptJournalEntryInput` accepts. Single
- * source of truth: derived from `JournalEntry` via `Pick<>` over the
- * encrypted-keys union.
+ * Pre-encryption shape — the projection of `JournalEntry` over its
+ * encrypted-keys union. The transform layer (when added) will accept
+ * this shape and produce the encrypted wire body.
  */
 export type JournalEntryEncryptedInput = Pick<JournalEntry, JournalEntryEncryptedFields>;
 
 /**
- * Server-emit shape — what `toJournalEntryResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ * Server-emit shape for `JournalEntry`: branded IDs and timestamps
+ * preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type JournalEntryResult = EncryptedWire<JournalEntryServerMetadata>;
 

--- a/packages/types/src/entities/journal-entry.ts
+++ b/packages/types/src/entities/journal-entry.ts
@@ -197,21 +197,15 @@ export type JournalEntryServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — the projection of `JournalEntry` over its
- * encrypted-keys union. The transform layer (when added) will accept
- * this shape and produce the encrypted wire body.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// JournalEntryEncryptedInput → JournalEntryServerMetadata
+//                           → JournalEntryResult → JournalEntryWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type JournalEntryEncryptedInput = Pick<JournalEntry, JournalEntryEncryptedFields>;
 
-/**
- * Server-emit shape for `JournalEntry`: branded IDs and timestamps
- * preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type JournalEntryResult = EncryptedWire<JournalEntryServerMetadata>;
 
-/**
- * JSON-serialized wire form of `JournalEntryResult`: branded IDs become plain
- * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type JournalEntryWire = Serialize<JournalEntryResult>;

--- a/packages/types/src/entities/lifecycle-event.ts
+++ b/packages/types/src/entities/lifecycle-event.ts
@@ -90,7 +90,9 @@ export interface StructureEntityFormationEvent extends LifecycleEventBase {
 export interface FormChangeEvent extends LifecycleEventBase {
   readonly eventType: "form-change";
   readonly memberId: MemberId;
+  /** Free-text user-supplied display label, not a branded identifier. See bean `types-yxgc` for branded-value-type follow-up. */
   readonly previousForm: string | null;
+  /** Free-text user-supplied display label, not a branded identifier. See bean `types-yxgc` for branded-value-type follow-up. */
   readonly newForm: string | null;
 }
 
@@ -98,7 +100,9 @@ export interface FormChangeEvent extends LifecycleEventBase {
 export interface NameChangeEvent extends LifecycleEventBase {
   readonly eventType: "name-change";
   readonly memberId: MemberId;
+  /** Free-text user-supplied display label, not a branded identifier. See bean `types-yxgc` for branded-value-type follow-up. */
   readonly previousName: string | null;
+  /** Free-text user-supplied display label, not a branded identifier. See bean `types-yxgc` for branded-value-type follow-up. */
   readonly newName: string;
 }
 
@@ -153,6 +157,7 @@ export type LifecycleEventEncryptedFields = "notes";
 /**
  * Pre-encryption shape — what `encryptLifecycleEventInput` accepts. Single source
  * of truth: derived from `LifecycleEvent` via `Pick<>` over the encrypted-keys union.
+ * Single-key projection over `"notes"` — not truncated.
  */
 export type LifecycleEventEncryptedInput = Pick<LifecycleEvent, LifecycleEventEncryptedFields>;
 

--- a/packages/types/src/entities/lifecycle-event.ts
+++ b/packages/types/src/entities/lifecycle-event.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   InnerWorldEntityId,
@@ -150,6 +151,12 @@ export type LifecycleEventType = LifecycleEvent["eventType"];
 export type LifecycleEventEncryptedFields = "notes";
 
 /**
+ * Pre-encryption shape — what `encryptLifecycleEventInput` accepts. Single source
+ * of truth: derived from `LifecycleEvent` via `Pick<>` over the encrypted-keys union.
+ */
+export type LifecycleEventEncryptedInput = Pick<LifecycleEvent, LifecycleEventEncryptedFields>;
+
+/**
  * Server-visible LifecycleEvent metadata — raw Drizzle row shape.
  *
  * Derived from the `LifecycleEvent` discriminated union by distributively
@@ -178,8 +185,13 @@ export type LifecycleEventServerMetadata = {
 };
 
 /**
- * JSON-wire representation of LifecycleEvent. Derived from the domain
- * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
+ * Server-emit shape — what `toLifecycleEventResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type LifecycleEventWire = Serialize<LifecycleEvent>;
+export type LifecycleEventResult = EncryptedWire<LifecycleEventServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `LifecycleEventResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type LifecycleEventWire = Serialize<LifecycleEventResult>;

--- a/packages/types/src/entities/lifecycle-event.ts
+++ b/packages/types/src/entities/lifecycle-event.ts
@@ -154,11 +154,14 @@ export type LifecycleEventType = LifecycleEvent["eventType"];
  */
 export type LifecycleEventEncryptedFields = "notes";
 
-/**
- * Pre-encryption shape — what `encryptLifecycleEventInput` accepts. Single source
- * of truth: derived from `LifecycleEvent` via `Pick<>` over the encrypted-keys union.
- * Single-key projection over `"notes"` — not truncated.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// LifecycleEventEncryptedInput → LifecycleEventServerMetadata
+//                             → LifecycleEventResult → LifecycleEventWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
+/** Single-key projection over `"notes"` — not truncated. */
 export type LifecycleEventEncryptedInput = Pick<LifecycleEvent, LifecycleEventEncryptedFields>;
 
 /**
@@ -189,14 +192,6 @@ export type LifecycleEventServerMetadata = {
   readonly archivedAt: UnixMillis | null;
 };
 
-/**
- * Server-emit shape — what `toLifecycleEventResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type LifecycleEventResult = EncryptedWire<LifecycleEventServerMetadata>;
 
-/**
- * JSON-serialized wire form of `LifecycleEventResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type LifecycleEventWire = Serialize<LifecycleEventResult>;

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -36,16 +36,6 @@ export type MemberPhotoEncryptedInput = Pick<MemberPhoto, MemberPhotoEncryptedFi
 export type ArchivedMemberPhoto = Archived<MemberPhoto>;
 
 /**
- * Request body for creating a member photo.
- *
- * @deprecated Use `z.infer<typeof CreateMemberPhotoBodySchema>`.
- */
-export interface CreateMemberPhotoBody {
-  readonly encryptedData: string;
-  readonly sortOrder?: number;
-}
-
-/**
  * Server-visible MemberPhoto metadata — raw Drizzle row shape.
  *
  * Derived from `MemberPhoto` by stripping the encrypted field keys bundled

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -26,8 +26,9 @@ export interface MemberPhoto {
 export type MemberPhotoEncryptedFields = "imageSource" | "sortOrder" | "caption";
 
 /**
- * Pre-encryption shape — what `encryptMemberPhotoInput` accepts. Single source
- * of truth: derived from `MemberPhoto` via `Pick<>` over the encrypted-keys union.
+ * Pre-encryption shape — the projection of `MemberPhoto` over its
+ * encrypted-keys union. The transform layer (when added) will accept
+ * this shape and produce the encrypted wire body.
  */
 export type MemberPhotoEncryptedInput = Pick<MemberPhoto, MemberPhotoEncryptedFields>;
 
@@ -66,7 +67,7 @@ export type MemberPhotoServerMetadata = Omit<MemberPhoto, MemberPhotoEncryptedFi
   };
 
 /**
- * Server-emit shape — what `toMemberPhotoResult` returns. Branded IDs and
+ * Server-emit shape — what `toPhotoResult` returns. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type MemberPhotoResult = EncryptedWire<MemberPhotoServerMetadata>;

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { MemberId, MemberPhotoId, SystemId } from "../ids.js";
 import type { ImageSource } from "../image-source.js";
@@ -24,14 +25,14 @@ export interface MemberPhoto {
  */
 export type MemberPhotoEncryptedFields = "imageSource" | "sortOrder" | "caption";
 
+/**
+ * Pre-encryption shape — what `encryptMemberPhotoInput` accepts. Single source
+ * of truth: derived from `MemberPhoto` via `Pick<>` over the encrypted-keys union.
+ */
+export type MemberPhotoEncryptedInput = Pick<MemberPhoto, MemberPhotoEncryptedFields>;
+
 /** An archived member photo — preserves all data with archive metadata. */
 export type ArchivedMemberPhoto = Archived<MemberPhoto>;
-
-/** Request body for creating a member photo. */
-export interface CreateMemberPhotoBody {
-  readonly encryptedData: string;
-  readonly sortOrder?: number;
-}
 
 /**
  * Server-visible MemberPhoto metadata — raw Drizzle row shape.
@@ -55,7 +56,13 @@ export type MemberPhotoServerMetadata = Omit<MemberPhoto, MemberPhotoEncryptedFi
   };
 
 /**
- * JSON-wire representation of a MemberPhoto. Derived from the domain
- * `MemberPhoto` type via `Serialize<T>`; branded IDs become plain strings.
+ * Server-emit shape — what `toMemberPhotoResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type MemberPhotoWire = Serialize<MemberPhoto>;
+export type MemberPhotoResult = EncryptedWire<MemberPhotoServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `MemberPhotoResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type MemberPhotoWire = Serialize<MemberPhotoResult>;

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -25,11 +25,13 @@ export interface MemberPhoto {
  */
 export type MemberPhotoEncryptedFields = "imageSource" | "sortOrder" | "caption";
 
-/**
- * Pre-encryption shape — the projection of `MemberPhoto` over its
- * encrypted-keys union. The transform layer (when added) will accept
- * this shape and produce the encrypted wire body.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// MemberPhotoEncryptedInput → MemberPhotoServerMetadata
+//                          → MemberPhotoResult → MemberPhotoWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type MemberPhotoEncryptedInput = Pick<MemberPhoto, MemberPhotoEncryptedFields>;
 
 /** An archived member photo — preserves all data with archive metadata. */
@@ -56,14 +58,6 @@ export type MemberPhotoServerMetadata = Omit<MemberPhoto, MemberPhotoEncryptedFi
     readonly archivedAt: UnixMillis | null;
   };
 
-/**
- * Server-emit shape — what `toPhotoResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type MemberPhotoResult = EncryptedWire<MemberPhotoServerMetadata>;
 
-/**
- * JSON-serialized wire form of `MemberPhotoResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type MemberPhotoWire = Serialize<MemberPhotoResult>;

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -35,6 +35,16 @@ export type MemberPhotoEncryptedInput = Pick<MemberPhoto, MemberPhotoEncryptedFi
 export type ArchivedMemberPhoto = Archived<MemberPhoto>;
 
 /**
+ * Request body for creating a member photo.
+ *
+ * @deprecated Use `z.infer<typeof CreateMemberPhotoBodySchema>`.
+ */
+export interface CreateMemberPhotoBody {
+  readonly encryptedData: string;
+  readonly sortOrder?: number;
+}
+
+/**
  * Server-visible MemberPhoto metadata — raw Drizzle row shape.
  *
  * Derived from `MemberPhoto` by stripping the encrypted field keys bundled

--- a/packages/types/src/entities/message.ts
+++ b/packages/types/src/entities/message.ts
@@ -53,13 +53,13 @@ export type ChatMessageServerMetadata = Omit<
 };
 
 /**
- * Pre-encryption shape — what `encryptChatMessageInput` accepts. Single source
+ * Pre-encryption shape — what `encryptMessageInput` accepts. Single source
  * of truth: derived from `ChatMessage` via `Pick<>` over the encrypted-keys union.
  */
 export type ChatMessageEncryptedInput = Pick<ChatMessage, ChatMessageEncryptedFields>;
 
 /**
- * Server-emit shape — what `toChatMessageResult` returns. Branded IDs and
+ * Server-emit shape — what `toMessageResult` returns. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type ChatMessageResult = EncryptedWire<ChatMessageServerMetadata>;

--- a/packages/types/src/entities/message.ts
+++ b/packages/types/src/entities/message.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { BlobId, ChannelId, MemberId, MessageId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -23,6 +24,17 @@ export interface ChatMessage extends AuditMetadata {
 export type ArchivedChatMessage = Archived<ChatMessage>;
 
 /**
+ * Keys of `ChatMessage` that are encrypted client-side before the server sees
+ * them. The server stores ciphertext in `encryptedData`; the plaintext columns
+ * are `channelId`, `replyToId`, `timestamp`, and `editedAt`.
+ * Consumed by:
+ * - `ChatMessageServerMetadata` (derived via `Omit`)
+ * - `ChatMessageEncryptedInput = Pick<ChatMessage, ChatMessageEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextChatMessage parity)
+ */
+export type ChatMessageEncryptedFields = "content" | "senderId" | "attachments" | "mentions";
+
+/**
  * Server-visible ChatMessage metadata — raw Drizzle row shape.
  *
  * Hybrid entity: plaintext columns (`channelId`, `replyToId`, `timestamp`,
@@ -33,7 +45,7 @@ export type ArchivedChatMessage = Archived<ChatMessage>;
  */
 export type ChatMessageServerMetadata = Omit<
   ChatMessage,
-  "senderId" | "content" | "attachments" | "mentions" | "archived"
+  ChatMessageEncryptedFields | "archived"
 > & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
@@ -41,8 +53,19 @@ export type ChatMessageServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a ChatMessage. Derived from the domain
- * `ChatMessage` type via `Serialize<T>`; branded IDs become plain strings,
- * `UnixMillis` becomes `number`.
+ * Pre-encryption shape — what `encryptChatMessageInput` accepts. Single source
+ * of truth: derived from `ChatMessage` via `Pick<>` over the encrypted-keys union.
  */
-export type ChatMessageWire = Serialize<ChatMessage>;
+export type ChatMessageEncryptedInput = Pick<ChatMessage, ChatMessageEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toChatMessageResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type ChatMessageResult = EncryptedWire<ChatMessageServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `ChatMessageResult`: branded IDs become plain
+ * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type ChatMessageWire = Serialize<ChatMessageResult>;

--- a/packages/types/src/entities/message.ts
+++ b/packages/types/src/entities/message.ts
@@ -52,20 +52,15 @@ export type ChatMessageServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptMessageInput` accepts. Single source
- * of truth: derived from `ChatMessage` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// ChatMessageEncryptedInput → ChatMessageServerMetadata
+//                          → ChatMessageResult → ChatMessageWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type ChatMessageEncryptedInput = Pick<ChatMessage, ChatMessageEncryptedFields>;
 
-/**
- * Server-emit shape — what `toMessageResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type ChatMessageResult = EncryptedWire<ChatMessageServerMetadata>;
 
-/**
- * JSON-serialized wire form of `ChatMessageResult`: branded IDs become plain
- * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type ChatMessageWire = Serialize<ChatMessageResult>;

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -37,6 +37,9 @@ export type ArchivedNote = Archived<Note>;
  * - `NoteServerMetadata` (derived via `Omit`)
  * - `NoteEncryptedInput = Pick<Note, NoteEncryptedFields>`
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextNote parity)
+ *
+ * Unlike `JournalEntry`, `Note`'s `author` is a server-side flattened plaintext column
+ * (split into `authorEntityType` + `authorEntityId`), not part of the encrypted blob.
  */
 export type NoteEncryptedFields = "title" | "content" | "backgroundColor";
 

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { AnyBrandedId, HexColor, NoteId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -28,6 +29,18 @@ export interface Note extends AuditMetadata {
 export type ArchivedNote = Archived<Note>;
 
 /**
+ * Keys of `Note` that are encrypted client-side before the server sees them.
+ * The server stores ciphertext in `encryptedData`; the `author` reference is
+ * flattened into plaintext columns (`authorEntityType` + `authorEntityId`) for
+ * indexing by author type.
+ * Consumed by:
+ * - `NoteServerMetadata` (derived via `Omit`)
+ * - `NoteEncryptedInput = Pick<Note, NoteEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextNote parity)
+ */
+export type NoteEncryptedFields = "title" | "content" | "backgroundColor";
+
+/**
  * Server-visible Note metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the polymorphic `author` reference is flattened on the DB
@@ -39,10 +52,7 @@ export type ArchivedNote = Archived<Note>;
  * carries `string` at the type level. `archived: false` on the domain flips
  * to a mutable boolean here, with a companion `archivedAt` timestamp.
  */
-export type NoteServerMetadata = Omit<
-  Note,
-  "author" | "title" | "content" | "backgroundColor" | "archived"
-> & {
+export type NoteServerMetadata = Omit<Note, NoteEncryptedFields | "author" | "archived"> & {
   readonly authorEntityType: NoteAuthorEntityType | null;
   readonly authorEntityId: AnyBrandedId | null;
   readonly archived: boolean;
@@ -51,8 +61,19 @@ export type NoteServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a Note. Derived from the domain `Note` type
- * via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
+ * Pre-encryption shape — what `encryptNoteInput` accepts. Single source of
+ * truth: derived from `Note` via `Pick<>` over the encrypted-keys union.
  */
-export type NoteWire = Serialize<Note>;
+export type NoteEncryptedInput = Pick<Note, NoteEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toNoteResult` returns. Branded IDs and timestamps
+ * preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type NoteResult = EncryptedWire<NoteServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `NoteResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type NoteWire = Serialize<NoteResult>;

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -77,20 +77,15 @@ export type NoteServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptNoteInput` accepts. Single source of
- * truth: derived from `Note` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// NoteEncryptedInput → NoteServerMetadata
+//                   → NoteResult → NoteWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type NoteEncryptedInput = Pick<Note, NoteEncryptedFields>;
 
-/**
- * Server-emit shape — what `toNoteResult` returns. Branded IDs and timestamps
- * preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type NoteResult = EncryptedWire<NoteServerMetadata>;
 
-/**
- * JSON-serialized wire form of `NoteResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type NoteWire = Serialize<NoteResult>;

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -44,6 +44,17 @@ export type ArchivedNote = Archived<Note>;
 export type NoteEncryptedFields = "title" | "content" | "backgroundColor";
 
 /**
+ * Domain field that is plaintext (not encrypted) but restructured on the
+ * server row into multiple flat columns. `author` is a polymorphic
+ * `EntityReference<...>` on the domain — on the server row it is split
+ * into `authorEntityType` + `authorEntityId` for indexing.
+ *
+ * Distinguished from `NoteEncryptedFields` (which lists keys whose values
+ * ride inside the encryptedData blob).
+ */
+export type NoteRestructuredPlaintextFields = "author";
+
+/**
  * Server-visible Note metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the polymorphic `author` reference is flattened on the DB
@@ -55,7 +66,10 @@ export type NoteEncryptedFields = "title" | "content" | "backgroundColor";
  * carries `string` at the type level. `archived: false` on the domain flips
  * to a mutable boolean here, with a companion `archivedAt` timestamp.
  */
-export type NoteServerMetadata = Omit<Note, NoteEncryptedFields | "author" | "archived"> & {
+export type NoteServerMetadata = Omit<
+  Note,
+  NoteEncryptedFields | NoteRestructuredPlaintextFields | "archived"
+> & {
   readonly authorEntityType: NoteAuthorEntityType | null;
   readonly authorEntityId: AnyBrandedId | null;
   readonly archived: boolean;

--- a/packages/types/src/entities/poll-vote.ts
+++ b/packages/types/src/entities/poll-vote.ts
@@ -32,6 +32,17 @@ export type ArchivedPollVote = Archived<PollVote>;
 export type PollVoteEncryptedFields = "comment";
 
 /**
+ * Domain field that is plaintext (not encrypted) but restructured on the
+ * server row into multiple flat columns. `voter` is a polymorphic
+ * `EntityReference<...>` on the domain — on the server row it is split
+ * into `voterEntityType` + `voterEntityId`.
+ *
+ * Distinguished from `PollVoteEncryptedFields` (which lists keys whose
+ * values ride inside the encryptedData blob).
+ */
+export type PollVoteRestructuredPlaintextFields = "voter";
+
+/**
  * Server-visible PollVote metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the polymorphic `voter` reference is stored as jsonb on the
@@ -46,7 +57,7 @@ export type PollVoteEncryptedFields = "comment";
  */
 export type PollVoteServerMetadata = Omit<
   PollVote,
-  PollVoteEncryptedFields | "voter" | "archived"
+  PollVoteEncryptedFields | PollVoteRestructuredPlaintextFields | "archived"
 > & {
   readonly systemId: SystemId;
   readonly voter: EntityReference<"member" | "structure-entity"> | null;

--- a/packages/types/src/entities/poll-vote.ts
+++ b/packages/types/src/entities/poll-vote.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { PollId, PollOptionId, PollVoteId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -20,6 +21,17 @@ export interface PollVote {
 export type ArchivedPollVote = Archived<PollVote>;
 
 /**
+ * Keys of `PollVote` that are encrypted client-side before the server sees
+ * them. The server stores ciphertext in `encryptedData`; the `voter` reference
+ * is stored as jsonb in the clear for efficient queries.
+ * Consumed by:
+ * - `PollVoteServerMetadata` (derived via `Omit`)
+ * - `PollVoteEncryptedInput = Pick<PollVote, PollVoteEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextPollVote parity)
+ */
+export type PollVoteEncryptedFields = "comment";
+
+/**
  * Server-visible PollVote metadata — raw Drizzle row shape.
  *
  * Hybrid entity: the polymorphic `voter` reference is stored as jsonb on the
@@ -32,7 +44,10 @@ export type ArchivedPollVote = Archived<PollVote>;
  * owning `systemId` FK (denormalized for partition-safe cascades) and the
  * full `AuditMetadata` triple, neither of which appears on the domain.
  */
-export type PollVoteServerMetadata = Omit<PollVote, "comment" | "voter" | "archived"> & {
+export type PollVoteServerMetadata = Omit<
+  PollVote,
+  PollVoteEncryptedFields | "voter" | "archived"
+> & {
   readonly systemId: SystemId;
   readonly voter: EntityReference<"member" | "structure-entity"> | null;
   readonly createdAt: UnixMillis;
@@ -44,8 +59,19 @@ export type PollVoteServerMetadata = Omit<PollVote, "comment" | "voter" | "archi
 };
 
 /**
- * JSON-wire representation of a PollVote. Derived from the domain
- * `PollVote` type via `Serialize<T>`; branded IDs become plain strings,
- * `UnixMillis` becomes `number`.
+ * Pre-encryption shape — what `encryptPollVoteInput` accepts. Single source of
+ * truth: derived from `PollVote` via `Pick<>` over the encrypted-keys union.
  */
-export type PollVoteWire = Serialize<PollVote>;
+export type PollVoteEncryptedInput = Pick<PollVote, PollVoteEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toPollVoteResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type PollVoteResult = EncryptedWire<PollVoteServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `PollVoteResult`: branded IDs become plain
+ * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type PollVoteWire = Serialize<PollVoteResult>;

--- a/packages/types/src/entities/poll-vote.ts
+++ b/packages/types/src/entities/poll-vote.ts
@@ -32,10 +32,13 @@ export type ArchivedPollVote = Archived<PollVote>;
 export type PollVoteEncryptedFields = "comment";
 
 /**
- * Domain field that is plaintext (not encrypted) but restructured on the
- * server row into multiple flat columns. `voter` is a polymorphic
- * `EntityReference<...>` on the domain — on the server row it is split
- * into `voterEntityType` + `voterEntityId`.
+ * Domain field that is plaintext on the server row but stored with a
+ * different shape than the domain implies. `voter` is a non-nullable
+ * `EntityReference<"member" | "structure-entity">` on the domain (every
+ * poll vote has a voter); on the server row the column is nullable in
+ * Drizzle's inferred type because a DB-level CHECK constraint enforces
+ * non-null without surfacing it through the column type. Same shape, just
+ * nullability flip (cf. `AcknowledgementRequestRestructuredPlaintextFields`).
  *
  * Distinguished from `PollVoteEncryptedFields` (which lists keys whose
  * values ride inside the encryptedData blob).

--- a/packages/types/src/entities/poll-vote.ts
+++ b/packages/types/src/entities/poll-vote.ts
@@ -69,20 +69,15 @@ export type PollVoteServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptPollVoteInput` accepts. Single source of
- * truth: derived from `PollVote` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// PollVoteEncryptedInput → PollVoteServerMetadata
+//                       → PollVoteResult → PollVoteWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type PollVoteEncryptedInput = Pick<PollVote, PollVoteEncryptedFields>;
 
-/**
- * Server-emit shape — what `toPollVoteResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type PollVoteResult = EncryptedWire<PollVoteServerMetadata>;
 
-/**
- * JSON-serialized wire form of `PollVoteResult`: branded IDs become plain
- * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type PollVoteWire = Serialize<PollVoteResult>;

--- a/packages/types/src/entities/poll.ts
+++ b/packages/types/src/entities/poll.ts
@@ -78,20 +78,15 @@ export type PollServerMetadata = Omit<Poll, PollEncryptedFields | "archived"> & 
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptPollInput` accepts. Single source of
- * truth: derived from `Poll` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// PollEncryptedInput → PollServerMetadata
+//                   → PollResult → PollWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type PollEncryptedInput = Pick<Poll, PollEncryptedFields>;
 
-/**
- * Server-emit shape — what `toPollResult` returns. Branded IDs and timestamps
- * preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type PollResult = EncryptedWire<PollServerMetadata>;
 
-/**
- * JSON-serialized wire form of `PollResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type PollWire = Serialize<PollResult>;

--- a/packages/types/src/entities/poll.ts
+++ b/packages/types/src/entities/poll.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { HexColor, MemberId, PollId, PollOptionId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -51,6 +52,18 @@ export interface Poll extends AuditMetadata {
 export type ArchivedPoll = Archived<Poll>;
 
 /**
+ * Keys of `Poll` that are encrypted client-side before the server sees them.
+ * The server stores ciphertext in `encryptedData`; the plaintext columns are
+ * scheduling and status flags plus `createdByMemberId` (FK for referential
+ * integrity).
+ * Consumed by:
+ * - `PollServerMetadata` (derived via `Omit`)
+ * - `PollEncryptedInput = Pick<Poll, PollEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextPoll parity)
+ */
+export type PollEncryptedFields = "title" | "description" | "options";
+
+/**
  * Server-visible Poll metadata — raw Drizzle row shape.
  *
  * Hybrid entity: plaintext columns for scheduling and status flags alongside
@@ -59,15 +72,26 @@ export type ArchivedPoll = Archived<Poll>;
  * FK for referential integrity. `archived: false` on the domain flips to a
  * mutable boolean here, with a companion `archivedAt` timestamp.
  */
-export type PollServerMetadata = Omit<Poll, "title" | "description" | "options" | "archived"> & {
+export type PollServerMetadata = Omit<Poll, PollEncryptedFields | "archived"> & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
   readonly encryptedData: EncryptedBlob;
 };
 
 /**
- * JSON-wire representation of a Poll. Derived from the domain `Poll` type
- * via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
+ * Pre-encryption shape — what `encryptPollInput` accepts. Single source of
+ * truth: derived from `Poll` via `Pick<>` over the encrypted-keys union.
  */
-export type PollWire = Serialize<Poll>;
+export type PollEncryptedInput = Pick<Poll, PollEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toPollResult` returns. Branded IDs and timestamps
+ * preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type PollResult = EncryptedWire<PollServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `PollResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type PollWire = Serialize<PollResult>;

--- a/packages/types/src/entities/relationship.ts
+++ b/packages/types/src/entities/relationship.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { MemberId, RelationshipId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -41,6 +42,12 @@ export interface Relationship {
  */
 export type RelationshipEncryptedFields = "label";
 
+/**
+ * Pre-encryption shape — what `encryptRelationshipInput` accepts. Single source
+ * of truth: derived from `Relationship` via `Pick<>` over the encrypted-keys union.
+ */
+export type RelationshipEncryptedInput = Pick<Relationship, RelationshipEncryptedFields>;
+
 export type ArchivedRelationship = Archived<Relationship>;
 
 /**
@@ -66,7 +73,13 @@ export type RelationshipServerMetadata = Omit<
   };
 
 /**
- * JSON-wire representation of a Relationship. Derived from the domain
- * `Relationship` type via `Serialize<T>`; branded IDs become plain strings.
+ * Server-emit shape — what `toRelationshipResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type RelationshipWire = Serialize<Relationship>;
+export type RelationshipResult = EncryptedWire<RelationshipServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `RelationshipResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type RelationshipWire = Serialize<RelationshipResult>;

--- a/packages/types/src/entities/relationship.ts
+++ b/packages/types/src/entities/relationship.ts
@@ -45,6 +45,7 @@ export type RelationshipEncryptedFields = "label";
 /**
  * Pre-encryption shape — what `encryptRelationshipInput` accepts. Single source
  * of truth: derived from `Relationship` via `Pick<>` over the encrypted-keys union.
+ * Single-key projection over `"label"` — not truncated.
  */
 export type RelationshipEncryptedInput = Pick<Relationship, RelationshipEncryptedFields>;
 

--- a/packages/types/src/entities/relationship.ts
+++ b/packages/types/src/entities/relationship.ts
@@ -42,11 +42,14 @@ export interface Relationship {
  */
 export type RelationshipEncryptedFields = "label";
 
-/**
- * Pre-encryption shape — what `encryptRelationshipInput` accepts. Single source
- * of truth: derived from `Relationship` via `Pick<>` over the encrypted-keys union.
- * Single-key projection over `"label"` — not truncated.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// RelationshipEncryptedInput → RelationshipServerMetadata
+//                           → RelationshipResult → RelationshipWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
+/** Single-key projection over `"label"` — not truncated. */
 export type RelationshipEncryptedInput = Pick<Relationship, RelationshipEncryptedFields>;
 
 export type ArchivedRelationship = Archived<Relationship>;
@@ -73,14 +76,6 @@ export type RelationshipServerMetadata = Omit<
     readonly archivedAt: UnixMillis | null;
   };
 
-/**
- * Server-emit shape — what `toRelationshipResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type RelationshipResult = EncryptedWire<RelationshipServerMetadata>;
 
-/**
- * JSON-serialized wire form of `RelationshipResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type RelationshipWire = Serialize<RelationshipResult>;

--- a/packages/types/src/entities/structure-entity-type.ts
+++ b/packages/types/src/entities/structure-entity-type.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { SystemId, SystemStructureEntityTypeId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -44,6 +45,15 @@ export type SystemStructureEntityTypeEncryptedFields =
   | "imageSource"
   | "emoji";
 
+/**
+ * Pre-encryption shape — what `encryptSystemStructureEntityTypeInput` accepts. Single source
+ * of truth: derived from `SystemStructureEntityType` via `Pick<>` over the encrypted-keys union.
+ */
+export type SystemStructureEntityTypeEncryptedInput = Pick<
+  SystemStructureEntityType,
+  SystemStructureEntityTypeEncryptedFields
+>;
+
 export type ArchivedSystemStructureEntityType = Archived<SystemStructureEntityType>;
 
 /**
@@ -65,8 +75,14 @@ export type SystemStructureEntityTypeServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of SystemStructureEntityType. Derived from the
- * domain `SystemStructureEntityType` type via `Serialize<T>`; branded IDs
- * become plain strings, `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toSystemStructureEntityTypeResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type SystemStructureEntityTypeWire = Serialize<SystemStructureEntityType>;
+export type SystemStructureEntityTypeResult =
+  EncryptedWire<SystemStructureEntityTypeServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `SystemStructureEntityTypeResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type SystemStructureEntityTypeWire = Serialize<SystemStructureEntityTypeResult>;

--- a/packages/types/src/entities/structure-entity-type.ts
+++ b/packages/types/src/entities/structure-entity-type.ts
@@ -46,7 +46,7 @@ export type SystemStructureEntityTypeEncryptedFields =
   | "emoji";
 
 /**
- * Pre-encryption shape — what `encryptSystemStructureEntityTypeInput` accepts. Single source
+ * Pre-encryption shape — what `encryptStructureEntityTypeInput` accepts. Single source
  * of truth: derived from `SystemStructureEntityType` via `Pick<>` over the encrypted-keys union.
  */
 export type SystemStructureEntityTypeEncryptedInput = Pick<
@@ -75,7 +75,7 @@ export type SystemStructureEntityTypeServerMetadata = Omit<
 };
 
 /**
- * Server-emit shape — what `toSystemStructureEntityTypeResult` returns. Branded IDs and
+ * Server-emit shape — what `toEntityTypeResult` returns. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type SystemStructureEntityTypeResult =

--- a/packages/types/src/entities/structure-entity-type.ts
+++ b/packages/types/src/entities/structure-entity-type.ts
@@ -45,10 +45,13 @@ export type SystemStructureEntityTypeEncryptedFields =
   | "imageSource"
   | "emoji";
 
-/**
- * Pre-encryption shape — what `encryptStructureEntityTypeInput` accepts. Single source
- * of truth: derived from `SystemStructureEntityType` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// SystemStructureEntityTypeEncryptedInput → SystemStructureEntityTypeServerMetadata
+//                                        → SystemStructureEntityTypeResult → SystemStructureEntityTypeWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type SystemStructureEntityTypeEncryptedInput = Pick<
   SystemStructureEntityType,
   SystemStructureEntityTypeEncryptedFields
@@ -74,15 +77,7 @@ export type SystemStructureEntityTypeServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toEntityTypeResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type SystemStructureEntityTypeResult =
   EncryptedWire<SystemStructureEntityTypeServerMetadata>;
 
-/**
- * JSON-serialized wire form of `SystemStructureEntityTypeResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type SystemStructureEntityTypeWire = Serialize<SystemStructureEntityTypeResult>;

--- a/packages/types/src/entities/structure-entity.ts
+++ b/packages/types/src/entities/structure-entity.ts
@@ -65,7 +65,7 @@ export type SystemStructureEntityEncryptedFields =
   | "emoji";
 
 /**
- * Pre-encryption shape — what `encryptSystemStructureEntityInput` accepts. Single source
+ * Pre-encryption shape — what `encryptStructureEntityInput` accepts. Single source
  * of truth: derived from `SystemStructureEntity` via `Pick<>` over the encrypted-keys union.
  */
 export type SystemStructureEntityEncryptedInput = Pick<
@@ -94,7 +94,7 @@ export type SystemStructureEntityServerMetadata = Omit<
 };
 
 /**
- * Server-emit shape — what `toSystemStructureEntityResult` returns. Branded IDs and
+ * Server-emit shape — what `toStructureEntityResult` returns. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type SystemStructureEntityResult = EncryptedWire<SystemStructureEntityServerMetadata>;

--- a/packages/types/src/entities/structure-entity.ts
+++ b/packages/types/src/entities/structure-entity.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type {
   HexColor,
@@ -63,6 +64,15 @@ export type SystemStructureEntityEncryptedFields =
   | "imageSource"
   | "emoji";
 
+/**
+ * Pre-encryption shape — what `encryptSystemStructureEntityInput` accepts. Single source
+ * of truth: derived from `SystemStructureEntity` via `Pick<>` over the encrypted-keys union.
+ */
+export type SystemStructureEntityEncryptedInput = Pick<
+  SystemStructureEntity,
+  SystemStructureEntityEncryptedFields
+>;
+
 export type ArchivedSystemStructureEntity = Archived<SystemStructureEntity>;
 
 /**
@@ -84,8 +94,13 @@ export type SystemStructureEntityServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of SystemStructureEntity. Derived from the
- * domain `SystemStructureEntity` type via `Serialize<T>`; branded IDs
- * become plain strings, `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toSystemStructureEntityResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type SystemStructureEntityWire = Serialize<SystemStructureEntity>;
+export type SystemStructureEntityResult = EncryptedWire<SystemStructureEntityServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `SystemStructureEntityResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type SystemStructureEntityWire = Serialize<SystemStructureEntityResult>;

--- a/packages/types/src/entities/structure-entity.ts
+++ b/packages/types/src/entities/structure-entity.ts
@@ -64,10 +64,13 @@ export type SystemStructureEntityEncryptedFields =
   | "imageSource"
   | "emoji";
 
-/**
- * Pre-encryption shape — what `encryptStructureEntityInput` accepts. Single source
- * of truth: derived from `SystemStructureEntity` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// SystemStructureEntityEncryptedInput → SystemStructureEntityServerMetadata
+//                                    → SystemStructureEntityResult → SystemStructureEntityWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type SystemStructureEntityEncryptedInput = Pick<
   SystemStructureEntity,
   SystemStructureEntityEncryptedFields
@@ -93,14 +96,6 @@ export type SystemStructureEntityServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — what `toStructureEntityResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type SystemStructureEntityResult = EncryptedWire<SystemStructureEntityServerMetadata>;
 
-/**
- * JSON-serialized wire form of `SystemStructureEntityResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type SystemStructureEntityWire = Serialize<SystemStructureEntityResult>;

--- a/packages/types/src/entities/system-settings.ts
+++ b/packages/types/src/entities/system-settings.ts
@@ -97,8 +97,9 @@ export type SystemSettingsEncryptedFields =
   | "onboardingComplete";
 
 /**
- * Pre-encryption shape — what `encryptSystemSettingsInput` accepts. Single source
- * of truth: derived from `SystemSettings` via `Pick<>` over the encrypted-keys union.
+ * Pre-encryption shape — the projection of `SystemSettings` over its
+ * encrypted-keys union. The transform layer (when added) will accept
+ * this shape and produce the encrypted wire body.
  */
 export type SystemSettingsEncryptedInput = Pick<SystemSettings, SystemSettingsEncryptedFields>;
 
@@ -123,7 +124,8 @@ export type SystemSettingsServerMetadata = Omit<
 };
 
 /**
- * Server-emit shape — what `toSystemSettingsResult` returns. Branded IDs and
+ * Server-emit shape — server's view of `SystemSettings` after applying
+ * `EncryptedWire<T>` to `SystemSettingsServerMetadata`. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type SystemSettingsResult = EncryptedWire<SystemSettingsServerMetadata>;

--- a/packages/types/src/entities/system-settings.ts
+++ b/packages/types/src/entities/system-settings.ts
@@ -96,11 +96,13 @@ export type SystemSettingsEncryptedFields =
   | "snapshotSchedule"
   | "onboardingComplete";
 
-/**
- * Pre-encryption shape — the projection of `SystemSettings` over its
- * encrypted-keys union. The transform layer (when added) will accept
- * this shape and produce the encrypted wire body.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// SystemSettingsEncryptedInput → SystemSettingsServerMetadata
+//                             → SystemSettingsResult → SystemSettingsWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type SystemSettingsEncryptedInput = Pick<SystemSettings, SystemSettingsEncryptedFields>;
 
 /**
@@ -123,15 +125,6 @@ export type SystemSettingsServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Server-emit shape — server's view of `SystemSettings` after applying
- * `EncryptedWire<T>` to `SystemSettingsServerMetadata`. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type SystemSettingsResult = EncryptedWire<SystemSettingsServerMetadata>;
 
-/**
- * JSON-serialized wire form of `SystemSettingsResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type SystemSettingsWire = Serialize<SystemSettingsResult>;

--- a/packages/types/src/entities/system-settings.ts
+++ b/packages/types/src/entities/system-settings.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { Locale } from "../i18n.js";
 import type { BucketId, SystemSettingsId, SystemId } from "../ids.js";
@@ -96,6 +97,12 @@ export type SystemSettingsEncryptedFields =
   | "onboardingComplete";
 
 /**
+ * Pre-encryption shape — what `encryptSystemSettingsInput` accepts. Single source
+ * of truth: derived from `SystemSettings` via `Pick<>` over the encrypted-keys union.
+ */
+export type SystemSettingsEncryptedInput = Pick<SystemSettings, SystemSettingsEncryptedFields>;
+
+/**
  * Server-visible SystemSettings metadata — raw Drizzle row shape.
  *
  * Derived from `SystemSettings` by stripping the encrypted field keys
@@ -116,8 +123,13 @@ export type SystemSettingsServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of SystemSettings. Derived from the domain
- * `SystemSettings` type via `Serialize<T>`; branded IDs become plain
- * strings, `UnixMillis` becomes `number`.
+ * Server-emit shape — what `toSystemSettingsResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type SystemSettingsWire = Serialize<SystemSettings>;
+export type SystemSettingsResult = EncryptedWire<SystemSettingsServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `SystemSettingsResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type SystemSettingsWire = Serialize<SystemSettingsResult>;

--- a/packages/types/src/entities/system.ts
+++ b/packages/types/src/entities/system.ts
@@ -57,7 +57,7 @@ export type SystemServerMetadata = Omit<System, SystemEncryptedFields | "setting
 };
 
 /**
- * Server-emit shape — what `toSystemResult` returns. Branded IDs and
+ * Server-emit shape — what `toSystemProfileResult` returns. Branded IDs and
  * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type SystemResult = EncryptedWire<SystemServerMetadata>;

--- a/packages/types/src/entities/system.ts
+++ b/packages/types/src/entities/system.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { AccountId, SystemId, SystemSettingsId } from "../ids.js";
 import type { ImageSource } from "../image-source.js";
@@ -23,6 +24,12 @@ export interface System extends AuditMetadata {
  * - `SystemServerMetadata` (derived via `Omit`)
  */
 export type SystemEncryptedFields = "name" | "displayName" | "description" | "avatarSource";
+
+/**
+ * Pre-encryption shape — what `encryptSystemInput` accepts. Single source
+ * of truth: derived from `System` via `Pick<>` over the encrypted-keys union.
+ */
+export type SystemEncryptedInput = Pick<System, SystemEncryptedFields>;
 
 /** @future Multi-system switcher list item — not yet implemented. */
 export interface SystemListItem {
@@ -50,8 +57,13 @@ export type SystemServerMetadata = Omit<System, SystemEncryptedFields | "setting
 };
 
 /**
- * JSON-wire representation of a System. Derived from the domain `System`
- * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
+ * Server-emit shape — what `toSystemResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
  */
-export type SystemWire = Serialize<System>;
+export type SystemResult = EncryptedWire<SystemServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `SystemResult`: branded IDs become plain strings;
+ * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type SystemWire = Serialize<SystemResult>;

--- a/packages/types/src/entities/system.ts
+++ b/packages/types/src/entities/system.ts
@@ -25,10 +25,13 @@ export interface System extends AuditMetadata {
  */
 export type SystemEncryptedFields = "name" | "displayName" | "description" | "avatarSource";
 
-/**
- * Pre-encryption shape — what `encryptSystemInput` accepts. Single source
- * of truth: derived from `System` via `Pick<>` over the encrypted-keys union.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// SystemEncryptedInput → SystemServerMetadata
+//                     → SystemResult → SystemWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type SystemEncryptedInput = Pick<System, SystemEncryptedFields>;
 
 /** @future Multi-system switcher list item — not yet implemented. */
@@ -56,14 +59,6 @@ export type SystemServerMetadata = Omit<System, SystemEncryptedFields | "setting
   readonly archivedAt: UnixMillis | null;
 };
 
-/**
- * Server-emit shape — what `toSystemProfileResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type SystemResult = EncryptedWire<SystemServerMetadata>;
 
-/**
- * JSON-serialized wire form of `SystemResult`: branded IDs become plain strings;
- * `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type SystemWire = Serialize<SystemResult>;

--- a/packages/types/src/entities/timer-config.ts
+++ b/packages/types/src/entities/timer-config.ts
@@ -55,21 +55,16 @@ export type TimerConfigServerMetadata = Omit<
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — what `encryptTimerConfigInput` accepts. Single source
- * of truth: derived from `TimerConfig` via `Pick<>` over the encrypted-keys union.
- * Single-key projection over `"promptText"` — not truncated.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// TimerConfigEncryptedInput → TimerConfigServerMetadata
+//                          → TimerConfigResult → TimerConfigWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
+/** Single-key projection over `"promptText"` — not truncated. */
 export type TimerConfigEncryptedInput = Pick<TimerConfig, TimerConfigEncryptedFields>;
 
-/**
- * Server-emit shape — what `toTimerConfigResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type TimerConfigResult = EncryptedWire<TimerConfigServerMetadata>;
 
-/**
- * JSON-serialized wire form of `TimerConfigResult`: branded IDs become plain
- * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type TimerConfigWire = Serialize<TimerConfigResult>;

--- a/packages/types/src/entities/timer-config.ts
+++ b/packages/types/src/entities/timer-config.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { SystemId, TimerId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -21,6 +22,19 @@ export interface TimerConfig extends AuditMetadata {
 export type ArchivedTimerConfig = Archived<TimerConfig>;
 
 /**
+ * Keys of `TimerConfig` that are encrypted client-side before the server sees
+ * them. The server stores ciphertext in `encryptedData`; the plaintext
+ * scheduling columns (`enabled`, `intervalMinutes`, `wakingHoursOnly`,
+ * `wakingStart`, `wakingEnd`) are kept in the clear so the server can schedule
+ * check-in record generation.
+ * Consumed by:
+ * - `TimerConfigServerMetadata` (derived via `Omit`)
+ * - `TimerConfigEncryptedInput = Pick<TimerConfig, TimerConfigEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextTimerConfig parity)
+ */
+export type TimerConfigEncryptedFields = "promptText";
+
+/**
  * Server-visible TimerConfig metadata — raw Drizzle row shape.
  *
  * Hybrid entity: plaintext scheduling columns (`enabled`, `intervalMinutes`,
@@ -31,7 +45,10 @@ export type ArchivedTimerConfig = Archived<TimerConfig>;
  * `archived: false` on the domain flips to a mutable boolean here, with a
  * companion `archivedAt` timestamp.
  */
-export type TimerConfigServerMetadata = Omit<TimerConfig, "promptText" | "archived"> & {
+export type TimerConfigServerMetadata = Omit<
+  TimerConfig,
+  TimerConfigEncryptedFields | "archived"
+> & {
   readonly nextCheckInAt: UnixMillis | null;
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
@@ -39,8 +56,19 @@ export type TimerConfigServerMetadata = Omit<TimerConfig, "promptText" | "archiv
 };
 
 /**
- * JSON-wire representation of a TimerConfig. Derived from the domain
- * `TimerConfig` type via `Serialize<T>`; branded IDs become plain strings,
- * `UnixMillis` becomes `number`.
+ * Pre-encryption shape — what `encryptTimerConfigInput` accepts. Single source
+ * of truth: derived from `TimerConfig` via `Pick<>` over the encrypted-keys union.
  */
-export type TimerConfigWire = Serialize<TimerConfig>;
+export type TimerConfigEncryptedInput = Pick<TimerConfig, TimerConfigEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toTimerConfigResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type TimerConfigResult = EncryptedWire<TimerConfigServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `TimerConfigResult`: branded IDs become plain
+ * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type TimerConfigWire = Serialize<TimerConfigResult>;

--- a/packages/types/src/entities/timer-config.ts
+++ b/packages/types/src/entities/timer-config.ts
@@ -58,6 +58,7 @@ export type TimerConfigServerMetadata = Omit<
 /**
  * Pre-encryption shape — what `encryptTimerConfigInput` accepts. Single source
  * of truth: derived from `TimerConfig` via `Pick<>` over the encrypted-keys union.
+ * Single-key projection over `"promptText"` — not truncated.
  */
 export type TimerConfigEncryptedInput = Pick<TimerConfig, TimerConfigEncryptedFields>;
 

--- a/packages/types/src/entities/wiki-page.ts
+++ b/packages/types/src/entities/wiki-page.ts
@@ -55,21 +55,15 @@ export type WikiPageServerMetadata = Omit<WikiPage, WikiPageEncryptedFields | "a
   readonly encryptedData: EncryptedBlob;
 };
 
-/**
- * Pre-encryption shape — the projection of `WikiPage` over its
- * encrypted-keys union. The transform layer (when added) will accept
- * this shape and produce the encrypted wire body.
- */
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// WikiPageEncryptedInput → WikiPageServerMetadata
+//                       → WikiPageResult → WikiPageWire
+// Per-alias JSDoc is intentionally minimal; the alias name plus the
+// chain anchor above carries the meaning. Per-alias docs only appear
+// when an entity diverges from the standard pattern.
+
 export type WikiPageEncryptedInput = Pick<WikiPage, WikiPageEncryptedFields>;
 
-/**
- * Server-emit shape for `WikiPage`: branded IDs and timestamps preserved;
- * `encryptedData` is wire-form `EncryptedBase64`.
- */
 export type WikiPageResult = EncryptedWire<WikiPageServerMetadata>;
 
-/**
- * JSON-serialized wire form of `WikiPageResult`: branded IDs become plain
- * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
- */
 export type WikiPageWire = Serialize<WikiPageResult>;

--- a/packages/types/src/entities/wiki-page.ts
+++ b/packages/types/src/entities/wiki-page.ts
@@ -1,3 +1,4 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { SlugHash, SystemId, WikiPageId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -22,19 +23,35 @@ export interface WikiPage extends AuditMetadata {
 export type ArchivedWikiPage = Archived<WikiPage>;
 
 /**
+ * Keys of `WikiPage` that are encrypted client-side before the server sees
+ * them. Every domain field except `systemId`, `id`, and the audit triple is
+ * bundled inside the opaque `encryptedData` blob. The server row substitutes a
+ * plaintext `slugHash` (SHA-256 of the decrypted slug) so uniqueness on
+ * `(systemId, slug)` can be enforced without the server ever reading the slug.
+ * Consumed by:
+ * - `WikiPageServerMetadata` (derived via `Omit`)
+ * - `WikiPageEncryptedInput = Pick<WikiPage, WikiPageEncryptedFields>`
+ * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextWikiPage parity)
+ */
+export type WikiPageEncryptedFields =
+  | "title"
+  | "slug"
+  | "blocks"
+  | "linkedFromPages"
+  | "tags"
+  | "linkedEntities";
+
+/**
  * Server-visible WikiPage metadata — raw Drizzle row shape.
  *
  * Hybrid entity: every domain field except `systemId`, `id`, and the audit
  * triple is bundled inside the opaque `encryptedData` blob. The server row
  * substitutes a plaintext `slugHash` (SHA-256 of the decrypted slug) so
  * uniqueness on `(systemId, slug)` can be enforced without the server ever
- * reading the slug itself. `archived: false` on the domain flips to a
- * mutable boolean here, with a companion `archivedAt` timestamp.
+ * reading the slug itself. `archived: false` on the domain flips to a mutable
+ * boolean here, with a companion `archivedAt` timestamp.
  */
-export type WikiPageServerMetadata = Omit<
-  WikiPage,
-  "title" | "slug" | "blocks" | "linkedFromPages" | "tags" | "linkedEntities" | "archived"
-> & {
+export type WikiPageServerMetadata = Omit<WikiPage, WikiPageEncryptedFields | "archived"> & {
   readonly slugHash: SlugHash;
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
@@ -42,8 +59,19 @@ export type WikiPageServerMetadata = Omit<
 };
 
 /**
- * JSON-wire representation of a WikiPage. Derived from the domain
- * `WikiPage` type via `Serialize<T>`; branded IDs become plain strings,
- * `UnixMillis` becomes `number`.
+ * Pre-encryption shape — what `encryptWikiPageInput` accepts. Single source of
+ * truth: derived from `WikiPage` via `Pick<>` over the encrypted-keys union.
  */
-export type WikiPageWire = Serialize<WikiPage>;
+export type WikiPageEncryptedInput = Pick<WikiPage, WikiPageEncryptedFields>;
+
+/**
+ * Server-emit shape — what `toWikiPageResult` returns. Branded IDs and
+ * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ */
+export type WikiPageResult = EncryptedWire<WikiPageServerMetadata>;
+
+/**
+ * JSON-serialized wire form of `WikiPageResult`: branded IDs become plain
+ * strings; `EncryptedBase64` becomes plain `string`; timestamps become numbers.
+ */
+export type WikiPageWire = Serialize<WikiPageResult>;

--- a/packages/types/src/entities/wiki-page.ts
+++ b/packages/types/src/entities/wiki-page.ts
@@ -23,23 +23,20 @@ export interface WikiPage extends AuditMetadata {
 export type ArchivedWikiPage = Archived<WikiPage>;
 
 /**
- * Keys of `WikiPage` that are encrypted client-side before the server sees
- * them. Every domain field except `systemId`, `id`, and the audit triple is
- * bundled inside the opaque `encryptedData` blob. The server row substitutes a
- * plaintext `slugHash` (SHA-256 of the decrypted slug) so uniqueness on
- * `(systemId, slug)` can be enforced without the server ever reading the slug.
+ * Keys of `WikiPage` that are encrypted client-side. Defined by exclusion
+ * (every domain field except `id`, `systemId`, `archived`, and the audit
+ * triple) so that adding a new field to `WikiPage` cannot silently escape
+ * encryption — the `Exclude` reflects the policy "encrypt by default".
+ *
  * Consumed by:
  * - `WikiPageServerMetadata` (derived via `Omit`)
  * - `WikiPageEncryptedInput = Pick<WikiPage, WikiPageEncryptedFields>`
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextWikiPage parity)
  */
-export type WikiPageEncryptedFields =
-  | "title"
-  | "slug"
-  | "blocks"
-  | "linkedFromPages"
-  | "tags"
-  | "linkedEntities";
+export type WikiPageEncryptedFields = Exclude<
+  keyof WikiPage,
+  "id" | "systemId" | "archived" | keyof AuditMetadata
+>;
 
 /**
  * Server-visible WikiPage metadata — raw Drizzle row shape.

--- a/packages/types/src/entities/wiki-page.ts
+++ b/packages/types/src/entities/wiki-page.ts
@@ -59,14 +59,15 @@ export type WikiPageServerMetadata = Omit<WikiPage, WikiPageEncryptedFields | "a
 };
 
 /**
- * Pre-encryption shape — what `encryptWikiPageInput` accepts. Single source of
- * truth: derived from `WikiPage` via `Pick<>` over the encrypted-keys union.
+ * Pre-encryption shape — the projection of `WikiPage` over its
+ * encrypted-keys union. The transform layer (when added) will accept
+ * this shape and produce the encrypted wire body.
  */
 export type WikiPageEncryptedInput = Pick<WikiPage, WikiPageEncryptedFields>;
 
 /**
- * Server-emit shape — what `toWikiPageResult` returns. Branded IDs and
- * timestamps preserved; `encryptedData` is wire-form `EncryptedBase64`.
+ * Server-emit shape for `WikiPage`: branded IDs and timestamps preserved;
+ * `encryptedData` is wire-form `EncryptedBase64`.
  */
 export type WikiPageResult = EncryptedWire<WikiPageServerMetadata>;
 

--- a/packages/validation/src/__tests__/contract-custom-fields.test.ts
+++ b/packages/validation/src/__tests__/contract-custom-fields.test.ts
@@ -7,19 +7,22 @@ import {
   UpdateFieldValueBodySchema,
 } from "../custom-fields.js";
 
-import type {
-  CreateFieldDefinitionBody,
-  SetFieldValueBody,
-  UpdateFieldDefinitionBody,
-  UpdateFieldValueBody,
-} from "@pluralscape/types";
+import type { Equal, FieldType } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 describe("CreateFieldDefinitionBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
+  it("infers the documented body shape", () => {
     expectTypeOf<
-      z.infer<typeof CreateFieldDefinitionBodySchema>
-    >().toEqualTypeOf<CreateFieldDefinitionBody>();
+      Equal<
+        z.infer<typeof CreateFieldDefinitionBodySchema>,
+        {
+          fieldType: FieldType;
+          required: boolean;
+          sortOrder: number;
+          encryptedData: string;
+        }
+      >
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input", () => {
@@ -85,10 +88,18 @@ describe("CreateFieldDefinitionBodySchema", () => {
 });
 
 describe("UpdateFieldDefinitionBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
+  it("infers the documented body shape", () => {
     expectTypeOf<
-      z.infer<typeof UpdateFieldDefinitionBodySchema>
-    >().toEqualTypeOf<UpdateFieldDefinitionBody>();
+      Equal<
+        z.infer<typeof UpdateFieldDefinitionBodySchema>,
+        {
+          required?: boolean;
+          sortOrder?: number;
+          encryptedData: string;
+          version: number;
+        }
+      >
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input", () => {
@@ -120,8 +131,10 @@ describe("UpdateFieldDefinitionBodySchema", () => {
 });
 
 describe("SetFieldValueBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
-    expectTypeOf<z.infer<typeof SetFieldValueBodySchema>>().toEqualTypeOf<SetFieldValueBody>();
+  it("infers the documented body shape", () => {
+    expectTypeOf<
+      Equal<z.infer<typeof SetFieldValueBodySchema>, { encryptedData: string }>
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input", () => {
@@ -136,10 +149,10 @@ describe("SetFieldValueBodySchema", () => {
 });
 
 describe("UpdateFieldValueBodySchema", () => {
-  it("schema infers the correct type (compile-time)", () => {
+  it("infers the documented body shape", () => {
     expectTypeOf<
-      z.infer<typeof UpdateFieldValueBodySchema>
-    >().toEqualTypeOf<UpdateFieldValueBody>();
+      Equal<z.infer<typeof UpdateFieldValueBodySchema>, { encryptedData: string; version: number }>
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input", () => {

--- a/packages/validation/src/__tests__/contract-custom-fields.test.ts
+++ b/packages/validation/src/__tests__/contract-custom-fields.test.ts
@@ -11,7 +11,7 @@ import type { Equal, FieldType } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 describe("CreateFieldDefinitionBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<
         z.infer<typeof CreateFieldDefinitionBodySchema>,
@@ -88,7 +88,7 @@ describe("CreateFieldDefinitionBodySchema", () => {
 });
 
 describe("UpdateFieldDefinitionBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<
         z.infer<typeof UpdateFieldDefinitionBodySchema>,
@@ -131,7 +131,7 @@ describe("UpdateFieldDefinitionBodySchema", () => {
 });
 
 describe("SetFieldValueBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<z.infer<typeof SetFieldValueBodySchema>, { encryptedData: string }>
     >().toEqualTypeOf<true>();
@@ -149,7 +149,7 @@ describe("SetFieldValueBodySchema", () => {
 });
 
 describe("UpdateFieldValueBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<z.infer<typeof UpdateFieldValueBodySchema>, { encryptedData: string; version: number }>
     >().toEqualTypeOf<true>();

--- a/packages/validation/src/__tests__/contract-custom-fields.test.ts
+++ b/packages/validation/src/__tests__/contract-custom-fields.test.ts
@@ -6,6 +6,10 @@ import {
   UpdateFieldDefinitionBodySchema,
   UpdateFieldValueBodySchema,
 } from "../custom-fields.js";
+import {
+  MAX_ENCRYPTED_FIELD_DATA_SIZE,
+  MAX_ENCRYPTED_FIELD_VALUE_SIZE,
+} from "../validation.constants.js";
 
 import type { Equal, FieldType } from "@pluralscape/types";
 import type { z } from "zod/v4";
@@ -74,6 +78,15 @@ describe("CreateFieldDefinitionBodySchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects encryptedData over MAX_ENCRYPTED_FIELD_DATA_SIZE", () => {
+    const oversized = "a".repeat(MAX_ENCRYPTED_FIELD_DATA_SIZE + 1);
+    const result = CreateFieldDefinitionBodySchema.safeParse({
+      fieldType: "text",
+      encryptedData: oversized,
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("strips unknown properties", () => {
     const result = CreateFieldDefinitionBodySchema.safeParse({
       fieldType: "text",
@@ -128,6 +141,15 @@ describe("UpdateFieldDefinitionBodySchema", () => {
     const result = UpdateFieldDefinitionBodySchema.safeParse({ encryptedData: "dGVzdA==" });
     expect(result.success).toBe(false);
   });
+
+  it("rejects encryptedData over MAX_ENCRYPTED_FIELD_DATA_SIZE", () => {
+    const oversized = "a".repeat(MAX_ENCRYPTED_FIELD_DATA_SIZE + 1);
+    const result = UpdateFieldDefinitionBodySchema.safeParse({
+      encryptedData: oversized,
+      version: 1,
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("SetFieldValueBodySchema", () => {
@@ -146,6 +168,12 @@ describe("SetFieldValueBodySchema", () => {
     const result = SetFieldValueBodySchema.safeParse({ encryptedData: "" });
     expect(result.success).toBe(false);
   });
+
+  it("rejects encryptedData over MAX_ENCRYPTED_FIELD_VALUE_SIZE", () => {
+    const oversized = "a".repeat(MAX_ENCRYPTED_FIELD_VALUE_SIZE + 1);
+    const result = SetFieldValueBodySchema.safeParse({ encryptedData: oversized });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("UpdateFieldValueBodySchema", () => {
@@ -162,6 +190,15 @@ describe("UpdateFieldValueBodySchema", () => {
 
   it("rejects missing version", () => {
     const result = UpdateFieldValueBodySchema.safeParse({ encryptedData: "dGVzdA==" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects encryptedData over MAX_ENCRYPTED_FIELD_VALUE_SIZE", () => {
+    const oversized = "a".repeat(MAX_ENCRYPTED_FIELD_VALUE_SIZE + 1);
+    const result = UpdateFieldValueBodySchema.safeParse({
+      encryptedData: oversized,
+      version: 1,
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/packages/validation/src/__tests__/contract-member.test.ts
+++ b/packages/validation/src/__tests__/contract-member.test.ts
@@ -11,7 +11,7 @@ import type { Equal } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 describe("CreateMemberBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<z.infer<typeof CreateMemberBodySchema>, { encryptedData: string }>
     >().toEqualTypeOf<true>();
@@ -42,7 +42,7 @@ describe("CreateMemberBodySchema", () => {
 });
 
 describe("UpdateMemberBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<z.infer<typeof UpdateMemberBodySchema>, { encryptedData: string; version: number }>
     >().toEqualTypeOf<true>();
@@ -65,7 +65,7 @@ describe("UpdateMemberBodySchema", () => {
 });
 
 describe("DuplicateMemberBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<
         z.infer<typeof DuplicateMemberBodySchema>,
@@ -106,7 +106,7 @@ describe("DuplicateMemberBodySchema", () => {
 });
 
 describe("CreateMemberPhotoBodySchema", () => {
-  it("infers the documented body shape", () => {
+  it("infers the correct body shape", () => {
     expectTypeOf<
       Equal<
         z.infer<typeof CreateMemberPhotoBodySchema>,

--- a/packages/validation/src/__tests__/contract-member.test.ts
+++ b/packages/validation/src/__tests__/contract-member.test.ts
@@ -7,7 +7,7 @@ import {
   UpdateMemberBodySchema,
 } from "../member.js";
 
-import type { CreateMemberPhotoBody, Equal } from "@pluralscape/types";
+import type { Equal } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 describe("CreateMemberBodySchema", () => {
@@ -108,8 +108,11 @@ describe("DuplicateMemberBodySchema", () => {
 describe("CreateMemberPhotoBodySchema", () => {
   it("infers the documented body shape", () => {
     expectTypeOf<
-      z.infer<typeof CreateMemberPhotoBodySchema>
-    >().toEqualTypeOf<CreateMemberPhotoBody>();
+      Equal<
+        z.infer<typeof CreateMemberPhotoBodySchema>,
+        { encryptedData: string; sortOrder?: number }
+      >
+    >().toEqualTypeOf<true>();
   });
 
   it("parses valid input without sortOrder", () => {

--- a/packages/validation/src/__tests__/contract-member.test.ts
+++ b/packages/validation/src/__tests__/contract-member.test.ts
@@ -6,6 +6,7 @@ import {
   DuplicateMemberBodySchema,
   UpdateMemberBodySchema,
 } from "../member.js";
+import { MAX_ENCRYPTED_PHOTO_DATA_SIZE } from "../validation.constants.js";
 
 import type { Equal } from "@pluralscape/types";
 import type { z } from "zod/v4";
@@ -139,6 +140,12 @@ describe("CreateMemberPhotoBodySchema", () => {
       encryptedData: "dGVzdA==",
       sortOrder: -1,
     });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects encryptedData over MAX_ENCRYPTED_PHOTO_DATA_SIZE", () => {
+    const oversized = "a".repeat(MAX_ENCRYPTED_PHOTO_DATA_SIZE + 1);
+    const result = CreateMemberPhotoBodySchema.safeParse({ encryptedData: oversized });
     expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Foundational PR 2 of the encrypted-entity SoT consolidation (ps-y4tb). Lands the canonical six-link type chain in `@pluralscape/types` for 28 of the 30 in-scope encrypted entities, building on the Member pilot from #560.

  X → XEncryptedFields → XEncryptedInput → XServerMetadata → XResult → XWire

Per entity:
- Added `XEncryptedInput = Pick<X, XEncryptedFields>` (canonical pre-encryption shape)
- Added `XResult = EncryptedWire<XServerMetadata>` (server-emit shape, EncryptedBase64 wire-form blob)
- Redefined `XWire = Serialize<XResult>` (was `Serialize<X>`)

## Original commits (initial scope)

1. **17 Class A entities** — bucket, custom-front, field-definition, field-value, fronting-comment, fronting-session, group, innerworld-canvas/entity/region, lifecycle-event, member-photo, relationship, structure-entity, structure-entity-type, system, system-settings.
2. **10 Class B entities** — lifted `XEncryptedFields` keys-union and applied the rest of the chain. Audit revealed nuance: in `acknowledgement`, `note`, and `poll-vote`, some fields in the existing `Omit` were plaintext (FK / restructured), not encrypted — keys-union restricted to encrypted-only.
3. **friend-connection** (1 of 2 Class D) — keys-union `"visibility"`, nullable `EncryptedBase64 | null` preserved through `EncryptedWire<T>`.

## Review-fix commits (added 2026-04-25)

After multi-agent review surfaced 16 critical/important/suggestion items, the PR was expanded to include:

4. **JSDoc accuracy pass** — fixed phantom function references and copy-paste mistakes in 28 entity JSDocs.
5. **`wiki-page` `Exclude<>` derivation** — encodes "encrypt-by-default" so newly-added domain fields land in ciphertext by default.
6. **Class B `XRestructuredPlaintextFields` aliases** — names the plaintext-but-restructured fields (`note.author`, `acknowledgement.createdByMemberId`, `poll-vote.voter`) so the divergence is explicit in the type surface.
7. **`friend-connection` `FriendConnectionAuxOmitFields`** — names the junction-table-derived Omit list with a 3-reasons JSDoc.
8. **End-to-end migrations + Body interface deletion** (per pre-production policy: no `@deprecated` shims):
   - `FieldDefinition` (create/update): services use `body: z.infer<typeof Schema>`, routes do `safeParse` boundary validation, Body interfaces deleted, redundant unit tests dropped.
   - `FieldValue` (set/update): same treatment for the shared owner-route factory.
   - `MemberPhoto` (create): same. Zero `@deprecated` annotations remain in `packages/types/`.
9. **Template JSDoc collapse** — replaced 28× repetitive per-alias JSDoc on the canonical chain with one anchor-block-per-file (-349 / +201 comment lines).
10. **PR review fixes** — schema-rejection-with-`details` route tests added across all 7 migrated routes; `.max()` size-constraint rejection tests added in contract tests for FieldDefinition / FieldValue / MemberPhoto schemas; `poll-vote.ts` `RestructuredPlaintextFields` JSDoc rewritten to match actual nullability-flip (was incorrectly copy-pasted from `note.ts`).

## Behavioral note: validation/ownership ordering

The end-to-end migrations move schema validation from **inside** the service (`safeParse` after `assertSystemOwnership`) to **upfront at the route boundary** (per Member-pilot pattern). This silently reorders the security gate:

- **Before:** malformed body to a non-owned system → 403 FORBIDDEN.
- **After:** malformed body to a non-owned system → 400 VALIDATION_ERROR.

This is **not** a member-existence oracle (the response shape is identical regardless of whether the system/member exists, because the ownership/active-record assertions never run). It only reveals "your body shape is wrong" before "you lack ownership", which any client trivially knows from its own request. No threat-model change, but worth flagging for security review.

## Deferred to follow-up beans

- **`ps-etbc`** (HIGH) — fleet completion: data transforms cleanup (entities other than FD/FV/MP), parity tests for 29 entities, SoT manifest extension, OpenAPI parity G7 form, documentation refresh.
- **`types-600s`** — CheckInRecord canonical chain (structurally divergent; needs `ServerInternal<T>` annotation first to plug idempotencyKey leak risk).
- **`types-1spw`** (from PR 1) — anchor G4 parity assertions to data-package transform return types after fleet rollout.
- **`types-yxgc`** — branded value types for lifecycle-event opaque strings (previousForm/newForm, previousName/newName).
- **`types-kk7a`** *(new, from this review)* — JSDoc cleanup (system, friend-connection, member-photo) + ADR-023 cross-reference fix.
- **`types-vmk9`** *(new, from this review)* — brand `pinHash` and tighten `Relationship.label` invariant via discriminated union.
- **`types-x61u`** *(new, from this review)* — harden encrypted-keys union with `Exclude<>` in `journal-entry`/`note` + defensive distributive Pick on `LifecycleEventEncryptedInput`.

## Test plan

- [x] `pnpm turbo run typecheck` — 21/21 packages pass
- [x] `pnpm turbo run lint` — 17/17 packages pass
- [x] `pnpm types:check-sot` — types/Drizzle/Zod/OpenAPI parity all green
- [x] `pnpm test:unit` — 12849/12849 pass + new schema-rejection + size-constraint tests
- [ ] CI green (unit / integration / E2E)
