### PR TITLE
refactor(ps-y4tb): batch 2 — LifecycleEvent + CheckInRecord canonical migrations

### DIFF
--- a/.beans/types-600s--apply-canonical-chain-to-checkinrecord-server-only.md
+++ b/.beans/types-600s--apply-canonical-chain-to-checkinrecord-server-only.md
@@ -1,11 +1,11 @@
 ---
 # types-600s
 title: Apply canonical chain to CheckInRecord (server-only encrypted payload)
-status: todo
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-04-25T19:17:08Z
-updated_at: 2026-04-25T19:17:11Z
+updated_at: 2026-04-26T10:22:23Z
 parent: ps-y4tb
 ---
 

--- a/.beans/types-600s--apply-canonical-chain-to-checkinrecord-server-only.md
+++ b/.beans/types-600s--apply-canonical-chain-to-checkinrecord-server-only.md
@@ -1,11 +1,11 @@
 ---
 # types-600s
 title: Apply canonical chain to CheckInRecord (server-only encrypted payload)
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-25T19:17:08Z
-updated_at: 2026-04-26T10:22:23Z
+updated_at: 2026-04-26T10:24:13Z
 parent: ps-y4tb
 ---
 
@@ -43,3 +43,19 @@ Class A/B entities follow a uniform pattern (`Pick<X, XEncryptedFields>` for `En
 - [ ] OpenAPI parity uses G7 `Equal<MemberResponseOpenApi, MemberWire>` form
 - [ ] `pnpm types:check-sot` passes
 - [ ] CI green
+
+## Summary of Changes
+
+CheckInRecord (hybrid entity — plaintext domain + optional encrypted blob) now follows the canonical chain:
+
+- `idempotencyKey` annotated `ServerInternal<string> | null` (not `ServerInternal<string | null>` — the intersection collapses null branches, so the brand goes on the non-null side); PG and SQLite `idempotencyKey` columns mirror via `.$type<ServerInternal<string>>()`
+- `CheckInRecordResult = EncryptedWire<CheckInRecordServerMetadata>` and `CheckInRecordWire = Serialize<CheckInRecordResult>`
+- `__sot-manifest__` entry gains `result`; manifest test asserts the new shape
+- OpenAPI `CheckInRecordResponse` got a `required` array; G7 parity assertion added (`Equal<…CheckInRecordResponse, CheckInRecordWire>`)
+
+Two SoT-wide adjustments shipped alongside:
+
+- `StripServerInternal<T>` in `encrypted-wire.ts` widened to use `Extract<T[K], ServerInternal<unknown>>` so nullable server-only fields (`ServerInternal<X> | null`) are also stripped — the previous `extends` form missed unions
+- `__serverInternal` is now a real runtime `Symbol(...)` and re-exported from `@pluralscape/types`, so cross-package Drizzle column inferences over `.$type<ServerInternal<…>>()` can be named in declaration emit (was tripping TS4023)
+
+PR: refactor/ps-y4tb-batch2-entity-migrations (commit 002772a0)

--- a/.beans/types-wozj--lifecycleevent-transform-canonical-type-chain-migr.md
+++ b/.beans/types-wozj--lifecycleevent-transform-canonical-type-chain-migr.md
@@ -1,11 +1,11 @@
 ---
 # types-wozj
 title: "LifecycleEvent transform: canonical type chain migration"
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-26T05:04:22Z
-updated_at: 2026-04-26T09:56:54Z
+updated_at: 2026-04-26T10:23:59Z
 blocked_by:
   - ps-etbc
 ---
@@ -56,3 +56,17 @@ Mobile consumers import `LifecycleEventRaw` / `LifecycleEventEncryptedPayload` f
 - Parent: ps-y4tb
 - Blocked-by: ps-etbc (PR #562)
 - Related: types-x61u (`Exclude<>` hardening for journal-entry/note + distributive Pick for lifecycle-event)
+
+## Summary of Changes
+
+LifecycleEvent now follows the canonical SoT chain:
+
+- `LifecycleEventEncryptedFields` widened to the full per-variant key union (`notes | relatedLifecycleEventId | previousForm | newForm | previousName | newName | entity | entityType`)
+- `LifecycleEventEncryptedInput` is the defensively-distributive `Pick<LifecycleEvent, Extract<keyof LifecycleEvent, …>>` so each variant contributes only the keys it owns
+- `LIFECYCLE_EVENT_ENCRYPTED_SCHEMAS` (Zod) selects per-variant validation by plaintext `eventType`
+- `LifecycleEventResult = EncryptedWire<LifecycleEventServerMetadata>` and `LifecycleEventWire = Serialize<LifecycleEventResult>`
+- Local `LifecycleEventEncryptedPayload`, `LifecycleEventRaw`, and `assertLifecycleEventPayload` deleted; mobile consumers migrated to canonical `LifecycleEventWire`
+- OpenAPI `PlaintextLifecycleEvent` now distributes across variants (oneOf-style)
+- Removed dead `encryptedData === null` defensive branch (the column is `notNull()` in PG and SQLite)
+
+PR: refactor/ps-y4tb-batch2-entity-migrations (commit 96c348e0)

--- a/.beans/types-wozj--lifecycleevent-transform-canonical-type-chain-migr.md
+++ b/.beans/types-wozj--lifecycleevent-transform-canonical-type-chain-migr.md
@@ -1,11 +1,11 @@
 ---
 # types-wozj
 title: "LifecycleEvent transform: canonical type chain migration"
-status: todo
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-04-26T05:04:22Z
-updated_at: 2026-04-26T05:04:22Z
+updated_at: 2026-04-26T09:56:54Z
 blocked_by:
   - ps-etbc
 ---

--- a/apps/api/src/jobs/check-in-generate.ts
+++ b/apps/api/src/jobs/check-in-generate.ts
@@ -8,7 +8,7 @@ import { computeNextCheckInAt } from "../lib/timer-scheduling.js";
 import { CHECK_IN_GENERATE_BATCH_SIZE } from "./jobs.constants.js";
 
 import type { JobHandler } from "@pluralscape/queue";
-import type { CheckInRecordId, SystemId, TimerId } from "@pluralscape/types";
+import type { CheckInRecordId, ServerInternal, SystemId, TimerId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /** Seconds per minute, used to convert interval minutes to milliseconds. */
@@ -86,7 +86,11 @@ export function createCheckInGenerateHandler(
           // Create the check-in record with idempotency key to prevent duplicates.
           // ON CONFLICT DO NOTHING ensures concurrent runs are safe.
           const recordId = brandId<CheckInRecordId>(createId(ID_PREFIXES.checkInRecord));
-          const idempotencyKey = computeIdempotencyKey(config.id, config.intervalMinutes, nowMs);
+          const idempotencyKey = computeIdempotencyKey(
+            config.id,
+            config.intervalMinutes,
+            nowMs,
+          ) as ServerInternal<string>;
 
           await db
             .insert(checkInRecords)

--- a/apps/mobile/src/__tests__/factories.ts
+++ b/apps/mobile/src/__tests__/factories.ts
@@ -14,6 +14,7 @@ import {
   encryptFieldValueInput,
 } from "@pluralscape/data/transforms/custom-field";
 import { encryptCustomFrontInput } from "@pluralscape/data/transforms/custom-front";
+import { encryptAndEncodeT1 } from "@pluralscape/data/transforms/decode-blob";
 import { encryptFrontingCommentInput } from "@pluralscape/data/transforms/fronting-comment";
 import { encryptFrontingReportInput } from "@pluralscape/data/transforms/fronting-report";
 import { encryptFrontingSessionInput } from "@pluralscape/data/transforms/fronting-session";
@@ -21,7 +22,6 @@ import { encryptGroupInput } from "@pluralscape/data/transforms/group";
 import { encryptCanvasUpdate } from "@pluralscape/data/transforms/innerworld-canvas";
 import { encryptInnerWorldEntityInput } from "@pluralscape/data/transforms/innerworld-entity";
 import { encryptInnerWorldRegionInput } from "@pluralscape/data/transforms/innerworld-region";
-import { encryptLifecycleEventInput } from "@pluralscape/data/transforms/lifecycle-event";
 import { encryptMemberInput } from "@pluralscape/data/transforms/member";
 import { encryptMessageInput } from "@pluralscape/data/transforms/message";
 import { encryptNoteInput } from "@pluralscape/data/transforms/note";
@@ -43,10 +43,6 @@ export { TEST_MASTER_KEY, TEST_SYSTEM_ID };
 
 import type { FieldDefinitionRaw, FieldValueRaw } from "@pluralscape/data/transforms/custom-field";
 import type { FrontingReportRaw } from "@pluralscape/data/transforms/fronting-report";
-import type {
-  LifecycleEventEncryptedPayload,
-  LifecycleEventRaw,
-} from "@pluralscape/data/transforms/lifecycle-event";
 import type { PollVoteServerWire } from "@pluralscape/data/transforms/poll";
 import type { SnapshotRaw } from "@pluralscape/data/transforms/snapshot";
 import type { NomenclatureSettingsWire } from "@pluralscape/data/transforms/system-settings";
@@ -81,6 +77,7 @@ import type {
   InnerWorldRegionId,
   InnerWorldRegionWire,
   LifecycleEventId,
+  LifecycleEventWire,
   MemberId,
   MemberWire,
   MessageId,
@@ -464,23 +461,22 @@ export function makeRawInnerworldRegion(
 export function makeRawLifecycleEvent(
   id: string,
   eventType: string,
-  payload: LifecycleEventEncryptedPayload,
-  plaintextMetadata: LifecycleEventRaw["plaintextMetadata"],
-  overrides?: Partial<LifecycleEventRaw>,
-): LifecycleEventRaw {
-  const encrypted = encryptLifecycleEventInput(payload, TEST_MASTER_KEY);
+  payload: unknown,
+  plaintextMetadata: LifecycleEventWire["plaintextMetadata"],
+  overrides?: Partial<LifecycleEventWire>,
+): LifecycleEventWire {
   return {
     id: brandId<LifecycleEventId>(id),
     systemId: TEST_SYSTEM_ID,
-    eventType: eventType as LifecycleEventRaw["eventType"],
+    eventType: eventType as LifecycleEventWire["eventType"],
     occurredAt: NOW,
     recordedAt: NOW,
     updatedAt: NOW,
+    encryptedData: encryptAndEncodeT1(payload, TEST_MASTER_KEY),
     plaintextMetadata,
     version: 1,
     archived: false,
     archivedAt: null,
-    ...encrypted,
     ...overrides,
   };
 }

--- a/apps/mobile/src/data/row-transforms/lifecycle.ts
+++ b/apps/mobile/src/data/row-transforms/lifecycle.ts
@@ -10,8 +10,8 @@ import {
   wrapArchived,
 } from "./primitives.js";
 
-import type { LifecycleEventWithArchive } from "@pluralscape/data/transforms/lifecycle-event";
 import type {
+  Archived,
   ArchivedCheckInRecord,
   ArchivedTimerConfig,
   CheckInRecord,
@@ -59,7 +59,9 @@ function assertLifecycleEvent(v: unknown): asserts v is LifecycleEvent {
   void v;
 }
 
-export function rowToLifecycleEvent(row: Record<string, unknown>): LifecycleEventWithArchive {
+export function rowToLifecycleEvent(
+  row: Record<string, unknown>,
+): LifecycleEvent | Archived<LifecycleEvent> {
   const id = rid(row);
   const archived = intToBool(row["archived"]);
   const eventType = guardedStr(

--- a/apps/mobile/src/hooks/__tests__/use-lifecycle-events.test.tsx
+++ b/apps/mobile/src/hooks/__tests__/use-lifecycle-events.test.tsx
@@ -9,8 +9,7 @@ import { makeRawLifecycleEvent } from "../../__tests__/factories.js";
 
 import { renderHookWithProviders, TEST_SYSTEM_ID } from "./helpers/render-hook-with-providers.js";
 
-import type { LifecycleEventRaw } from "@pluralscape/data/transforms/lifecycle-event";
-import type { LifecycleEventId } from "@pluralscape/types";
+import type { LifecycleEventId, LifecycleEventWire } from "@pluralscape/types";
 
 beforeAll(async () => {
   configureSodium(new WasmSodiumAdapter());
@@ -118,7 +117,7 @@ const {
   useDeleteLifecycleEvent,
 } = await import("../use-lifecycle-events.js");
 
-function makeDiscoveryEvent(id: string, memberId: string): LifecycleEventRaw {
+function makeDiscoveryEvent(id: string, memberId: string): LifecycleEventWire {
   return makeRawLifecycleEvent(id, "discovery", { notes: null }, { memberIds: [memberId] });
 }
 

--- a/apps/mobile/src/hooks/use-lifecycle-events.ts
+++ b/apps/mobile/src/hooks/use-lifecycle-events.ts
@@ -18,11 +18,14 @@ import {
 
 import type { RouterInput, RouterOutput } from "@pluralscape/api-client/trpc";
 import type {
-  LifecycleEventPage as LifecycleEventRawPage,
-  LifecycleEventRaw,
-  LifecycleEventWithArchive,
-} from "@pluralscape/data/transforms/lifecycle-event";
-import type { LifecycleEventId, LifecycleEventType } from "@pluralscape/types";
+  Archived,
+  LifecycleEvent,
+  LifecycleEventId,
+  LifecycleEventType,
+  LifecycleEventWire,
+} from "@pluralscape/types";
+
+type LifecycleEventDecrypted = LifecycleEvent | Archived<LifecycleEvent>;
 
 interface LifecycleEventListOpts extends SystemIdOverride {
   readonly limit?: number;
@@ -33,8 +36,8 @@ interface LifecycleEventListOpts extends SystemIdOverride {
 export function useLifecycleEvent(
   eventId: LifecycleEventId,
   opts?: SystemIdOverride,
-): DataQuery<LifecycleEventWithArchive> {
-  return useOfflineFirstQuery<LifecycleEventRaw, LifecycleEventWithArchive>({
+): DataQuery<LifecycleEventDecrypted> {
+  return useOfflineFirstQuery<LifecycleEventWire, LifecycleEventDecrypted>({
     queryKey: ["lifecycle_events", eventId],
     table: "lifecycle_events",
     entityId: eventId,
@@ -45,14 +48,14 @@ export function useLifecycleEvent(
       trpc.lifecycleEvent.get.useQuery(
         { systemId, eventId },
         { enabled, select },
-      ) as DataQuery<LifecycleEventWithArchive>,
+      ) as DataQuery<LifecycleEventDecrypted>,
   });
 }
 
 export function useLifecycleEventsList(
   opts?: LifecycleEventListOpts,
-): DataListQuery<LifecycleEventWithArchive> {
-  return useOfflineFirstInfiniteQuery<LifecycleEventRaw, LifecycleEventWithArchive>({
+): DataListQuery<LifecycleEventDecrypted> {
+  return useOfflineFirstInfiniteQuery<LifecycleEventWire, LifecycleEventDecrypted>({
     queryKey: ["lifecycle_events", "list", opts?.includeArchived ?? false],
     table: "lifecycle_events",
     rowTransform: rowToLifecycleEvent,
@@ -77,10 +80,10 @@ export function useLifecycleEventsList(
         },
         {
           enabled,
-          getNextPageParam: (lastPage: LifecycleEventRawPage) => lastPage.nextCursor,
+          getNextPageParam: (lastPage: { nextCursor: string | null }) => lastPage.nextCursor,
           select,
         },
-      ) as DataListQuery<LifecycleEventWithArchive>,
+      ) as DataListQuery<LifecycleEventDecrypted>,
   });
 }
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13828,6 +13828,17 @@ components:
         A check-in record created by the timer scheduler or manually.
         Can be responded to or dismissed.
       type: object
+      required:
+        - id
+        - systemId
+        - timerConfigId
+        - scheduledAt
+        - respondedByMemberId
+        - respondedAt
+        - dismissed
+        - encryptedData
+        - archived
+        - archivedAt
       properties:
         id:
           type: string
@@ -16164,17 +16175,97 @@ components:
       description: |
         **Encrypted into**: `encryptedData` on lifecycle event create endpoint.
 
-        Encrypted details of a lifecycle event. Note: `eventType`, `occurredAt`,
-        and `plaintextMetadata` (member/structure/entity/region IDs) are sent
-        as separate plaintext fields because the server needs them for querying
-        and relationship tracking. Encryption tier: **T1**.
-      type: object
-      required:
-        - notes
-      properties:
-        notes:
-          type: string
-          nullable: true
+        Per-variant encrypted details of a lifecycle event. `eventType`,
+        `occurredAt`, and `plaintextMetadata` (member/structure/entity/region
+        IDs) are sent as separate plaintext fields. Encryption tier: **T1**.
+
+        Each variant carries `notes` plus its own variant-specific keys.
+      oneOf:
+        - description: Split, Fusion, Merge, Unmerge, Discovery, StructureEntityFormation, StructureMove — notes only
+          type: object
+          required:
+            - notes
+          properties:
+            notes:
+              type: string
+              nullable: true
+        - description: DormancyStart, DormancyEnd — notes + relatedLifecycleEventId
+          type: object
+          required:
+            - notes
+            - relatedLifecycleEventId
+          properties:
+            notes:
+              type: string
+              nullable: true
+            relatedLifecycleEventId:
+              type: string
+              nullable: true
+        - description: Archival — notes + entity reference
+          type: object
+          required:
+            - notes
+            - entity
+          properties:
+            notes:
+              type: string
+              nullable: true
+            entity:
+              type: object
+              required:
+                - entityType
+                - entityId
+              properties:
+                entityType:
+                  type: string
+                entityId:
+                  type: string
+        - description: FormChange — notes + previousForm + newForm
+          type: object
+          required:
+            - notes
+            - previousForm
+            - newForm
+          properties:
+            notes:
+              type: string
+              nullable: true
+            previousForm:
+              type: string
+              nullable: true
+            newForm:
+              type: string
+              nullable: true
+        - description: NameChange — notes + previousName + newName
+          type: object
+          required:
+            - notes
+            - previousName
+            - newName
+          properties:
+            notes:
+              type: string
+              nullable: true
+            previousName:
+              type: string
+              nullable: true
+            newName:
+              type: string
+        - description: InnerworldMove — notes + entityType
+          type: object
+          required:
+            - notes
+            - entityType
+          properties:
+            notes:
+              type: string
+              nullable: true
+            entityType:
+              type: string
+              enum:
+                - member
+                - landmark
+                - structure-entity
     PlaintextInnerworldRegion:
       description: |
         **Encrypted into**: `encryptedData` on innerworld region create/update endpoints.

--- a/docs/openapi/schemas/plaintext.yaml
+++ b/docs/openapi/schemas/plaintext.yaml
@@ -468,16 +468,79 @@ PlaintextLifecycleEvent:
   description: |
     **Encrypted into**: `encryptedData` on lifecycle event create endpoint.
 
-    Encrypted details of a lifecycle event. Note: `eventType`, `occurredAt`,
-    and `plaintextMetadata` (member/structure/entity/region IDs) are sent
-    as separate plaintext fields because the server needs them for querying
-    and relationship tracking. Encryption tier: **T1**.
-  type: object
-  required: [notes]
-  properties:
-    notes:
-      type: string
-      nullable: true
+    Per-variant encrypted details of a lifecycle event. `eventType`,
+    `occurredAt`, and `plaintextMetadata` (member/structure/entity/region
+    IDs) are sent as separate plaintext fields. Encryption tier: **T1**.
+
+    Each variant carries `notes` plus its own variant-specific keys.
+  oneOf:
+    - description: Split, Fusion, Merge, Unmerge, Discovery, StructureEntityFormation, StructureMove — notes only
+      type: object
+      required: [notes]
+      properties:
+        notes:
+          type: string
+          nullable: true
+    - description: DormancyStart, DormancyEnd — notes + relatedLifecycleEventId
+      type: object
+      required: [notes, relatedLifecycleEventId]
+      properties:
+        notes:
+          type: string
+          nullable: true
+        relatedLifecycleEventId:
+          type: string
+          nullable: true
+    - description: Archival — notes + entity reference
+      type: object
+      required: [notes, entity]
+      properties:
+        notes:
+          type: string
+          nullable: true
+        entity:
+          type: object
+          required: [entityType, entityId]
+          properties:
+            entityType:
+              type: string
+            entityId:
+              type: string
+    - description: FormChange — notes + previousForm + newForm
+      type: object
+      required: [notes, previousForm, newForm]
+      properties:
+        notes:
+          type: string
+          nullable: true
+        previousForm:
+          type: string
+          nullable: true
+        newForm:
+          type: string
+          nullable: true
+    - description: NameChange — notes + previousName + newName
+      type: object
+      required: [notes, previousName, newName]
+      properties:
+        notes:
+          type: string
+          nullable: true
+        previousName:
+          type: string
+          nullable: true
+        newName:
+          type: string
+    - description: InnerworldMove — notes + entityType
+      type: object
+      required: [notes, entityType]
+      properties:
+        notes:
+          type: string
+          nullable: true
+        entityType:
+          type: string
+          enum: [member, landmark, structure-entity]
 
 PlaintextInnerworldRegion:
   description: |

--- a/docs/openapi/schemas/timers.yaml
+++ b/docs/openapi/schemas/timers.yaml
@@ -88,6 +88,17 @@ CheckInRecordResponse:
     A check-in record created by the timer scheduler or manually.
     Can be responded to or dismissed.
   type: object
+  required:
+    - id
+    - systemId
+    - timerConfigId
+    - scheduledAt
+    - respondedByMemberId
+    - respondedAt
+    - dismissed
+    - encryptedData
+    - archived
+    - archivedAt
   properties:
     id:
       type: string

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -6742,25 +6742,25 @@ export interface components {
      *     Can be responded to or dismissed.
      */
     CheckInRecordResponse: {
-      id?: string;
-      systemId?: string;
-      timerConfigId?: string;
+      id: string;
+      systemId: string;
+      timerConfigId: string;
       /**
        * Format: int64
        * @description Unix milliseconds when the check-in was scheduled
        */
-      scheduledAt?: number;
-      respondedByMemberId?: string | null;
+      scheduledAt: number;
+      respondedByMemberId: string | null;
       /**
        * Format: int64
        * @description Unix milliseconds when the check-in was responded to
        */
-      respondedAt?: number | null;
-      dismissed?: boolean;
-      encryptedData?: string | null;
-      archived?: boolean;
+      respondedAt: number | null;
+      dismissed: boolean;
+      encryptedData: string | null;
+      archived: boolean;
       /** Format: int64 */
-      archivedAt?: number | null;
+      archivedAt: number | null;
     };
     CreateCheckInRecordRequest: {
       /** @description Timer config ID (tmr_ prefix) */
@@ -8033,14 +8033,42 @@ export interface components {
     /**
      * @description **Encrypted into**: `encryptedData` on lifecycle event create endpoint.
      *
-     *     Encrypted details of a lifecycle event. Note: `eventType`, `occurredAt`,
-     *     and `plaintextMetadata` (member/structure/entity/region IDs) are sent
-     *     as separate plaintext fields because the server needs them for querying
-     *     and relationship tracking. Encryption tier: **T1**.
+     *     Per-variant encrypted details of a lifecycle event. `eventType`,
+     *     `occurredAt`, and `plaintextMetadata` (member/structure/entity/region
+     *     IDs) are sent as separate plaintext fields. Encryption tier: **T1**.
+     *
+     *     Each variant carries `notes` plus its own variant-specific keys.
      */
-    PlaintextLifecycleEvent: {
-      notes: string | null;
-    };
+    PlaintextLifecycleEvent:
+      | {
+          notes: string | null;
+        }
+      | {
+          notes: string | null;
+          relatedLifecycleEventId: string | null;
+        }
+      | {
+          notes: string | null;
+          entity: {
+            entityType: string;
+            entityId: string;
+          };
+        }
+      | {
+          notes: string | null;
+          previousForm: string | null;
+          newForm: string | null;
+        }
+      | {
+          notes: string | null;
+          previousName: string | null;
+          newName: string;
+        }
+      | {
+          notes: string | null;
+          /** @enum {string} */
+          entityType: "member" | "landmark" | "structure-entity";
+        };
     /**
      * @description **Encrypted into**: `encryptedData` on innerworld region create/update endpoints.
      *

--- a/packages/data/src/transforms/__tests__/lifecycle-event.test.ts
+++ b/packages/data/src/transforms/__tests__/lifecycle-event.test.ts
@@ -1,6 +1,6 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
-import { toUnixMillis, brandId } from "@pluralscape/types";
+import { brandId } from "@pluralscape/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { encryptAndEncodeT1 } from "../decode-blob.js";
@@ -13,9 +13,8 @@ import {
 
 import { makeBase64Blob } from "./helpers.js";
 
-import type { LifecycleEventEncryptedPayload, LifecycleEventRaw } from "../lifecycle-event.js";
 import type { KdfMasterKey } from "@pluralscape/crypto";
-import type { LifecycleEventId, LifecycleEventType, SystemId } from "@pluralscape/types";
+import type { LifecycleEventId, LifecycleEventType, LifecycleEventWire } from "@pluralscape/types";
 
 let masterKey: KdfMasterKey;
 
@@ -25,18 +24,24 @@ beforeAll(async () => {
   masterKey = generateMasterKey();
 });
 
-const NOW = toUnixMillis(1_700_000_000_000);
-const LATER = toUnixMillis(1_700_001_000_000);
+const NOW = 1_700_000_000_000;
+const LATER = 1_700_001_000_000;
 
+/**
+ * `payload` is `unknown` because the encrypted blob is opaque on the wire and
+ * tests intentionally exercise both well-formed per-variant inputs and
+ * malformed inputs (negative cases for schema validation). Per-variant type
+ * safety is enforced by the Zod schemas in the decryption path, not here.
+ */
 function makeRaw(
   eventType: LifecycleEventType,
-  payload: LifecycleEventEncryptedPayload,
+  payload: unknown,
   plaintextMetadata: Record<string, readonly string[]> | null,
-  overrides?: Partial<LifecycleEventRaw>,
-): LifecycleEventRaw {
+  overrides?: Partial<LifecycleEventWire>,
+): LifecycleEventWire {
   return {
-    id: brandId<LifecycleEventId>("evt_001"),
-    systemId: brandId<SystemId>("sys_test"),
+    id: "evt_001",
+    systemId: "sys_test",
     eventType,
     occurredAt: NOW,
     recordedAt: NOW,
@@ -54,7 +59,7 @@ function makeRaw(
 
 describe("decryptLifecycleEvent — split", () => {
   it("decrypts split event", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: "Split happened" };
+    const payload = { notes: "Split happened" };
     const meta = { memberIds: ["mem_src", "mem_r1", "mem_r2"] };
     const result = decryptLifecycleEvent(makeRaw("split", payload, meta), masterKey);
 
@@ -71,7 +76,7 @@ describe("decryptLifecycleEvent — split", () => {
 
 describe("decryptLifecycleEvent — fusion", () => {
   it("decrypts fusion event", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a", "mem_b", "mem_result"] };
     const result = decryptLifecycleEvent(makeRaw("fusion", payload, meta), masterKey);
 
@@ -88,7 +93,7 @@ describe("decryptLifecycleEvent — fusion", () => {
 
 describe("decryptLifecycleEvent — merge", () => {
   it("decrypts merge event", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a", "mem_b"] };
     const result = decryptLifecycleEvent(makeRaw("merge", payload, meta), masterKey);
 
@@ -103,7 +108,7 @@ describe("decryptLifecycleEvent — merge", () => {
 
 describe("decryptLifecycleEvent — unmerge", () => {
   it("decrypts unmerge event", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a", "mem_b"] };
     const result = decryptLifecycleEvent(makeRaw("unmerge", payload, meta), masterKey);
 
@@ -118,7 +123,7 @@ describe("decryptLifecycleEvent — unmerge", () => {
 
 describe("decryptLifecycleEvent — dormancy-start", () => {
   it("decrypts dormancy-start with relatedLifecycleEventId", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       relatedLifecycleEventId: brandId<LifecycleEventId>("evt_related"),
     };
@@ -133,7 +138,7 @@ describe("decryptLifecycleEvent — dormancy-start", () => {
   });
 
   it("decrypts dormancy-start with null relatedLifecycleEventId", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       relatedLifecycleEventId: null,
     };
@@ -150,7 +155,7 @@ describe("decryptLifecycleEvent — dormancy-start", () => {
 
 describe("decryptLifecycleEvent — dormancy-end", () => {
   it("decrypts dormancy-end event", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: "Woke up",
       relatedLifecycleEventId: brandId<LifecycleEventId>("evt_start"),
     };
@@ -170,7 +175,7 @@ describe("decryptLifecycleEvent — dormancy-end", () => {
 
 describe("decryptLifecycleEvent — discovery", () => {
   it("decrypts discovery event", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: "New member found" };
+    const payload = { notes: "New member found" };
     const meta = { memberIds: ["mem_new"] };
     const result = decryptLifecycleEvent(makeRaw("discovery", payload, meta), masterKey);
 
@@ -186,7 +191,7 @@ describe("decryptLifecycleEvent — discovery", () => {
 
 describe("decryptLifecycleEvent — archival", () => {
   it("decrypts archival event", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       entity: { entityType: "member", entityId: "mem_archived" },
     };
@@ -204,7 +209,7 @@ describe("decryptLifecycleEvent — archival", () => {
 
 describe("decryptLifecycleEvent — structure-entity-formation", () => {
   it("decrypts structure-entity-formation event", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a"], structureIds: ["se_result"] };
     const result = decryptLifecycleEvent(
       makeRaw("structure-entity-formation", payload, meta),
@@ -223,7 +228,7 @@ describe("decryptLifecycleEvent — structure-entity-formation", () => {
 
 describe("decryptLifecycleEvent — form-change", () => {
   it("decrypts form-change event", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       previousForm: "child",
       newForm: "adult",
@@ -240,7 +245,7 @@ describe("decryptLifecycleEvent — form-change", () => {
   });
 
   it("handles null previousForm and newForm", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       previousForm: null,
       newForm: null,
@@ -259,7 +264,7 @@ describe("decryptLifecycleEvent — form-change", () => {
 
 describe("decryptLifecycleEvent — name-change", () => {
   it("decrypts name-change event", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       previousName: "Old Name",
       newName: "New Name",
@@ -276,7 +281,7 @@ describe("decryptLifecycleEvent — name-change", () => {
   });
 
   it("handles null previousName", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       previousName: null,
       newName: "First Name",
@@ -295,7 +300,7 @@ describe("decryptLifecycleEvent — name-change", () => {
 
 describe("decryptLifecycleEvent — structure-move", () => {
   it("decrypts with fromStructure and toStructure (2 structureIds)", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a"], structureIds: ["se_from", "se_to"] };
     const result = decryptLifecycleEvent(makeRaw("structure-move", payload, meta), masterKey);
 
@@ -314,7 +319,7 @@ describe("decryptLifecycleEvent — structure-move", () => {
   });
 
   it("decrypts with null fromStructure (1 structureId)", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a"], structureIds: ["se_to"] };
     const result = decryptLifecycleEvent(makeRaw("structure-move", payload, meta), masterKey);
 
@@ -332,7 +337,7 @@ describe("decryptLifecycleEvent — structure-move", () => {
 
 describe("decryptLifecycleEvent — innerworld-move", () => {
   it("decrypts with fromRegionId and toRegionId (2 regionIds)", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       entityType: "member",
     };
@@ -349,7 +354,7 @@ describe("decryptLifecycleEvent — innerworld-move", () => {
   });
 
   it("decrypts with only toRegionId (1 regionId)", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       entityType: "landmark",
     };
@@ -363,7 +368,7 @@ describe("decryptLifecycleEvent — innerworld-move", () => {
   });
 
   it("decrypts with both null (0 regionIds)", () => {
-    const payload: LifecycleEventEncryptedPayload = {
+    const payload = {
       notes: null,
       entityType: "structure-entity",
     };
@@ -380,21 +385,8 @@ describe("decryptLifecycleEvent — innerworld-move", () => {
 // ── Shared behaviors ──────────────────────────────────────────────────
 
 describe("decryptLifecycleEvent — shared", () => {
-  it("defaults notes to null when encryptedData is null", () => {
-    const raw = makeRaw(
-      "discovery",
-      { notes: null },
-      { memberIds: ["mem_a"] },
-      {
-        encryptedData: null,
-      },
-    );
-    const result = decryptLifecycleEvent(raw, masterKey);
-    expect(result.notes).toBeNull();
-  });
-
   it("returns archived variant with archivedAt", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a"] };
     const raw = makeRaw("discovery", payload, meta, {
       archived: true,
@@ -409,7 +401,7 @@ describe("decryptLifecycleEvent — shared", () => {
   });
 
   it("throws when archived=true but archivedAt is null", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const meta = { memberIds: ["mem_a"] };
     const raw = makeRaw("discovery", payload, meta, {
       archived: true,
@@ -446,7 +438,7 @@ describe("decryptLifecycleEventPage", () => {
 
 describe("encryptLifecycleEventInput", () => {
   it("round-trips through decrypt", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: "Test note" };
+    const payload = { notes: "Test note" };
     const { encryptedData } = encryptLifecycleEventInput(payload, masterKey);
     const raw = makeRaw("discovery", payload, { memberIds: ["mem_a"] }, { encryptedData });
     const result = decryptLifecycleEvent(raw, masterKey);
@@ -456,16 +448,16 @@ describe("encryptLifecycleEventInput", () => {
 
 describe("encryptLifecycleEventUpdate", () => {
   it("includes version", () => {
-    const payload: LifecycleEventEncryptedPayload = { notes: null };
+    const payload = { notes: null };
     const result = encryptLifecycleEventUpdate(payload, 5, masterKey);
     expect(result.version).toBe(5);
     expect(typeof result.encryptedData).toBe("string");
   });
 });
 
-// ── Validation ────────────────────────────────────────────────────────
+// ── Schema validation ─────────────────────────────────────────────────
 
-describe("assertLifecycleEventPayload", () => {
+describe("decryptLifecycleEvent — schema validation", () => {
   it("throws when blob is not an object", () => {
     const raw = makeRaw(
       "discovery",
@@ -475,7 +467,34 @@ describe("assertLifecycleEventPayload", () => {
         encryptedData: makeBase64Blob("string", masterKey),
       },
     );
-    expect(() => decryptLifecycleEvent(raw, masterKey)).toThrow("not an object");
+    // Zod parse throws when the decrypted blob is not an object
+    expect(() => decryptLifecycleEvent(raw, masterKey)).toThrow();
+  });
+
+  it("throws when archival blob missing entity field", () => {
+    // Encrypt only `notes` — schema requires `entity` for archival variant
+    const encryptedData = encryptAndEncodeT1({ notes: null }, masterKey);
+    const raw = makeRaw(
+      "archival",
+      { notes: null },
+      { memberIds: ["mem_a"] },
+      {
+        encryptedData,
+      },
+    );
+    expect(() => decryptLifecycleEvent(raw, masterKey)).toThrow();
+  });
+
+  it("throws when name-change blob missing newName field", () => {
+    // Encrypt only `notes + previousName` — schema requires `newName`
+    const encryptedData = encryptAndEncodeT1({ notes: null, previousName: "Old" }, masterKey);
+    const raw = makeRaw(
+      "name-change",
+      { notes: null, previousName: "Old", newName: "x" },
+      { memberIds: ["mem_a"] },
+      { encryptedData },
+    );
+    expect(() => decryptLifecycleEvent(raw, masterKey)).toThrow();
   });
 });
 
@@ -526,19 +545,5 @@ describe("decryptLifecycleEvent — metadata validation", () => {
       { entityIds: [], regionIds: [] },
     );
     expect(() => decryptLifecycleEvent(raw, masterKey)).toThrow("missing required entityIds");
-  });
-
-  it("throws on archival with missing payload.entity", () => {
-    const raw = makeRaw("archival", { notes: null }, { memberIds: ["mem_a"] });
-    expect(() => decryptLifecycleEvent(raw, masterKey)).toThrow("missing required field: entity");
-  });
-
-  it("throws on name-change with missing payload.newName", () => {
-    const raw = makeRaw(
-      "name-change",
-      { notes: null, previousName: "Old" },
-      { memberIds: ["mem_a"] },
-    );
-    expect(() => decryptLifecycleEvent(raw, masterKey)).toThrow("missing required field: newName");
   });
 });

--- a/packages/data/src/transforms/lifecycle-event.ts
+++ b/packages/data/src/transforms/lifecycle-event.ts
@@ -1,92 +1,36 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
+import { LIFECYCLE_EVENT_ENCRYPTED_SCHEMAS } from "@pluralscape/validation";
 
-import {
-  assertObjectBlob,
-  decodeAndDecryptT1,
-  encryptInput,
-  encryptUpdate,
-} from "./decode-blob.js";
+import { decodeAndDecryptT1, encryptInput, encryptUpdate } from "./decode-blob.js";
 
 import type { KdfMasterKey } from "@pluralscape/crypto";
 import type {
+  Archived,
   EntityReference,
   InnerWorldEntityId,
   InnerWorldEntityType,
   InnerWorldRegionId,
   LifecycleEvent,
+  LifecycleEventEncryptedInput,
   LifecycleEventId,
-  LifecycleEventType,
+  LifecycleEventWire,
   MemberId,
   SystemId,
   SystemStructureEntityId,
-  UnixMillis,
 } from "@pluralscape/types";
 
-// ── Encrypted payload ─────────────────────────────────────────────────
-
-/** Fields inside the T1 encrypted blob. */
-export interface LifecycleEventEncryptedPayload {
-  readonly notes: string | null;
-  readonly relatedLifecycleEventId?: LifecycleEventId | null;
-  readonly previousForm?: string | null;
-  readonly newForm?: string | null;
-  readonly previousName?: string | null;
-  readonly newName?: string;
-  readonly entity?: EntityReference;
-  readonly entityType?: InnerWorldEntityType;
-}
-
-// ── Decrypted output — reuse the domain union ─────────────────────────
-
-export type LifecycleEventDecrypted = LifecycleEvent;
-
-/** A lifecycle event with archive status attached by the transform layer. */
-export type LifecycleEventWithArchive =
-  | (LifecycleEventDecrypted & { readonly archived: false })
-  | (LifecycleEventDecrypted & { readonly archived: true; readonly archivedAt: UnixMillis });
-
-// ── Wire types ────────────────────────────────────────────────────────
-
-/** Plaintext metadata on the wire — unbranded string arrays. */
-export interface PlaintextMetadataWire {
-  readonly memberIds?: readonly string[];
-  readonly structureIds?: readonly string[];
-  readonly entityIds?: readonly string[];
-  readonly regionIds?: readonly string[];
-}
-
-export interface LifecycleEventRaw {
-  readonly id: LifecycleEventId;
-  readonly systemId: SystemId;
-  readonly eventType: LifecycleEventType;
-  readonly occurredAt: UnixMillis;
-  readonly recordedAt: UnixMillis;
-  readonly updatedAt: UnixMillis;
-  readonly encryptedData: string | null;
-  readonly plaintextMetadata: PlaintextMetadataWire | null;
-  readonly version: number;
-  readonly archived: boolean;
-  readonly archivedAt: UnixMillis | null;
-}
-
 export interface LifecycleEventPage {
-  readonly data: readonly LifecycleEventRaw[];
+  readonly data: readonly LifecycleEventWire[];
   readonly nextCursor: string | null;
-}
-
-// ── Validators ────────────────────────────────────────────────────────
-
-function assertLifecycleEventPayload(raw: unknown): asserts raw is LifecycleEventEncryptedPayload {
-  assertObjectBlob(raw, "lifecycleEvent");
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
-function metaIds(
-  meta: PlaintextMetadataWire | null,
-  key: keyof PlaintextMetadataWire,
-): readonly string[] {
-  return meta?.[key] ?? [];
+/** Reads an ID array from plaintextMetadata, returning empty array if absent. */
+function metaIds(meta: Record<string, unknown> | null, key: string): readonly string[] {
+  const val = meta?.[key];
+  if (!Array.isArray(val)) return [];
+  return val as readonly string[];
 }
 
 function atOrThrow(arr: readonly string[], index: number, label: string): string {
@@ -110,38 +54,26 @@ function firstOrThrow(arr: readonly string[], label: string): string {
 // ── Transforms ────────────────────────────────────────────────────────
 
 export function decryptLifecycleEvent(
-  raw: LifecycleEventRaw,
+  raw: LifecycleEventWire,
   masterKey: KdfMasterKey,
-): LifecycleEventWithArchive {
-  let payload: LifecycleEventEncryptedPayload;
-
-  if (raw.encryptedData !== null) {
-    const plaintext = decodeAndDecryptT1(raw.encryptedData, masterKey);
-    assertLifecycleEventPayload(plaintext);
-    payload = plaintext;
-  } else {
-    payload = { notes: null };
-  }
+): LifecycleEvent | Archived<LifecycleEvent> {
+  // Per-variant schema selection: eventType is plaintext on the wire
+  const plaintext = decodeAndDecryptT1(raw.encryptedData, masterKey);
+  const schema = LIFECYCLE_EVENT_ENCRYPTED_SCHEMAS[raw.eventType];
+  const validated = schema.parse(plaintext);
 
   const shared = {
-    id: raw.id,
-    systemId: raw.systemId,
-    occurredAt: raw.occurredAt,
-    recordedAt: raw.recordedAt,
-    notes: payload.notes,
+    id: brandId<LifecycleEventId>(raw.id),
+    systemId: brandId<SystemId>(raw.systemId),
+    occurredAt: toUnixMillis(raw.occurredAt),
+    recordedAt: toUnixMillis(raw.recordedAt),
+    notes: validated.notes,
+    archived: false as const,
   };
 
-  function withArchive<T>(
-    base: T,
-  ): (T & { archived: false }) | (T & { archived: true; archivedAt: UnixMillis }) {
-    if (raw.archived) {
-      if (raw.archivedAt === null) throw new Error("Archived lifecycleEvent missing archivedAt");
-      return { ...base, archived: true as const, archivedAt: raw.archivedAt };
-    }
-    return { ...base, archived: false as const };
-  }
+  const meta = raw.plaintextMetadata as Record<string, unknown> | null;
 
-  const meta = raw.plaintextMetadata;
+  let domain: LifecycleEvent;
 
   switch (raw.eventType) {
     case "split": {
@@ -149,101 +81,119 @@ export function decryptLifecycleEvent(
       if (ids.length < 2) {
         throw new Error("lifecycleEvent split requires at least 2 memberIds in plaintextMetadata");
       }
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "split" as const,
         sourceMemberId: brandId<MemberId>(firstOrThrow(ids, "memberIds")),
         resultMemberIds: ids.slice(1).map((id) => brandId<MemberId>(id)),
-      });
+      };
+      break;
     }
     case "fusion": {
       const ids = metaIds(meta, "memberIds");
       if (ids.length < 2) {
         throw new Error("lifecycleEvent fusion requires at least 2 memberIds in plaintextMetadata");
       }
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "fusion" as const,
         sourceMemberIds: ids.slice(0, -1).map((id) => brandId<MemberId>(id)),
         resultMemberId: brandId<MemberId>(atOrThrow(ids, ids.length - 1, "memberIds")),
-      });
+      };
+      break;
     }
     case "merge":
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "merge" as const,
         memberIds: metaIds(meta, "memberIds").map((id) => brandId<MemberId>(id)),
-      });
+      };
+      break;
     case "unmerge":
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "unmerge" as const,
         memberIds: metaIds(meta, "memberIds").map((id) => brandId<MemberId>(id)),
-      });
-    case "dormancy-start":
-      return withArchive({
+      };
+      break;
+    case "dormancy-start": {
+      const v = validated as { notes: string | null; relatedLifecycleEventId: string | null };
+      domain = {
         ...shared,
         eventType: "dormancy-start" as const,
         memberId: brandId<MemberId>(firstOrThrow(metaIds(meta, "memberIds"), "memberIds")),
-        relatedLifecycleEventId: payload.relatedLifecycleEventId
-          ? brandId<LifecycleEventId>(payload.relatedLifecycleEventId)
+        relatedLifecycleEventId: v.relatedLifecycleEventId
+          ? brandId<LifecycleEventId>(v.relatedLifecycleEventId)
           : null,
-      });
-    case "dormancy-end":
-      return withArchive({
+      };
+      break;
+    }
+    case "dormancy-end": {
+      const v = validated as { notes: string | null; relatedLifecycleEventId: string | null };
+      domain = {
         ...shared,
         eventType: "dormancy-end" as const,
         memberId: brandId<MemberId>(firstOrThrow(metaIds(meta, "memberIds"), "memberIds")),
-        relatedLifecycleEventId: payload.relatedLifecycleEventId
-          ? brandId<LifecycleEventId>(payload.relatedLifecycleEventId)
+        relatedLifecycleEventId: v.relatedLifecycleEventId
+          ? brandId<LifecycleEventId>(v.relatedLifecycleEventId)
           : null,
-      });
+      };
+      break;
+    }
     case "discovery":
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "discovery" as const,
         memberId: brandId<MemberId>(firstOrThrow(metaIds(meta, "memberIds"), "memberIds")),
-      });
+      };
+      break;
     case "archival": {
-      if (payload.entity === undefined) {
-        throw new Error("Decrypted lifecycleEvent(archival) blob missing required field: entity");
-      }
-      return withArchive({
+      const v = validated as {
+        notes: string | null;
+        entity: { entityType: string; entityId: string };
+      };
+      domain = {
         ...shared,
         eventType: "archival" as const,
-        entity: payload.entity,
-      });
+        entity: v.entity as EntityReference,
+      };
+      break;
     }
     case "structure-entity-formation":
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "structure-entity-formation" as const,
         memberId: brandId<MemberId>(firstOrThrow(metaIds(meta, "memberIds"), "memberIds")),
         resultStructureEntityId: brandId<SystemStructureEntityId>(
           firstOrThrow(metaIds(meta, "structureIds"), "structureIds"),
         ),
-      });
-    case "form-change":
-      return withArchive({
+      };
+      break;
+    case "form-change": {
+      const v = validated as {
+        notes: string | null;
+        previousForm: string | null;
+        newForm: string | null;
+      };
+      domain = {
         ...shared,
         eventType: "form-change" as const,
         memberId: brandId<MemberId>(firstOrThrow(metaIds(meta, "memberIds"), "memberIds")),
-        previousForm: (payload.previousForm as string | null) ?? null,
-        newForm: (payload.newForm as string | null) ?? null,
-      });
+        previousForm: v.previousForm,
+        newForm: v.newForm,
+      };
+      break;
+    }
     case "name-change": {
-      if (payload.newName === undefined) {
-        throw new Error(
-          "Decrypted lifecycleEvent(name-change) blob missing required field: newName",
-        );
-      }
-      return withArchive({
+      const v = validated as { notes: string | null; previousName: string | null; newName: string };
+      domain = {
         ...shared,
         eventType: "name-change" as const,
         memberId: brandId<MemberId>(firstOrThrow(metaIds(meta, "memberIds"), "memberIds")),
-        previousName: (payload.previousName as string | null) ?? null,
-        newName: payload.newName,
-      });
+        previousName: v.previousName,
+        newName: v.newName,
+      };
+      break;
     }
     case "structure-move": {
       const sIds = metaIds(meta, "structureIds");
@@ -268,23 +218,19 @@ export function decryptLifecycleEvent(
               entityType: "structure-entity",
               entityId: brandId<SystemStructureEntityId>(atOrThrow(sIds, 0, "structureIds")),
             };
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "structure-move" as const,
         memberId: mId,
         fromStructure,
         toStructure,
-      });
+      };
+      break;
     }
     case "innerworld-move": {
       const eIds = metaIds(meta, "entityIds");
       const rIds = metaIds(meta, "regionIds");
-      const iwEntityType = payload.entityType;
-      if (iwEntityType === undefined) {
-        throw new Error(
-          "Decrypted lifecycleEvent(innerworld-move) blob missing required field: entityType",
-        );
-      }
+      const v = validated as { notes: string | null; entityType: InnerWorldEntityType };
       const fromRegionId: InnerWorldRegionId | null =
         rIds.length >= 2 ? brandId<InnerWorldRegionId>(atOrThrow(rIds, 0, "regionIds")) : null;
       const toRegionId: InnerWorldRegionId | null =
@@ -293,27 +239,38 @@ export function decryptLifecycleEvent(
           : rIds.length === 1
             ? brandId<InnerWorldRegionId>(atOrThrow(rIds, 0, "regionIds"))
             : null;
-      return withArchive({
+      domain = {
         ...shared,
         eventType: "innerworld-move" as const,
         entityId: brandId<InnerWorldEntityId>(firstOrThrow(eIds, "entityIds")),
-        entityType: iwEntityType,
+        entityType: v.entityType,
         fromRegionId,
         toRegionId,
-      });
+      };
+      break;
     }
     default: {
       const _exhaustive: never = raw.eventType;
       throw new Error(`Unknown lifecycle event type: ${String(_exhaustive)}`);
     }
   }
+
+  if (raw.archived) {
+    if (raw.archivedAt === null) throw new Error("Archived lifecycleEvent missing archivedAt");
+    return {
+      ...domain,
+      archived: true as const,
+      archivedAt: toUnixMillis(raw.archivedAt),
+    } as Archived<LifecycleEvent>;
+  }
+  return domain;
 }
 
 export function decryptLifecycleEventPage(
   raw: LifecycleEventPage,
   masterKey: KdfMasterKey,
 ): {
-  data: LifecycleEventWithArchive[];
+  data: (LifecycleEvent | Archived<LifecycleEvent>)[];
   nextCursor: string | null;
 } {
   return {
@@ -323,14 +280,14 @@ export function decryptLifecycleEventPage(
 }
 
 export function encryptLifecycleEventInput(
-  data: LifecycleEventEncryptedPayload,
+  data: LifecycleEventEncryptedInput,
   masterKey: KdfMasterKey,
 ): { encryptedData: string } {
   return encryptInput(data, masterKey);
 }
 
 export function encryptLifecycleEventUpdate(
-  data: LifecycleEventEncryptedPayload,
+  data: LifecycleEventEncryptedInput,
   version: number,
   masterKey: KdfMasterKey,
 ): { encryptedData: string; version: number } {

--- a/packages/db/src/schema/pg/timers.ts
+++ b/packages/db/src/schema/pg/timers.ts
@@ -23,7 +23,13 @@ import { pgTimeFormatCheck } from "../../helpers/check.js";
 import { members } from "./members.js";
 import { systems } from "./systems.js";
 
-import type { CheckInRecordId, MemberId, SystemId, TimerId } from "@pluralscape/types";
+import type {
+  CheckInRecordId,
+  MemberId,
+  ServerInternal,
+  SystemId,
+  TimerId,
+} from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const timerConfigs = pgTable(
@@ -76,7 +82,12 @@ export const checkInRecords = pgTable(
     dismissed: boolean("dismissed").notNull().default(false),
     respondedByMemberId: brandedId<MemberId>("responded_by_member_id"),
     encryptedData: pgEncryptedBlob("encrypted_data"),
-    idempotencyKey: varchar("idempotency_key", { length: 255 }),
+    /**
+     * Server-generated dedup key for webhook-driven response writes.
+     * Branded `ServerInternal<…>` so `EncryptedWire<T>` strips it from
+     * the wire envelope (never leaked to clients).
+     */
+    idempotencyKey: varchar("idempotency_key", { length: 255 }).$type<ServerInternal<string>>(),
     ...archivable(),
   },
   (t) => [

--- a/packages/db/src/schema/sqlite/timers.ts
+++ b/packages/db/src/schema/sqlite/timers.ts
@@ -22,7 +22,13 @@ import { sqliteTimeFormatCheck } from "../../helpers/check.js";
 import { members } from "./members.js";
 import { systems } from "./systems.js";
 
-import type { CheckInRecordId, MemberId, SystemId, TimerId } from "@pluralscape/types";
+import type {
+  CheckInRecordId,
+  MemberId,
+  ServerInternal,
+  SystemId,
+  TimerId,
+} from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
 export const timerConfigs = sqliteTable(
@@ -75,7 +81,12 @@ export const checkInRecords = sqliteTable(
     dismissed: integer("dismissed", { mode: "boolean" }).notNull().default(false),
     respondedByMemberId: brandedId<MemberId>("responded_by_member_id"),
     encryptedData: sqliteEncryptedBlob("encrypted_data"),
-    idempotencyKey: text("idempotency_key"),
+    /**
+     * Server-generated dedup key for webhook-driven response writes.
+     * Branded `ServerInternal<…>` so `EncryptedWire<T>` strips it from
+     * the wire envelope (never leaked to clients).
+     */
+    idempotencyKey: text("idempotency_key").$type<ServerInternal<string>>(),
     ...archivable(),
   },
   (t) => [

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -60,6 +60,7 @@ import type {
 } from "./entities/channel.js";
 import type {
   CheckInRecord,
+  CheckInRecordResult,
   CheckInRecordServerMetadata,
   CheckInRecordWire,
 } from "./entities/check-in-record.js";
@@ -615,9 +616,11 @@ export type SotEntityManifest = {
   CheckInRecord: {
     domain: CheckInRecord;
     server: CheckInRecordServerMetadata;
+    result: CheckInRecordResult;
     wire: CheckInRecordWire;
-    // Hybrid entity: plaintext domain with optional `encryptedData` blob
-    // (server-only column; no keys-subset of `CheckInRecord`).
+    // Hybrid entity: plaintext domain with an optional `encryptedData`
+    // blob and a `ServerInternal<…>` `idempotencyKey`. No per-field
+    // encrypted-keys subset, so `encryptedFields` is `never`.
     encryptedFields: never;
   };
   // ── Cluster 8: Communication + engagement ─────────────────────────────

--- a/packages/types/src/__tests__/sot-manifest.test.ts
+++ b/packages/types/src/__tests__/sot-manifest.test.ts
@@ -7,6 +7,12 @@ import type {
   AuditLogEntryWire,
 } from "../entities/audit-log-entry.js";
 import type {
+  CheckInRecord,
+  CheckInRecordResult,
+  CheckInRecordServerMetadata,
+  CheckInRecordWire,
+} from "../entities/check-in-record.js";
+import type {
   Member,
   MemberEncryptedInput,
   MemberResult,
@@ -42,6 +48,18 @@ describe("SotEntityManifest", () => {
       SotEntityManifest["AuditLogEntry"]["server"]
     >().toEqualTypeOf<AuditLogEntryServerMetadata>();
     expectTypeOf<SotEntityManifest["AuditLogEntry"]["wire"]>().toEqualTypeOf<AuditLogEntryWire>();
+  });
+
+  it("registers CheckInRecord (hybrid: no encryptedInput) with domain/server/result/wire", () => {
+    expectTypeOf<SotEntityManifest["CheckInRecord"]["domain"]>().toEqualTypeOf<CheckInRecord>();
+    expectTypeOf<
+      SotEntityManifest["CheckInRecord"]["server"]
+    >().toEqualTypeOf<CheckInRecordServerMetadata>();
+    expectTypeOf<
+      SotEntityManifest["CheckInRecord"]["result"]
+    >().toEqualTypeOf<CheckInRecordResult>();
+    expectTypeOf<SotEntityManifest["CheckInRecord"]["wire"]>().toEqualTypeOf<CheckInRecordWire>();
+    expectTypeOf<SotEntityManifest["CheckInRecord"]["encryptedFields"]>().toEqualTypeOf<never>();
   });
 
   it("includes the pilot entities", () => {

--- a/packages/types/src/encrypted-wire.ts
+++ b/packages/types/src/encrypted-wire.ts
@@ -13,8 +13,12 @@ import type { ServerInternal } from "./server-internal.js";
  * Example:
  *   type MemberResult = EncryptedWire<MemberServerMetadata>;
  */
+// Drops every key whose value type contains any `ServerInternal<…>` branch.
+// `Extract<T[K], ServerInternal<unknown>>` finds the marked branches inside
+// the value's union (e.g. `ServerInternal<string> | null`); if non-empty the
+// key is server-only and must not appear on the wire.
 type StripServerInternal<T> = {
-  [K in keyof T as T[K] extends ServerInternal<unknown> ? never : K]: T[K];
+  [K in keyof T as Extract<T[K], ServerInternal<unknown>> extends never ? K : never]: T[K];
 };
 
 export type EncryptedWire<T extends { readonly encryptedData: EncryptedBlob | null }> = Omit<

--- a/packages/types/src/entities/check-in-record.ts
+++ b/packages/types/src/entities/check-in-record.ts
@@ -1,5 +1,7 @@
+import type { EncryptedWire } from "../encrypted-wire.js";
 import type { EncryptedBlob } from "../encryption-primitives.js";
 import type { CheckInRecordId, MemberId, SystemId, TimerId } from "../ids.js";
+import type { ServerInternal } from "../server-internal.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
 import type { Archived } from "../utility.js";
@@ -23,30 +25,30 @@ export interface CheckInRecord {
 /** An archived check-in record. */
 export type ArchivedCheckInRecord = Archived<CheckInRecord>;
 
+// ── Canonical chain (see ADR-023) ────────────────────────────────────
+// CheckInRecord is a hybrid: the domain is plaintext (no encrypted
+// fields), but the server row carries an optional `encryptedData` blob
+// (mood/note attached to a response) and a server-only `idempotencyKey`
+// (webhook dedup, never leaked to clients). Because there are no
+// per-variant encrypted fields, the chain is:
+//   CheckInRecord → CheckInRecordServerMetadata
+//                → CheckInRecordResult → CheckInRecordWire
+// (no `EncryptedFields` / `EncryptedInput` aliases).
+
 /**
  * Server-visible CheckInRecord metadata — raw Drizzle row shape.
  *
- * Hybrid entity: the domain is plaintext (all fields server-visible), but
- * the server row carries two DB-only columns not on the domain:
- *   - `encryptedData` — optional encrypted payload attached to a response
- *     (e.g. mood/note captured with the check-in); nullable because
- *     records start out as scheduled-but-not-responded.
- *   - `idempotencyKey` — server-generated dedup key for webhook-driven
- *     response writes; never leaked to clients.
- *
  * The `archived` literal on the domain (`false`) widens to `boolean` to
  * match the DB column (archive toggles via `Archived<T>` on the domain
- * side; the DB just stores a boolean).
+ * side; the DB just stores a boolean). `idempotencyKey` is marked
+ * `ServerInternal<…>` so `EncryptedWire<T>` strips it from the wire.
  */
 export type CheckInRecordServerMetadata = Omit<CheckInRecord, "archived"> & {
   readonly archived: boolean;
   readonly encryptedData: EncryptedBlob | null;
-  readonly idempotencyKey: string | null;
+  readonly idempotencyKey: ServerInternal<string> | null;
 };
 
-/**
- * JSON-wire representation of CheckInRecord. Derived from the domain type
- * via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`.
- */
-export type CheckInRecordWire = Serialize<CheckInRecord>;
+export type CheckInRecordResult = EncryptedWire<CheckInRecordServerMetadata>;
+
+export type CheckInRecordWire = Serialize<CheckInRecordResult>;

--- a/packages/types/src/entities/lifecycle-event.ts
+++ b/packages/types/src/entities/lifecycle-event.ts
@@ -18,6 +18,8 @@ import type { InnerWorldEntityType } from "./innerworld-entity.js";
  *
  * Intentionally does not extend AuditMetadata — lifecycle events are
  * append-only immutable records with their own timestamp semantics.
+ * `archived: false` is included to enable the `Archived<LifecycleEvent>`
+ * utility type for the archived variant.
  */
 interface LifecycleEventBase {
   readonly id: LifecycleEventId;
@@ -25,6 +27,7 @@ interface LifecycleEventBase {
   readonly occurredAt: UnixMillis;
   readonly recordedAt: UnixMillis;
   readonly notes: string | null;
+  readonly archived: false;
 }
 
 /** A member split into one or more new members. */
@@ -143,16 +146,31 @@ export type LifecycleEvent =
 export type LifecycleEventType = LifecycleEvent["eventType"];
 
 /**
- * Keys of `LifecycleEvent` that are encrypted client-side before the
- * server sees them. Plaintext siblings (`eventType`, `occurredAt`, and
+ * Keys of `LifecycleEvent` variants that are encrypted client-side before
+ * the server sees them. Plaintext siblings (`eventType`, `occurredAt`, and
  * the event-specific plaintext metadata — member/structure/entity/region
  * IDs) travel as separate request fields and are intentionally excluded.
+ *
+ * Because `LifecycleEvent` is a discriminated union with per-variant
+ * differences, this is the union of every key that may appear in any
+ * encrypted blob. The distributive `LifecycleEventEncryptedInput` below
+ * then projects each variant by its own key intersection, so no variant
+ * is forced to carry keys it does not own.
+ *
  * Consumed by:
  * - `__sot-manifest__.ts` (manifest's `encryptedFields` slot)
  * - `LifecycleEventServerMetadata` (derived via `Omit`)
  * - `scripts/openapi-wire-parity.type-test.ts` (PlaintextLifecycleEvent parity)
  */
-export type LifecycleEventEncryptedFields = "notes";
+export type LifecycleEventEncryptedFields =
+  | "notes"
+  | "relatedLifecycleEventId"
+  | "previousForm"
+  | "newForm"
+  | "previousName"
+  | "newName"
+  | "entity"
+  | "entityType";
 
 // ── Canonical chain (see ADR-023) ────────────────────────────────────
 // LifecycleEventEncryptedInput → LifecycleEventServerMetadata
@@ -161,9 +179,14 @@ export type LifecycleEventEncryptedFields = "notes";
 // chain anchor above carries the meaning. Per-alias docs only appear
 // when an entity diverges from the standard pattern.
 
-/** Single-key projection over `"notes"` — not truncated. */
+/**
+ * Per-variant projection over encrypted keys. `Extract<keyof V, ...>`
+ * intersects the encrypted-fields union with each variant's own keys so
+ * that `Pick<SplitEvent, "relatedLifecycleEventId">` (which would error)
+ * never occurs — each variant contributes only the keys it actually owns.
+ */
 export type LifecycleEventEncryptedInput = LifecycleEvent extends unknown
-  ? Pick<LifecycleEvent, LifecycleEventEncryptedFields>
+  ? Pick<LifecycleEvent, Extract<keyof LifecycleEvent, LifecycleEventEncryptedFields>>
   : never;
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -127,6 +127,12 @@ export type {
 } from "./encryption-primitives.js";
 
 // ── Server-internal marker ───────────────────────────────────────
+// `__serverInternal` (the unique symbol) is re-exported alongside the
+// type so consumers using `.$type<ServerInternal<T>>()` produce a
+// declaration-emit shape that TypeScript can name. Without the value
+// re-export, generic table inferences over branded columns trigger
+// TS4023 ("…cannot be named").
+export { __serverInternal } from "./server-internal.js";
 export type { ServerInternal } from "./server-internal.js";
 
 // ── Response unions ──────────────────────────────────────────────

--- a/packages/types/src/server-internal.ts
+++ b/packages/types/src/server-internal.ts
@@ -1,9 +1,11 @@
 /**
  * @internal — symbol is exported only so sibling type-level helpers
  * (`Serialize<T>` in `type-assertions.ts`) can structurally pattern-match
- * the marker. Not for direct consumption.
+ * the marker, and so cross-package Drizzle column inferences over
+ * `.$type<ServerInternal<…>>()` can be named in declaration emit. Not
+ * for direct consumption.
  */
-export declare const __serverInternal: unique symbol;
+export const __serverInternal: unique symbol = Symbol("__serverInternal");
 
 /**
  * Marks a field on a `*ServerMetadata` type as server-fill-only — it is not

--- a/packages/validation/src/__tests__/type-parity/lifecycle-event.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/lifecycle-event.type.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Zod parity check for the LifecycleEvent discriminated union.
+ *
+ * `LifecycleEvent` is a discriminated union on `eventType` — a plain
+ * `Pick<Union, K>` would only accept keys present on every variant, so
+ * the domain projection uses a `DistributivePick` helper (the same
+ * pattern the OpenAPI parity gate uses). The Zod schema is a `z.union(...)`
+ * (not `z.discriminatedUnion` — the `eventType` discriminator is plaintext
+ * on the wire, not inside the encrypted blob). Its inferred type is the
+ * union of each variant's picked shape, which equals the distributive pick.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { LifecycleEventEncryptedInputSchema } from "../../lifecycle-event.js";
+import type { Equal, LifecycleEvent, LifecycleEventEncryptedFields } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+/**
+ * Per-variant `Pick` applied across a union's members. Matches the helper
+ * used in `scripts/openapi-wire-parity.type-test.ts` so the Zod, OpenAPI,
+ * and domain projections all agree on how encrypted keys project into
+ * each variant.
+ */
+type DistributivePick<T, K extends PropertyKey> = T extends unknown
+  ? Pick<T, Extract<keyof T, K>>
+  : never;
+
+describe("LifecycleEvent Zod parity", () => {
+  it("LifecycleEventEncryptedInputSchema matches DistributivePick<LifecycleEvent, LifecycleEventEncryptedFields>", () => {
+    expectTypeOf<
+      Equal<
+        z.infer<typeof LifecycleEventEncryptedInputSchema>,
+        DistributivePick<LifecycleEvent, LifecycleEventEncryptedFields>
+      >
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -95,6 +95,8 @@ export {
   CreateLifecycleEventBodySchema,
   UpdateLifecycleEventBodySchema,
   LIFECYCLE_EVENT_TYPES,
+  LifecycleEventEncryptedInputSchema,
+  LIFECYCLE_EVENT_ENCRYPTED_SCHEMAS,
   validateLifecycleMetadata,
 } from "./lifecycle-event.js";
 export type { PlaintextMetadata } from "./lifecycle-event.js";

--- a/packages/validation/src/lifecycle-event.ts
+++ b/packages/validation/src/lifecycle-event.ts
@@ -78,6 +78,108 @@ export function validateLifecycleMetadata(
   return schema.safeParse(metadata);
 }
 
+// ── Per-variant encrypted-input schemas ───────────────────────────
+// The discriminator (`eventType`) is plaintext on the wire, not inside
+// the blob, so `z.discriminatedUnion` is not applicable here. The
+// transform selects the per-variant schema via LIFECYCLE_EVENT_ENCRYPTED_SCHEMAS
+// keyed on `raw.eventType`.
+
+const baseEncrypted = { notes: z.string().nullable() } as const;
+
+const SplitEncryptedSchema = z.object(baseEncrypted).readonly();
+const FusionEncryptedSchema = z.object(baseEncrypted).readonly();
+const MergeEncryptedSchema = z.object(baseEncrypted).readonly();
+const UnmergeEncryptedSchema = z.object(baseEncrypted).readonly();
+const DiscoveryEncryptedSchema = z.object(baseEncrypted).readonly();
+const StructureEntityFormationEncryptedSchema = z.object(baseEncrypted).readonly();
+const StructureMoveEncryptedSchema = z.object(baseEncrypted).readonly();
+
+const DormancyStartEncryptedSchema = z
+  .object({
+    ...baseEncrypted,
+    relatedLifecycleEventId: brandedString<"LifecycleEventId">().nullable(),
+  })
+  .readonly();
+
+const DormancyEndEncryptedSchema = z
+  .object({
+    ...baseEncrypted,
+    relatedLifecycleEventId: brandedString<"LifecycleEventId">().nullable(),
+  })
+  .readonly();
+
+const ArchivalEncryptedSchema = z
+  .object({
+    ...baseEncrypted,
+    entity: z
+      .object({
+        entityType: z.string(),
+        entityId: z.string(),
+      })
+      .readonly(),
+  })
+  .readonly();
+
+const FormChangeEncryptedSchema = z
+  .object({
+    ...baseEncrypted,
+    previousForm: z.string().nullable(),
+    newForm: z.string().nullable(),
+  })
+  .readonly();
+
+const NameChangeEncryptedSchema = z
+  .object({
+    ...baseEncrypted,
+    previousName: z.string().nullable(),
+    newName: z.string(),
+  })
+  .readonly();
+
+const InnerworldMoveEncryptedSchema = z
+  .object({
+    ...baseEncrypted,
+    entityType: z.enum(["member", "landmark", "structure-entity"]),
+  })
+  .readonly();
+
+/** Union of all per-variant encrypted-input shapes. */
+export const LifecycleEventEncryptedInputSchema = z.union([
+  SplitEncryptedSchema,
+  FusionEncryptedSchema,
+  MergeEncryptedSchema,
+  UnmergeEncryptedSchema,
+  DormancyStartEncryptedSchema,
+  DormancyEndEncryptedSchema,
+  DiscoveryEncryptedSchema,
+  ArchivalEncryptedSchema,
+  StructureEntityFormationEncryptedSchema,
+  FormChangeEncryptedSchema,
+  NameChangeEncryptedSchema,
+  StructureMoveEncryptedSchema,
+  InnerworldMoveEncryptedSchema,
+]);
+
+/**
+ * Map of `eventType` → per-variant Zod schema, used by the transform to
+ * select the correct schema before parsing the decrypted blob.
+ */
+export const LIFECYCLE_EVENT_ENCRYPTED_SCHEMAS = {
+  split: SplitEncryptedSchema,
+  fusion: FusionEncryptedSchema,
+  merge: MergeEncryptedSchema,
+  unmerge: UnmergeEncryptedSchema,
+  "dormancy-start": DormancyStartEncryptedSchema,
+  "dormancy-end": DormancyEndEncryptedSchema,
+  discovery: DiscoveryEncryptedSchema,
+  archival: ArchivalEncryptedSchema,
+  "structure-entity-formation": StructureEntityFormationEncryptedSchema,
+  "form-change": FormChangeEncryptedSchema,
+  "name-change": NameChangeEncryptedSchema,
+  "structure-move": StructureMoveEncryptedSchema,
+  "innerworld-move": InnerworldMoveEncryptedSchema,
+} as const;
+
 // ── Plaintext metadata schema (loose for body validation) ─────────
 
 const PlaintextMetadataSchema = z.object({

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -293,10 +293,15 @@ expectTypeOf<
   >
 >().toEqualTypeOf<true>();
 
+// `LifecycleEvent` is a discriminated union whose variants carry
+// different encrypted keys — a plain `Pick<Union, K>` would only accept
+// keys present on *every* variant. `DistributivePick` distributes the
+// pick over each member, intersecting with that member's own keys so
+// each variant contributes only the fields it actually owns.
 expectTypeOf<
   Equal<
     components["schemas"]["PlaintextLifecycleEvent"],
-    Serialize<Pick<LifecycleEvent, LifecycleEventEncryptedFields>>
+    Serialize<DistributivePick<LifecycleEvent, LifecycleEventEncryptedFields>>
   >
 >().toEqualTypeOf<true>();
 

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -37,6 +37,7 @@ import type { components } from "../packages/api-client/src/generated/api-types.
 import type {
   AuditLogEntry,
   AuditLogEntryWire,
+  CheckInRecordWire,
   CustomFront,
   CustomFrontEncryptedFields,
   CustomFrontWire,
@@ -188,6 +189,15 @@ expectTypeOf<
 
 expectTypeOf<
   Equal<components["schemas"]["CanvasResponse"], InnerWorldCanvasWire>
+>().toEqualTypeOf<true>();
+
+// CheckInRecord is a hybrid (no `EncryptedFields`/`EncryptedInput`): the
+// domain is plaintext but the server row carries an optional encrypted
+// blob. `EncryptedWire<…>` strips the `ServerInternal<…>` `idempotencyKey`,
+// so this single check enforces both the plaintext envelope and the
+// nullable `encryptedData` shape on the wire.
+expectTypeOf<
+  Equal<components["schemas"]["CheckInRecordResponse"], CheckInRecordWire>
 >().toEqualTypeOf<true>();
 
 // ── OpenAPI ↔ Wire parity: Cluster 8 (deferred) ────────────────────


### PR DESCRIPTION
## Summary

Batch 2 of the ps-y4tb encrypted-entity SoT consolidation: migrates the two remaining residual entities to the canonical type chain documented in ADR-023.

- **types-wozj — LifecycleEvent**: discriminated union with per-variant encrypted fields. Widens `LifecycleEventEncryptedFields` to the full per-variant key union, replaces local `LifecycleEventEncryptedPayload`/`LifecycleEventRaw`/`assertLifecycleEventPayload` with canonical `LifecycleEventEncryptedInput` and per-variant Zod schemas (`LIFECYCLE_EVENT_ENCRYPTED_SCHEMAS`), distributes the OpenAPI `PlaintextLifecycleEvent` schema across variants, and migrates mobile consumers. Also drops the dead `encryptedData === null` branch (the column is `notNull()` in PG and SQLite).
- **types-600s — CheckInRecord**: hybrid entity with no domain-side encrypted fields but an optional encrypted blob and a server-only `idempotencyKey`. Promotes the chain to `CheckInRecordResult = EncryptedWire<CheckInRecordServerMetadata>` + `CheckInRecordWire = Serialize<CheckInRecordResult>`, brands `idempotencyKey` as `ServerInternal<string> | null` (PG/SQLite columns mirror via `.$type<…>()`), tightens the OpenAPI `CheckInRecordResponse` with a `required` array, and adds a G7 parity assertion.

## Cross-cutting changes (CheckInRecord enabled)

- **`StripServerInternal<T>`** in `encrypted-wire.ts` now uses `Extract<T[K], ServerInternal<unknown>>` so nullable server-only fields (`ServerInternal<X> | null`) are also stripped — the previous `extends` form missed unions.
- **`__serverInternal`** is now a real runtime `Symbol(...)` and re-exported from `@pluralscape/types`. Cross-package Drizzle column inferences over `.$type<ServerInternal<…>>()` were tripping TS4023 (\"…cannot be named\") in declaration emit because the symbol had no value-level export.

## Verification

- `pnpm types:check-sot` ✓ (types + Drizzle + Zod + OpenAPI-Wire parity)
- `pnpm typecheck` ✓ (21/21)
- `pnpm lint` ✓ (zero warnings)
- `pnpm format` ✓
- `pnpm test:unit` ✓ (12871 passed, 1 skipped, 1 todo)
- `pnpm test:integration` ✓ (3055 passed, 11 skipped)
- `pnpm test:e2e` ✓ (507 passed, 2 skipped)

## Test plan

- [x] LifecycleEvent transform unit tests (per-variant decrypt + schema validation + metadata validation)
- [x] CheckInRecord Drizzle parity (PG + SQLite rows match `CheckInRecordServerMetadata`)
- [x] CheckInRecord OpenAPI G7 parity (`CheckInRecordResponse ≡ CheckInRecordWire`)
- [x] SoT manifest test asserts the new CheckInRecord shape (domain/server/result/wire/encryptedFields)
- [x] No regressions in mobile lifecycle hooks or factories

## Bean refs

- `types-wozj` (LifecycleEvent canonical chain) — completed
- `types-600s` (CheckInRecord canonical chain) — completed
- Parent: `ps-y4tb`