### PR TITLE
refactor(types,validation,openapi,api,data,mobile): ps-y4tb batch 3 — parity infrastructure

### DIFF
--- a/.beans/types-1spw--anchor-g4-parity-assertions-to-data-transform-retu.md
+++ b/.beans/types-1spw--anchor-g4-parity-assertions-to-data-transform-retu.md
@@ -1,11 +1,11 @@
 ---
 # types-1spw
 title: Anchor G4 parity assertions to data transform return types
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-25T09:05:46Z
-updated_at: 2026-04-25T09:05:51Z
+updated_at: 2026-04-26T11:54:04Z
 parent: ps-y4tb
 ---
 
@@ -43,3 +43,14 @@ Apply to the full encrypted-entity fleet _after_ PR 2 of ps-y4tb lands the inlin
 - Parent: ps-y4tb (Encrypted-entity type SoT consolidation)
 - Related: ADR-023 (Zod ↔ types alignment)
 - Plan reference: `docs/superpowers/plans/2026-04-25-ps-y4tb-encrypted-entity-sot-consolidation.md` Task 3.7 (cycle constraint note)
+
+## Summary of Changes
+
+G4 (Body Zod ↔ Transform output) parity assertions for the encrypted-entity fleet now live in `packages/data/src/__tests__/type-parity/<entity>.type.test.ts`, anchored to `ReturnType<typeof encryptXInput>` so transform return-type drift fails the test mechanically.
+
+- 25 per-entity test files in `packages/data/src/__tests__/type-parity/` (Member pilot + 24 fleet entities: acknowledgement, board-message, channel, custom-front, field-definition, field-value, fronting-comment, fronting-report, fronting-session, group, innerworld-canvas, innerworld-entity, innerworld-region, lifecycle-event, message, note, poll, privacy-bucket, relationship, snapshot, structure-entity, structure-entity-type, system-settings, timer-config)
+- Inline-shape G4 assertions removed from `packages/validation/src/__tests__/contract-member.test.ts`, `contract-custom-fields.test.ts`, and `type-parity/member.type.test.ts`
+- Acknowledgement Confirm parity skipped (intentional design — `ConfirmAcknowledgementBodySchema.encryptedData` is `.optional()` because clients may confirm without re-encrypting; the transform always returns required `encryptedData: string`)
+- 45 G4 assertions across 25 files all pass
+
+PR: refactor/ps-y4tb-batch3-parity-infrastructure

--- a/.beans/types-iupb--cluster-8-openapi-g7-parity-reconcile-optional-vs.md
+++ b/.beans/types-iupb--cluster-8-openapi-g7-parity-reconcile-optional-vs.md
@@ -1,11 +1,11 @@
 ---
 # types-iupb
 title: "Cluster 8 OpenAPI G7 parity: reconcile optional-vs-nullable for hybrid encrypted entities"
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-26T05:03:58Z
-updated_at: 2026-04-26T05:03:58Z
+updated_at: 2026-04-26T11:54:30Z
 blocked_by:
   - ps-etbc
 ---
@@ -65,3 +65,25 @@ PollVote needs a separate path — its OpenAPI response is a hand-rolled shape (
 - Parent: ps-y4tb
 - Blocked-by: ps-etbc (PR #562)
 - File: `scripts/openapi-wire-parity.type-test.ts` lines around the "Cluster 8 (deferred)" block
+
+## Summary of Changes
+
+G7 full-equality OpenAPI ↔ canonical wire parity restored for 8 entities (7 envelope entities + PollVote). The "Cluster 8 (deferred)" carve-out is gone.
+
+**G7 added (8 entities):**
+
+- Channel, Message (ChatMessage), Note, BoardMessage, Poll, TimerConfig, Acknowledgement (note: schema name `AcknowledgementResponse` does not match canonical `AcknowledgementRequestWire` — divergence documented inline)
+- PollVote: response widened to include `systemId`, `version`, `updatedAt`; `PollVoteServerWire` shim deleted; `decryptPollVote(raw: PollVoteWire, …)` consumes the canonical type directly
+
+**Real drift discovered + fixed:**
+
+- TimerConfig OpenAPI was missing the server-tracked plaintext column `nextCheckInAt` entirely; spec was widened to match the canonical `TimerConfigServerMetadata`
+- PollVote schema had three EncryptedEntity-pattern fields missing (systemId, version, updatedAt); widened in lock-step with the response handler and tests
+
+**Deferred (2 entities):**
+
+- JournalEntry, WikiPage — canonical wire types exist (`JournalEntryWire`, `WikiPageWire`) but no OpenAPI route schema is authored yet. G7 deferred until the routes are added; comment in the parity test points at types-iupb.
+
+**Tests updated:** PollVote response-shape assertions in 5 test fixtures across api routes/tRPC/services were widened with the three new fields (no `expect.objectContaining` masking).
+
+PR: refactor/ps-y4tb-batch3-parity-infrastructure

--- a/apps/api/src/__tests__/routes/poll-votes.test.ts
+++ b/apps/api/src/__tests__/routes/poll-votes.test.ts
@@ -62,15 +62,18 @@ const RESULTS_URL = `/systems/${SYS_ID}/polls/${POLL_ID}/results`;
 
 const MOCK_VOTE = {
   id: VOTE_ID as never,
+  systemId: SYS_ID as never,
   pollId: POLL_ID as never,
   optionId: "opt_550e8400-e29b-41d4-a716-446655440003" as never,
   voter: { entityType: "member" as const, entityId: brandId<MemberId>("mem_test") },
   isVeto: false,
   votedAt: 1000 as never,
   encryptedData: "dGVzdA==" as EncryptedBase64,
+  version: 1,
   archived: false,
   archivedAt: null,
   createdAt: 1000 as never,
+  updatedAt: 1000 as never,
 };
 
 const VALID_UPDATE_BODY = {

--- a/apps/api/src/__tests__/routes/polls/crud.test.ts
+++ b/apps/api/src/__tests__/routes/polls/crud.test.ts
@@ -92,15 +92,18 @@ const MOCK_POLL: PollResult = {
 
 const MOCK_VOTE: PollVoteResult = {
   id: VOTE_ID as never,
+  systemId: MOCK_AUTH.systemId as never,
   pollId: POLL_ID as never,
   optionId: null,
   voter: null,
   isVeto: false,
   votedAt: 1000 as never,
   encryptedData: "dGVzdA==" as EncryptedBase64,
+  version: 1,
   archived: false,
   archivedAt: null,
   createdAt: 1000 as never,
+  updatedAt: 1000 as never,
 };
 
 // ── Tests ────────────────────────────────────────────────────────

--- a/apps/api/src/__tests__/services/poll-vote.service.test.ts
+++ b/apps/api/src/__tests__/services/poll-vote.service.test.ts
@@ -126,9 +126,11 @@ function makeVoteRow(overrides: Record<string, unknown> = {}): Record<string, un
     isVeto: false,
     votedAt: 1000,
     encryptedData: new Uint8Array([1, 2, 3]),
+    version: 1,
     archived: false,
     archivedAt: null,
     createdAt: 1000,
+    updatedAt: 1000,
     ...overrides,
   };
 }

--- a/apps/api/src/__tests__/services/poll-vote.service.update-delete-results.test.ts
+++ b/apps/api/src/__tests__/services/poll-vote.service.update-delete-results.test.ts
@@ -129,9 +129,11 @@ function makeVoteRow(overrides: Record<string, unknown> = {}): Record<string, un
     isVeto: false,
     votedAt: 1000,
     encryptedData: new Uint8Array([1, 2, 3]),
+    version: 1,
     archived: false,
     archivedAt: null,
     createdAt: 1000,
+    updatedAt: 1000,
     ...overrides,
   };
 }

--- a/apps/api/src/__tests__/trpc/routers/poll.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/poll.test.ts
@@ -98,15 +98,18 @@ const MOCK_POLL_RESULT = {
 
 const MOCK_VOTE_RESULT = {
   id: VOTE_ID,
+  systemId: MOCK_SYSTEM_ID,
   pollId: POLL_ID,
   optionId: null,
   voter: null,
   isVeto: false,
   votedAt: 1_700_000_000_000 as UnixMillis,
   encryptedData: "base64data==" as EncryptedBase64,
+  version: 1,
   archived: false,
   archivedAt: null,
   createdAt: 1_700_000_000_000 as UnixMillis,
+  updatedAt: 1_700_000_000_000 as UnixMillis,
 };
 
 describe("poll router", () => {

--- a/apps/api/src/services/poll-vote/internal.ts
+++ b/apps/api/src/services/poll-vote/internal.ts
@@ -8,33 +8,40 @@ import type {
   PollId,
   PollOptionId,
   PollVoteId,
+  SystemId,
   UnixMillis,
 } from "@pluralscape/types";
 
 export interface PollVoteResult {
   readonly id: PollVoteId;
+  readonly systemId: SystemId;
   readonly pollId: PollId;
   readonly optionId: PollOptionId | null;
   readonly voter: EntityReference<"member" | "structure-entity"> | null;
   readonly isVeto: boolean;
   readonly votedAt: UnixMillis;
   readonly encryptedData: string;
+  readonly version: number;
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
   readonly createdAt: UnixMillis;
+  readonly updatedAt: UnixMillis;
 }
 
 export function toVoteResult(row: typeof pollVotes.$inferSelect): PollVoteResult {
   return {
     id: brandId<PollVoteId>(row.id),
+    systemId: brandId<SystemId>(row.systemId),
     pollId: brandId<PollId>(row.pollId),
     optionId: row.optionId ? brandId<PollOptionId>(row.optionId) : null,
     voter: row.voter,
     isVeto: row.isVeto,
     votedAt: toUnixMillis(row.votedAt),
     encryptedData: encryptedBlobToBase64(row.encryptedData),
+    version: row.version,
     archived: row.archived,
     archivedAt: toUnixMillisOrNull(row.archivedAt),
     createdAt: toUnixMillis(row.createdAt),
+    updatedAt: toUnixMillis(row.updatedAt),
   };
 }

--- a/apps/mobile/src/__tests__/factories.ts
+++ b/apps/mobile/src/__tests__/factories.ts
@@ -43,7 +43,6 @@ export { TEST_MASTER_KEY, TEST_SYSTEM_ID };
 
 import type { FieldDefinitionRaw, FieldValueRaw } from "@pluralscape/data/transforms/custom-field";
 import type { FrontingReportRaw } from "@pluralscape/data/transforms/fronting-report";
-import type { PollVoteServerWire } from "@pluralscape/data/transforms/poll";
 import type { SnapshotRaw } from "@pluralscape/data/transforms/snapshot";
 import type { NomenclatureSettingsWire } from "@pluralscape/data/transforms/system-settings";
 import type {
@@ -87,6 +86,7 @@ import type {
   PollId,
   PollOptionId,
   PollVoteId,
+  PollVoteWire,
   PollWire,
   RelationshipId,
   RelationshipType,
@@ -610,19 +610,22 @@ export function makeRawPoll(id: string, overrides?: Partial<PollWire>): PollWire
 export function makeRawPollVote(
   id: string,
   pollId: string,
-  overrides?: Partial<PollVoteServerWire>,
-): PollVoteServerWire {
+  overrides?: Partial<PollVoteWire>,
+): PollVoteWire {
   const encrypted = encryptPollVoteInput({ comment: "My comment" }, TEST_MASTER_KEY);
   return {
     id: brandId<PollVoteId>(id),
+    systemId: TEST_SYSTEM_ID,
     pollId: brandId<PollId>(pollId),
     optionId: brandId<PollOptionId>("opt-1"),
     voter: { entityType: "member" as const, entityId: brandId<MemberId>("mem-voter") },
     isVeto: false,
     votedAt: NOW,
+    version: 1,
     archived: false,
     archivedAt: null,
     createdAt: NOW,
+    updatedAt: NOW,
     ...encrypted,
     ...overrides,
   };

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13745,6 +13745,13 @@ components:
       allOf:
         - $ref: "#/components/schemas/EncryptedEntity"
         - type: object
+          required:
+            - intervalMinutes
+            - wakingHoursOnly
+            - wakingStart
+            - wakingEnd
+            - enabled
+            - nextCheckInAt
           properties:
             enabled:
               type: boolean
@@ -13768,6 +13775,11 @@ components:
               nullable: true
               pattern: ^(?:[01]\d|2[0-3]):[0-5]\d$
               description: End of waking hours (HH:MM, required when wakingHoursOnly=true)
+            nextCheckInAt:
+              type: integer
+              format: int64
+              nullable: true
+              description: Server-tracked Unix milliseconds of the next scheduled check-in (null when disabled or not yet scheduled)
     CreateTimerConfigRequest:
       type: object
       required:
@@ -17145,6 +17157,7 @@ components:
         - type: object
           required:
             - type
+            - parentId
             - sortOrder
           properties:
             type:
@@ -17215,7 +17228,9 @@ components:
         - type: object
           required:
             - channelId
+            - replyToId
             - timestamp
+            - editedAt
           properties:
             channelId:
               type: string
@@ -17357,6 +17372,9 @@ components:
       allOf:
         - $ref: "#/components/schemas/EncryptedEntity"
         - type: object
+          required:
+            - authorEntityType
+            - authorEntityId
           properties:
             authorEntityType:
               type: string
@@ -17419,8 +17437,11 @@ components:
         - $ref: "#/components/schemas/EncryptedEntity"
         - type: object
           required:
+            - createdByMemberId
             - kind
             - status
+            - closedAt
+            - endsAt
             - allowMultipleVotes
             - maxVotesPerMember
             - allowAbstain
@@ -17680,6 +17701,7 @@ components:
         - $ref: "#/components/schemas/EncryptedEntity"
         - type: object
           required:
+            - createdByMemberId
             - confirmed
           properties:
             createdByMemberId:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -17548,19 +17548,27 @@ components:
       type: object
       required:
         - id
+        - systemId
         - pollId
         - isVeto
         - votedAt
         - encryptedData
+        - version
+        - updatedAt
         - archived
+        - archivedAt
         - createdAt
+        - optionId
+        - voter
       properties:
         id:
           type: string
           description: Vote ID
+        systemId:
+          type: string
+          description: Owning system
         pollId:
           type: string
-          pattern: ^poll_
           description: Poll this vote belongs to
         optionId:
           type: string
@@ -17592,6 +17600,10 @@ components:
           type: string
           contentEncoding: base64
           description: T1-encrypted vote data (optional comment, etc.)
+        version:
+          type: integer
+          minimum: 1
+          description: Optimistic concurrency version
         archived:
           type: boolean
         archivedAt:
@@ -17602,6 +17614,10 @@ components:
           type: integer
           format: int64
           description: Unix milliseconds
+        updatedAt:
+          type: integer
+          format: int64
+          description: Last modification timestamp (Unix milliseconds)
     CastVoteRequest:
       type: object
       required:

--- a/docs/openapi/schemas/acknowledgements.yaml
+++ b/docs/openapi/schemas/acknowledgements.yaml
@@ -6,7 +6,7 @@ AcknowledgementResponse:
   allOf:
     - $ref: "./common.yaml#/EncryptedEntity"
     - type: object
-      required: [confirmed]
+      required: [createdByMemberId, confirmed]
       properties:
         createdByMemberId:
           type: string

--- a/docs/openapi/schemas/channels.yaml
+++ b/docs/openapi/schemas/channels.yaml
@@ -6,7 +6,7 @@ ChannelResponse:
   allOf:
     - $ref: "./common.yaml#/EncryptedEntity"
     - type: object
-      required: [type, sortOrder]
+      required: [type, parentId, sortOrder]
       properties:
         type:
           type: string

--- a/docs/openapi/schemas/messages.yaml
+++ b/docs/openapi/schemas/messages.yaml
@@ -6,7 +6,7 @@ MessageResponse:
   allOf:
     - $ref: "./common.yaml#/EncryptedEntity"
     - type: object
-      required: [channelId, timestamp]
+      required: [channelId, replyToId, timestamp, editedAt]
       properties:
         channelId:
           type: string

--- a/docs/openapi/schemas/notes.yaml
+++ b/docs/openapi/schemas/notes.yaml
@@ -6,6 +6,7 @@ NoteResponse:
   allOf:
     - $ref: "./common.yaml#/EncryptedEntity"
     - type: object
+      required: [authorEntityType, authorEntityId]
       properties:
         authorEntityType:
           type: string

--- a/docs/openapi/schemas/polls.yaml
+++ b/docs/openapi/schemas/polls.yaml
@@ -59,14 +59,31 @@ PollVoteResponse:
     A vote cast on a poll. Voters are polymorphic entity references
     (member or structure entity).
   type: object
-  required: [id, pollId, isVeto, votedAt, encryptedData, archived, createdAt]
+  required:
+    [
+      id,
+      systemId,
+      pollId,
+      isVeto,
+      votedAt,
+      encryptedData,
+      version,
+      updatedAt,
+      archived,
+      archivedAt,
+      createdAt,
+      optionId,
+      voter,
+    ]
   properties:
     id:
       type: string
       description: Vote ID
+    systemId:
+      type: string
+      description: Owning system
     pollId:
       type: string
-      pattern: ^poll_
       description: Poll this vote belongs to
     optionId:
       type: string
@@ -94,6 +111,10 @@ PollVoteResponse:
       type: string
       contentEncoding: base64
       description: T1-encrypted vote data (optional comment, etc.)
+    version:
+      type: integer
+      minimum: 1
+      description: Optimistic concurrency version
     archived:
       type: boolean
     archivedAt:
@@ -104,6 +125,10 @@ PollVoteResponse:
       type: integer
       format: int64
       description: Unix milliseconds
+    updatedAt:
+      type: integer
+      format: int64
+      description: Last modification timestamp (Unix milliseconds)
 
 CreatePollRequest:
   type: object

--- a/docs/openapi/schemas/polls.yaml
+++ b/docs/openapi/schemas/polls.yaml
@@ -6,7 +6,16 @@ PollResponse:
   allOf:
     - $ref: "./common.yaml#/EncryptedEntity"
     - type: object
-      required: [kind, status, allowMultipleVotes, maxVotesPerMember, allowAbstain, allowVeto]
+      required:
+        - createdByMemberId
+        - kind
+        - status
+        - closedAt
+        - endsAt
+        - allowMultipleVotes
+        - maxVotesPerMember
+        - allowAbstain
+        - allowVeto
       properties:
         createdByMemberId:
           type: string

--- a/docs/openapi/schemas/timers.yaml
+++ b/docs/openapi/schemas/timers.yaml
@@ -5,6 +5,13 @@ TimerConfigResponse:
   allOf:
     - $ref: "./common.yaml#/EncryptedEntity"
     - type: object
+      required:
+        - intervalMinutes
+        - wakingHoursOnly
+        - wakingStart
+        - wakingEnd
+        - enabled
+        - nextCheckInAt
       properties:
         enabled:
           type: boolean
@@ -28,6 +35,11 @@ TimerConfigResponse:
           nullable: true
           pattern: "^(?:[01]\\d|2[0-3]):[0-5]\\d$"
           description: "End of waking hours (HH:MM, required when wakingHoursOnly=true)"
+        nextCheckInAt:
+          type: integer
+          format: int64
+          nullable: true
+          description: "Server-tracked Unix milliseconds of the next scheduled check-in (null when disabled or not yet scheduled)"
 
 CreateTimerConfigRequest:
   type: object

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -6708,15 +6708,20 @@ export interface components {
      */
     TimerConfigResponse: components["schemas"]["EncryptedEntity"] & {
       /** @description Whether the timer is actively scheduling check-ins */
-      enabled?: boolean;
+      enabled: boolean;
       /** @description Minutes between check-in records */
-      intervalMinutes?: number | null;
+      intervalMinutes: number | null;
       /** @description If true, only generate check-ins during waking hours */
-      wakingHoursOnly?: boolean | null;
+      wakingHoursOnly: boolean | null;
       /** @description Start of waking hours (HH:MM, required when wakingHoursOnly=true) */
-      wakingStart?: string | null;
+      wakingStart: string | null;
       /** @description End of waking hours (HH:MM, required when wakingHoursOnly=true) */
-      wakingEnd?: string | null;
+      wakingEnd: string | null;
+      /**
+       * Format: int64
+       * @description Server-tracked Unix milliseconds of the next scheduled check-in (null when disabled or not yet scheduled)
+       */
+      nextCheckInAt: number | null;
     };
     CreateTimerConfigRequest: {
       /** @description T1-encrypted PlaintextTimerConfig */
@@ -8627,7 +8632,7 @@ export interface components {
        */
       type: "category" | "channel";
       /** @description Parent category ID (null for top-level channels/categories) */
-      parentId?: string | null;
+      parentId: string | null;
       /** @description Display order within parent scope */
       sortOrder: number;
     };
@@ -8655,7 +8660,7 @@ export interface components {
       /** @description Channel this message belongs to */
       channelId: string;
       /** @description ID of the message being replied to (null if not a reply) */
-      replyToId?: string | null;
+      replyToId: string | null;
       /**
        * Format: int64
        * @description Message send time in Unix milliseconds (used for partition pruning)
@@ -8665,7 +8670,7 @@ export interface components {
        * Format: int64
        * @description Unix milliseconds when last edited (null until first edit)
        */
-      editedAt?: number | null;
+      editedAt: number | null;
     };
     CreateMessageRequest: {
       /** @description T1-encrypted message content (text, sender proxy identity, etc.) */
@@ -8724,9 +8729,9 @@ export interface components {
        * @description Author entity type (null for system-wide notes)
        * @enum {string|null}
        */
-      authorEntityType?: "member" | "structure-entity" | null;
+      authorEntityType: "member" | "structure-entity" | null;
       /** @description Author entity ID (null for system-wide notes) */
-      authorEntityId?: string | null;
+      authorEntityId: string | null;
     };
     CreateNoteRequest: {
       /** @description T1-encrypted note content (rich text, background color, etc.) */
@@ -8750,7 +8755,7 @@ export interface components {
      */
     PollResponse: components["schemas"]["EncryptedEntity"] & {
       /** @description Member who created the poll (null if not attributed) */
-      createdByMemberId?: string | null;
+      createdByMemberId: string | null;
       /**
        * @description Poll kind
        * @enum {string}
@@ -8765,12 +8770,12 @@ export interface components {
        * Format: int64
        * @description Unix milliseconds when the poll was closed (null while open)
        */
-      closedAt?: number | null;
+      closedAt: number | null;
       /**
        * Format: int64
        * @description Optional scheduled end time in Unix milliseconds
        */
-      endsAt?: number | null;
+      endsAt: number | null;
       /** @description Whether voters can cast more than one vote */
       allowMultipleVotes: boolean;
       /** @description Maximum votes per voter (must be 1 when allowMultipleVotes is false) */
@@ -8880,7 +8885,7 @@ export interface components {
      */
     AcknowledgementResponse: components["schemas"]["EncryptedEntity"] & {
       /** @description Member who created the acknowledgement (null if not attributed) */
-      createdByMemberId?: string | null;
+      createdByMemberId: string | null;
       /** @description Whether the target member has confirmed this acknowledgement */
       confirmed: boolean;
     };

--- a/packages/api-client/src/generated/api-types.ts
+++ b/packages/api-client/src/generated/api-types.ts
@@ -8815,12 +8815,14 @@ export interface components {
     PollVoteResponse: {
       /** @description Vote ID */
       id: string;
+      /** @description Owning system */
+      systemId: string;
       /** @description Poll this vote belongs to */
       pollId: string;
       /** @description Selected option ID (null for abstain) */
-      optionId?: string | null;
+      optionId: string | null;
       /** @description Voter entity reference */
-      voter?: {
+      voter: {
         /** @enum {string} */
         entityType: "member" | "structure-entity";
         entityId: string;
@@ -8834,14 +8836,21 @@ export interface components {
       votedAt: number;
       /** @description T1-encrypted vote data (optional comment, etc.) */
       encryptedData: string;
+      /** @description Optimistic concurrency version */
+      version: number;
       archived: boolean;
       /** Format: int64 */
-      archivedAt?: number | null;
+      archivedAt: number | null;
       /**
        * Format: int64
        * @description Unix milliseconds
        */
       createdAt: number;
+      /**
+       * Format: int64
+       * @description Last modification timestamp (Unix milliseconds)
+       */
+      updatedAt: number;
     };
     CastVoteRequest: {
       /** @description Selected option ID (null for abstain) */

--- a/packages/data/src/__tests__/type-parity/acknowledgement.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/acknowledgement.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Acknowledgement.
+ *
+ * Anchored to `ReturnType<typeof encryptAcknowledgementInput>`, so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ *
+ * NOTE: `ConfirmAcknowledgementBodySchema.encryptedData` is intentionally
+ * optional (clients may confirm without re-encrypting), while
+ * `encryptAcknowledgementConfirm` always returns a populated `encryptedData`.
+ * That asymmetry is by design (route accepts skip-encrypt confirm), so no
+ * Confirm parity assertion is included here.
+ */
+
+import { CreateAcknowledgementBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptAcknowledgementInput } from "../../transforms/acknowledgement.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Acknowledgement G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateAcknowledgementBodySchema's encryptedData slice equals encryptAcknowledgementInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateAcknowledgementBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptAcknowledgementInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/board-message.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/board-message.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for BoardMessage.
+ *
+ * Anchored to `ReturnType<typeof encryptBoardMessageInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateBoardMessageBodySchema,
+  UpdateBoardMessageBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptBoardMessageInput,
+  encryptBoardMessageUpdate,
+} from "../../transforms/board-message.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("BoardMessage G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateBoardMessageBodySchema's encryptedData slice equals encryptBoardMessageInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateBoardMessageBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptBoardMessageInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateBoardMessageBodySchema's encryptedData+version slice equals encryptBoardMessageUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateBoardMessageBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptBoardMessageUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/channel.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/channel.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Channel.
+ *
+ * Anchored to `ReturnType<typeof encryptChannelInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateChannelBodySchema, UpdateChannelBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptChannelInput, encryptChannelUpdate } from "../../transforms/channel.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Channel G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateChannelBodySchema's encryptedData slice equals encryptChannelInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateChannelBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptChannelInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateChannelBodySchema's encryptedData+version slice equals encryptChannelUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateChannelBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptChannelUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/custom-front.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/custom-front.type.test.ts
@@ -1,0 +1,39 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for CustomFront.
+ *
+ * Anchored to `ReturnType<typeof encryptCustomFrontInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateCustomFrontBodySchema, UpdateCustomFrontBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptCustomFrontInput,
+  encryptCustomFrontUpdate,
+} from "../../transforms/custom-front.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("CustomFront G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateCustomFrontBodySchema's encryptedData slice equals encryptCustomFrontInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateCustomFrontBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptCustomFrontInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateCustomFrontBodySchema's encryptedData+version slice equals encryptCustomFrontUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateCustomFrontBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptCustomFrontUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/field-definition.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/field-definition.type.test.ts
@@ -1,0 +1,27 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for FieldDefinition.
+ *
+ * Anchored to `ReturnType<typeof encryptFieldDefinitionInput>`, so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateFieldDefinitionBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptFieldDefinitionInput } from "../../transforms/custom-field.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("FieldDefinition G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateFieldDefinitionBodySchema's encryptedData slice equals encryptFieldDefinitionInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateFieldDefinitionBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptFieldDefinitionInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/field-value.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/field-value.type.test.ts
@@ -1,0 +1,24 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for FieldValue.
+ *
+ * Anchored to `ReturnType<typeof encryptFieldValueInput>`, so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { SetFieldValueBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptFieldValueInput } from "../../transforms/custom-field.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("FieldValue G4 parity (transform output ↔ Zod body schema)", () => {
+  it("SetFieldValueBodySchema's encryptedData slice equals encryptFieldValueInput output", () => {
+    type SetBodyEncryptedSlice = Pick<z.infer<typeof SetFieldValueBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptFieldValueInput>;
+    expectTypeOf<Equal<SetBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/fronting-comment.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/fronting-comment.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for FrontingComment.
+ *
+ * Anchored to `ReturnType<typeof encryptFrontingCommentInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateFrontingCommentBodySchema,
+  UpdateFrontingCommentBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptFrontingCommentInput,
+  encryptFrontingCommentUpdate,
+} from "../../transforms/fronting-comment.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("FrontingComment G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateFrontingCommentBodySchema's encryptedData slice equals encryptFrontingCommentInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateFrontingCommentBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptFrontingCommentInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateFrontingCommentBodySchema's encryptedData+version slice equals encryptFrontingCommentUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateFrontingCommentBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptFrontingCommentUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/fronting-report.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/fronting-report.type.test.ts
@@ -1,0 +1,27 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for FrontingReport.
+ *
+ * Anchored to `ReturnType<typeof encryptFrontingReportInput>`, so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateFrontingReportBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptFrontingReportInput } from "../../transforms/fronting-report.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("FrontingReport G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateFrontingReportBodySchema's encryptedData slice equals encryptFrontingReportInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateFrontingReportBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptFrontingReportInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/fronting-session.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/fronting-session.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for FrontingSession.
+ *
+ * Anchored to `ReturnType<typeof encryptFrontingSessionInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateFrontingSessionBodySchema,
+  UpdateFrontingSessionBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptFrontingSessionInput,
+  encryptFrontingSessionUpdate,
+} from "../../transforms/fronting-session.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("FrontingSession G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateFrontingSessionBodySchema's encryptedData slice equals encryptFrontingSessionInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateFrontingSessionBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptFrontingSessionInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateFrontingSessionBodySchema's encryptedData+version slice equals encryptFrontingSessionUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateFrontingSessionBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptFrontingSessionUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/group.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/group.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Group.
+ *
+ * Anchored to `ReturnType<typeof encryptGroupInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateGroupBodySchema, UpdateGroupBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptGroupInput, encryptGroupUpdate } from "../../transforms/group.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Group G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateGroupBodySchema's encryptedData slice equals encryptGroupInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateGroupBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptGroupInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateGroupBodySchema's encryptedData+version slice equals encryptGroupUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateGroupBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptGroupUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/innerworld-canvas.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/innerworld-canvas.type.test.ts
@@ -1,0 +1,27 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for InnerWorldCanvas.
+ *
+ * Anchored to `ReturnType<typeof encryptCanvasUpdate>`, so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { UpdateCanvasBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptCanvasUpdate } from "../../transforms/innerworld-canvas.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("InnerWorldCanvas G4 parity (transform output ↔ Zod body schema)", () => {
+  it("UpdateCanvasBodySchema's encryptedData+version slice equals encryptCanvasUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateCanvasBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptCanvasUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/innerworld-entity.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/innerworld-entity.type.test.ts
@@ -1,0 +1,36 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for InnerWorldEntity.
+ *
+ * Anchored to `ReturnType<typeof encryptInnerWorldEntityInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateEntityBodySchema, UpdateEntityBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptInnerWorldEntityInput,
+  encryptInnerWorldEntityUpdate,
+} from "../../transforms/innerworld-entity.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("InnerWorldEntity G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateEntityBodySchema's encryptedData slice equals encryptInnerWorldEntityInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateEntityBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptInnerWorldEntityInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateEntityBodySchema's encryptedData+version slice equals encryptInnerWorldEntityUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateEntityBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptInnerWorldEntityUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/innerworld-region.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/innerworld-region.type.test.ts
@@ -1,0 +1,36 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for InnerWorldRegion.
+ *
+ * Anchored to `ReturnType<typeof encryptInnerWorldRegionInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateRegionBodySchema, UpdateRegionBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptInnerWorldRegionInput,
+  encryptInnerWorldRegionUpdate,
+} from "../../transforms/innerworld-region.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("InnerWorldRegion G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateRegionBodySchema's encryptedData slice equals encryptInnerWorldRegionInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateRegionBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptInnerWorldRegionInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateRegionBodySchema's encryptedData+version slice equals encryptInnerWorldRegionUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateRegionBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptInnerWorldRegionUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/lifecycle-event.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/lifecycle-event.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for LifecycleEvent.
+ *
+ * Anchored to `ReturnType<typeof encryptLifecycleEventInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateLifecycleEventBodySchema,
+  UpdateLifecycleEventBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptLifecycleEventInput,
+  encryptLifecycleEventUpdate,
+} from "../../transforms/lifecycle-event.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("LifecycleEvent G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateLifecycleEventBodySchema's encryptedData slice equals encryptLifecycleEventInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateLifecycleEventBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptLifecycleEventInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateLifecycleEventBodySchema's encryptedData+version slice equals encryptLifecycleEventUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateLifecycleEventBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptLifecycleEventUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/member.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/member.type.test.ts
@@ -1,0 +1,47 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Member.
+ *
+ * Anchored to `ReturnType<typeof encryptMemberInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateMemberBodySchema,
+  DuplicateMemberBodySchema,
+  UpdateMemberBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptMemberInput, encryptMemberUpdate } from "../../transforms/member.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Member G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateMemberBodySchema's encryptedData slice equals encryptMemberInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateMemberBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptMemberInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateMemberBodySchema's encryptedData+version slice equals encryptMemberUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateMemberBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptMemberUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("DuplicateMemberBodySchema = encryptMemberInput output + duplication knobs", () => {
+    type DuplicateBody = z.infer<typeof DuplicateMemberBodySchema>;
+    type Expected = ReturnType<typeof encryptMemberInput> & {
+      copyPhotos: boolean;
+      copyFields: boolean;
+      copyMemberships: boolean;
+    };
+    expectTypeOf<Equal<DuplicateBody, Expected>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/message.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/message.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Message.
+ *
+ * Anchored to `ReturnType<typeof encryptMessageInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateMessageBodySchema, UpdateMessageBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptMessageInput, encryptMessageUpdate } from "../../transforms/message.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Message G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateMessageBodySchema's encryptedData slice equals encryptMessageInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateMessageBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptMessageInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateMessageBodySchema's encryptedData+version slice equals encryptMessageUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateMessageBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptMessageUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/note.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/note.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Note.
+ *
+ * Anchored to `ReturnType<typeof encryptNoteInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateNoteBodySchema, UpdateNoteBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptNoteInput, encryptNoteUpdate } from "../../transforms/note.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Note G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateNoteBodySchema's encryptedData slice equals encryptNoteInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateNoteBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptNoteInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateNoteBodySchema's encryptedData+version slice equals encryptNoteUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateNoteBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptNoteUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/poll.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/poll.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Poll.
+ *
+ * Anchored to `ReturnType<typeof encryptPollInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreatePollBodySchema, UpdatePollBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptPollInput, encryptPollUpdate } from "../../transforms/poll.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Poll G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreatePollBodySchema's encryptedData slice equals encryptPollInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreatePollBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptPollInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdatePollBodySchema's encryptedData+version slice equals encryptPollUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdatePollBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptPollUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/privacy-bucket.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/privacy-bucket.type.test.ts
@@ -1,0 +1,33 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for PrivacyBucket.
+ *
+ * Anchored to `ReturnType<typeof encryptBucketInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateBucketBodySchema, UpdateBucketBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptBucketInput, encryptBucketUpdate } from "../../transforms/privacy-bucket.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("PrivacyBucket G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateBucketBodySchema's encryptedData slice equals encryptBucketInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateBucketBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptBucketInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateBucketBodySchema's encryptedData+version slice equals encryptBucketUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateBucketBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptBucketUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/relationship.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/relationship.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Relationship.
+ *
+ * Anchored to `ReturnType<typeof encryptRelationshipInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateRelationshipBodySchema,
+  UpdateRelationshipBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptRelationshipInput,
+  encryptRelationshipUpdate,
+} from "../../transforms/relationship.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Relationship G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateRelationshipBodySchema's encryptedData slice equals encryptRelationshipInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateRelationshipBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptRelationshipInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateRelationshipBodySchema's encryptedData+version slice equals encryptRelationshipUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateRelationshipBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptRelationshipUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/snapshot.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/snapshot.type.test.ts
@@ -1,0 +1,24 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for Snapshot.
+ *
+ * Anchored to `ReturnType<typeof encryptSnapshotInput>`, so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateSnapshotBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { encryptSnapshotInput } from "../../transforms/snapshot.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Snapshot G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateSnapshotBodySchema's encryptedData slice equals encryptSnapshotInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<z.infer<typeof CreateSnapshotBodySchema>, "encryptedData">;
+    type TransformOutput = ReturnType<typeof encryptSnapshotInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/structure-entity-type.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/structure-entity-type.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for StructureEntityType.
+ *
+ * Anchored to `ReturnType<typeof encryptStructureEntityTypeInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateStructureEntityTypeBodySchema,
+  UpdateStructureEntityTypeBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptStructureEntityTypeInput,
+  encryptStructureEntityTypeUpdate,
+} from "../../transforms/structure-entity-type.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("StructureEntityType G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateStructureEntityTypeBodySchema's encryptedData slice equals encryptStructureEntityTypeInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateStructureEntityTypeBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptStructureEntityTypeInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateStructureEntityTypeBodySchema's encryptedData+version slice equals encryptStructureEntityTypeUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateStructureEntityTypeBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptStructureEntityTypeUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/structure-entity.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/structure-entity.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for StructureEntity.
+ *
+ * Anchored to `ReturnType<typeof encryptStructureEntityInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  CreateStructureEntityBodySchema,
+  UpdateStructureEntityBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptStructureEntityInput,
+  encryptStructureEntityUpdate,
+} from "../../transforms/structure-entity.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("StructureEntity G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateStructureEntityBodySchema's encryptedData slice equals encryptStructureEntityInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateStructureEntityBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptStructureEntityInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateStructureEntityBodySchema's encryptedData+version slice equals encryptStructureEntityUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateStructureEntityBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptStructureEntityUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/system-settings.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/system-settings.type.test.ts
@@ -1,0 +1,42 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for SystemSettings (and Nomenclature).
+ *
+ * Anchored to `ReturnType<typeof encryptSystemSettingsUpdate>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import {
+  UpdateNomenclatureBodySchema,
+  UpdateSystemSettingsBodySchema,
+} from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptNomenclatureUpdate,
+  encryptSystemSettingsUpdate,
+} from "../../transforms/system-settings.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("SystemSettings G4 parity (transform output ↔ Zod body schema)", () => {
+  it("UpdateSystemSettingsBodySchema's encryptedData+version slice equals encryptSystemSettingsUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateSystemSettingsBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptSystemSettingsUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateNomenclatureBodySchema's encryptedData+version slice equals encryptNomenclatureUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateNomenclatureBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptNomenclatureUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/__tests__/type-parity/timer-config.type.test.ts
+++ b/packages/data/src/__tests__/type-parity/timer-config.type.test.ts
@@ -1,0 +1,39 @@
+/**
+ * G4 parity (Body Zod ↔ Transform output) for TimerConfig.
+ *
+ * Anchored to `ReturnType<typeof encryptTimerConfigInput>` etc., so a transform
+ * return-type drift fails this test mechanically. Lives in `@pluralscape/data`
+ * because data depends on validation; the inverse import path would create a
+ * workspace cycle. See bean `types-1spw`.
+ */
+
+import { CreateTimerConfigBodySchema, UpdateTimerConfigBodySchema } from "@pluralscape/validation";
+import { describe, expectTypeOf, it } from "vitest";
+
+import {
+  encryptTimerConfigInput,
+  encryptTimerConfigUpdate,
+} from "../../transforms/timer-check-in.js";
+
+import type { Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("TimerConfig G4 parity (transform output ↔ Zod body schema)", () => {
+  it("CreateTimerConfigBodySchema's encryptedData slice equals encryptTimerConfigInput output", () => {
+    type CreateBodyEncryptedSlice = Pick<
+      z.infer<typeof CreateTimerConfigBodySchema>,
+      "encryptedData"
+    >;
+    type TransformOutput = ReturnType<typeof encryptTimerConfigInput>;
+    expectTypeOf<Equal<CreateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+
+  it("UpdateTimerConfigBodySchema's encryptedData+version slice equals encryptTimerConfigUpdate output", () => {
+    type UpdateBodyEncryptedSlice = Pick<
+      z.infer<typeof UpdateTimerConfigBodySchema>,
+      "encryptedData" | "version"
+    >;
+    type TransformOutput = ReturnType<typeof encryptTimerConfigUpdate>;
+    expectTypeOf<Equal<UpdateBodyEncryptedSlice, TransformOutput>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/data/src/transforms/__tests__/poll.test.ts
+++ b/packages/data/src/transforms/__tests__/poll.test.ts
@@ -101,6 +101,7 @@ function makeServerPollVote(overrides?: {
 }) {
   return {
     id: brandId<PollVoteId>("pv_abc123"),
+    systemId: brandId<SystemId>("sys_xyz789"),
     pollId: brandId<PollId>("poll_abc123"),
     optionId: brandId<PollOptionId>("opt_001") as PollOptionId | null,
     voter: { entityType: "member" as const, entityId: "mem_voter" } as EntityReference<
@@ -109,9 +110,11 @@ function makeServerPollVote(overrides?: {
     isVeto: false,
     votedAt: toUnixMillis(1_700_000_500_000),
     encryptedData: encryptAndEncodeT1(makePollVoteEncryptedInput(), masterKey),
+    version: 1,
     archived: false as boolean,
     archivedAt: null as UnixMillis | null,
     createdAt: toUnixMillis(1_700_000_500_000),
+    updatedAt: toUnixMillis(1_700_000_500_000),
     ...overrides,
   };
 }

--- a/packages/data/src/transforms/poll.ts
+++ b/packages/data/src/transforms/poll.ts
@@ -27,14 +27,6 @@ export interface PollPage {
   readonly nextCursor: string | null;
 }
 
-/**
- * Server-emitted wire shape for a PollVote — derived from `PollVoteWire` by
- * stripping `systemId`/`version`/`updatedAt`, none of which the API
- * serializer surfaces (the canonical type carries them because Drizzle
- * parity holds for the row, not the wire).
- */
-export type PollVoteServerWire = Omit<PollVoteWire, "systemId" | "version" | "updatedAt">;
-
 export function decryptPoll(raw: PollWire, masterKey: KdfMasterKey): Poll | Archived<Poll> {
   const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey);
   const validated = PollEncryptedInputSchema.parse(decrypted);
@@ -93,7 +85,7 @@ export function encryptPollUpdate(
 }
 
 export function decryptPollVote(
-  raw: PollVoteServerWire,
+  raw: PollVoteWire,
   masterKey: KdfMasterKey,
 ): PollVote | ArchivedPollVote {
   const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey);

--- a/packages/validation/src/__tests__/contract-custom-fields.test.ts
+++ b/packages/validation/src/__tests__/contract-custom-fields.test.ts
@@ -153,11 +153,8 @@ describe("UpdateFieldDefinitionBodySchema", () => {
 });
 
 describe("SetFieldValueBodySchema", () => {
-  it("infers the correct body shape", () => {
-    expectTypeOf<
-      Equal<z.infer<typeof SetFieldValueBodySchema>, { encryptedData: string }>
-    >().toEqualTypeOf<true>();
-  });
+  // Body↔Transform G4 parity for FieldValue is asserted in
+  // packages/data/src/__tests__/type-parity/field-value.type.test.ts.
 
   it("parses valid input", () => {
     const result = SetFieldValueBodySchema.safeParse({ encryptedData: "dGVzdA==" });
@@ -177,11 +174,8 @@ describe("SetFieldValueBodySchema", () => {
 });
 
 describe("UpdateFieldValueBodySchema", () => {
-  it("infers the correct body shape", () => {
-    expectTypeOf<
-      Equal<z.infer<typeof UpdateFieldValueBodySchema>, { encryptedData: string; version: number }>
-    >().toEqualTypeOf<true>();
-  });
+  // No G4 parity test exists for FieldValue update (no encryptFieldValueUpdate
+  // transform); the runtime contract below is the only check.
 
   it("parses valid input", () => {
     const result = UpdateFieldValueBodySchema.safeParse({ encryptedData: "dGVzdA==", version: 1 });

--- a/packages/validation/src/__tests__/contract-member.test.ts
+++ b/packages/validation/src/__tests__/contract-member.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { CreateMemberPhotoBodySchema, ReorderPhotosBodySchema } from "../member-photo.js";
 import {
@@ -8,16 +8,10 @@ import {
 } from "../member.js";
 import { MAX_ENCRYPTED_PHOTO_DATA_SIZE } from "../validation.constants.js";
 
-import type { Equal } from "@pluralscape/types";
-import type { z } from "zod/v4";
+// Body-schema shape parity (G4) lives in `packages/data/src/__tests__/type-parity/`
+// — see bean `types-1spw`. This file owns the runtime parse-validation tests.
 
 describe("CreateMemberBodySchema", () => {
-  it("infers the correct body shape", () => {
-    expectTypeOf<
-      Equal<z.infer<typeof CreateMemberBodySchema>, { encryptedData: string }>
-    >().toEqualTypeOf<true>();
-  });
-
   it("parses valid input", () => {
     const result = CreateMemberBodySchema.safeParse({ encryptedData: "dGVzdA==" });
     expect(result.success).toBe(true);
@@ -43,12 +37,6 @@ describe("CreateMemberBodySchema", () => {
 });
 
 describe("UpdateMemberBodySchema", () => {
-  it("infers the correct body shape", () => {
-    expectTypeOf<
-      Equal<z.infer<typeof UpdateMemberBodySchema>, { encryptedData: string; version: number }>
-    >().toEqualTypeOf<true>();
-  });
-
   it("parses valid input", () => {
     const result = UpdateMemberBodySchema.safeParse({ encryptedData: "dGVzdA==", version: 1 });
     expect(result.success).toBe(true);
@@ -66,20 +54,6 @@ describe("UpdateMemberBodySchema", () => {
 });
 
 describe("DuplicateMemberBodySchema", () => {
-  it("infers the correct body shape", () => {
-    expectTypeOf<
-      Equal<
-        z.infer<typeof DuplicateMemberBodySchema>,
-        {
-          encryptedData: string;
-          copyPhotos: boolean;
-          copyFields: boolean;
-          copyMemberships: boolean;
-        }
-      >
-    >().toEqualTypeOf<true>();
-  });
-
   it("parses valid input with defaults", () => {
     const result = DuplicateMemberBodySchema.safeParse({ encryptedData: "dGVzdA==" });
     expect(result.success).toBe(true);
@@ -107,15 +81,6 @@ describe("DuplicateMemberBodySchema", () => {
 });
 
 describe("CreateMemberPhotoBodySchema", () => {
-  it("infers the correct body shape", () => {
-    expectTypeOf<
-      Equal<
-        z.infer<typeof CreateMemberPhotoBodySchema>,
-        { encryptedData: string; sortOrder?: number }
-      >
-    >().toEqualTypeOf<true>();
-  });
-
   it("parses valid input without sortOrder", () => {
     const result = CreateMemberPhotoBodySchema.safeParse({ encryptedData: "dGVzdA==" });
     expect(result.success).toBe(true);

--- a/packages/validation/src/__tests__/type-parity/member.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/member.type.test.ts
@@ -1,26 +1,13 @@
 /**
- * Zod parity for Member. Locks the canonical chain:
- * - G3: Domain ↔ Zod encrypted input
- * - G4: Body Zod ↔ data-package transform output (inline-shape form)
- *
- * Body shapes are owned by the Zod schemas; no interface types exist in
- * `@pluralscape/types` to assert against.
- *
- * Note: `@pluralscape/data` depends on `@pluralscape/validation`, so we
- * cannot import from `@pluralscape/data` here without creating a circular
- * dependency. G4 assertions inline the transform output shapes directly;
- * the canonical, import-anchored form lives in the data package per
- * follow-up bean `types-1spw`.
+ * G3 parity for Member (Domain ↔ Zod encrypted input). G4 (Body Zod ↔
+ * Transform output) lives in `packages/data/src/__tests__/type-parity/`
+ * because data depends on validation; the inverse import direction would
+ * create a workspace cycle. See bean `types-1spw`.
  */
 
 import { describe, expectTypeOf, it } from "vitest";
 
-import {
-  CreateMemberBodySchema,
-  DuplicateMemberBodySchema,
-  MemberEncryptedInputSchema,
-  UpdateMemberBodySchema,
-} from "../../member.js";
+import { MemberEncryptedInputSchema } from "../../member.js";
 
 import type {
   Equal,
@@ -41,32 +28,5 @@ describe("Member parity (G3: Domain ↔ Zod encrypted input)", () => {
     expectTypeOf<
       Equal<MemberEncryptedInput, Pick<Member, MemberEncryptedFields>>
     >().toEqualTypeOf<true>();
-  });
-});
-
-describe("Member parity (G4: Body Zod ↔ Transform output)", () => {
-  it("CreateMemberBodySchema matches encryptMemberInput return shape", () => {
-    // Mirrors encryptMemberInput in packages/data/src/transforms/member.ts.
-    expectTypeOf<
-      Equal<z.infer<typeof CreateMemberBodySchema>, { encryptedData: string }>
-    >().toEqualTypeOf<true>();
-  });
-
-  it("UpdateMemberBodySchema matches encryptMemberUpdate return shape", () => {
-    // Mirrors encryptMemberUpdate in packages/data/src/transforms/member.ts.
-    expectTypeOf<
-      Equal<z.infer<typeof UpdateMemberBodySchema>, { encryptedData: string; version: number }>
-    >().toEqualTypeOf<true>();
-  });
-
-  it("DuplicateMemberBodySchema includes the same wire envelope plus duplication knobs", () => {
-    type Inferred = z.infer<typeof DuplicateMemberBodySchema>;
-    type Expected = {
-      encryptedData: string;
-      copyPhotos: boolean;
-      copyFields: boolean;
-      copyMemberships: boolean;
-    };
-    expectTypeOf<Equal<Inferred, Expected>>().toEqualTypeOf<true>();
   });
 });

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -82,6 +82,7 @@ import type {
   NomenclatureEncryptedFields,
   NomenclatureSettings,
   NoteWire,
+  PollVoteWire,
   PollWire,
   Relationship,
   RelationshipEncryptedFields,
@@ -220,6 +221,10 @@ expectTypeOf<
 >().toEqualTypeOf<true>();
 
 expectTypeOf<Equal<components["schemas"]["PollResponse"], PollWire>>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<components["schemas"]["PollVoteResponse"], PollVoteWire>
+>().toEqualTypeOf<true>();
 
 // TimerConfig: server adds plaintext `nextCheckInAt` to the row for
 // scheduling without requiring blob decryption (see TimerConfigServerMetadata).

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -35,8 +35,12 @@
 
 import type { components } from "../packages/api-client/src/generated/api-types.js";
 import type {
+  AcknowledgementRequestWire,
   AuditLogEntry,
   AuditLogEntryWire,
+  BoardMessageWire,
+  ChannelWire,
+  ChatMessageWire,
   CheckInRecordWire,
   CustomFront,
   CustomFrontEncryptedFields,
@@ -77,6 +81,8 @@ import type {
   MemberWire,
   NomenclatureEncryptedFields,
   NomenclatureSettings,
+  NoteWire,
+  PollWire,
   Relationship,
   RelationshipEncryptedFields,
   Serialize,
@@ -95,6 +101,7 @@ import type {
   SystemStructureEntityTypeEncryptedFields,
   SystemStructureEntityTypeWire,
   SystemStructureEntityWire,
+  TimerConfigWire,
 } from "../packages/types/src/index.js";
 import { expectTypeOf } from "vitest";
 
@@ -200,16 +207,36 @@ expectTypeOf<
   Equal<components["schemas"]["CheckInRecordResponse"], CheckInRecordWire>
 >().toEqualTypeOf<true>();
 
-// ── OpenAPI ↔ Wire parity: Cluster 8 (deferred) ────────────────────
-//
-// Channel, ChatMessage, Note, BoardMessage, Poll, TimerConfig are
-// encrypted hybrids whose canonical wire types now exist, but their
-// OpenAPI `<X>Response` schemas mark several plaintext columns as
-// optional (`field?: T`) while the canonical types declare them
-// required-nullable (`field: T | null`). G7 full equality is deferred
-// until the OpenAPI generator emits required-nullable for those
-// columns (or the canonical types are widened to optional). Fix in a
-// follow-up; the envelope tripwire above still covers shared columns.
+expectTypeOf<Equal<components["schemas"]["ChannelResponse"], ChannelWire>>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<components["schemas"]["MessageResponse"], ChatMessageWire>
+>().toEqualTypeOf<true>();
+
+expectTypeOf<Equal<components["schemas"]["NoteResponse"], NoteWire>>().toEqualTypeOf<true>();
+
+expectTypeOf<
+  Equal<components["schemas"]["BoardMessageResponse"], BoardMessageWire>
+>().toEqualTypeOf<true>();
+
+expectTypeOf<Equal<components["schemas"]["PollResponse"], PollWire>>().toEqualTypeOf<true>();
+
+// TimerConfig: server adds plaintext `nextCheckInAt` to the row for
+// scheduling without requiring blob decryption (see TimerConfigServerMetadata).
+expectTypeOf<
+  Equal<components["schemas"]["TimerConfigResponse"], TimerConfigWire>
+>().toEqualTypeOf<true>();
+
+// Acknowledgement: OpenAPI schema name (`AcknowledgementResponse`) diverges
+// from the canonical type name (`AcknowledgementRequestWire`) — the domain
+// type is `AcknowledgementRequest`, the API surface trims the suffix.
+expectTypeOf<
+  Equal<components["schemas"]["AcknowledgementResponse"], AcknowledgementRequestWire>
+>().toEqualTypeOf<true>();
+
+// JournalEntryResponse and WikiPageResponse: canonical wire types exist
+// (`JournalEntryWire`, `WikiPageWire`) but no OpenAPI route schema is
+// authored yet. G7 deferred until the routes are added — see types-iupb.
 
 // ── OpenAPI ↔ domain parity: RelationshipResponse ──────────────────
 //


### PR DESCRIPTION
## Summary

Closes the two parity-gate gaps left after ps-etbc (PR #562) and the batch 1/2 follow-ups: relocates G4 (Body Zod ↔ Transform output) parity assertions from `packages/validation` to `packages/data` so they can anchor to the actual transform return types, and converts the remaining 9 OpenAPI G7 carve-outs to full equality plus widens `PollVote`'s API response to match its canonical wire.

## Part A — G4 parity relocation (types-1spw)

- 25 per-entity test files in `packages/data/src/__tests__/type-parity/<entity>.type.test.ts` anchor `Pick<z.infer<typeof Create<X>BodySchema>, "encryptedData">` to `ReturnType<typeof encrypt<X>Input>` (and similarly for `Update`/`version`). A transform return-type drift now fails the test mechanically.
- Inline-shape G4 assertions removed from `contract-member.test.ts`, `contract-custom-fields.test.ts`, and `type-parity/member.type.test.ts` (the data-side test owns them now).
- Acknowledgement Confirm parity intentionally skipped — `ConfirmAcknowledgementBodySchema.encryptedData` is `.optional()` because clients may confirm without re-encrypting; the transform always returns required `encryptedData: string`. Documented inline.

## Part B — OpenAPI G7 reconciliation (types-iupb)

- 8 G7 full-equality assertions added: Channel, Message (ChatMessage), Note, BoardMessage, Poll, TimerConfig, Acknowledgement, PollVote. The "Cluster 8 (deferred)" carve-out comment block is gone.
- OpenAPI source schemas tightened: missing fields added to `required: [...]` so optional-nullable became required-nullable.
- Two real-drift cases reconciled at the spec source:
  - **TimerConfig** OpenAPI was missing the plaintext server-tracked column `nextCheckInAt` entirely. Added with `nullable: true` + included in `required`.
  - **PollVote** response was missing `systemId`, `version`, and `updatedAt` (the EncryptedEntity-pattern fields). Widened the schema, the route handler, the tRPC procedure, and 5 fixture sites in tests.
- **`PollVoteServerWire` shim deleted** from `packages/data/src/transforms/poll.ts`. `decryptPollVote(raw: PollVoteWire, …)` now consumes the canonical wire type directly.
- **JournalEntry / WikiPage**: canonical wire types exist (`JournalEntryWire`, `WikiPageWire`) but no OpenAPI route schema is authored yet. G7 deferred until the routes are added; documented in the parity test pointing at types-iupb.

## Verification

- `pnpm types:check-sot` ✓ (types + Drizzle + Zod + OpenAPI-Wire parity)
- `pnpm typecheck` ✓ (21/21)
- `pnpm lint` ✓ (zero warnings)
- `pnpm format` ✓
- `pnpm test:unit` ✓ (12907 passed, 1 skipped, 1 todo)
- `pnpm test:integration` ✓ (3055 passed, 11 skipped)
- `pnpm test:e2e` ✓ (507 passed, 2 skipped)

## Test plan

- [x] G4 parity tests pass for every entity
- [x] G7 parity assertions land for 8 envelope entities
- [x] PollVote response-shape assertions in route/tRPC/service tests widened with the three new fields (no \`expect.objectContaining\` masking)
- [x] No regressions in mobile poll-vote consumer

## Bean refs

- \`types-1spw\` (G4 parity relocation) — completed
- \`types-iupb\` (OpenAPI G7 reconciliation) — completed
- Parent: \`ps-y4tb\`