### PR TITLE
refactor(types,validation,db,api,data,mobile): ps-y4tb batch 1 — type hardening sweep

### DIFF
--- a/.beans/types-kk7a--ps-y4tb-followup-jsdoc-adr-cross-reference-cleanup.md
+++ b/.beans/types-kk7a--ps-y4tb-followup-jsdoc-adr-cross-reference-cleanup.md
@@ -1,11 +1,11 @@
 ---
 # types-kk7a
 title: "ps-y4tb followup: JSDoc + ADR cross-reference cleanup (system, friend-connection, member-photo, ADR-023)"
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-25T23:18:05Z
-updated_at: 2026-04-25T23:18:05Z
+updated_at: 2026-04-26T08:45:31Z
 parent: ps-y4tb
 ---
 
@@ -50,3 +50,12 @@ Decide and either fix the comments or write the ADR.
 
 - Parent: ps-y4tb
 - Triggered by: PR #561 review (2026-04-25)
+
+## Summary of Changes
+
+Closed by ps-y4tb-batch1 PR.
+
+- system.ts JSDoc explicitly notes that archived is a server-only field with no domain counterpart
+- friend-connection.ts FriendConnectionAuxOmitFields JSDoc carries the three orthogonal Omit reasons; FriendConnectionServerMetadata cross-links via {@link}
+- member-photo.ts: sortOrder dropped from MemberPhotoEncryptedFields (it was already plaintext on the server for indexing); OpenAPI PlaintextMemberPhoto updated; Drizzle parity test JSDoc refreshed
+- ADR-023 Decision section now lists all six chain types as primary bullets

--- a/.beans/types-vmk9--ps-y4tb-followup-brand-pinhash-tighten-relationshi.md
+++ b/.beans/types-vmk9--ps-y4tb-followup-brand-pinhash-tighten-relationshi.md
@@ -1,11 +1,11 @@
 ---
 # types-vmk9
 title: "ps-y4tb followup: brand pinHash + tighten Relationship.label invariant"
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-25T23:18:23Z
-updated_at: 2026-04-25T23:18:23Z
+updated_at: 2026-04-26T08:45:31Z
 parent: ps-y4tb
 ---
 
@@ -76,3 +76,16 @@ Migrate consumers (data transforms, validation schemas, openapi parity types) to
 
 - Parent: ps-y4tb
 - Triggered by: PR #561 review (2026-04-25)
+
+## Summary of Changes
+
+Closed by ps-y4tb-batch1 PR.
+
+- PinHash brand declared in @pluralscape/types and applied to SystemSettingsServerMetadata.pinHash
+- pinHash columns in PG and SQLite schemas branded via .$type<PinHash | null>()
+- Hash-construction call sites in pin.service.ts and account-pin.service.ts cast to PinHash
+- Relationship converted to a discriminated union (CustomRelationship | StandardRelationship)
+- RelationshipEncryptedInput is the distributive Pick (`{ label: string } | {}`)
+- Validation split into CustomRelationshipEncryptedSchema (.string()) + StandardRelationshipEncryptedSchema (.strict())
+- Transform narrows on raw.type to select the right schema
+- OpenAPI PlaintextRelationship updated to oneOf; mobile consumers narrow on type === 'custom' before reading label

--- a/.beans/types-x61u--ps-y4tb-followup-harden-encrypted-keys-union-with.md
+++ b/.beans/types-x61u--ps-y4tb-followup-harden-encrypted-keys-union-with.md
@@ -1,11 +1,11 @@
 ---
 # types-x61u
 title: "ps-y4tb followup: harden encrypted-keys union with Exclude<> (journal-entry, note) + defensive distributive Pick (lifecycle-event)"
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-25T23:18:43Z
-updated_at: 2026-04-25T23:18:43Z
+updated_at: 2026-04-26T08:45:31Z
 parent: ps-y4tb
 ---
 
@@ -100,3 +100,11 @@ In \`packages/types/src/**tests**/encrypted-fields-policy.test.ts\` (new), asser
 
 - Parent: ps-y4tb
 - Triggered by: PR #561 review (2026-04-25)
+
+## Summary of Changes
+
+Closed by ps-y4tb-batch1 PR: 13 commits on branch refactor/ps-y4tb-batch1-hardening.
+
+- JournalEntryEncryptedFields and NoteEncryptedFields now derive via Exclude<keyof X, allowlist> (encrypt-by-default policy)
+- LifecycleEventEncryptedInput is defensively distributive
+- New parity guard test at packages/types/src/**tests**/encrypted-fields-policy.test.ts locks the current key sets in

--- a/apps/api/src/services/account-pin.service.ts
+++ b/apps/api/src/services/account-pin.service.ts
@@ -14,7 +14,7 @@ import { hashPinOffload, verifyPinOffload } from "../lib/kdf-offload.js";
 import { withAccountTransaction } from "../lib/rls-context.js";
 
 import type { AuditWriter } from "../lib/audit-writer.js";
-import type { AccountId, SystemId } from "@pluralscape/types";
+import type { AccountId, PinHash, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /**
@@ -57,7 +57,7 @@ export async function setAccountPin(
     throw new ApiHttpError(HTTP_BAD_REQUEST, "VALIDATION_ERROR", "Invalid PIN payload");
   }
 
-  const pinHash = await hashPinOffload(parsed.data.pin);
+  const pinHash = (await hashPinOffload(parsed.data.pin)) as PinHash;
 
   await withAccountTransaction(db, accountId, async (tx) => {
     const systemId = await resolveSystemId(tx, accountId);

--- a/apps/api/src/services/pin.service.ts
+++ b/apps/api/src/services/pin.service.ts
@@ -15,7 +15,7 @@ import { tenantCtx } from "../lib/tenant-context.js";
 
 import type { AuditWriter } from "../lib/audit-writer.js";
 import type { AuthContext } from "../lib/auth-context.js";
-import type { SystemId } from "@pluralscape/types";
+import type { PinHash, SystemId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /**
@@ -42,7 +42,7 @@ export async function setPin(
 
   assertSystemOwnership(systemId, auth);
 
-  const pinHash = await hashPinOffload(parsed.data.pin);
+  const pinHash = (await hashPinOffload(parsed.data.pin)) as PinHash;
 
   await withTenantTransaction(db, tenantCtx(systemId, auth), async (tx) => {
     const updated = await tx

--- a/apps/mobile/src/__tests__/factories.ts
+++ b/apps/mobile/src/__tests__/factories.ts
@@ -639,9 +639,9 @@ export function makeRawRelationship(
   opts?: { encryptedData?: string },
   overrides?: Partial<RelationshipWire>,
 ): RelationshipWire {
+  // Default to a standard (non-custom) relationship: blob is `{}`
   const encryptedData =
-    opts?.encryptedData ??
-    encryptRelationshipInput({ label: `Label ${id}` }, TEST_MASTER_KEY).encryptedData;
+    opts?.encryptedData ?? encryptRelationshipInput({}, TEST_MASTER_KEY).encryptedData;
 
   return {
     id: brandId<RelationshipId>(id),

--- a/apps/mobile/src/data/__tests__/row-transforms.test.ts
+++ b/apps/mobile/src/data/__tests__/row-transforms.test.ts
@@ -659,14 +659,14 @@ describe("rowToAcknowledgement", () => {
 // ── relationship (system-core, boolean bidirectional) ─────────────────────────
 
 describe("rowToRelationship", () => {
-  it("maps relationship row with bidirectional boolean", () => {
+  it("maps standard relationship row — no label key", () => {
     const row: Record<string, unknown> = {
       id: "rel-1",
       system_id: "sys-1",
       source_member_id: "mem-1",
       target_member_id: "mem-2",
       type: "sibling",
-      label: "Twin",
+      label: null,
       bidirectional: 1,
       created_at: 1_700_000_000_000,
       archived: 0,
@@ -678,9 +678,31 @@ describe("rowToRelationship", () => {
     expect(result.sourceMemberId).toBe("mem-1");
     expect(result.targetMemberId).toBe("mem-2");
     expect(result.type).toBe("sibling");
-    expect(result.label).toBe("Twin");
+    expect("label" in result).toBe(false);
     expect(result.bidirectional).toBe(true);
     expect(result.createdAt).toBe(1_700_000_000_000);
+    expect(result.archived).toBe(false);
+  });
+
+  it("maps custom relationship row — carries label", () => {
+    const row: Record<string, unknown> = {
+      id: "rel-2",
+      system_id: "sys-1",
+      source_member_id: "mem-1",
+      target_member_id: "mem-2",
+      type: "custom",
+      label: "Twin",
+      bidirectional: 0,
+      created_at: 1_700_000_000_000,
+      archived: 0,
+    };
+
+    const result = rowToRelationship(row);
+
+    expect(result.type).toBe("custom");
+    if (result.type === "custom") {
+      expect(result.label).toBe("Twin");
+    }
     expect(result.archived).toBe(false);
   });
 });

--- a/apps/mobile/src/data/row-transforms/identity.ts
+++ b/apps/mobile/src/data/row-transforms/identity.ts
@@ -126,7 +126,9 @@ export function rowToRelationship(
   const id = rid(row);
   const archived = intToBool(row["archived"]);
   const createdAt = guardedToMs(row["created_at"], "relationships", "created_at", id);
-  const base: Relationship = {
+  const type = guardedStr(row["type"], "relationships", "type", id) as Relationship["type"];
+
+  const baseShared = {
     id: guardedStr(row["id"], "relationships", "id", id) as Relationship["id"],
     systemId: guardedStr(
       row["system_id"],
@@ -146,11 +148,20 @@ export function rowToRelationship(
       "target_member_id",
       id,
     ) as Relationship["targetMemberId"],
-    type: guardedStr(row["type"], "relationships", "type", id) as Relationship["type"],
-    label: strOrNull(row["label"], "relationships", "label", id),
     bidirectional: intToBool(row["bidirectional"]),
     createdAt,
-    archived: false,
+    archived: false as const,
   };
+
+  // Discriminate on `type` — custom carries a label, standard does not.
+  const base: Relationship =
+    type === "custom"
+      ? {
+          ...baseShared,
+          type: "custom" as const,
+          label: guardedStr(row["label"], "relationships", "label", id),
+        }
+      : { ...baseShared, type };
+
   return archived ? wrapArchived(base, createdAt) : base;
 }

--- a/apps/mobile/src/hooks/__tests__/use-relationships.test.tsx
+++ b/apps/mobile/src/hooks/__tests__/use-relationships.test.tsx
@@ -130,7 +130,6 @@ describe("useRelationship", () => {
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
     });
-    expect(result.current.data?.label).toBe("Label rel_1");
     expect(result.current.data?.type).toBe("sibling");
     expect(result.current.data?.archived).toBe(false);
   });
@@ -178,8 +177,8 @@ describe("useRelationshipsList", () => {
     const items = firstPage && "data" in firstPage ? firstPage.data : [];
     expect(pages).toHaveLength(1);
     expect(items).toHaveLength(2);
-    expect(items[0]?.label).toBe("Label rel_1");
-    expect(items[1]?.label).toBe("Label rel_2");
+    expect(items[0]?.type).toBe("sibling");
+    expect(items[1]?.type).toBe("sibling");
   });
 
   it("does not fetch when masterKey is null", () => {

--- a/docs/adr/023-zod-type-alignment.md
+++ b/docs/adr/023-zod-type-alignment.md
@@ -12,13 +12,18 @@ Drizzle cannot be the source of truth: the server only sees metadata columns plu
 
 ## Decision
 
-Every domain entity publishes three named types from `packages/types`:
+Every encrypted domain entity publishes a six-link canonical chain from `packages/types`:
 
-- **`<Entity>`** — full decrypted domain shape. Branded IDs, `Date` objects, all decrypted fields. No DB-internal columns.
-- **`<Entity>ServerMetadata`** — raw Drizzle row. Branded IDs, `Date`, `encryptedData: Uint8Array` for encrypted entities, plus DB-internal columns (search_tsv, partition keys, computed columns) where applicable.
-- **`<Entity>Wire`** — JSON-serialized view. Almost always `type <Entity>Wire = Serialize<Entity>`; hand-authored only when the `Serialize<T>` transform can't express the shape.
+1. **`<Entity>`** — full decrypted domain shape. Branded IDs, `Date` objects, all decrypted fields. No DB-internal columns.
+2. **`<Entity>EncryptedFields`** — keys-union of fields encrypted client-side. Either a literal union or `Exclude<keyof <Entity>, allowlist>` when the policy is "encrypt every field except an allowlist".
+3. **`<Entity>EncryptedInput`** — `Pick<<Entity>, <Entity>EncryptedFields>`. The shape callers encrypt and submit to `encryptedData`. Use a defensively distributive form (`<Entity> extends unknown ? Pick<…> : never`) when `<Entity>` is a discriminated union.
+4. **`<Entity>ServerMetadata`** — raw Drizzle row. Branded IDs, `Date`, `encryptedData: EncryptedBlob` (or `| null`), plus DB-internal columns (search_tsv, partition keys, computed columns) and `ServerInternal<…>`-marked server-fill-only fields.
+5. **`<Entity>Result`** — `EncryptedWire<<Entity>ServerMetadata>`. Server JS-runtime response shape: `encryptedData` brand-tagged as `EncryptedBase64`, `ServerInternal<…>` fields stripped.
+6. **`<Entity>Wire`** — `Serialize<<Entity>Result>`. JSON-serialized HTTP shape: brands strip to plain `string`, `UnixMillis` becomes `number`, `EncryptedBase64` collapses to `string`.
 
-A fourth helper, **`EncryptedWire<T>`** (`packages/types/src/encrypted-wire.ts`), publishes the wire envelope produced by base64-encoding `encryptedData` for transport: `Omit<T, "encryptedData"> & { readonly encryptedData: string | (string | null) }`, with nullability preserved from `T`. The earlier "envelope is API-layer only" stance (kept locally inside `scripts/openapi-wire-parity.type-test.ts`) is reversed — when 30+ effective re-declarations of the same transform accumulate across the services tree, the SoT argument flips. Per-entity service `<X>Result` types are now derivations: `type <X>Result = EncryptedWire<<X>ServerMetadata>`. Hand-rolled `<X>Result` interfaces are reserved for cases where the wire shape genuinely diverges from the metadata (denormalized server-internal fields that must not leak, polymorphic refs the wire widens to plain string, validated narrowings of `Record<string, unknown>` payloads, etc.); each retained hand-roll documents _why_ in a comment above the interface.
+Plaintext entities publish only `<Entity>` → `<Entity>ServerMetadata` → `<Entity>Wire`.
+
+The `EncryptedWire<T>` helper (`packages/types/src/encrypted-wire.ts`) and `Serialize<T>` together produce links 5 and 6 mechanically; only the keys-union and the server metadata require hand-authoring per entity. Per-entity service `<X>Result` types are derivations: `type <X>Result = EncryptedWire<<X>ServerMetadata>`. Hand-rolled `<X>Result` interfaces are reserved for cases where the wire shape genuinely diverges from the metadata (denormalized server-internal fields that must not leak, polymorphic refs the wire widens to plain string, validated narrowings of `Record<string, unknown>` payloads, etc.); each retained hand-roll documents _why_ in a comment above the interface.
 
 Downstream layers derive-or-assert-equal rather than redefine:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15863,13 +15863,10 @@ components:
       type: object
       required:
         - imageSource
-        - sortOrder
         - caption
       properties:
         imageSource:
           $ref: "#/components/schemas/PlaintextImageSource"
-        sortOrder:
-          type: number
         caption:
           type: string
           nullable: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16057,16 +16057,21 @@ components:
         Note: `sourceMemberId`, `targetMemberId`, `type`, and `bidirectional`
         are sent as **separate plaintext fields** in the request body (not inside
         `encryptedData`) because the server needs them for querying.
-        The `encryptedData` contains only the user-visible label and any
-        additional notes. Encryption tier: **T1**.
-      type: object
-      required:
-        - label
-      properties:
-        label:
-          type: string
-          nullable: true
-          description: User-defined label (meaningful when type is "custom")
+        The `encryptedData` is a discriminated blob: custom-type relationships
+        carry `{ label: string }`, standard-type relationships carry `{}`.
+        Encryption tier: **T1**.
+      oneOf:
+        - description: Custom-type relationship — carries a user-defined label.
+          type: object
+          required:
+            - label
+          properties:
+            label:
+              type: string
+              description: User-defined label for a custom relationship type.
+        - description: Standard-type relationship — no label field.
+          type: object
+          properties: {}
     PlaintextStructureEntityType:
       description: |
         **Encrypted into**: `encryptedData` on structure entity type create/update endpoints.

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -205,12 +205,10 @@ PlaintextMemberPhoto:
 
     A photo entry in a member's gallery. Encryption tier: **T1**.
   type: object
-  required: [imageSource, sortOrder, caption]
+  required: [imageSource, caption]
   properties:
     imageSource:
       $ref: "#/PlaintextImageSource"
-    sortOrder:
-      type: number
     caption:
       type: string
       nullable: true

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -374,15 +374,20 @@ PlaintextRelationship:
     Note: `sourceMemberId`, `targetMemberId`, `type`, and `bidirectional`
     are sent as **separate plaintext fields** in the request body (not inside
     `encryptedData`) because the server needs them for querying.
-    The `encryptedData` contains only the user-visible label and any
-    additional notes. Encryption tier: **T1**.
-  type: object
-  required: [label]
-  properties:
-    label:
-      type: string
-      nullable: true
-      description: User-defined label (meaningful when type is "custom")
+    The `encryptedData` is a discriminated blob: custom-type relationships
+    carry `{ label: string }`, standard-type relationships carry `{}`.
+    Encryption tier: **T1**.
+  oneOf:
+    - description: Custom-type relationship — carries a user-defined label.
+      type: object
+      required: [label]
+      properties:
+        label:
+          type: string
+          description: User-defined label for a custom relationship type.
+    - description: Standard-type relationship — no label field.
+      type: object
+      properties: {}
 
 PlaintextStructureEntityType:
   description: |

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7976,13 +7976,16 @@ export interface components {
      *     Note: `sourceMemberId`, `targetMemberId`, `type`, and `bidirectional`
      *     are sent as **separate plaintext fields** in the request body (not inside
      *     `encryptedData`) because the server needs them for querying.
-     *     The `encryptedData` contains only the user-visible label and any
-     *     additional notes. Encryption tier: **T1**.
+     *     The `encryptedData` is a discriminated blob: custom-type relationships
+     *     carry `{ label: string }`, standard-type relationships carry `{}`.
+     *     Encryption tier: **T1**.
      */
-    PlaintextRelationship: {
-      /** @description User-defined label (meaningful when type is "custom") */
-      label: string | null;
-    };
+    PlaintextRelationship:
+      | {
+          /** @description User-defined label for a custom relationship type. */
+          label: string;
+        }
+      | Record<string, never>;
     /**
      * @description **Encrypted into**: `encryptedData` on structure entity type create/update endpoints.
      *

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -7874,7 +7874,6 @@ export interface components {
      */
     PlaintextMemberPhoto: {
       imageSource: components["schemas"]["PlaintextImageSource"];
-      sortOrder: number;
       caption: string | null;
     };
     /**

--- a/packages/data/src/transforms/__tests__/relationship.test.ts
+++ b/packages/data/src/transforms/__tests__/relationship.test.ts
@@ -33,7 +33,8 @@ beforeAll(async () => {
 
 const NOW = toUnixMillis(1_700_000_000_000);
 
-function makeRawRelationship(overrides?: Partial<RelationshipWire>): RelationshipWire {
+// Standard (non-custom) relationship: blob is `{}`
+function makeRawStandardRelationship(overrides?: Partial<RelationshipWire>): RelationshipWire {
   return {
     id: brandId<RelationshipId>("rel_001"),
     systemId: brandId<SystemId>("sys_test"),
@@ -44,29 +45,49 @@ function makeRawRelationship(overrides?: Partial<RelationshipWire>): Relationshi
     createdAt: NOW,
     updatedAt: NOW,
     version: 1,
-    encryptedData: encryptAndEncodeT1(
-      { label: "Sibling bond" } satisfies RelationshipEncryptedInput,
-      masterKey,
-    ),
+    encryptedData: encryptAndEncodeT1({} satisfies RelationshipEncryptedInput, masterKey),
     archived: false,
     archivedAt: null,
     ...overrides,
   };
 }
 
-describe("decryptRelationship", () => {
-  it("decrypts label from encrypted data", () => {
-    const result = decryptRelationship(makeRawRelationship(), masterKey);
-    expect(result.label).toBe("Sibling bond");
+// Custom relationship: blob carries `{ label }`
+function makeRawCustomRelationship(
+  label: string,
+  overrides?: Partial<RelationshipWire>,
+): RelationshipWire {
+  return {
+    id: brandId<RelationshipId>("rel_002"),
+    systemId: brandId<SystemId>("sys_test"),
+    sourceMemberId: brandId<MemberId>("mem_1"),
+    targetMemberId: brandId<MemberId>("mem_2"),
+    type: "custom" as RelationshipType,
+    bidirectional: false,
+    createdAt: NOW,
+    updatedAt: NOW,
+    version: 1,
+    encryptedData: encryptAndEncodeT1({ label } satisfies RelationshipEncryptedInput, masterKey),
+    archived: false,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+describe("decryptRelationship — standard type", () => {
+  it("decrypts standard relationship with no label", () => {
+    const result = decryptRelationship(makeRawStandardRelationship(), masterKey);
     expect(result.sourceMemberId).toBe("mem_1");
     expect(result.targetMemberId).toBe("mem_2");
     expect(result.type).toBe("sibling");
     expect(result.bidirectional).toBe(true);
     expect(result.archived).toBe(false);
+    // Standard relationships have no `label` key
+    expect("label" in result).toBe(false);
   });
 
   it("handles null member IDs", () => {
-    const raw = makeRawRelationship({ sourceMemberId: null, targetMemberId: null });
+    const raw = makeRawStandardRelationship({ sourceMemberId: null, targetMemberId: null });
     const result = decryptRelationship(raw, masterKey);
     expect(result.sourceMemberId).toBeNull();
     expect(result.targetMemberId).toBeNull();
@@ -74,9 +95,8 @@ describe("decryptRelationship", () => {
 
   it("returns archived variant with archivedAt", () => {
     const archivedAt = toUnixMillis(1_700_002_000_000);
-    const raw = makeRawRelationship({ archived: true, archivedAt });
+    const raw = makeRawStandardRelationship({ archived: true, archivedAt });
     const result = decryptRelationship(raw, masterKey);
-
     expect(result.archived).toBe(true);
     if (result.archived) {
       expect(result.archivedAt).toBe(archivedAt);
@@ -84,19 +104,50 @@ describe("decryptRelationship", () => {
   });
 
   it("throws when archived=true but archivedAt is null", () => {
-    const raw = makeRawRelationship({ archived: true, archivedAt: null });
+    const raw = makeRawStandardRelationship({ archived: true, archivedAt: null });
     expect(() => decryptRelationship(raw, masterKey)).toThrow("missing archivedAt");
   });
 
   it("throws on corrupted encryptedData", () => {
-    const raw = makeRawRelationship({ encryptedData: "not-valid-base64!!!" });
+    const raw = makeRawStandardRelationship({ encryptedData: "not-valid-base64!!!" });
+    expect(() => decryptRelationship(raw, masterKey)).toThrow();
+  });
+});
+
+describe("decryptRelationship — custom type", () => {
+  it("decrypts label from encrypted data", () => {
+    const result = decryptRelationship(makeRawCustomRelationship("My bond"), masterKey);
+    expect(result.type).toBe("custom");
+    if (result.type === "custom") {
+      expect(result.label).toBe("My bond");
+    }
+    expect(result.archived).toBe(false);
+  });
+
+  it("custom type with archived variant carries archivedAt", () => {
+    const archivedAt = toUnixMillis(1_700_002_000_000);
+    const raw = makeRawCustomRelationship("Archived bond", { archived: true, archivedAt });
+    const result = decryptRelationship(raw, masterKey);
+    expect(result.archived).toBe(true);
+    if (result.archived) {
+      expect(result.archivedAt).toBe(archivedAt);
+    }
+  });
+
+  it("throws when custom blob is missing label", () => {
+    const raw = makeRawCustomRelationship("placeholder", {
+      encryptedData: makeBase64Blob({ notLabel: "x" }, masterKey),
+    });
     expect(() => decryptRelationship(raw, masterKey)).toThrow();
   });
 });
 
 describe("decryptRelationshipPage", () => {
   it("decrypts all items and preserves cursor", () => {
-    const page = { data: [makeRawRelationship(), makeRawRelationship()], nextCursor: "cursor_abc" };
+    const page = {
+      data: [makeRawStandardRelationship(), makeRawCustomRelationship("bond")],
+      nextCursor: "cursor_abc",
+    };
     const result = decryptRelationshipPage(page, masterKey);
     expect(result.data).toHaveLength(2);
     expect(result.nextCursor).toBe("cursor_abc");
@@ -109,33 +160,55 @@ describe("decryptRelationshipPage", () => {
   });
 });
 
-describe("encryptRelationshipInput", () => {
-  it("round-trips through decrypt", () => {
+describe("encryptRelationshipInput — custom", () => {
+  it("round-trips label through decrypt", () => {
     const fields: RelationshipEncryptedInput = { label: "Test Label" };
     const { encryptedData } = encryptRelationshipInput(fields, masterKey);
-    const raw = makeRawRelationship({ encryptedData });
+    const raw = makeRawCustomRelationship("ignored", { encryptedData });
     const result = decryptRelationship(raw, masterKey);
-    expect(result.label).toBe("Test Label");
+    expect(result.type).toBe("custom");
+    if (result.type === "custom") {
+      expect(result.label).toBe("Test Label");
+    }
+  });
+});
+
+describe("encryptRelationshipInput — standard", () => {
+  it("round-trips empty object through decrypt", () => {
+    const fields: RelationshipEncryptedInput = {};
+    const { encryptedData } = encryptRelationshipInput(fields, masterKey);
+    const raw = makeRawStandardRelationship({ encryptedData });
+    const result = decryptRelationship(raw, masterKey);
+    expect(result.type).toBe("sibling");
+    expect("label" in result).toBe(false);
   });
 });
 
 describe("encryptRelationshipUpdate", () => {
-  it("includes version", () => {
+  it("includes version for custom type", () => {
     const result = encryptRelationshipUpdate({ label: "Updated" }, 3, masterKey);
     expect(result.version).toBe(3);
+    expect(typeof result.encryptedData).toBe("string");
+  });
+
+  it("includes version for standard type", () => {
+    const result = encryptRelationshipUpdate({}, 5, masterKey);
+    expect(result.version).toBe(5);
     expect(typeof result.encryptedData).toBe("string");
   });
 });
 
 describe("RelationshipEncryptedInputSchema validation", () => {
-  it("throws when blob is not an object", () => {
-    const raw = makeRawRelationship({ encryptedData: makeBase64Blob("string", masterKey) });
+  it("throws when blob is not an object (standard path)", () => {
+    const raw = makeRawStandardRelationship({
+      encryptedData: makeBase64Blob("string", masterKey),
+    });
     expect(() => decryptRelationship(raw, masterKey)).toThrow();
   });
 
-  it("throws when label is missing", () => {
-    const raw = makeRawRelationship({
-      encryptedData: makeBase64Blob({ notLabel: "x" }, masterKey),
+  it("throws when custom blob is not an object", () => {
+    const raw = makeRawCustomRelationship("x", {
+      encryptedData: makeBase64Blob("string", masterKey),
     });
     expect(() => decryptRelationship(raw, masterKey)).toThrow();
   });

--- a/packages/data/src/transforms/__tests__/relationship.test.ts
+++ b/packages/data/src/transforms/__tests__/relationship.test.ts
@@ -198,6 +198,15 @@ describe("encryptRelationshipUpdate", () => {
   });
 });
 
+describe("StandardRelationshipEncryptedSchema — strict mode", () => {
+  it("rejects standard-type relationship whose blob carries unexpected keys", () => {
+    const raw = makeRawStandardRelationship({
+      encryptedData: makeBase64Blob({ label: "leaked" }, masterKey),
+    });
+    expect(() => decryptRelationship(raw, masterKey)).toThrow();
+  });
+});
+
 describe("RelationshipEncryptedInputSchema validation", () => {
   it("throws when blob is not an object (standard path)", () => {
     const raw = makeRawStandardRelationship({

--- a/packages/data/src/transforms/relationship.ts
+++ b/packages/data/src/transforms/relationship.ts
@@ -1,5 +1,8 @@
 import { brandId, toUnixMillis } from "@pluralscape/types";
-import { RelationshipEncryptedInputSchema } from "@pluralscape/validation";
+import {
+  CustomRelationshipEncryptedSchema,
+  StandardRelationshipEncryptedSchema,
+} from "@pluralscape/validation";
 
 import { decodeAndDecryptT1, encryptInput, encryptUpdate } from "./decode-blob.js";
 
@@ -24,25 +27,37 @@ export function decryptRelationship(
   masterKey: KdfMasterKey,
 ): Relationship | Archived<Relationship> {
   const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey);
-  const validated = RelationshipEncryptedInputSchema.parse(decrypted);
-  const label = validated.label;
 
-  const base = {
+  const baseShared = {
     id: brandId<RelationshipId>(raw.id),
     systemId: brandId<SystemId>(raw.systemId),
     sourceMemberId: raw.sourceMemberId === null ? null : brandId<MemberId>(raw.sourceMemberId),
     targetMemberId: raw.targetMemberId === null ? null : brandId<MemberId>(raw.targetMemberId),
-    type: raw.type,
-    label,
     bidirectional: raw.bidirectional,
     createdAt: toUnixMillis(raw.createdAt),
   };
 
+  // `type` is plaintext on the wire — use it to select the correct schema for
+  // the decrypted blob. Custom carries `{ label }`, standard carries `{}`.
+  let domainObj: Relationship;
+  if (raw.type === "custom") {
+    const validated = CustomRelationshipEncryptedSchema.parse(decrypted);
+    domainObj = {
+      ...baseShared,
+      type: "custom" as const,
+      label: validated.label,
+      archived: false as const,
+    };
+  } else {
+    StandardRelationshipEncryptedSchema.parse(decrypted);
+    domainObj = { ...baseShared, type: raw.type, archived: false as const };
+  }
+
   if (raw.archived) {
     if (raw.archivedAt === null) throw new Error("Archived relationship missing archivedAt");
-    return { ...base, archived: true as const, archivedAt: toUnixMillis(raw.archivedAt) };
+    return { ...domainObj, archived: true as const, archivedAt: toUnixMillis(raw.archivedAt) };
   }
-  return { ...base, archived: false as const };
+  return domainObj;
 }
 
 export function decryptRelationshipPage(

--- a/packages/db/src/__tests__/schema-pg-system-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-system-settings.integration.test.ts
@@ -16,7 +16,7 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
-import type { SystemId, SystemSettingsId } from "@pluralscape/types";
+import type { PinHash, SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, systemSettings };
@@ -47,7 +47,7 @@ describe("PG system_settings schema", () => {
       id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
       systemId,
       locale: "en",
-      pinHash: "$argon2id$hash123",
+      pinHash: brandId<PinHash>("$argon2id$hash123"),
       biometricEnabled: true,
       encryptedData: data,
       createdAt: now,

--- a/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
+++ b/packages/db/src/__tests__/schema-sqlite-system-settings.integration.test.ts
@@ -16,7 +16,7 @@ import {
   testBlob,
 } from "./helpers/sqlite-helpers.js";
 
-import type { SystemId, SystemSettingsId } from "@pluralscape/types";
+import type { PinHash, SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 
 const schema = { accounts, systems, systemSettings };
@@ -49,7 +49,7 @@ describe("SQLite system_settings schema", () => {
         id: brandId<SystemSettingsId>(`sset_${crypto.randomUUID()}`),
         systemId,
         locale: "en",
-        pinHash: "$argon2id$test-hash",
+        pinHash: brandId<PinHash>("$argon2id$test-hash"),
         biometricEnabled: true,
         encryptedData: data,
         createdAt: now,

--- a/packages/db/src/__tests__/type-parity/member-photo.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/member-photo.type.test.ts
@@ -1,16 +1,19 @@
 /**
  * Drizzle parity check: the MemberPhoto row shape inferred from the
- * `memberPhotos` table structurally matches `MemberPhotoServerMetadata`
+ * `member_photos` table structurally matches `MemberPhotoServerMetadata`
  * in @pluralscape/types.
  *
- * `MemberPhotoServerMetadata` strips the encrypted field keys from the
- * domain (`imageSource`, `caption` ride inside `encryptedData`; the
- * domain marks `sortOrder` encrypted but the DB keeps it plaintext for
- * index-based ordering, so we add it back) and adds the DB-only columns
- * the domain type doesn't carry: `systemId` (denormalized from `members`
- * for RLS), full `AuditMetadata` (the domain interface lacks it), the
- * `EncryptedBlob` itself, and archivable metadata. See
- * `member.type.test.ts` for the general rationale behind the
+ * Server-side additions over the `MemberPhoto` domain:
+ * - `encryptedData: EncryptedBlob` — the T1 blob holding `imageSource`
+ *   and `caption` (the only encrypted fields on the domain).
+ * - `archived: boolean` — widens the domain's `false` literal to match
+ *   the DB column.
+ *
+ * `sortOrder` is plaintext on both sides: the domain carries it as a
+ * top-level field (used by mobile sort UI), and the DB stores it as a
+ * plain integer column for index-based ordering.
+ *
+ * See `member.type.test.ts` for the general rationale behind the
  * brand-stripped comparison.
  */
 

--- a/packages/db/src/__tests__/type-parity/system-settings.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/system-settings.type.test.ts
@@ -10,13 +10,20 @@
  * `biometricEnabled` (server-visible for device-transfer policy) plus
  * `encryptedData`. See `member.type.test.ts` for the general rationale
  * behind the brand-stripped comparison.
+ *
+ * `Serialize` is used on both sides of the equality check to strip the
+ * `PinHash` brand (and any future brands) down to their primitive
+ * equivalents before comparison. Drizzle emits `pinHash` as
+ * `string | null` (a bare `varchar` column), while the domain type now
+ * carries `PinHash | null`; stripping brands makes the check structurally
+ * sound without widening other fields.
  */
 
 import { describe, expectTypeOf, it } from "vitest";
 
 import { systemSettings } from "../../schema/pg/system-settings.js";
 
-import type { Equal, SystemSettingsServerMetadata } from "@pluralscape/types";
+import type { Equal, Serialize, SystemSettingsServerMetadata } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
 describe("SystemSettings Drizzle parity", () => {
@@ -25,8 +32,10 @@ describe("SystemSettings Drizzle parity", () => {
     expectTypeOf<keyof Row>().toEqualTypeOf<keyof SystemSettingsServerMetadata>();
   });
 
-  it("system_settings Drizzle row equals SystemSettingsServerMetadata", () => {
+  it("system_settings Drizzle row equals SystemSettingsServerMetadata (brand-stripped)", () => {
     type Row = InferSelectModel<typeof systemSettings>;
-    expectTypeOf<Equal<Row, SystemSettingsServerMetadata>>().toEqualTypeOf<true>();
+    expectTypeOf<
+      Equal<Serialize<Row>, Serialize<SystemSettingsServerMetadata>>
+    >().toEqualTypeOf<true>();
   });
 });

--- a/packages/db/src/__tests__/type-parity/system-settings.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/system-settings.type.test.ts
@@ -8,22 +8,14 @@
  * the blob, not its own column), and `nomenclature` (stored in the
  * `nomenclature_settings` table). It adds `pinHash` and
  * `biometricEnabled` (server-visible for device-transfer policy) plus
- * `encryptedData`. See `member.type.test.ts` for the general rationale
- * behind the brand-stripped comparison.
- *
- * `Serialize` is used on both sides of the equality check to strip the
- * `PinHash` brand (and any future brands) down to their primitive
- * equivalents before comparison. Drizzle emits `pinHash` as
- * `string | null` (a bare `varchar` column), while the domain type now
- * carries `PinHash | null`; stripping brands makes the check structurally
- * sound without widening other fields.
+ * `encryptedData`.
  */
 
 import { describe, expectTypeOf, it } from "vitest";
 
 import { systemSettings } from "../../schema/pg/system-settings.js";
 
-import type { Equal, Serialize, SystemSettingsServerMetadata } from "@pluralscape/types";
+import type { Equal, SystemSettingsServerMetadata } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
 describe("SystemSettings Drizzle parity", () => {
@@ -32,10 +24,8 @@ describe("SystemSettings Drizzle parity", () => {
     expectTypeOf<keyof Row>().toEqualTypeOf<keyof SystemSettingsServerMetadata>();
   });
 
-  it("system_settings Drizzle row equals SystemSettingsServerMetadata (brand-stripped)", () => {
+  it("system_settings Drizzle row equals SystemSettingsServerMetadata", () => {
     type Row = InferSelectModel<typeof systemSettings>;
-    expectTypeOf<
-      Equal<Serialize<Row>, Serialize<SystemSettingsServerMetadata>>
-    >().toEqualTypeOf<true>();
+    expectTypeOf<Equal<Row, SystemSettingsServerMetadata>>().toEqualTypeOf<true>();
   });
 });

--- a/packages/db/src/schema/pg/system-settings.ts
+++ b/packages/db/src/schema/pg/system-settings.ts
@@ -6,7 +6,7 @@ import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.pg.j
 
 import { systems } from "./systems.js";
 
-import type { Locale, SystemId, SystemSettingsId } from "@pluralscape/types";
+import type { Locale, PinHash, SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const systemSettings = pgTable(
@@ -19,7 +19,7 @@ export const systemSettings = pgTable(
       .references(() => systems.id, { onDelete: "cascade" }),
     locale: varchar("locale", { length: 255 }).$type<Locale>(),
     /** Must use Argon2id — PINs are low-entropy (4-6 digits) and trivially reversible with weak hashes. */
-    pinHash: varchar("pin_hash", { length: 512 }),
+    pinHash: varchar("pin_hash", { length: 512 }).$type<PinHash | null>(),
     /**
      * Server-side cache of the biometricEnabled value stored inside the
      * encrypted AppLockConfig blob (encryptedData). Duplicated here so

--- a/packages/db/src/schema/sqlite/system-settings.ts
+++ b/packages/db/src/schema/sqlite/system-settings.ts
@@ -6,7 +6,7 @@ import { timestamps, versioned, versionCheckFor } from "../../helpers/audit.sqli
 
 import { systems } from "./systems.js";
 
-import type { Locale, SystemId, SystemSettingsId } from "@pluralscape/types";
+import type { Locale, PinHash, SystemId, SystemSettingsId } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const systemSettings = sqliteTable(
@@ -19,7 +19,7 @@ export const systemSettings = sqliteTable(
       .references(() => systems.id, { onDelete: "cascade" }),
     locale: text("locale").$type<Locale>(),
     /** Must use Argon2id — PINs are low-entropy (4-6 digits) and trivially reversible with weak hashes. */
-    pinHash: text("pin_hash"),
+    pinHash: text("pin_hash").$type<PinHash | null>(),
     biometricEnabled: integer("biometric_enabled", { mode: "boolean" }).notNull().default(false),
     encryptedData: sqliteEncryptedBlob("encrypted_data").notNull(),
     ...timestamps(),

--- a/packages/types/src/__tests__/encrypted-fields-policy.test.ts
+++ b/packages/types/src/__tests__/encrypted-fields-policy.test.ts
@@ -2,15 +2,16 @@ import { describe, it, expectTypeOf } from "vitest";
 
 import type { JournalEntryEncryptedFields } from "../entities/journal-entry.js";
 import type { Equal } from "../type-assertions.js";
+import type { AuditMetadata } from "../utility.js";
 
 describe("encrypted-fields policy guard", () => {
-  it("JournalEntryEncryptedFields equals the documented literal union", () => {
+  it("contains exactly the fields encrypted before server storage", () => {
     type Expected = "title" | "author" | "blocks" | "tags" | "linkedEntities" | "frontingSnapshots";
     expectTypeOf<Equal<JournalEntryEncryptedFields, Expected>>().toEqualTypeOf<true>();
   });
 
   it("JournalEntryEncryptedFields excludes the allowlisted plaintext keys", () => {
-    type Allowlist = "id" | "systemId" | "frontingSessionId" | "archived";
+    type Allowlist = "id" | "systemId" | "frontingSessionId" | "archived" | keyof AuditMetadata;
     expectTypeOf<Extract<JournalEntryEncryptedFields, Allowlist>>().toEqualTypeOf<never>();
   });
 });

--- a/packages/types/src/__tests__/encrypted-fields-policy.test.ts
+++ b/packages/types/src/__tests__/encrypted-fields-policy.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expectTypeOf } from "vitest";
+
+import type { JournalEntryEncryptedFields } from "../entities/journal-entry.js";
+import type { Equal } from "../type-assertions.js";
+
+describe("encrypted-fields policy guard", () => {
+  it("JournalEntryEncryptedFields equals the documented literal union", () => {
+    type Expected = "title" | "author" | "blocks" | "tags" | "linkedEntities" | "frontingSnapshots";
+    expectTypeOf<Equal<JournalEntryEncryptedFields, Expected>>().toEqualTypeOf<true>();
+  });
+
+  it("JournalEntryEncryptedFields excludes the allowlisted plaintext keys", () => {
+    type Allowlist = "id" | "systemId" | "frontingSessionId" | "archived";
+    expectTypeOf<Extract<JournalEntryEncryptedFields, Allowlist>>().toEqualTypeOf<never>();
+  });
+});

--- a/packages/types/src/__tests__/encrypted-fields-policy.test.ts
+++ b/packages/types/src/__tests__/encrypted-fields-policy.test.ts
@@ -5,7 +5,7 @@ import type { NoteEncryptedFields } from "../entities/note.js";
 import type { Equal } from "../type-assertions.js";
 import type { AuditMetadata } from "../utility.js";
 
-describe("encrypted-fields policy guard", () => {
+describe("JournalEntry encrypted-fields policy guard", () => {
   it("contains exactly the fields encrypted before server storage", () => {
     type Expected = "title" | "author" | "blocks" | "tags" | "linkedEntities" | "frontingSnapshots";
     expectTypeOf<Equal<JournalEntryEncryptedFields, Expected>>().toEqualTypeOf<true>();
@@ -23,7 +23,7 @@ describe("Note encrypted-fields policy guard", () => {
     expectTypeOf<Equal<NoteEncryptedFields, Expected>>().toEqualTypeOf<true>();
   });
 
-  it("excludes id, systemId, author, archived, and audit fields", () => {
+  it("NoteEncryptedFields excludes the allowlisted plaintext keys", () => {
     type Allowlist = "id" | "systemId" | "author" | "archived" | keyof AuditMetadata;
     expectTypeOf<Extract<NoteEncryptedFields, Allowlist>>().toEqualTypeOf<never>();
   });

--- a/packages/types/src/__tests__/encrypted-fields-policy.test.ts
+++ b/packages/types/src/__tests__/encrypted-fields-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expectTypeOf } from "vitest";
 
 import type { JournalEntryEncryptedFields } from "../entities/journal-entry.js";
+import type { NoteEncryptedFields } from "../entities/note.js";
 import type { Equal } from "../type-assertions.js";
 import type { AuditMetadata } from "../utility.js";
 
@@ -13,5 +14,17 @@ describe("encrypted-fields policy guard", () => {
   it("JournalEntryEncryptedFields excludes the allowlisted plaintext keys", () => {
     type Allowlist = "id" | "systemId" | "frontingSessionId" | "archived" | keyof AuditMetadata;
     expectTypeOf<Extract<JournalEntryEncryptedFields, Allowlist>>().toEqualTypeOf<never>();
+  });
+});
+
+describe("Note encrypted-fields policy guard", () => {
+  it("contains exactly the fields encrypted before server storage", () => {
+    type Expected = "title" | "content" | "backgroundColor";
+    expectTypeOf<Equal<NoteEncryptedFields, Expected>>().toEqualTypeOf<true>();
+  });
+
+  it("excludes id, systemId, author, archived, and audit fields", () => {
+    type Allowlist = "id" | "systemId" | "author" | "archived" | keyof AuditMetadata;
+    expectTypeOf<Extract<NoteEncryptedFields, Allowlist>>().toEqualTypeOf<never>();
   });
 });

--- a/packages/types/src/__tests__/structure.test.ts
+++ b/packages/types/src/__tests__/structure.test.ts
@@ -2,6 +2,7 @@ import { assertType, describe, expectTypeOf, it } from "vitest";
 
 import type {
   ArchivedRelationship,
+  CustomRelationship,
   Relationship,
   RelationshipType,
 } from "../entities/relationship.js";
@@ -85,29 +86,33 @@ describe("Relationship", () => {
     expectTypeOf<Relationship>().not.toExtend<AuditMetadata>();
   });
 
-  it("has correct field types", () => {
+  it("has correct field types on shared keys", () => {
     expectTypeOf<Relationship["id"]>().toEqualTypeOf<RelationshipId>();
     expectTypeOf<Relationship["systemId"]>().toEqualTypeOf<SystemId>();
     expectTypeOf<Relationship["sourceMemberId"]>().toEqualTypeOf<MemberId | null>();
     expectTypeOf<Relationship["targetMemberId"]>().toEqualTypeOf<MemberId | null>();
     expectTypeOf<Relationship["type"]>().toEqualTypeOf<RelationshipType>();
-    expectTypeOf<Relationship["label"]>().toEqualTypeOf<string | null>();
     expectTypeOf<Relationship["bidirectional"]>().toEqualTypeOf<boolean>();
     expectTypeOf<Relationship["createdAt"]>().toEqualTypeOf<UnixMillis>();
+  });
+
+  it("label exists only on custom variant", () => {
+    // label is not on the union base — access via narrowed type only
+    expectTypeOf<CustomRelationship["label"]>().toEqualTypeOf<string>();
   });
 
   it("has archived as false literal", () => {
     expectTypeOf<Relationship["archived"]>().toEqualTypeOf<false>();
   });
 
-  it("has exact shape", () => {
+  it("has exact shape — union of both variant key sets", () => {
+    // keyof (A | B) = keyof A & keyof B (shared keys only)
     expectTypeOf<keyof Relationship>().toEqualTypeOf<
       | "id"
       | "systemId"
       | "sourceMemberId"
       | "targetMemberId"
       | "type"
-      | "label"
       | "bidirectional"
       | "createdAt"
       | "archived"

--- a/packages/types/src/entities/friend-connection.ts
+++ b/packages/types/src/entities/friend-connection.ts
@@ -51,11 +51,19 @@ export type FriendConnectionEncryptedInput = Pick<
 >;
 
 /**
- * Domain field absent from the server row for STRUCTURAL reasons (the
- * value lives in a junction table — `friend_bucket_assignments`), not
- * because it is encrypted. Distinguished from
- * `FriendConnectionEncryptedFields` (encrypted blob) and `archived`
- * (literal-to-boolean flip).
+ * Domain keys omitted from `FriendConnectionServerMetadata` for one of three
+ * orthogonal reasons:
+ *
+ * 1. **Junction-table derivation** — `assignedBucketIds` is computed by
+ *    joining the `bucket_friend_connections` junction table at read time,
+ *    not stored on the friend-connection row.
+ * 2. **Encrypted-blob derivation** — `visibility` lives inside the T1
+ *    `encryptedData` blob; the server never sees its plaintext form.
+ * 3. **Domain-only convention** — `archived` exists on the domain as a
+ *    discriminated literal (widens to `boolean` server-side), so the omit
+ *    avoids the type collision.
+ *
+ * @see FriendConnectionServerMetadata
  */
 export type FriendConnectionAuxOmitFields = "assignedBucketIds";
 
@@ -63,13 +71,9 @@ export type FriendConnectionAuxOmitFields = "assignedBucketIds";
  * Server-visible FriendConnection metadata — raw Drizzle row shape.
  *
  * The Omit clause names three orthogonal reasons a domain key is absent
- * from the server row:
- *   1. `FriendConnectionEncryptedFields` — value lives in `encryptedData`
- *   2. `FriendConnectionAuxOmitFields` — value lives in a junction table
- *   3. `"archived"` — domain literal `false` flips to mutable boolean below
- *
- * Adds the nullable `encryptedData` column (nullable because pending
- * connections have no visibility blob yet) and `archivedAt`.
+ * from the server row — see {@link FriendConnectionAuxOmitFields} for the
+ * full enumeration. Adds the nullable `encryptedData` column (nullable
+ * because pending connections have no visibility blob yet) and `archivedAt`.
  */
 export type FriendConnectionServerMetadata = Omit<
   FriendConnection,

--- a/packages/types/src/entities/journal-entry.ts
+++ b/packages/types/src/entities/journal-entry.ts
@@ -169,13 +169,10 @@ export type ArchivedJournalEntry = Archived<JournalEntry>;
  * - `JournalEntryEncryptedInput = Pick<JournalEntry, JournalEntryEncryptedFields>`
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextJournalEntry parity)
  */
-export type JournalEntryEncryptedFields =
-  | "title"
-  | "author"
-  | "blocks"
-  | "tags"
-  | "linkedEntities"
-  | "frontingSnapshots";
+export type JournalEntryEncryptedFields = Exclude<
+  keyof JournalEntry,
+  "id" | "systemId" | "frontingSessionId" | "archived" | keyof AuditMetadata
+>;
 
 /**
  * Server-visible JournalEntry metadata — raw Drizzle row shape.

--- a/packages/types/src/entities/journal-entry.ts
+++ b/packages/types/src/entities/journal-entry.ts
@@ -161,9 +161,20 @@ export type ArchivedJournalEntry = Archived<JournalEntry>;
 
 /**
  * Keys of `JournalEntry` that are encrypted client-side before the server
- * sees them. The server stores ciphertext in `encryptedData`; the only
- * plaintext column (besides the audit triple and `systemId`/`id`) is
- * `frontingSessionId`, kept in the clear as a FK for efficient joins.
+ * sees them — derived via `Exclude<keyof JournalEntry, ...>` (encrypt-by-default
+ * policy: every new field is encrypted unless explicitly allowlisted).
+ *
+ * Excluded (plaintext) keys and the rationale for each:
+ * - `id`               — primary key; required for upsert routing and FK references
+ * - `systemId`         — partition key; required for RLS context and tenant isolation
+ * - `frontingSessionId`— FK into the partitioned fronting-sessions table; kept clear
+ *                        so the server can perform efficient joins without decrypting
+ * - `archived`         — boolean flag; server must query it for archival/restore
+ *                        operations and index maintenance without decrypting the blob
+ * - `createdAt`, `updatedAt`, `version` (from `AuditMetadata`) — server-managed audit
+ *                        columns written by the database; never part of the encrypted
+ *                        payload
+ *
  * Consumed by:
  * - `JournalEntryServerMetadata` (derived via `Omit`)
  * - `JournalEntryEncryptedInput = Pick<JournalEntry, JournalEntryEncryptedFields>`

--- a/packages/types/src/entities/lifecycle-event.ts
+++ b/packages/types/src/entities/lifecycle-event.ts
@@ -162,7 +162,9 @@ export type LifecycleEventEncryptedFields = "notes";
 // when an entity diverges from the standard pattern.
 
 /** Single-key projection over `"notes"` — not truncated. */
-export type LifecycleEventEncryptedInput = Pick<LifecycleEvent, LifecycleEventEncryptedFields>;
+export type LifecycleEventEncryptedInput = LifecycleEvent extends unknown
+  ? Pick<LifecycleEvent, LifecycleEventEncryptedFields>
+  : never;
 
 /**
  * Server-visible LifecycleEvent metadata — raw Drizzle row shape.

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -23,7 +23,7 @@ export interface MemberPhoto {
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextMemberPhoto parity)
  * - `MemberPhotoServerMetadata` (derived via `Omit`)
  */
-export type MemberPhotoEncryptedFields = "imageSource" | "sortOrder" | "caption";
+export type MemberPhotoEncryptedFields = "imageSource" | "caption";
 
 // ── Canonical chain (see ADR-023) ────────────────────────────────────
 // MemberPhotoEncryptedInput → MemberPhotoServerMetadata
@@ -44,9 +44,9 @@ export type ArchivedMemberPhoto = Archived<MemberPhoto>;
  * inside `encryptedData` and `archived` (server tracks a mutable boolean
  * with a companion `archivedAt` timestamp, domain uses `false` literal).
  * Adds DB-only columns the domain type doesn't carry: `systemId`
- * (denormalized from `members` for RLS), `sortOrder` kept plaintext in DB
- * for index-based ordering (present in domain but marked encrypted),
- * full `AuditMetadata` (`createdAt`/`updatedAt`/`version`),
+ * (denormalized from `members` for RLS), `sortOrder` kept as a plaintext
+ * column for index-based ordering (re-added explicitly here so the DB shape
+ * is unambiguous), full `AuditMetadata` (`createdAt`/`updatedAt`/`version`),
  * `encryptedData` (the T1 blob), and `archived`/`archivedAt`.
  */
 export type MemberPhotoServerMetadata = Omit<MemberPhoto, MemberPhotoEncryptedFields | "archived"> &

--- a/packages/types/src/entities/member-photo.ts
+++ b/packages/types/src/entities/member-photo.ts
@@ -40,19 +40,23 @@ export type ArchivedMemberPhoto = Archived<MemberPhoto>;
 /**
  * Server-visible MemberPhoto metadata — raw Drizzle row shape.
  *
- * Derived from `MemberPhoto` by stripping the encrypted field keys bundled
- * inside `encryptedData` and `archived` (server tracks a mutable boolean
- * with a companion `archivedAt` timestamp, domain uses `false` literal).
- * Adds DB-only columns the domain type doesn't carry: `systemId`
- * (denormalized from `members` for RLS), `sortOrder` kept as a plaintext
- * column for index-based ordering (re-added explicitly here so the DB shape
- * is unambiguous), full `AuditMetadata` (`createdAt`/`updatedAt`/`version`),
- * `encryptedData` (the T1 blob), and `archived`/`archivedAt`.
+ * Derived from `MemberPhoto` by stripping the encrypted field keys
+ * (`imageSource`, `caption`) that ride inside `encryptedData`, and
+ * `archived` (server tracks a mutable boolean with a companion
+ * `archivedAt` timestamp; the domain uses the `false` literal).
+ *
+ * Adds DB-only columns the domain type doesn't carry:
+ * - `systemId` — denormalized from `members` for RLS
+ * - `encryptedData: EncryptedBlob` — T1 blob carrying the encrypted fields
+ * - `archived: boolean` / `archivedAt` — archive lifecycle columns
+ * - full `AuditMetadata` (`createdAt` / `updatedAt` / `version`)
+ *
+ * `sortOrder` is plaintext on both sides and flows through from `MemberPhoto`
+ * via the `Omit`; no re-declaration needed.
  */
 export type MemberPhotoServerMetadata = Omit<MemberPhoto, MemberPhotoEncryptedFields | "archived"> &
   AuditMetadata & {
     readonly systemId: SystemId;
-    readonly sortOrder: number;
     readonly encryptedData: EncryptedBlob;
     readonly archived: boolean;
     readonly archivedAt: UnixMillis | null;

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -29,19 +29,27 @@ export interface Note extends AuditMetadata {
 export type ArchivedNote = Archived<Note>;
 
 /**
- * Keys of `Note` that are encrypted client-side before the server sees them.
- * The server stores ciphertext in `encryptedData`; the `author` reference is
- * flattened into plaintext columns (`authorEntityType` + `authorEntityId`) for
- * indexing by author type.
+ * Keys of `Note` whose values are encrypted client-side before the server
+ * sees them (encrypt-by-default policy via `Exclude<>`).
+ *
+ * Excluded keys and rationale:
+ * - `id` / `systemId` — structural identity, required for server routing
+ * - `author` — restructured plaintext: the polymorphic `EntityReference`
+ *   flattens into separate `authorEntityType` + `authorEntityId` server
+ *   columns for indexing; the value is never inside the encrypted blob
+ * - `archived` — mutable server-side flag with companion `archivedAt`
+ * - `createdAt` / `updatedAt` / `updatedBy` (via `AuditMetadata`) —
+ *   server-managed audit timestamps and actor reference
+ *
  * Consumed by:
  * - `NoteServerMetadata` (derived via `Omit`)
  * - `NoteEncryptedInput = Pick<Note, NoteEncryptedFields>`
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextNote parity)
- *
- * Unlike `JournalEntry`, `Note`'s `author` is a server-side flattened plaintext column
- * (split into `authorEntityType` + `authorEntityId`), not part of the encrypted blob.
  */
-export type NoteEncryptedFields = "title" | "content" | "backgroundColor";
+export type NoteEncryptedFields = Exclude<
+  keyof Note,
+  "id" | "systemId" | "author" | "archived" | keyof AuditMetadata
+>;
 
 /**
  * Domain field that is plaintext (not encrypted) but restructured on the

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -38,7 +38,7 @@ export type ArchivedNote = Archived<Note>;
  *   flattens into separate `authorEntityType` + `authorEntityId` server
  *   columns for indexing; the value is never inside the encrypted blob
  * - `archived` — mutable server-side flag with companion `archivedAt`
- * - `createdAt` / `updatedAt` / `updatedBy` (via `AuditMetadata`) —
+ * - `createdAt` / `updatedAt` / `version` (via `AuditMetadata`) —
  *   server-managed audit timestamps and actor reference
  *
  * Consumed by:

--- a/packages/types/src/entities/relationship.ts
+++ b/packages/types/src/entities/relationship.ts
@@ -3,7 +3,7 @@ import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { MemberId, RelationshipId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
-import type { Archived, AuditMetadata } from "../utility.js";
+import type { Archived } from "../utility.js";
 
 /** The kind of relationship between two members. */
 export type RelationshipType =
@@ -18,19 +18,29 @@ export type RelationshipType =
   | "source"
   | "custom";
 
-/** A relationship between two members. */
-export interface Relationship {
+interface RelationshipBase {
   readonly id: RelationshipId;
   readonly systemId: SystemId;
   readonly sourceMemberId: MemberId | null;
   readonly targetMemberId: MemberId | null;
-  readonly type: RelationshipType;
-  /** User-defined label — only meaningful when type is "custom". */
-  readonly label: string | null;
   readonly bidirectional: boolean;
   readonly createdAt: UnixMillis;
   readonly archived: false;
 }
+
+/** A custom-type relationship — carries a user-defined label. */
+export interface CustomRelationship extends RelationshipBase {
+  readonly type: "custom";
+  readonly label: string;
+}
+
+/** A standard-type relationship — no user-defined label. */
+export interface StandardRelationship extends RelationshipBase {
+  readonly type: Exclude<RelationshipType, "custom">;
+}
+
+/** A relationship between two members. Discriminated by `type`. */
+export type Relationship = CustomRelationship | StandardRelationship;
 
 /**
  * Keys of `Relationship` that are encrypted client-side before the server sees
@@ -38,7 +48,6 @@ export interface Relationship {
  * sent plaintext because the server needs them for querying. Consumed by:
  * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextRelationship parity)
- * - Plan 2 fleet will consume when deriving `RelationshipServerMetadata`.
  */
 export type RelationshipEncryptedFields = "label";
 
@@ -49,32 +58,40 @@ export type RelationshipEncryptedFields = "label";
 // chain anchor above carries the meaning. Per-alias docs only appear
 // when an entity diverges from the standard pattern.
 
-/** Single-key projection over `"label"` — not truncated. */
-export type RelationshipEncryptedInput = Pick<Relationship, RelationshipEncryptedFields>;
+/**
+ * Distributive Pick over the union — `{ label: string }` for the custom
+ * variant, `{}` for standard variants (which carry no label key at all).
+ */
+export type RelationshipEncryptedInput = Relationship extends unknown
+  ? Pick<Relationship, Extract<keyof Relationship, RelationshipEncryptedFields>>
+  : never;
 
 export type ArchivedRelationship = Archived<Relationship>;
 
 /**
  * Server-visible Relationship metadata — raw Drizzle row shape.
  *
- * Derived from `Relationship` by stripping the encrypted field key
- * (`label` rides inside `encryptedData`) and `archived` (server tracks a
- * mutable boolean with a companion `archivedAt` timestamp, domain uses
- * `false` literal). Adds DB-only columns the domain doesn't carry:
- * `encryptedData` (T1 blob), `archived`/`archivedAt`, and the rest of
- * `AuditMetadata` (`updatedAt`/`version` — the domain carries only
- * `createdAt`). Non-"custom" relationships carry an empty label inside
- * the blob rather than a nullable column.
+ * Declared as a single non-union shape because the Drizzle `relationships`
+ * table returns one object shape (not a union). The discriminated union is
+ * purely a domain-level invariant enforced after decryption. The server
+ * carries `type: RelationshipType` (flat) and `label` lives inside
+ * `encryptedData`. Adds DB-only columns: `encryptedData`, `archived`/
+ * `archivedAt`, `updatedAt`, `version`.
  */
-export type RelationshipServerMetadata = Omit<
-  Relationship,
-  RelationshipEncryptedFields | "archived"
-> &
-  Omit<AuditMetadata, "createdAt"> & {
-    readonly encryptedData: EncryptedBlob;
-    readonly archived: boolean;
-    readonly archivedAt: UnixMillis | null;
-  };
+export type RelationshipServerMetadata = {
+  readonly id: RelationshipId;
+  readonly systemId: SystemId;
+  readonly sourceMemberId: MemberId | null;
+  readonly targetMemberId: MemberId | null;
+  readonly type: RelationshipType;
+  readonly bidirectional: boolean;
+  readonly encryptedData: EncryptedBlob;
+  readonly archived: boolean;
+  readonly archivedAt: UnixMillis | null;
+  readonly createdAt: UnixMillis;
+  readonly updatedAt: UnixMillis;
+  readonly version: number;
+};
 
 export type RelationshipResult = EncryptedWire<RelationshipServerMetadata>;
 

--- a/packages/types/src/entities/system-settings.ts
+++ b/packages/types/src/entities/system-settings.ts
@@ -1,7 +1,7 @@
 import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { Locale } from "../i18n.js";
-import type { BucketId, SystemSettingsId, SystemId } from "../ids.js";
+import type { Brand, BucketId, SystemSettingsId, SystemId } from "../ids.js";
 import type { LittlesSafeModeConfig } from "../littles-safe-mode.js";
 import type { NomenclatureSettings } from "../nomenclature.js";
 import type { Serialize } from "../type-assertions.js";
@@ -116,11 +116,19 @@ export type SystemSettingsEncryptedInput = Pick<SystemSettings, SystemSettingsEn
  * (server-visible for device-transfer policy enforcement without
  * decrypting the settings blob) and `encryptedData`.
  */
+/**
+ * Argon2id-hashed PIN. Branded `string` to prevent assigning an unhashed PIN
+ * by mistake. Constructed only at the hashing call site (`hashPinOffload` in
+ * `apps/api/src/services/pin.service.ts` and `account-pin.service.ts`); never
+ * exposed to clients.
+ */
+export type PinHash = Brand<string, "PinHash">;
+
 export type SystemSettingsServerMetadata = Omit<
   SystemSettings,
   SystemSettingsEncryptedFields | "defaultBucketId" | "nomenclature"
 > & {
-  readonly pinHash: string | null;
+  readonly pinHash: PinHash | null;
   readonly biometricEnabled: boolean;
   readonly encryptedData: EncryptedBlob;
 };

--- a/packages/types/src/entities/system-settings.ts
+++ b/packages/types/src/entities/system-settings.ts
@@ -106,6 +106,14 @@ export type SystemSettingsEncryptedFields =
 export type SystemSettingsEncryptedInput = Pick<SystemSettings, SystemSettingsEncryptedFields>;
 
 /**
+ * Argon2id-hashed PIN. Branded `string` to prevent assigning an unhashed PIN
+ * by mistake. Constructed only at the hashing call site (`hashPinOffload` in
+ * `apps/api/src/services/pin.service.ts` and `account-pin.service.ts`); never
+ * exposed to clients.
+ */
+export type PinHash = Brand<string, "PinHash">;
+
+/**
  * Server-visible SystemSettings metadata — raw Drizzle row shape.
  *
  * Derived from `SystemSettings` by stripping the encrypted field keys
@@ -116,14 +124,6 @@ export type SystemSettingsEncryptedInput = Pick<SystemSettings, SystemSettingsEn
  * (server-visible for device-transfer policy enforcement without
  * decrypting the settings blob) and `encryptedData`.
  */
-/**
- * Argon2id-hashed PIN. Branded `string` to prevent assigning an unhashed PIN
- * by mistake. Constructed only at the hashing call site (`hashPinOffload` in
- * `apps/api/src/services/pin.service.ts` and `account-pin.service.ts`); never
- * exposed to clients.
- */
-export type PinHash = Brand<string, "PinHash">;
-
 export type SystemSettingsServerMetadata = Omit<
   SystemSettings,
   SystemSettingsEncryptedFields | "defaultBucketId" | "nomenclature"

--- a/packages/types/src/entities/system.ts
+++ b/packages/types/src/entities/system.ts
@@ -44,6 +44,12 @@ export interface SystemListItem {
 /**
  * Server-visible System metadata — raw Drizzle row shape.
  *
+ * Divergence from domain: the server row carries `archived: boolean` even
+ * though `System` (the decrypted domain shape) has no `archived` field.
+ * Systems are not user-archivable; the column exists at the DB layer for
+ * uniform soft-deletion plumbing across all entity tables, but no domain
+ * code path reads or writes it. Treat the field as server-only state.
+ *
  * Derived from `System` by stripping the encrypted field keys (bundled
  * inside `encryptedData`) and `settingsId` (which lives on the companion
  * `system_settings` table, joined on `systemId`, not as a column on

--- a/packages/validation/src/__tests__/type-parity/relationship.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/relationship.type.test.ts
@@ -1,24 +1,39 @@
 /**
  * Zod parity check: `z.infer<typeof RelationshipEncryptedInputSchema>`
- * structurally matches `Pick<Relationship, RelationshipEncryptedFields>` —
- * the canonical pre-encryption projection derived from the domain type.
- *
- * Asserts directly against `Pick<Relationship, RelationshipEncryptedFields>`
- * (rather than importing `RelationshipEncryptedInput` from
- * `@pluralscape/data`) to avoid creating a reverse dependency from
- * validation → data.
+ * structurally matches `RelationshipEncryptedInput` — the distributive Pick
+ * that yields `{ label: string }` for custom variants and `{}` for standard
+ * variants. Asserts directly against the distributive Pick expression
+ * (rather than importing `RelationshipEncryptedInput` from `@pluralscape/data`)
+ * to avoid a reverse dependency from validation → data.
  */
 
 import { describe, expectTypeOf, it } from "vitest";
 
-import type { RelationshipEncryptedInputSchema } from "../../relationship.js";
+import type {
+  RelationshipEncryptedInputSchema,
+  CustomRelationshipEncryptedSchema,
+  StandardRelationshipEncryptedSchema,
+} from "../../relationship.js";
 import type { Equal, Relationship, RelationshipEncryptedFields } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 describe("Relationship Zod parity", () => {
-  it("RelationshipEncryptedInputSchema matches Pick<Relationship, RelationshipEncryptedFields>", () => {
+  it("RelationshipEncryptedInputSchema matches distributive RelationshipEncryptedInput", () => {
     type Inferred = z.infer<typeof RelationshipEncryptedInputSchema>;
-    type Expected = Pick<Relationship, RelationshipEncryptedFields>;
+    // Distributive Pick: `{ label: string }` for custom, `{}` for standard
+    type Expected = Relationship extends unknown
+      ? Pick<Relationship, Extract<keyof Relationship, RelationshipEncryptedFields>>
+      : never;
     expectTypeOf<Equal<Inferred, Expected>>().toEqualTypeOf<true>();
+  });
+
+  it("CustomRelationshipEncryptedSchema has required label: string", () => {
+    type Inferred = z.infer<typeof CustomRelationshipEncryptedSchema>;
+    expectTypeOf<Equal<Inferred, { readonly label: string }>>().toEqualTypeOf<true>();
+  });
+
+  it("StandardRelationshipEncryptedSchema is an empty object", () => {
+    type Inferred = z.infer<typeof StandardRelationshipEncryptedSchema>;
+    expectTypeOf<Equal<Inferred, Record<string, never>>>().toEqualTypeOf<true>();
   });
 });

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -85,8 +85,10 @@ export {
 } from "./structure.js";
 export {
   CreateRelationshipBodySchema,
+  CustomRelationshipEncryptedSchema,
   RELATIONSHIP_TYPES,
   RelationshipEncryptedInputSchema,
+  StandardRelationshipEncryptedSchema,
   UpdateRelationshipBodySchema,
 } from "./relationship.js";
 export {

--- a/packages/validation/src/relationship.ts
+++ b/packages/validation/src/relationship.ts
@@ -25,9 +25,11 @@ export const CustomRelationshipEncryptedSchema = z.object({ label: z.string() })
 
 /**
  * Runtime validator for a standard-type pre-encryption Relationship input.
- * Standard relationships carry no label — the blob is an empty object.
+ * Standard relationships carry no label — the blob MUST be an empty object.
+ * Strict mode rejects any extra keys (defense against schema drift or
+ * misrouted custom blobs).
  */
-export const StandardRelationshipEncryptedSchema = z.object({}).readonly();
+export const StandardRelationshipEncryptedSchema = z.object({}).strict().readonly();
 
 /**
  * Union of both encrypted-input schemas. `z.infer` yields `{ label: string } | {}`,

--- a/packages/validation/src/relationship.ts
+++ b/packages/validation/src/relationship.ts
@@ -17,16 +17,27 @@ export const RELATIONSHIP_TYPES = [
 ] as const;
 
 /**
- * Runtime validator for the pre-encryption Relationship input. Every field
- * of `RelationshipEncryptedInput` (in `@pluralscape/data`) must be present
- * and well-formed. Zod compile-time parity is checked in
- * `__tests__/type-parity/relationship.type.test.ts`.
+ * Runtime validator for the custom-type pre-encryption Relationship input.
+ * The `type` discriminant is plaintext on the wire (not inside the blob), so
+ * callers must select the correct schema before parsing the decrypted payload.
  */
-export const RelationshipEncryptedInputSchema = z
-  .object({
-    label: z.string().nullable(),
-  })
-  .readonly();
+export const CustomRelationshipEncryptedSchema = z.object({ label: z.string() }).readonly();
+
+/**
+ * Runtime validator for a standard-type pre-encryption Relationship input.
+ * Standard relationships carry no label — the blob is an empty object.
+ */
+export const StandardRelationshipEncryptedSchema = z.object({}).readonly();
+
+/**
+ * Union of both encrypted-input schemas. `z.infer` yields `{ label: string } | {}`,
+ * matching the distributive `RelationshipEncryptedInput` canonical type.
+ * Zod compile-time parity checked in `__tests__/type-parity/relationship.type.test.ts`.
+ */
+export const RelationshipEncryptedInputSchema = z.union([
+  CustomRelationshipEncryptedSchema,
+  StandardRelationshipEncryptedSchema,
+]);
 
 export const CreateRelationshipBodySchema = z
   .object({

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -258,7 +258,13 @@ expectTypeOf<
 expectTypeOf<
   Equal<
     components["schemas"]["PlaintextRelationship"],
-    Serialize<Pick<Relationship, RelationshipEncryptedFields>>
+    // Distributive Pick — `{ label: string }` for custom, `{}` for standard.
+    // Matches `RelationshipEncryptedInput` (see packages/types/src/entities/relationship.ts).
+    Serialize<
+      Relationship extends unknown
+        ? Pick<Relationship, Extract<keyof Relationship, RelationshipEncryptedFields>>
+        : never
+    >
   >
 >().toEqualTypeOf<true>();
 


### PR DESCRIPTION
## Summary

Closes types-x61u, types-vmk9, types-kk7a — type-system + JSDoc tightening per the ps-y4tb followups spec (`docs/superpowers/specs/2026-04-26-ps-y4tb-followups-design.md`).

### types-x61u — `Exclude<>` derivations + defensive distributive Pick

- `JournalEntryEncryptedFields` and `NoteEncryptedFields` derive via `Exclude<keyof X, allowlist>` (encrypt-by-default policy: a future domain field defaults to encrypted unless explicitly allowlisted)
- `LifecycleEventEncryptedInput` is defensively distributive (`LifecycleEvent extends unknown ? Pick<…> : never`) so a future variant overriding `notes` doesn't break the union
- New parity guard test at `packages/types/src/__tests__/encrypted-fields-policy.test.ts` locks the current key sets in

### types-vmk9 — PinHash brand + Relationship discriminated union

- `PinHash` brand declared in `@pluralscape/types`; applied to `SystemSettingsServerMetadata.pinHash`
- Both PG and SQLite `pinHash` columns branded via `.\$type<PinHash | null>()`; integration tests fixed up
- Hash-construction call sites in `pin.service.ts` and `account-pin.service.ts` cast to `PinHash`
- `Relationship` is now a discriminated union: `CustomRelationship` carries `label: string`, `StandardRelationship` has no `label` key
- `RelationshipEncryptedInput` is the distributive Pick (`{ label: string } | {}`)
- Validation split into `CustomRelationshipEncryptedSchema` (`.string()`, no nullable) and `StandardRelationshipEncryptedSchema` (`.strict()` — rejects extra keys, defends against schema drift / misrouted blobs)
- `RelationshipServerMetadata` declared as explicit single-shape (Drizzle row stays flat; the discriminated union is a domain-level invariant only)
- Transform narrows on `raw.type` to select the right schema; mobile `rowToRelationship` mirrors the pattern
- OpenAPI `PlaintextRelationship` updated to `oneOf`

### types-kk7a — JSDoc tightening + member-photo sortOrder

- `system.ts` JSDoc explicitly notes that `archived` is a server-only field with no domain counterpart
- `friend-connection.ts` `FriendConnectionAuxOmitFields` JSDoc carries the three orthogonal Omit reasons (junction-table derivation, encrypted-blob derivation, domain-only convention); `FriendConnectionServerMetadata` cross-links via `{@link}`
- `member-photo.ts` `MemberPhotoEncryptedFields` no longer includes `sortOrder` (it was already plaintext on the server for indexing — the encrypted blob carrying a redundant copy was a semantic lie); OpenAPI `PlaintextMemberPhoto` updated; Drizzle parity test JSDoc refreshed
- ADR-023 Decision section now lists all six chain types as primary bullets (was three)

## Verification

Local:
- \`pnpm format\` — clean
- \`pnpm lint\` — 17/17 packages green (zero warnings)
- \`pnpm types:check-sot\` — all 4 sub-checks pass (types, Drizzle parity, Zod parity, OpenAPI-Wire parity)
- \`pnpm typecheck\` — 21/21 packages green
- \`pnpm test:unit\` — 12870 passed / 1 skipped / 1 todo
- \`pnpm test:integration\` — 3055 passed / 11 skipped
- \`pnpm test:e2e\` — 507 passed / 2 skipped

## Test plan

- [x] \`pnpm types:check-sot\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test:unit\`
- [x] \`pnpm test:integration\`
- [x] \`pnpm test:e2e\`