### PR TITLE
feat(types,validation): ps-qmyt — Class C canonical-chain extension

### DIFF
--- a/.beans/ps-8e36--pr-578-review-fixes-class-c-extension.md
+++ b/.beans/ps-8e36--pr-578-review-fixes-class-c-extension.md
@@ -1,0 +1,107 @@
+---
+# ps-8e36
+title: "PR #578 review fixes — Class C extension"
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-27T14:10:54Z
+updated_at: 2026-04-27T14:38:59Z
+---
+
+Address all critical, important, and suggestion items from the multi-agent review of PR #578 (ps-qmyt Class C canonical-chain extension).
+
+## Plan
+
+See `/home/theprismsystem/.claude-prism/plans/fix-all-the-critical-harmonic-waffle.md`
+
+## Tasks
+
+### Critical
+
+- [x] 1.1 Register `ApiKey` in `scripts/openapi-wire-parity.type-test.ts`
+- [x] 1.2 Add E2E negative-property assertions in `apps/api-e2e/src/tests/api-keys/crud.spec.ts`
+
+### Important — Documentation errata
+
+- [x] 2.1 Replace nonexistent type names + line citation in `ApiKeyWire` JSDoc + condense
+- [x] 2.2 Fix SoT manifest header docstring contradiction
+- [x] 2.3 ADR-023 — taxonomy intro + sharpen Class C wire clause + formalize `<X>ServerVisible`
+- [x] 2.4 Restate `ApiKeyEncryptedPayloadSchema` warning as positive contract
+
+### Important — Type / Schema hardening
+
+- [x] 3.1 Schema-level invariants (`name.min(1)`, `publicKey.length === 32`)
+- [x] 3.2 New `T3EncryptedBytes` brand + retrofit ApiKey.encryptedKeyMaterial + WebhookDelivery.encryptedData
+- [x] 3.3 Regression trap: pin exact `ApiKeyServerVisible` keyset
+
+### Important — Test coverage
+
+- [x] 4.1 Runtime safeParse tests for `ApiKeyEncryptedPayloadSchema`
+- [x] 4.2 Runtime safeParse tests for `DeviceInfoSchema`
+- [x] 4.3 Runtime safeParse tests for `SnapshotContentSchema`
+
+### Suggestions
+
+- [x] 5.1 Couple `ApiKeyEncryptedPayload.keyType` to `ApiKey.keyType` via exhaustiveness assertion
+- [x] 5.2 `DeviceInfo` JSDoc — acknowledge `encryptedData` nullability
+- [x] 5.3 `// TODO(types-8f84)` marker at `SnapshotContent` junction-type usage
+- [x] 5.4 Update bean types-8f84 — symbol reference instead of line citation
+- [x] 5.5 Drop redundant Class C manifest inline one-liner comments
+- [x] 5.6 Drop redundant `ApiKeyEncryptedPayload` JSDoc paragraph
+- [x] 5.7 Open follow-up bean (`types-emid`) for wiring parity gates at decrypt boundary
+
+## Skipped (user-confirmed)
+
+- 3.4 SoT manifest `class` discriminator — structural distinction already exists; 2.2 docstring fix addresses reader confusion.
+
+## Summary of Changes
+
+All critical, important, and suggestion items from the multi-agent review of PR #578 are addressed.
+
+### Critical (2)
+
+- **1.1** Registered `ApiKey` in `scripts/openapi-wire-parity.type-test.ts` — `components["schemas"]["ApiKeyResponse"] ≡ ApiKeyWire` parity gate locks in the fail-closed allowlist.
+- **1.2** Added E2E negative-property assertions to `apps/api-e2e/src/tests/api-keys/crud.spec.ts` — list/get response bodies must not expose `tokenHash`, `encryptedData`, `encryptedKeyMaterial`, or `accountId`.
+
+### Important — Documentation (4)
+
+- **2.1** Rewrote `ApiKeyWire` JSDoc — replaced nonexistent `ApiKeyResponse`/`ApiKeyCreateResponse` symbols with `ApiKeyResult`/`ApiKeyCreateResult`; dropped rotting line citation; condensed.
+- **2.2** Fixed SoT manifest header docstring — Class C entries now correctly described (was contradicting them).
+- **2.3** ADR-023 — added Class A/C/E taxonomy intro; sharpened Class C wire-shape clause to state the Class E sidecar rule explicitly; formalized `<X>ServerVisible` naming convention.
+- **2.4** Restated `ApiKeyEncryptedPayloadSchema` JSDoc as positive in-memory contract; added inline TODO at `publicKey` Uint8Array site for grep-discoverability.
+
+### Important — Type / Schema hardening (3)
+
+- **3.1** Added `name.min(1)` and `publicKey.length === 32` (using `PUBLIC_KEY_BYTE_LENGTH`) refines on `ApiKeyEncryptedPayloadSchema`.
+- **3.2** Introduced `T3EncryptedBytes` brand mirroring `EncryptedBase64`; retrofitted `ApiKeyServerMetadata.encryptedKeyMaterial` and `WebhookDeliveryServerMetadata.encryptedData`; `.$type<T3EncryptedBytes>()` on Drizzle columns; `encryptWebhookPayload` brand-constructs at the encrypt site; `toT3EncryptedBytes` helper in `apps/api/src/lib/encrypted-blob.ts` mirrors `toServerSecret`.
+- **3.3** Added `keyof ApiKeyServerVisible` regression trap in `sot-manifest.test.ts` — pins the exact 9-key allowlist so widening fails the test.
+
+### Important — Test coverage (3)
+
+- **4.1** Created `packages/validation/src/__tests__/api-key.test.ts` — 9 `safeParse` tests covering both variants of the discriminated union, unknown discriminator rejection, name-empty rejection, publicKey size mismatches.
+- **4.2** Created `packages/validation/src/__tests__/session.test.ts` — 5 `safeParse` tests for `DeviceInfoSchema`.
+- **4.3** Created `packages/validation/src/__tests__/snapshot.test.ts` — 6 `safeParse` tests for `SnapshotContentSchema` including invalid relationship type / missing fields / invalid innerworld entityType.
+
+### Suggestions (7)
+
+- **5.1** Compile-time exhaustiveness assertion that `ApiKeyEncryptedPayload["keyType"]` ≡ `ApiKey["keyType"]` in `sot-manifest.test.ts`.
+- **5.2** `DeviceInfo` JSDoc acknowledges `encryptedData: EncryptedBlob | null`.
+- **5.3** Inline `// TODO(types-8f84):` marker at `SnapshotContent`'s server-shaped junction-type fields.
+- **5.4** Updated `types-8f84` bean — replaced rotting line citation with field-name references.
+- **5.5** Stripped redundant Class C manifest inline one-liner comments from all three Class C entries (~3 lines saved each).
+- **5.6** Dropped redundant `ApiKeyEncryptedPayload` JSDoc paragraph that restated the type definition.
+- **5.7** Created follow-up bean `types-emid` tracking wiring of the three Class C parity schemas to runtime decrypt boundaries.
+
+### Skipped (user-confirmed)
+
+- **3.4** SoT manifest `class` discriminator field — structural distinction already exists; 2.2 docstring fix addresses reader confusion. ~50 lines of churn avoided for purely declarative labeling.
+
+### Verification
+
+- `pnpm types:check-sot` — green (4/4 parity gates)
+- `pnpm typecheck` — green
+- `pnpm lint` — zero warnings
+- `pnpm format` — clean
+- `pnpm test:unit` — 13000 passed / 1 skipped / 1 todo
+- `pnpm test:integration` — 3055 passed / 11 skipped
+- `pnpm test:e2e` — 507 passed / 2 skipped

--- a/.beans/ps-qmyt--class-c-structurally-divergent-encryption-api-key.md
+++ b/.beans/ps-qmyt--class-c-structurally-divergent-encryption-api-key.md
@@ -1,11 +1,11 @@
 ---
 # ps-qmyt
 title: "Class C structurally-divergent encryption: api-key, session, system-snapshot"
-status: draft
+status: completed
 type: feature
 priority: normal
 created_at: 2026-04-25T08:07:36Z
-updated_at: 2026-04-25T08:07:49Z
+updated_at: 2026-04-27T05:50:07Z
 parent: ps-cd6x
 blocked_by:
   - ps-y4tb
@@ -57,3 +57,23 @@ For each entity:
 ## Blocked-by
 
 ps-y4tb (encrypted-entity SoT consolidation) — proves the pattern; this work extends it to bespoke cases.
+
+## Summary of Changes
+
+Class C canonical-chain extension landed for api-key, session, system-snapshot. ADR-023 grew two sections (Class C + Class E) so PR4 (ps-f3ox) is doc-only.
+
+### ADR-023 amendments (in this PR)
+
+- Class C — divergent encrypted payload (auxiliary type IS the EncryptedInput; no alias)
+- Class E — server-side T3 encryption (no canonical chain; documented exception)
+
+### Per-entity work
+
+- **Session:** `DeviceInfoSchema` in `packages/validation/src/session.ts`; parity test; manifest entry; JSDoc on `DeviceInfo` references Class C
+- **System-snapshot:** `SnapshotContentSchema` in `packages/validation/src/snapshot.ts`; parity test; manifest entry; JSDoc on `SnapshotContent` references Class C
+- **ApiKey:** new `ApiKeyEncryptedPayload` discriminated union in `packages/types/src/entities/api-key.ts`; `ApiKeyEncryptedPayloadSchema` in validation; parity test; manifest entry; `encryptedKeyMaterial` documented as Class E exception; `ApiKeyWire` audit yielded a wire-shape tightening to `Serialize<ApiKeyServerVisible>` matching the existing `ApiKeyResult` handler shape (no client ripple required)
+
+### Verification
+
+- `pnpm types:check-sot` — green
+- `pnpm typecheck` / `lint` / `test:unit` / `test:integration` / `test:e2e` — green (E2E: 507 passed, 2 skipped)

--- a/.beans/types-8f84--snapshotcontent-uses-server-shaped-junction-types.md
+++ b/.beans/types-8f84--snapshotcontent-uses-server-shaped-junction-types.md
@@ -3,13 +3,14 @@
 title: SnapshotContent uses server-shaped junction types — consider plaintext-snapshot projections
 status: todo
 type: task
+priority: normal
 created_at: 2026-04-27T13:11:45Z
-updated_at: 2026-04-27T13:11:45Z
+updated_at: 2026-04-27T14:14:50Z
 ---
 
 Pre-existing on main, surfaced during ps-qmyt code review (PR3 of M9a closeout).
 
-`SnapshotContent` (`packages/types/src/entities/system-snapshot.ts:134-136`) references `SystemStructureEntityLink`, `SystemStructureEntityMemberLink`, and `SystemStructureEntityAssociation` directly. These types include server-shaped fields like `systemId` and `createdAt` which clients faithfully snapshot inside the encrypted blob.
+`SnapshotContent` (in `packages/types/src/entities/system-snapshot.ts`) references `SystemStructureEntityLink`, `SystemStructureEntityMemberLink`, and `SystemStructureEntityAssociation` directly via the `structureEntityLinks`, `structureEntityMemberLinks`, and `structureEntityAssociations` fields. These types include server-shaped fields like `systemId` and `createdAt` which clients faithfully snapshot inside the encrypted blob.
 
 The existing convention in the same type uses dedicated `SnapshotMember`, `SnapshotGroup`, etc. projections that omit server-only fields. The three junction types break that convention.
 

--- a/.beans/types-8f84--snapshotcontent-uses-server-shaped-junction-types.md
+++ b/.beans/types-8f84--snapshotcontent-uses-server-shaped-junction-types.md
@@ -1,0 +1,24 @@
+---
+# types-8f84
+title: SnapshotContent uses server-shaped junction types — consider plaintext-snapshot projections
+status: todo
+type: task
+created_at: 2026-04-27T13:11:45Z
+updated_at: 2026-04-27T13:11:45Z
+---
+
+Pre-existing on main, surfaced during ps-qmyt code review (PR3 of M9a closeout).
+
+`SnapshotContent` (`packages/types/src/entities/system-snapshot.ts:134-136`) references `SystemStructureEntityLink`, `SystemStructureEntityMemberLink`, and `SystemStructureEntityAssociation` directly. These types include server-shaped fields like `systemId` and `createdAt` which clients faithfully snapshot inside the encrypted blob.
+
+The existing convention in the same type uses dedicated `SnapshotMember`, `SnapshotGroup`, etc. projections that omit server-only fields. The three junction types break that convention.
+
+## Proposal
+
+Add `SnapshotStructureEntityLink`, `SnapshotStructureEntityMemberLink`, `SnapshotStructureEntityAssociation` projections matching the existing snapshot-projection convention. Update `SnapshotContentSchema` (`packages/validation/src/snapshot.ts`) accordingly.
+
+## Acceptance
+
+- `SnapshotContent` references only `Snapshot*` projections, not the server-shaped types
+- `SnapshotContentSchema` parity test still passes
+- No data migration needed (snapshots are encrypted blobs and clients re-render from current snapshot logic)

--- a/.beans/types-emid--wire-class-c-parity-schemas-to-runtime-decrypt-bou.md
+++ b/.beans/types-emid--wire-class-c-parity-schemas-to-runtime-decrypt-bou.md
@@ -1,0 +1,32 @@
+---
+# types-emid
+title: Wire Class C parity schemas to runtime decrypt boundaries
+status: todo
+type: task
+created_at: 2026-04-27T14:30:14Z
+updated_at: 2026-04-27T14:30:14Z
+---
+
+Three Zod parity schemas for Class C entities are currently parity-gates only — not yet wired to a runtime parse boundary. This bean tracks wiring them at the decrypt callsites once those callsites materialize.
+
+## Schemas
+
+- `ApiKeyEncryptedPayloadSchema` (`packages/validation/src/api-key.ts`)
+- `DeviceInfoSchema` (`packages/validation/src/session.ts`)
+- `SnapshotContentSchema` (`packages/validation/src/snapshot.ts`)
+
+## Why deferred
+
+The schemas exist as compile-time parity gates so type and Zod stay in sync. Runtime parsing requires a JSON-vs-binary adapter for `publicKey` (the in-memory schema rejects strings). Without a concrete decrypt callsite to wire to, runtime adoption was deferred from the original ADR-023 Class C extension PR (#578).
+
+## Acceptance
+
+- Schemas consumed at the actual decrypt callsites for ApiKey / Session / SystemSnapshot blobs
+- JSON-vs-binary adapters in place (e.g., `EncryptedBase64Schema` for `publicKey` in ApiKeyEncryptedPayload)
+- The "in-memory contract" comments in the validation modules removed once wired
+
+## Related
+
+- ps-qmyt (original Class C extension)
+- ps-8e36 (PR #578 review fixes)
+- types-8f84 (SnapshotContent server-shaped junction projections — adjacent cleanup)

--- a/apps/api-e2e/src/tests/api-keys/crud.spec.ts
+++ b/apps/api-e2e/src/tests/api-keys/crud.spec.ts
@@ -42,6 +42,12 @@ test.describe("API keys CRUD", () => {
       const body = (await res.json()) as { data: { id: string; keyType: string } };
       expect(body.data.id).toBe(keyId);
       expect(body.data.keyType).toBe("metadata");
+      // Fail-closed allowlist guard (ADR-023 Class C): the wire surface must
+      // never include sensitive server-only columns.
+      expect(body.data).not.toHaveProperty("tokenHash");
+      expect(body.data).not.toHaveProperty("encryptedData");
+      expect(body.data).not.toHaveProperty("encryptedKeyMaterial");
+      expect(body.data).not.toHaveProperty("accountId");
     });
 
     await test.step("list includes the key", async () => {
@@ -50,6 +56,13 @@ test.describe("API keys CRUD", () => {
       const body = (await res.json()) as { data: Array<{ id: string }> };
       const ids = body.data.map((k) => k.id);
       expect(ids).toContain(keyId);
+      const listed = body.data.find((k) => k.id === keyId);
+      expect(listed).toBeDefined();
+      // Same fail-closed guard on the list endpoint.
+      expect(listed).not.toHaveProperty("tokenHash");
+      expect(listed).not.toHaveProperty("encryptedData");
+      expect(listed).not.toHaveProperty("encryptedKeyMaterial");
+      expect(listed).not.toHaveProperty("accountId");
     });
 
     await test.step("revoke API key", async () => {

--- a/apps/api/src/__tests__/services/api-key.service.test.ts
+++ b/apps/api/src/__tests__/services/api-key.service.test.ts
@@ -68,6 +68,7 @@ vi.mock("../../lib/encrypted-blob.js", () => ({
     nonce: new Uint8Array(24),
     ciphertext: new Uint8Array(16),
   })),
+  toT3EncryptedBytes: vi.fn((bytes: Uint8Array) => bytes),
 }));
 
 vi.mock("@pluralscape/db/pg", () => ({

--- a/apps/api/src/__tests__/services/webhook-config.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/webhook-config.service.integration.test.ts
@@ -45,6 +45,7 @@ import type {
   AccountId,
   ServerSecret,
   SystemId,
+  T3EncryptedBytes,
   WebhookDeliveryId,
   WebhookId,
 } from "@pluralscape/types";
@@ -318,7 +319,7 @@ describe("webhook-config.service (PGlite integration)", () => {
         eventType: "fronting.started",
         status: "pending",
         attemptCount: 0,
-        encryptedData: new Uint8Array([1, 2, 3]),
+        encryptedData: new Uint8Array([1, 2, 3]) as T3EncryptedBytes,
         createdAt: toUnixMillis(Date.now()),
       });
 

--- a/apps/api/src/__tests__/services/webhook-delivery-cleanup.integration.test.ts
+++ b/apps/api/src/__tests__/services/webhook-delivery-cleanup.integration.test.ts
@@ -17,6 +17,7 @@ import type {
   AccountId,
   ServerSecret,
   SystemId,
+  T3EncryptedBytes,
   WebhookDeliveryId,
   WebhookId,
 } from "@pluralscape/types";
@@ -72,7 +73,7 @@ describe("webhook-delivery-cleanup (PGlite integration)", () => {
       eventType: "fronting.started",
       status,
       attemptCount: status === "pending" ? 0 : 1,
-      encryptedData: new Uint8Array([1, 2, 3]),
+      encryptedData: new Uint8Array([1, 2, 3]) as T3EncryptedBytes,
       createdAt,
     });
     return id;

--- a/apps/api/src/lib/encrypted-blob.ts
+++ b/apps/api/src/lib/encrypted-blob.ts
@@ -9,13 +9,23 @@ import { MAX_ENCRYPTED_DATA_BYTES } from "../service.constants.js";
 
 import { ApiHttpError } from "./api-error.js";
 
-import type { EncryptedBase64, EncryptedBlob } from "@pluralscape/types";
+import type { EncryptedBase64, EncryptedBlob, T3EncryptedBytes } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 export function encryptedBlobToBase64(blob: EncryptedBlob): EncryptedBase64 {
   // Brand-construction site: the only place plain base64 is lifted to the
   // EncryptedBase64 wire brand. Mirror of `brandId` for ID brands.
   return Buffer.from(serializeEncryptedBlob(blob)).toString("base64") as EncryptedBase64;
+}
+
+/**
+ * Narrow raw bytes into a `T3EncryptedBytes` brand without a double-cast
+ * (mirror of `toServerSecret`). The brand is a compile-time phantom; the
+ * runtime bytes are unchanged. Callers are responsible for ensuring the
+ * input bytes really are server-side T3 ciphertext (per ADR-023 Class E).
+ */
+export function toT3EncryptedBytes(bytes: Uint8Array): T3EncryptedBytes {
+  return bytes as T3EncryptedBytes;
 }
 
 export function encryptedBlobToBase64OrNull(blob: EncryptedBlob | null): EncryptedBase64 | null {

--- a/apps/api/src/services/api-key/create.ts
+++ b/apps/api/src/services/api-key/create.ts
@@ -13,7 +13,7 @@ import { CreateApiKeyBodySchema } from "@pluralscape/validation";
 
 import { HTTP_BAD_REQUEST } from "../../http.constants.js";
 import { ApiHttpError } from "../../lib/api-error.js";
-import { validateEncryptedBlob } from "../../lib/encrypted-blob.js";
+import { toT3EncryptedBytes, validateEncryptedBlob } from "../../lib/encrypted-blob.js";
 import { withTenantTransaction } from "../../lib/rls-context.js";
 import { assertSystemOwnership } from "../../lib/system-ownership.js";
 import { tenantCtx } from "../../lib/tenant-context.js";
@@ -88,7 +88,8 @@ export async function createApiKey(
         scopes,
         encryptedData: blob,
         encryptedKeyMaterial: encryptedKeyMaterial
-          ? Buffer.from(encryptedKeyMaterial, "base64")
+          ? // Brand-construction boundary: client-supplied base64 → T3 bytes.
+            toT3EncryptedBytes(Buffer.from(encryptedKeyMaterial, "base64"))
           : null,
         createdAt: timestamp,
         lastUsedAt: null,

--- a/apps/api/src/services/webhook-payload-encryption.ts
+++ b/apps/api/src/services/webhook-payload-encryption.ts
@@ -10,6 +10,7 @@ import { env } from "../env.js";
 import { fromHex } from "../lib/hex.js";
 
 import type { AeadKey } from "@pluralscape/crypto";
+import type { T3EncryptedBytes } from "@pluralscape/types";
 
 /** Expected hex length for a 32-byte AEAD key. */
 const ENCRYPTION_KEY_HEX_LENGTH = AEAD_KEY_BYTES * 2;
@@ -37,9 +38,11 @@ export function getWebhookPayloadEncryptionKey(): AeadKey {
 
 /**
  * Encrypt a webhook payload using XChaCha20-Poly1305 with the server-held key.
- * Returns the combined nonce + ciphertext as a Uint8Array suitable for bytea storage.
+ * Returns the combined nonce + ciphertext as `T3EncryptedBytes` (ADR-023
+ * Class E) suitable for bytea storage. This is the brand-construction site —
+ * raw bytes become T3 ciphertext here.
  */
-export function encryptWebhookPayload(plaintext: string, key: AeadKey): Uint8Array {
+export function encryptWebhookPayload(plaintext: string, key: AeadKey): T3EncryptedBytes {
   assertAeadKey(key);
   const adapter = getSodium();
   const plaintextBytes = new TextEncoder().encode(plaintext);
@@ -47,7 +50,8 @@ export function encryptWebhookPayload(plaintext: string, key: AeadKey): Uint8Arr
   const combined = new Uint8Array(AEAD_NONCE_BYTES + result.ciphertext.length);
   combined.set(result.nonce, 0);
   combined.set(result.ciphertext, AEAD_NONCE_BYTES);
-  return combined;
+  // Brand at the encrypt boundary — phantom marker, no runtime cost.
+  return combined as T3EncryptedBytes;
 }
 
 /**

--- a/docs/adr/023-zod-type-alignment.md
+++ b/docs/adr/023-zod-type-alignment.md
@@ -23,6 +23,12 @@ Every encrypted domain entity publishes a six-link canonical chain from `package
 
 Plaintext entities publish only `<Entity>` → `<Entity>ServerMetadata` → `<Entity>Wire`.
 
+The taxonomy of encrypted-data shapes covered by this ADR:
+
+- **Class A** — canonical six-link chain (above). The encrypted blob is a key-subset of the entity (`<X>EncryptedInput = Pick<<X>, K>`).
+- **Class C** — divergent encrypted payload. The encrypted blob carries an auxiliary type that is **not** a key-subset of the entity (e.g., `DeviceInfo` for `Session`). Detailed in the "Class C" subsection below.
+- **Class E** — server-side T3 encryption. The payload is encrypted with a server-held key, not E2E. The canonical chain does **not** extend to it. Detailed in the "Class E" subsection below.
+
 The `EncryptedWire<T>` helper (`packages/types/src/encrypted-wire.ts`) and `Serialize<T>` together produce links 5 and 6 mechanically; only the keys-union and the server metadata require hand-authoring per entity. Per-entity service `<X>Result` types are derivations: `type <X>Result = EncryptedWire<<X>ServerMetadata>`. Hand-rolled `<X>Result` interfaces are reserved for cases where the wire shape genuinely diverges from the metadata (denormalized server-internal fields that must not leak, polymorphic refs the wire widens to plain string, validated narrowings of `Record<string, unknown>` payloads, etc.); each retained hand-roll documents _why_ in a comment above the interface.
 
 Downstream layers derive-or-assert-equal rather than redefine:
@@ -102,24 +108,26 @@ Class A's six-link chain assumes `<X>EncryptedInput = Pick<<X>, K>`. For Class C
 - The auxiliary type is published in `packages/types/src/entities/<entity>.ts` and used **directly** as the canonical "encrypted input" — no `<X>EncryptedInput` alias is introduced (aliases are forbidden under the pre-production policy).
 - The Zod parity gate is named after the auxiliary type: `<AuxiliaryType>Schema` in `packages/validation/src/<entity>.ts`. The parity assertion in `packages/validation/src/__tests__/type-parity/<entity>.type.test.ts` is `Equal<z.infer<typeof <AuxiliaryType>Schema>, <AuxiliaryType>>`.
 - The SoT manifest's `encryptedInput` slot points at the auxiliary type by name.
-- `<X>Result` and `<X>Wire` are decided per-entity. The current Class C entities all keep the encrypted blob server-side and surface the plaintext columns only — `Session` and `SystemSnapshot` use `Serialize<<X>>` (the encrypted column is absent from the domain type), and `ApiKey` uses `Serialize<<X>ServerVisible>` where `<X>ServerVisible` is a `Pick`-projection of `<X>ServerMetadata` over the columns the server can publish without decryption. Each wire type's JSDoc documents the chosen rationale.
+- `<X>Result` and `<X>Wire` follow this rule: if `<X>ServerMetadata` has no Class E sidecar columns, `<X>Wire = Serialize<<X>>` is sufficient (the encrypted blob is absent from the domain `<X>`). If it has a Class E sidecar (e.g., `ApiKey.encryptedKeyMaterial`), define `<X>ServerVisible = Pick<<X>ServerMetadata, ...>` as a positive allowlist excluding the sidecar, and use `<X>Wire = Serialize<<X>ServerVisible>`. The positive `Pick` allowlist is fail-closed — a future column added to `<X>ServerMetadata` defaults to excluded from the wire surface. Each wire type's JSDoc documents the chosen rationale.
+- The naming convention for the projection is `<X>ServerVisible`. Currently used by `ApiKey` (the only Class C entity with a Class E sidecar today). `Session` and `SystemSnapshot` use `Serialize<<X>>` directly because their server metadata has no sidecar.
 
 Class C entities (3): api-key, session, system-snapshot.
 
 ### Class E — server-side T3 encryption
 
-Some encrypted payloads are encrypted with a **server-held key**, not E2E. The payload is `Uint8Array` (raw bytes), not `EncryptedBlob` (which carries the T1 envelope). Server-side encryption never crosses the wire to clients — clients see only the entity's plaintext metadata.
+Some encrypted payloads are encrypted with a **server-held key**, not E2E. The payload is `T3EncryptedBytes` (a phantom-branded `Uint8Array` from `packages/types/src/encryption-primitives.ts`), not `EncryptedBlob` (which carries the T1 envelope). Server-side encryption never crosses the wire to clients — clients see only the entity's plaintext metadata.
 
 The canonical chain does **not** extend to Class E:
 
-- `<X>Wire = Serialize<<X>>` — the server-only `encryptedData` (or `encryptedKeyMaterial`) Uint8Array is stripped by being absent from the domain type
+- `<X>Wire = Serialize<<X>>` — the server-only `encryptedData` (or `encryptedKeyMaterial`) `T3EncryptedBytes` is stripped by being absent from the domain type
 - No `<X>EncryptedInput` is published — there is no client-supplied input shape
 - No Zod parity for the encrypted payload — its shape is server-internal
+- The `T3EncryptedBytes` brand is constructed at the encrypt boundary (e.g., `encryptWebhookPayload` in `apps/api/src/services/webhook-payload-encryption.ts`) or via the `toT3EncryptedBytes` helper (`apps/api/src/lib/encrypted-blob.ts`); Drizzle columns use `.$type<T3EncryptedBytes>()` to thread the brand through reads.
 
 Class E surfaces (2):
 
-- **Entity-level:** `webhook-delivery` (`WebhookDeliveryServerMetadata.encryptedData: Uint8Array`)
-- **Column-level inside a Class C entity:** `ApiKeyServerMetadata.encryptedKeyMaterial: Uint8Array | null` (only present on `CryptoApiKey` rows). The `ApiKey` entity is therefore a hybrid Class C + Class E — its primary encrypted blob follows the Class C convention, while the side-channel key material is documented as a Class E exception.
+- **Entity-level:** `webhook-delivery` (`WebhookDeliveryServerMetadata.encryptedData: T3EncryptedBytes`)
+- **Column-level inside a Class C entity:** `ApiKeyServerMetadata.encryptedKeyMaterial: T3EncryptedBytes | null` (only present on `CryptoApiKey` rows). The `ApiKey` entity is therefore a hybrid Class C + Class E — its primary encrypted blob follows the Class C convention, while the side-channel key material is documented as a Class E exception.
 
 ### Enforcement — `pnpm types:check-sot`
 

--- a/docs/adr/023-zod-type-alignment.md
+++ b/docs/adr/023-zod-type-alignment.md
@@ -95,6 +95,32 @@ reviewers.
 The Member-pilot transform (`packages/data/src/transforms/member.ts`) is the
 canonical reference shape for new transforms.
 
+### Class C — divergent encrypted payload
+
+Class A's six-link chain assumes `<X>EncryptedInput = Pick<<X>, K>`. For Class C, the encrypted blob carries an auxiliary type that is **not** a key-subset of the entity:
+
+- The auxiliary type is published in `packages/types/src/entities/<entity>.ts` and used **directly** as the canonical "encrypted input" — no `<X>EncryptedInput` alias is introduced (aliases are forbidden under the pre-production policy).
+- The Zod parity gate is named after the auxiliary type: `<AuxiliaryType>Schema` in `packages/validation/src/<entity>.ts`. The parity assertion in `packages/validation/src/__tests__/type-parity/<entity>.type.test.ts` is `Equal<z.infer<typeof <AuxiliaryType>Schema>, <AuxiliaryType>>`.
+- The SoT manifest's `encryptedInput` slot points at the auxiliary type by name.
+- `<X>Result` and `<X>Wire` are decided per-entity. For zero-knowledge entities, Wire usually equals `Serialize<EncryptedWire<<X>ServerMetadata>>` and clients decrypt locally. For entities where the server briefly handles plaintext at one specific moment (e.g. `ApiKey` at creation time via `ApiKeyWithSecret`), the chosen rationale is documented in JSDoc on the wire type.
+
+Class C entities (3): api-key, session, system-snapshot.
+
+### Class E — server-side T3 encryption
+
+Some encrypted payloads are encrypted with a **server-held key**, not E2E. The payload is `Uint8Array` (raw bytes), not `EncryptedBlob` (which carries the T1 envelope). Server-side encryption never crosses the wire to clients — clients see only the entity's plaintext metadata.
+
+The canonical chain does **not** extend to Class E:
+
+- `<X>Wire = Serialize<<X>>` — the server-only `encryptedData` (or `encryptedKeyMaterial`) Uint8Array is stripped by being absent from the domain type
+- No `<X>EncryptedInput` is published — there is no client-supplied input shape
+- No Zod parity for the encrypted payload — its shape is server-internal
+
+Class E surfaces (2):
+
+- **Entity-level:** `webhook-delivery` (`WebhookDeliveryServerMetadata.encryptedData: Uint8Array`)
+- **Column-level inside a Class C entity:** `ApiKeyServerMetadata.encryptedKeyMaterial: Uint8Array | null` (only present on `CryptoApiKey` rows). The `ApiKey` entity is therefore a hybrid Class C + Class E — its primary encrypted blob follows the Class C convention, while the side-channel key material is documented as a Class E exception.
+
 ### Enforcement — `pnpm types:check-sot`
 
 A single root script (`scripts/check-types-sot.ts`) runs all three parity mechanisms sequentially, short-circuiting on first failure. CI step in `.github/workflows/ci.yml` blocks on failure. Drift at any layer fails CI.

--- a/docs/adr/023-zod-type-alignment.md
+++ b/docs/adr/023-zod-type-alignment.md
@@ -102,7 +102,7 @@ Class A's six-link chain assumes `<X>EncryptedInput = Pick<<X>, K>`. For Class C
 - The auxiliary type is published in `packages/types/src/entities/<entity>.ts` and used **directly** as the canonical "encrypted input" — no `<X>EncryptedInput` alias is introduced (aliases are forbidden under the pre-production policy).
 - The Zod parity gate is named after the auxiliary type: `<AuxiliaryType>Schema` in `packages/validation/src/<entity>.ts`. The parity assertion in `packages/validation/src/__tests__/type-parity/<entity>.type.test.ts` is `Equal<z.infer<typeof <AuxiliaryType>Schema>, <AuxiliaryType>>`.
 - The SoT manifest's `encryptedInput` slot points at the auxiliary type by name.
-- `<X>Result` and `<X>Wire` are decided per-entity. For zero-knowledge entities, Wire usually equals `Serialize<EncryptedWire<<X>ServerMetadata>>` and clients decrypt locally. For entities where the server briefly handles plaintext at one specific moment (e.g. `ApiKey` at creation time via `ApiKeyWithSecret`), the chosen rationale is documented in JSDoc on the wire type.
+- `<X>Result` and `<X>Wire` are decided per-entity. The current Class C entities all keep the encrypted blob server-side and surface the plaintext columns only — `Session` and `SystemSnapshot` use `Serialize<<X>>` (the encrypted column is absent from the domain type), and `ApiKey` uses `Serialize<<X>ServerVisible>` where `<X>ServerVisible` is a `Pick`-projection of `<X>ServerMetadata` over the columns the server can publish without decryption. Each wire type's JSDoc documents the chosen rationale.
 
 Class C entities (3): api-key, session, system-snapshot.
 

--- a/packages/db/src/__tests__/schema-pg-api-keys.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-api-keys.integration.test.ts
@@ -16,10 +16,14 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
-import type { AccountId, ApiKeyId, BucketId, SystemId } from "@pluralscape/types";
+import type { AccountId, ApiKeyId, BucketId, SystemId, T3EncryptedBytes } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, apiKeys };
+
+function t3(bytes: readonly number[]): T3EncryptedBytes {
+  return new Uint8Array(bytes) as T3EncryptedBytes;
+}
 
 describe("PG api_keys schema", () => {
   let client: PGlite;
@@ -71,7 +75,7 @@ describe("PG api_keys schema", () => {
     const now = fixtureNow();
     const id = brandId<ApiKeyId>(crypto.randomUUID());
     const tokenHash = `hash_${crypto.randomUUID()}`;
-    const keyMaterial = new Uint8Array([1, 2, 3, 4, 5]);
+    const keyMaterial = t3([1, 2, 3, 4, 5]);
 
     await db.insert(apiKeys).values({
       id,
@@ -271,7 +275,7 @@ describe("PG api_keys schema", () => {
         keyType: "metadata",
         tokenHash: `hash_${crypto.randomUUID()}`,
         scopes: ["full"],
-        encryptedKeyMaterial: new Uint8Array([1, 2, 3]),
+        encryptedKeyMaterial: t3([1, 2, 3]),
         createdAt: now,
       }),
     ).rejects.toThrow();

--- a/packages/db/src/__tests__/schema-pg-views.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-views.integration.test.ts
@@ -56,6 +56,7 @@ import type {
   ServerInternal,
   ServerSecret,
   SessionId,
+  T3EncryptedBytes,
   SystemId,
   SystemStructureEntityAssociationId,
   SystemStructureEntityId,
@@ -340,7 +341,7 @@ describe("PG views / query helpers", () => {
         status: "failed",
         attemptCount: 2,
         nextRetryAt: toUnixMillis(now - 60000),
-        encryptedData: new Uint8Array([1, 2, 3]),
+        encryptedData: new Uint8Array([1, 2, 3]) as T3EncryptedBytes,
         createdAt: now,
       });
       // Over limit, nextRetryAt in the past
@@ -352,7 +353,7 @@ describe("PG views / query helpers", () => {
         status: "failed",
         attemptCount: 5,
         nextRetryAt: toUnixMillis(now - 60000),
-        encryptedData: new Uint8Array([1, 2, 3]),
+        encryptedData: new Uint8Array([1, 2, 3]) as T3EncryptedBytes,
         createdAt: now,
       });
       // Under limit but nextRetryAt in the future — should NOT be returned
@@ -364,7 +365,7 @@ describe("PG views / query helpers", () => {
         status: "failed",
         attemptCount: 2,
         nextRetryAt: toUnixMillis(now + 60000),
-        encryptedData: new Uint8Array([1, 2, 3]),
+        encryptedData: new Uint8Array([1, 2, 3]) as T3EncryptedBytes,
         createdAt: now,
       });
 

--- a/packages/db/src/__tests__/schema-pg-webhooks.integration.test.ts
+++ b/packages/db/src/__tests__/schema-pg-webhooks.integration.test.ts
@@ -19,13 +19,23 @@ import {
   testBlob,
 } from "./helpers/pg-helpers.js";
 
-import type { ApiKeyId, ServerSecret, WebhookDeliveryId, WebhookId } from "@pluralscape/types";
+import type {
+  ApiKeyId,
+  ServerSecret,
+  T3EncryptedBytes,
+  WebhookDeliveryId,
+  WebhookId,
+} from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const schema = { accounts, systems, apiKeys, webhookConfigs, webhookDeliveries };
 
 function secret(bytes: readonly number[]): ServerSecret {
   return new Uint8Array(bytes) as ServerSecret;
+}
+
+function t3(bytes: readonly number[]): T3EncryptedBytes {
+  return new Uint8Array(bytes) as T3EncryptedBytes;
 }
 
 describe("PG webhooks schema", () => {
@@ -291,7 +301,7 @@ describe("PG webhooks schema", () => {
         webhookId: whId,
         systemId,
         eventType: "member.created",
-        encryptedData: new Uint8Array([1, 2, 3]),
+        encryptedData: t3([1, 2, 3]),
         createdAt: now,
       });
 
@@ -324,7 +334,7 @@ describe("PG webhooks schema", () => {
           webhookId: whId,
           systemId,
           eventType: "invalid.event" as "member.created",
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         }),
       ).rejects.toThrow();
@@ -353,7 +363,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created",
           attemptCount: -1,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         }),
       ).rejects.toThrow();
@@ -382,7 +392,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created",
           httpStatus: 999,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         }),
       ).rejects.toThrow();
@@ -410,7 +420,7 @@ describe("PG webhooks schema", () => {
         webhookId: whId,
         systemId,
         eventType: "member.created",
-        encryptedData: new Uint8Array([1, 2, 3]),
+        encryptedData: t3([1, 2, 3]),
         createdAt: now,
       });
 
@@ -442,7 +452,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created",
           status: "queued" as "pending",
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         }),
       ).rejects.toThrow();
@@ -476,7 +486,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created" as const,
           status: "success" as const,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: thirtyOneDaysAgo,
         },
         {
@@ -485,7 +495,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created" as const,
           status: "failed" as const,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         },
         {
@@ -494,7 +504,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created" as const,
           status: "pending" as const,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: thirtyOneDaysAgo,
         },
       ]);
@@ -534,7 +544,7 @@ describe("PG webhooks schema", () => {
         webhookId: whId,
         systemId,
         eventType: "member.created",
-        encryptedData: new Uint8Array([1, 2, 3]),
+        encryptedData: t3([1, 2, 3]),
         createdAt: now,
       });
 
@@ -570,7 +580,7 @@ describe("PG webhooks schema", () => {
           eventType: "member.created" as const,
           status: "pending" as const,
           nextRetryAt: retryAt,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         },
         {
@@ -579,7 +589,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created" as const,
           status: "success" as const,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         },
         {
@@ -588,7 +598,7 @@ describe("PG webhooks schema", () => {
           systemId,
           eventType: "member.created" as const,
           status: "failed" as const,
-          encryptedData: new Uint8Array([1, 2, 3]),
+          encryptedData: t3([1, 2, 3]),
           createdAt: now,
         },
       ]);

--- a/packages/db/src/schema/pg/api-keys.ts
+++ b/packages/db/src/schema/pg/api-keys.ts
@@ -24,6 +24,7 @@ import type {
   ApiKeyScope,
   BucketId,
   SystemId,
+  T3EncryptedBytes,
 } from "@pluralscape/types";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
@@ -40,7 +41,7 @@ export const apiKeys = pgTable(
     tokenHash: varchar("token_hash", { length: 255 }).notNull(),
     scopes: jsonb("scopes").notNull().$type<readonly ApiKeyScope[]>(),
     encryptedData: pgEncryptedBlob("encrypted_data").notNull(),
-    encryptedKeyMaterial: pgBinary("encrypted_key_material"),
+    encryptedKeyMaterial: pgBinary("encrypted_key_material").$type<T3EncryptedBytes>(),
     createdAt: pgTimestamp("created_at").notNull(),
     lastUsedAt: pgTimestamp("last_used_at"),
     revokedAt: pgTimestamp("revoked_at"),

--- a/packages/db/src/schema/pg/webhooks.ts
+++ b/packages/db/src/schema/pg/webhooks.ts
@@ -30,6 +30,7 @@ import type {
   ApiKeyId,
   ServerSecret,
   SystemId,
+  T3EncryptedBytes,
   WebhookDeliveryId,
   WebhookDeliveryStatus,
   WebhookEventType,
@@ -91,7 +92,7 @@ export const webhookDeliveries = pgTable(
     attemptCount: integer("attempt_count").notNull().default(0),
     lastAttemptAt: pgTimestamp("last_attempt_at"),
     nextRetryAt: pgTimestamp("next_retry_at"),
-    encryptedData: pgBinary("encrypted_data").notNull(),
+    encryptedData: pgBinary("encrypted_data").notNull().$type<T3EncryptedBytes>(),
     createdAt: pgTimestamp("created_at").notNull(),
   },
   (t) => [

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -12,7 +12,12 @@ import type {
   AcknowledgementRequestServerMetadata,
   AcknowledgementRequestWire,
 } from "./entities/acknowledgement.js";
-import type { ApiKey, ApiKeyServerMetadata, ApiKeyWire } from "./entities/api-key.js";
+import type {
+  ApiKey,
+  ApiKeyEncryptedPayload,
+  ApiKeyServerMetadata,
+  ApiKeyWire,
+} from "./entities/api-key.js";
 import type {
   AuditLogEntry,
   AuditLogEntryServerMetadata,
@@ -253,7 +258,12 @@ import type {
   RelationshipServerMetadata,
   RelationshipWire,
 } from "./entities/relationship.js";
-import type { Session, SessionServerMetadata, SessionWire } from "./entities/session.js";
+import type {
+  DeviceInfo,
+  Session,
+  SessionServerMetadata,
+  SessionWire,
+} from "./entities/session.js";
 import type {
   SystemStructureEntityAssociation,
   SystemStructureEntityAssociationEncryptedFields,
@@ -297,6 +307,7 @@ import type {
   SystemSettingsWire,
 } from "./entities/system-settings.js";
 import type {
+  SnapshotContent,
   SystemSnapshot,
   SystemSnapshotServerMetadata,
   SystemSnapshotWire,
@@ -531,12 +542,14 @@ export type SotEntityManifest = {
   };
   SystemSnapshot: {
     domain: SystemSnapshot;
+    encryptedFields: never; // Class C — SnapshotContent is not a keys-subset of SystemSnapshot.
+    encryptedInput: SnapshotContent;
     server: SystemSnapshotServerMetadata;
     wire: SystemSnapshotWire;
-    // Hybrid entity: plaintext metadata + opaque `encryptedData` blob whose
-    // decrypted shape (`SnapshotContent`) lives in its own type, not as a
-    // keys-subset of `SystemSnapshot`. No `encryptedFields` union.
-    encryptedFields: never;
+    // Class C entity per ADR-023: the encrypted blob carries the auxiliary
+    // type `SnapshotContent` (members, structure entities, relationships,
+    // groups, innerworld snapshot — point-in-time view-only data). Clients
+    // decrypt locally to render the snapshot.
   };
   StructureEntityMemberLink: {
     domain: SystemStructureEntityMemberLink;
@@ -556,12 +569,15 @@ export type SotEntityManifest = {
   };
   ApiKey: {
     domain: ApiKey;
+    encryptedFields: never; // Class C — no keys-subset of ApiKey is encrypted.
+    encryptedInput: ApiKeyEncryptedPayload;
     server: ApiKeyServerMetadata;
     wire: ApiKeyWire;
-    // Plaintext entity at the domain level — server splits domain fields
-    // across flat columns + opaque `encryptedData`; no domain-level
-    // encryptedFields keys-union exists.
-    encryptedFields: never;
+    // Class C entity per ADR-023: the encrypted blob carries the auxiliary
+    // type `ApiKeyEncryptedPayload` (discriminated over keyType: metadata
+    // carries `name`; crypto adds `publicKey`). The wire shape strips both
+    // the encrypted blob and the Class E `encryptedKeyMaterial` column —
+    // see ApiKeyWire JSDoc.
   };
   AuthKey: {
     domain: AuthKey;
@@ -595,10 +611,14 @@ export type SotEntityManifest = {
   };
   Session: {
     domain: Session;
+    encryptedFields: never; // Class C — DeviceInfo lives in encryptedData, not in the domain keyset.
+    encryptedInput: DeviceInfo;
     server: SessionServerMetadata;
     wire: SessionWire;
-    // Plaintext entity — no encrypted fields in the domain keyset.
-    encryptedFields: never;
+    // Class C entity per ADR-023: the encrypted blob carries the auxiliary
+    // type `DeviceInfo` (platform/appVersion/deviceName). The domain
+    // `Session` exposes only session-lifecycle metadata — clients
+    // decrypt `DeviceInfo` locally.
   };
   StructureEntityLink: {
     domain: SystemStructureEntityLink;

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -360,9 +360,12 @@ import type {
  * - `domain`         — the full decrypted domain shape (`<Entity>`)
  * - `encryptedFields`— keys-union of encrypted fields (or `never` for
  *                      plaintext / hybrid entities with no keys-subset union)
- * - `encryptedInput` — `Pick<<Entity>, <Entity>EncryptedFields>` (the shape
- *                      callers encrypt). Omitted for entities where
- *                      `encryptedFields` is `never`.
+ * - `encryptedInput` — for Class A entities (`encryptedFields` is a real
+ *                      keys-union), this is `Pick<<Entity>, <Entity>EncryptedFields>`.
+ *                      For Class C entities (`encryptedFields: never` plus a
+ *                      divergent encrypted payload), this is the auxiliary
+ *                      type carried inside the blob (see ADR-023). Omitted
+ *                      for plaintext entities with no encrypted blob.
  * - `server`         — the server-visible Drizzle row shape
  *                      (`<Entity>ServerMetadata`)
  * - `result`         — `EncryptedWire<<Entity>ServerMetadata>` (server's
@@ -542,7 +545,7 @@ export type SotEntityManifest = {
   };
   SystemSnapshot: {
     domain: SystemSnapshot;
-    encryptedFields: never; // Class C — SnapshotContent is not a keys-subset of SystemSnapshot.
+    encryptedFields: never;
     encryptedInput: SnapshotContent;
     server: SystemSnapshotServerMetadata;
     wire: SystemSnapshotWire;
@@ -569,7 +572,7 @@ export type SotEntityManifest = {
   };
   ApiKey: {
     domain: ApiKey;
-    encryptedFields: never; // Class C — no keys-subset of ApiKey is encrypted.
+    encryptedFields: never;
     encryptedInput: ApiKeyEncryptedPayload;
     server: ApiKeyServerMetadata;
     wire: ApiKeyWire;
@@ -611,7 +614,7 @@ export type SotEntityManifest = {
   };
   Session: {
     domain: Session;
-    encryptedFields: never; // Class C — DeviceInfo lives in encryptedData, not in the domain keyset.
+    encryptedFields: never;
     encryptedInput: DeviceInfo;
     server: SessionServerMetadata;
     wire: SessionWire;

--- a/packages/types/src/__tests__/sot-manifest.test.ts
+++ b/packages/types/src/__tests__/sot-manifest.test.ts
@@ -5,6 +5,7 @@ import type {
   ApiKey,
   ApiKeyEncryptedPayload,
   ApiKeyServerMetadata,
+  ApiKeyServerVisible,
   ApiKeyWire,
 } from "../entities/api-key.js";
 import type {
@@ -37,7 +38,7 @@ import type {
   SystemSnapshotServerMetadata,
   SystemSnapshotWire,
 } from "../entities/system-snapshot.js";
-import type { Extends } from "../type-assertions.js";
+import type { Equal, Extends } from "../type-assertions.js";
 
 describe("SotEntityManifest", () => {
   it("entries carry at minimum a domain + encryptedFields pair", () => {
@@ -114,5 +115,27 @@ describe("SotEntityManifest", () => {
     >().toEqualTypeOf<SystemSnapshotServerMetadata>();
     expectTypeOf<SotEntityManifest["SystemSnapshot"]["wire"]>().toEqualTypeOf<SystemSnapshotWire>();
     expectTypeOf<SotEntityManifest["SystemSnapshot"]["encryptedFields"]>().toEqualTypeOf<never>();
+  });
+
+  it("pins the exact ApiKeyServerVisible keyset (fail-closed allowlist guard)", () => {
+    type ExpectedVisibleKeys =
+      | "id"
+      | "systemId"
+      | "keyType"
+      | "scopes"
+      | "createdAt"
+      | "lastUsedAt"
+      | "revokedAt"
+      | "expiresAt"
+      | "scopedBucketIds";
+    expectTypeOf<keyof ApiKeyServerVisible>().toEqualTypeOf<ExpectedVisibleKeys>();
+  });
+
+  it("ApiKeyEncryptedPayload.keyType is exhaustive against ApiKey.keyType", () => {
+    // If `ApiKey` ever adds a new keyType literal, this fails to compile —
+    // forcing the encrypted payload's discriminator to stay in sync.
+    expectTypeOf<
+      Equal<ApiKeyEncryptedPayload["keyType"], ApiKey["keyType"]>
+    >().toEqualTypeOf<true>();
   });
 });

--- a/packages/types/src/__tests__/sot-manifest.test.ts
+++ b/packages/types/src/__tests__/sot-manifest.test.ts
@@ -2,6 +2,12 @@ import { describe, expectTypeOf, it } from "vitest";
 
 import type { SotEntityManifest } from "../__sot-manifest__.js";
 import type {
+  ApiKey,
+  ApiKeyEncryptedPayload,
+  ApiKeyServerMetadata,
+  ApiKeyWire,
+} from "../entities/api-key.js";
+import type {
   AuditLogEntry,
   AuditLogEntryServerMetadata,
   AuditLogEntryWire,
@@ -19,6 +25,18 @@ import type {
   MemberServerMetadata,
   MemberWire,
 } from "../entities/member.js";
+import type {
+  DeviceInfo,
+  Session,
+  SessionServerMetadata,
+  SessionWire,
+} from "../entities/session.js";
+import type {
+  SnapshotContent,
+  SystemSnapshot,
+  SystemSnapshotServerMetadata,
+  SystemSnapshotWire,
+} from "../entities/system-snapshot.js";
 import type { Extends } from "../type-assertions.js";
 
 describe("SotEntityManifest", () => {
@@ -66,5 +84,35 @@ describe("SotEntityManifest", () => {
     expectTypeOf<
       Extends<"Member" | "AuditLogEntry", keyof SotEntityManifest>
     >().toEqualTypeOf<true>();
+  });
+
+  it("registers ApiKey (Class C) with the auxiliary-type encryptedInput", () => {
+    expectTypeOf<SotEntityManifest["ApiKey"]["domain"]>().toEqualTypeOf<ApiKey>();
+    expectTypeOf<
+      SotEntityManifest["ApiKey"]["encryptedInput"]
+    >().toEqualTypeOf<ApiKeyEncryptedPayload>();
+    expectTypeOf<SotEntityManifest["ApiKey"]["server"]>().toEqualTypeOf<ApiKeyServerMetadata>();
+    expectTypeOf<SotEntityManifest["ApiKey"]["wire"]>().toEqualTypeOf<ApiKeyWire>();
+    expectTypeOf<SotEntityManifest["ApiKey"]["encryptedFields"]>().toEqualTypeOf<never>();
+  });
+
+  it("registers Session (Class C) with DeviceInfo as encryptedInput", () => {
+    expectTypeOf<SotEntityManifest["Session"]["domain"]>().toEqualTypeOf<Session>();
+    expectTypeOf<SotEntityManifest["Session"]["encryptedInput"]>().toEqualTypeOf<DeviceInfo>();
+    expectTypeOf<SotEntityManifest["Session"]["server"]>().toEqualTypeOf<SessionServerMetadata>();
+    expectTypeOf<SotEntityManifest["Session"]["wire"]>().toEqualTypeOf<SessionWire>();
+    expectTypeOf<SotEntityManifest["Session"]["encryptedFields"]>().toEqualTypeOf<never>();
+  });
+
+  it("registers SystemSnapshot (Class C) with SnapshotContent as encryptedInput", () => {
+    expectTypeOf<SotEntityManifest["SystemSnapshot"]["domain"]>().toEqualTypeOf<SystemSnapshot>();
+    expectTypeOf<
+      SotEntityManifest["SystemSnapshot"]["encryptedInput"]
+    >().toEqualTypeOf<SnapshotContent>();
+    expectTypeOf<
+      SotEntityManifest["SystemSnapshot"]["server"]
+    >().toEqualTypeOf<SystemSnapshotServerMetadata>();
+    expectTypeOf<SotEntityManifest["SystemSnapshot"]["wire"]>().toEqualTypeOf<SystemSnapshotWire>();
+    expectTypeOf<SotEntityManifest["SystemSnapshot"]["encryptedFields"]>().toEqualTypeOf<never>();
   });
 });

--- a/packages/types/src/encryption-primitives.ts
+++ b/packages/types/src/encryption-primitives.ts
@@ -84,6 +84,26 @@ declare const __serverSecret: unique symbol;
  */
 export type ServerSecret = Uint8Array & { readonly [__serverSecret]: true };
 
+// ── T3EncryptedBytes ───────────────────────────────────────────
+
+declare const __t3EncryptedBytes: unique symbol;
+
+/**
+ * Branded type for ciphertext encrypted with a server-held key (T3 server-side
+ * encryption per ADR-023's Class E section). Distinct from `EncryptedBlob`
+ * (T1/T2, carries the envelope) and `ServerSecret` (the signing key itself,
+ * not ciphertext).
+ *
+ * Surfaces:
+ * - `WebhookDeliveryServerMetadata.encryptedData` — encrypted webhook payload
+ * - `ApiKeyServerMetadata.encryptedKeyMaterial` — encrypted private key bytes
+ *   for crypto-typed API keys (Class E sidecar inside a Class C entity)
+ *
+ * Constructed at encrypt boundaries; consumers reading from Drizzle columns
+ * branded via `.$type<T3EncryptedBytes>()` receive the brand for free.
+ */
+export type T3EncryptedBytes = Uint8Array & { readonly [__t3EncryptedBytes]: true };
+
 // ── Server/Client variant pattern ──────────────────────────────
 // Server types carry EncryptedBlob; Client types have flat decrypted fields.
 // Only defined for completed domain modules.

--- a/packages/types/src/entities/api-key.ts
+++ b/packages/types/src/entities/api-key.ts
@@ -57,6 +57,20 @@ export interface ApiKeyWithSecret {
 }
 
 /**
+ * The decrypted content of an ApiKey row's `encryptedData` blob.
+ *
+ * Class C auxiliary type per ADR-023 — the SoT manifest's `encryptedInput`
+ * slot for `ApiKey` points at this type directly (no alias).
+ * Parity gate: `ApiKeyEncryptedPayloadSchema` in `packages/validation/src/api-key.ts`.
+ *
+ * Discriminated over `keyType`: metadata-only keys carry just `name`;
+ * crypto-capable keys additionally carry `publicKey: Uint8Array`.
+ */
+export type ApiKeyEncryptedPayload =
+  | { readonly keyType: "metadata"; readonly name: string }
+  | { readonly keyType: "crypto"; readonly name: string; readonly publicKey: Uint8Array };
+
+/**
  * Server-visible ApiKey metadata — raw Drizzle row shape.
  *
  * The domain `ApiKey` type is a discriminated union (metadata vs crypto)
@@ -74,6 +88,14 @@ export interface ApiKeyServerMetadata {
   readonly tokenHash: string;
   readonly scopes: readonly ApiKeyScope[];
   readonly encryptedData: EncryptedBlob;
+  /**
+   * Server-side T3-encrypted private key material for `keyType === "crypto"`
+   * rows. Encrypted with a server-held key (not E2E) — clients never see it.
+   *
+   * Class E exception per ADR-023 — the canonical chain does not extend
+   * here. `ApiKey` is a hybrid Class C + Class E entity: `encryptedData`
+   * follows Class C (above), `encryptedKeyMaterial` is documented as Class E.
+   */
   readonly encryptedKeyMaterial: Uint8Array | null;
   readonly createdAt: UnixMillis;
   readonly lastUsedAt: UnixMillis | null;

--- a/packages/types/src/entities/api-key.ts
+++ b/packages/types/src/entities/api-key.ts
@@ -1,4 +1,4 @@
-import type { EncryptedBlob } from "../encryption-primitives.js";
+import type { EncryptedBlob, T3EncryptedBytes } from "../encryption-primitives.js";
 import type { AccountId, ApiKeyId, Brand, BucketId, SystemId } from "../ids.js";
 import type { ScopeDomain, ScopeTier } from "../scope-domains.js";
 import type { UnixMillis } from "../timestamps.js";
@@ -62,9 +62,6 @@ export interface ApiKeyWithSecret {
  * Class C auxiliary type per ADR-023 — the SoT manifest's `encryptedInput`
  * slot for `ApiKey` points at this type directly (no alias).
  * Parity gate: `ApiKeyEncryptedPayloadSchema` in `packages/validation/src/api-key.ts`.
- *
- * Discriminated over `keyType`: metadata-only keys carry just `name`;
- * crypto-capable keys additionally carry `publicKey: Uint8Array`.
  */
 export type ApiKeyEncryptedPayload =
   | { readonly keyType: "metadata"; readonly name: string }
@@ -96,7 +93,7 @@ export interface ApiKeyServerMetadata {
    * here. `ApiKey` is a hybrid Class C + Class E entity: `encryptedData`
    * follows Class C (above), `encryptedKeyMaterial` is documented as Class E.
    */
-  readonly encryptedKeyMaterial: Uint8Array | null;
+  readonly encryptedKeyMaterial: T3EncryptedBytes | null;
   readonly createdAt: UnixMillis;
   readonly lastUsedAt: UnixMillis | null;
   readonly revokedAt: UnixMillis | null;
@@ -127,23 +124,18 @@ export type ApiKeyServerVisible = Pick<
 >;
 
 /**
- * JSON-wire representation of an ApiKey row.
+ * JSON-wire representation of an ApiKey row — the plaintext columns the
+ * server can publish without decrypting `encryptedData`.
  *
- * **Wire shape rationale (Class C):** The Class C auxiliary type
- * `ApiKeyEncryptedPayload` (carrying `name` and, for `keyType === "crypto"`,
- * `publicKey`) lives inside the `encryptedData` blob. Pluralscape is
- * zero-knowledge — the server cannot decrypt that blob — so the wire
- * surfaces only the plaintext columns (`ApiKeyServerVisible`). Listing
- * (`GET /api-keys`) and get (`GET /api-keys/:id`) endpoints both return
- * this shape (see `apps/api/src/services/api-key/queries.ts:30-85`).
+ * **Wire shape rationale (Class C):** Pluralscape is zero-knowledge — the
+ * server cannot decrypt the `ApiKeyEncryptedPayload` (`name` plus, for
+ * `keyType === "crypto"`, `publicKey`) inside `encryptedData`. The
+ * `listApiKeys` / `getApiKey` handlers in
+ * `apps/api/src/services/api-key/queries.ts` project to `ApiKeyResult`
+ * (`apps/api/src/services/api-key/internal.ts`). The `createApiKey`
+ * handler augments that shape with the plaintext `token` once at creation
+ * as `ApiKeyCreateResult` (`apps/api/src/services/api-key/create.ts`).
  *
- * The creation endpoint (`POST /api-keys`) returns this shape augmented
- * with the plaintext `token` field — represented in OpenAPI as
- * `ApiKeyCreateResponse = ApiKeyResponse + { token }`. The plaintext
- * blob payload is never echoed back from any endpoint; the caller
- * already holds it from the request.
- *
- * `Serialize<T>` strips brands: branded IDs become plain `string`,
- * `UnixMillis` becomes `number`.
+ * `Serialize<T>` strips brands: branded IDs → `string`, `UnixMillis` → `number`.
  */
 export type ApiKeyWire = Serialize<ApiKeyServerVisible>;

--- a/packages/types/src/entities/api-key.ts
+++ b/packages/types/src/entities/api-key.ts
@@ -105,8 +105,40 @@ export interface ApiKeyServerMetadata {
 }
 
 /**
- * JSON-wire representation of an ApiKey. Derived from the domain `ApiKey`
- * type via `Serialize<T>`; branded IDs become plain strings, `UnixMillis`
- * becomes `number`, `Uint8Array` becomes `string` (base64).
+ * Server-visible plaintext fields of an ApiKey row — the columns the
+ * server can surface without decrypting `encryptedData`. Equivalent to
+ * `ApiKeyServerMetadata` minus the per-account marker (`accountId`),
+ * the auth secret (`tokenHash`), and the two encrypted columns
+ * (`encryptedData` Class C blob + `encryptedKeyMaterial` Class E
+ * server-side material).
+ *
+ * Used by the listing/get response shape; the Class C `name` and
+ * `publicKey` fields from the encrypted blob never appear here, so
+ * clients see no decrypted payload from these endpoints.
  */
-export type ApiKeyWire = Serialize<ApiKey>;
+export type ApiKeyServerVisible = Omit<
+  ApiKeyServerMetadata,
+  "accountId" | "tokenHash" | "encryptedData" | "encryptedKeyMaterial"
+>;
+
+/**
+ * JSON-wire representation of an ApiKey row.
+ *
+ * **Wire shape rationale (Class C):** The Class C auxiliary type
+ * `ApiKeyEncryptedPayload` (carrying `name` and, for `keyType === "crypto"`,
+ * `publicKey`) lives inside the `encryptedData` blob. Pluralscape is
+ * zero-knowledge — the server cannot decrypt that blob — so the wire
+ * surfaces only the plaintext columns (`ApiKeyServerVisible`). Listing
+ * (`GET /api-keys`) and get (`GET /api-keys/:id`) endpoints both return
+ * this shape (see `apps/api/src/services/api-key/queries.ts:30-85`).
+ *
+ * The creation endpoint (`POST /api-keys`) returns this shape augmented
+ * with the plaintext `token` field — represented in OpenAPI as
+ * `ApiKeyCreateResponse = ApiKeyResponse + { token }`. The plaintext
+ * blob payload is never echoed back from any endpoint; the caller
+ * already holds it from the request.
+ *
+ * `Serialize<T>` strips brands: branded IDs become plain `string`,
+ * `UnixMillis` becomes `number`.
+ */
+export type ApiKeyWire = Serialize<ApiKeyServerVisible>;

--- a/packages/types/src/entities/api-key.ts
+++ b/packages/types/src/entities/api-key.ts
@@ -106,19 +106,24 @@ export interface ApiKeyServerMetadata {
 
 /**
  * Server-visible plaintext fields of an ApiKey row — the columns the
- * server can surface without decrypting `encryptedData`. Equivalent to
- * `ApiKeyServerMetadata` minus the per-account marker (`accountId`),
- * the auth secret (`tokenHash`), and the two encrypted columns
- * (`encryptedData` Class C blob + `encryptedKeyMaterial` Class E
- * server-side material).
+ * server can surface without decrypting `encryptedData`.
  *
- * Used by the listing/get response shape; the Class C `name` and
- * `publicKey` fields from the encrypted blob never appear here, so
- * clients see no decrypted payload from these endpoints.
+ * Expressed as a positive allowlist (`Pick`) so a future column added
+ * to `ApiKeyServerMetadata` defaults to **excluded** from the wire
+ * surface. This is fail-closed: a new sensitive column cannot leak
+ * by accident.
  */
-export type ApiKeyServerVisible = Omit<
+export type ApiKeyServerVisible = Pick<
   ApiKeyServerMetadata,
-  "accountId" | "tokenHash" | "encryptedData" | "encryptedKeyMaterial"
+  | "id"
+  | "systemId"
+  | "keyType"
+  | "scopes"
+  | "createdAt"
+  | "lastUsedAt"
+  | "revokedAt"
+  | "expiresAt"
+  | "scopedBucketIds"
 >;
 
 /**

--- a/packages/types/src/entities/session.ts
+++ b/packages/types/src/entities/session.ts
@@ -15,7 +15,12 @@ export interface Session {
 
 /**
  * Device metadata stored inside the session's encryptedData blob.
- * The server never sees this in plaintext — it is T1 encrypted.
+ * The server never sees this in plaintext — it is T1 encrypted client-side.
+ *
+ * Class C auxiliary type per ADR-023 — the SoT manifest's
+ * `encryptedInput` slot for `Session` points at this type directly
+ * (no alias). Parity gate: `DeviceInfoSchema` in
+ * `packages/validation/src/session.ts`.
  */
 export interface DeviceInfo {
   readonly platform: string;

--- a/packages/types/src/entities/session.ts
+++ b/packages/types/src/entities/session.ts
@@ -17,6 +17,11 @@ export interface Session {
  * Device metadata stored inside the session's encryptedData blob.
  * The server never sees this in plaintext — it is T1 encrypted client-side.
  *
+ * `SessionServerMetadata.encryptedData` is `EncryptedBlob | null`; when
+ * non-null, the decrypted shape is `DeviceInfo`. Sessions without
+ * encrypted data (e.g., legacy or programmatic API-token sessions) have
+ * no `DeviceInfo`.
+ *
  * Class C auxiliary type per ADR-023 — the SoT manifest's
  * `encryptedInput` slot for `Session` points at this type directly
  * (no alias). Parity gate: `DeviceInfoSchema` in

--- a/packages/types/src/entities/system-snapshot.ts
+++ b/packages/types/src/entities/system-snapshot.ts
@@ -118,7 +118,13 @@ export interface SnapshotInnerworldEntity {
   readonly name: string | null;
 }
 
-/** The decrypted content of a system snapshot blob. */
+/**
+ * The decrypted content of a system snapshot blob.
+ *
+ * Class C auxiliary type per ADR-023 — the SoT manifest's `encryptedInput`
+ * slot for `SystemSnapshot` points at this type directly (no alias).
+ * Parity gate: `SnapshotContentSchema` in `packages/validation/src/snapshot.ts`.
+ */
 export interface SnapshotContent {
   readonly name: string | null;
   readonly description: string | null;

--- a/packages/types/src/entities/system-snapshot.ts
+++ b/packages/types/src/entities/system-snapshot.ts
@@ -131,6 +131,9 @@ export interface SnapshotContent {
   readonly members: readonly SnapshotMember[];
   readonly structureEntityTypes: readonly SnapshotStructureEntityType[];
   readonly structureEntities: readonly SnapshotStructureEntity[];
+  // TODO(types-8f84): replace SystemStructure* with Snapshot* projections
+  // (omits server-shaped systemId / createdAt) per the snapshot-projection
+  // convention used by SnapshotMember/Group/Region above.
   readonly structureEntityLinks: readonly SystemStructureEntityLink[];
   readonly structureEntityMemberLinks: readonly SystemStructureEntityMemberLink[];
   readonly structureEntityAssociations: readonly SystemStructureEntityAssociation[];

--- a/packages/types/src/entities/webhook-delivery.ts
+++ b/packages/types/src/entities/webhook-delivery.ts
@@ -1,3 +1,4 @@
+import type { T3EncryptedBytes } from "../encryption-primitives.js";
 import type { SystemId, WebhookDeliveryId, WebhookId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
@@ -26,10 +27,11 @@ export interface WebhookDelivery {
  * Derived from `WebhookDelivery` by adding the server-only
  * `encryptedData` column — the T3-encrypted payload the server stores
  * to sign at delivery time. The payload itself is encrypted with a
- * server-held key (not E2E), so it's `Uint8Array` not `EncryptedBlob`.
+ * server-held key (not E2E), so it's `T3EncryptedBytes` not
+ * `EncryptedBlob` — see ADR-023 Class E.
  */
 export type WebhookDeliveryServerMetadata = WebhookDelivery & {
-  readonly encryptedData: Uint8Array;
+  readonly encryptedData: T3EncryptedBytes;
 };
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -126,6 +126,7 @@ export type {
   EncryptedString,
   EncryptedBase64,
   ServerSecret,
+  T3EncryptedBytes,
   DecryptFn,
   EncryptFn,
 } from "./encryption-primitives.js";

--- a/packages/validation/src/__tests__/api-key.test.ts
+++ b/packages/validation/src/__tests__/api-key.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiKeyEncryptedPayloadSchema } from "../api-key.js";
+import { PUBLIC_KEY_BYTE_LENGTH } from "../validation.constants.js";
+
+describe("ApiKeyEncryptedPayloadSchema", () => {
+  it("accepts a valid metadata-key payload", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "metadata",
+      name: "ci-bot",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid crypto-key payload (32-byte publicKey)", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "crypto",
+      name: "session-key",
+      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown keyType discriminator", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "signing",
+      name: "rogue",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a crypto payload missing publicKey", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "crypto",
+      name: "missing-key",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty name on metadata variant", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "metadata",
+      name: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty name on crypto variant", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "crypto",
+      name: "",
+      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a publicKey shorter than 32 bytes", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "crypto",
+      name: "short-key",
+      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH - 1),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a publicKey longer than 32 bytes", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "crypto",
+      name: "long-key",
+      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a base64 string for publicKey (in-memory contract)", () => {
+    const result = ApiKeyEncryptedPayloadSchema.safeParse({
+      keyType: "crypto",
+      name: "string-key",
+      publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validation/src/__tests__/session.test.ts
+++ b/packages/validation/src/__tests__/session.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { DeviceInfoSchema } from "../session.js";
+
+describe("DeviceInfoSchema", () => {
+  it("accepts a fully-populated DeviceInfo", () => {
+    const result = DeviceInfoSchema.safeParse({
+      platform: "ios",
+      appVersion: "1.0.0",
+      deviceName: "iPhone 15",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.platform).toBe("ios");
+      expect(result.data.appVersion).toBe("1.0.0");
+      expect(result.data.deviceName).toBe("iPhone 15");
+    }
+  });
+
+  it("rejects a payload missing platform", () => {
+    const result = DeviceInfoSchema.safeParse({
+      appVersion: "1.0.0",
+      deviceName: "Pixel 7",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a payload missing appVersion", () => {
+    const result = DeviceInfoSchema.safeParse({
+      platform: "android",
+      deviceName: "Pixel 7",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a payload missing deviceName", () => {
+    const result = DeviceInfoSchema.safeParse({
+      platform: "android",
+      appVersion: "1.0.0",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-string platform", () => {
+    const result = DeviceInfoSchema.safeParse({
+      platform: 42,
+      appVersion: "1.0.0",
+      deviceName: "Tablet",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validation/src/__tests__/snapshot.test.ts
+++ b/packages/validation/src/__tests__/snapshot.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import { SnapshotContentSchema } from "../snapshot.js";
+
+const EMPTY_CONTENT = {
+  name: null,
+  description: null,
+  members: [],
+  structureEntityTypes: [],
+  structureEntities: [],
+  structureEntityLinks: [],
+  structureEntityMemberLinks: [],
+  structureEntityAssociations: [],
+  relationships: [],
+  groups: [],
+  innerworldRegions: [],
+  innerworldEntities: [],
+};
+
+describe("SnapshotContentSchema", () => {
+  it("accepts a minimal empty SnapshotContent", () => {
+    const result = SnapshotContentSchema.safeParse(EMPTY_CONTENT);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a populated SnapshotContent (one of each sub-array)", () => {
+    const now = Date.now();
+    const result = SnapshotContentSchema.safeParse({
+      ...EMPTY_CONTENT,
+      name: "Pre-merge snapshot",
+      description: null,
+      members: [
+        {
+          id: "mem_1",
+          name: "Alex",
+          pronouns: ["they/them"],
+          description: "Test member",
+          tags: [],
+          saturationLevel: null,
+          archived: false,
+        },
+      ],
+      structureEntityTypes: [{ id: "set_1", name: "Headmate", description: null }],
+      structureEntities: [
+        {
+          id: "se_1",
+          entityTypeId: "set_1",
+          name: "Outer Council",
+          description: null,
+        },
+      ],
+      structureEntityLinks: [
+        {
+          id: "sel_1",
+          systemId: "sys_1",
+          entityId: "se_1",
+          parentEntityId: null,
+          sortOrder: 0,
+          createdAt: now,
+        },
+      ],
+      structureEntityMemberLinks: [
+        {
+          id: "seml_1",
+          systemId: "sys_1",
+          parentEntityId: null,
+          memberId: "mem_1",
+          sortOrder: 0,
+          createdAt: now,
+        },
+      ],
+      structureEntityAssociations: [
+        {
+          id: "sea_1",
+          systemId: "sys_1",
+          sourceEntityId: "se_1",
+          targetEntityId: "se_1",
+          createdAt: now,
+        },
+      ],
+      relationships: [
+        {
+          sourceMemberId: "mem_1",
+          targetMemberId: "mem_1",
+          type: "sibling",
+          bidirectional: true,
+          label: null,
+        },
+      ],
+      groups: [
+        {
+          id: "grp_1",
+          name: "Front team",
+          description: null,
+          parentGroupId: null,
+          memberIds: ["mem_1"],
+        },
+      ],
+      innerworldRegions: [
+        {
+          id: "iwr_1",
+          name: "Library",
+          description: null,
+          parentRegionId: null,
+        },
+      ],
+      innerworldEntities: [
+        {
+          id: "iwe_1",
+          regionId: null,
+          entityType: "landmark",
+          name: "Fountain",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid relationship type", () => {
+    const result = SnapshotContentSchema.safeParse({
+      ...EMPTY_CONTENT,
+      relationships: [
+        {
+          sourceMemberId: "mem_1",
+          targetMemberId: "mem_2",
+          type: "frenemies",
+          bidirectional: false,
+          label: null,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a SnapshotMember missing required `id`", () => {
+    const result = SnapshotContentSchema.safeParse({
+      ...EMPTY_CONTENT,
+      members: [
+        {
+          name: "Anonymous",
+          pronouns: [],
+          description: null,
+          tags: [],
+          saturationLevel: null,
+          archived: false,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid innerworld entity entityType", () => {
+    const result = SnapshotContentSchema.safeParse({
+      ...EMPTY_CONTENT,
+      innerworldEntities: [
+        {
+          id: "iwe_1",
+          regionId: null,
+          entityType: "wormhole",
+          name: null,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a top-level missing field", () => {
+    const partial = { ...EMPTY_CONTENT };
+    Reflect.deleteProperty(partial, "members");
+    const result = SnapshotContentSchema.safeParse(partial);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validation/src/__tests__/type-parity/api-key.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/api-key.type.test.ts
@@ -1,0 +1,14 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import { ApiKeyEncryptedPayloadSchema } from "../../api-key.js";
+
+import type { ApiKeyEncryptedPayload, Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("ApiKey Zod parity (Class C — ApiKeyEncryptedPayload)", () => {
+  it("z.infer<typeof ApiKeyEncryptedPayloadSchema> equals ApiKeyEncryptedPayload", () => {
+    expectTypeOf<
+      Equal<z.infer<typeof ApiKeyEncryptedPayloadSchema>, ApiKeyEncryptedPayload>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/validation/src/__tests__/type-parity/session.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/session.type.test.ts
@@ -1,0 +1,12 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import { DeviceInfoSchema } from "../../session.js";
+
+import type { DeviceInfo, Equal } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("Session Zod parity (Class C — DeviceInfo)", () => {
+  it("z.infer<typeof DeviceInfoSchema> equals DeviceInfo", () => {
+    expectTypeOf<Equal<z.infer<typeof DeviceInfoSchema>, DeviceInfo>>().toEqualTypeOf<true>();
+  });
+});

--- a/packages/validation/src/__tests__/type-parity/system-snapshot.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/system-snapshot.type.test.ts
@@ -1,0 +1,14 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import { SnapshotContentSchema } from "../../snapshot.js";
+
+import type { Equal, SnapshotContent } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("SystemSnapshot Zod parity (Class C — SnapshotContent)", () => {
+  it("z.infer<typeof SnapshotContentSchema> equals SnapshotContent", () => {
+    expectTypeOf<
+      Equal<z.infer<typeof SnapshotContentSchema>, SnapshotContent>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/validation/src/api-key.ts
+++ b/packages/validation/src/api-key.ts
@@ -1,7 +1,7 @@
 import { ALL_API_KEY_SCOPES } from "@pluralscape/types";
 import { z } from "zod/v4";
 
-import { MAX_ENCRYPTED_DATA_SIZE } from "./validation.constants.js";
+import { MAX_ENCRYPTED_DATA_SIZE, PUBLIC_KEY_BYTE_LENGTH } from "./validation.constants.js";
 
 import type { ApiKeyEncryptedPayload } from "@pluralscape/types";
 
@@ -30,16 +30,11 @@ export const CreateApiKeyBodySchema = z
 
 /**
  * Zod parity for `ApiKeyEncryptedPayload` — the Class C auxiliary type
- * encrypted inside an ApiKey row's `encryptedData` blob. Discriminated
- * over `keyType`: `"metadata"` carries `name`; `"crypto"` adds
- * `publicKey: Uint8Array`. The compile-time parity test asserts
- * `z.infer<typeof ApiKeyEncryptedPayloadSchema>` equals
- * `ApiKeyEncryptedPayload`.
+ * encrypted inside an ApiKey row's `encryptedData` blob.
  *
- * Currently a parity gate only — not yet wired to a runtime parse
- * boundary. If/when consumed at the decrypt boundary, `publicKey` will
- * need a base64-string adapter since JSON-deserialized payloads arrive
- * as strings, not `Uint8Array`.
+ * Validates the in-memory shape after decode. The schema rejects
+ * base64 strings for `publicKey` — any JSON-string boundary requires a
+ * base64-string adapter before parsing.
  */
 export const ApiKeyEncryptedPayloadSchema: z.ZodType<ApiKeyEncryptedPayload> = z.discriminatedUnion(
   "keyType",
@@ -47,14 +42,20 @@ export const ApiKeyEncryptedPayloadSchema: z.ZodType<ApiKeyEncryptedPayload> = z
     z
       .object({
         keyType: z.literal("metadata"),
-        name: z.string(),
+        name: z.string().min(1),
       })
       .readonly(),
     z
       .object({
         keyType: z.literal("crypto"),
-        name: z.string(),
-        publicKey: z.instanceof(Uint8Array),
+        name: z.string().min(1),
+        // In-memory contract — replace with EncryptedBase64Schema if wired to a JSON parse boundary.
+        publicKey: z
+          .instanceof(Uint8Array)
+          .refine(
+            (buf) => buf.length === PUBLIC_KEY_BYTE_LENGTH,
+            "publicKey must be 32 bytes (X25519)",
+          ),
       })
       .readonly(),
   ],

--- a/packages/validation/src/api-key.ts
+++ b/packages/validation/src/api-key.ts
@@ -35,6 +35,11 @@ export const CreateApiKeyBodySchema = z
  * `publicKey: Uint8Array`. The compile-time parity test asserts
  * `z.infer<typeof ApiKeyEncryptedPayloadSchema>` equals
  * `ApiKeyEncryptedPayload`.
+ *
+ * Currently a parity gate only — not yet wired to a runtime parse
+ * boundary. If/when consumed at the decrypt boundary, `publicKey` will
+ * need a base64-string adapter since JSON-deserialized payloads arrive
+ * as strings, not `Uint8Array`.
  */
 export const ApiKeyEncryptedPayloadSchema: z.ZodType<ApiKeyEncryptedPayload> = z.discriminatedUnion(
   "keyType",

--- a/packages/validation/src/api-key.ts
+++ b/packages/validation/src/api-key.ts
@@ -3,6 +3,8 @@ import { z } from "zod/v4";
 
 import { MAX_ENCRYPTED_DATA_SIZE } from "./validation.constants.js";
 
+import type { ApiKeyEncryptedPayload } from "@pluralscape/types";
+
 /** Key types matching the DB enum constraint. */
 const API_KEY_KEY_TYPES = ["metadata", "crypto"] as const;
 
@@ -25,3 +27,30 @@ export const CreateApiKeyBodySchema = z
     },
   )
   .readonly();
+
+/**
+ * Zod parity for `ApiKeyEncryptedPayload` — the Class C auxiliary type
+ * encrypted inside an ApiKey row's `encryptedData` blob. Discriminated
+ * over `keyType`: `"metadata"` carries `name`; `"crypto"` adds
+ * `publicKey: Uint8Array`. The compile-time parity test asserts
+ * `z.infer<typeof ApiKeyEncryptedPayloadSchema>` equals
+ * `ApiKeyEncryptedPayload`.
+ */
+export const ApiKeyEncryptedPayloadSchema: z.ZodType<ApiKeyEncryptedPayload> = z.discriminatedUnion(
+  "keyType",
+  [
+    z
+      .object({
+        keyType: z.literal("metadata"),
+        name: z.string(),
+      })
+      .readonly(),
+    z
+      .object({
+        keyType: z.literal("crypto"),
+        name: z.string(),
+        publicKey: z.instanceof(Uint8Array),
+      })
+      .readonly(),
+  ],
+);

--- a/packages/validation/src/session.ts
+++ b/packages/validation/src/session.ts
@@ -1,0 +1,19 @@
+import { z } from "zod/v4";
+
+import type { DeviceInfo } from "@pluralscape/types";
+
+/**
+ * Zod schema for `DeviceInfo` — the auxiliary type encrypted inside a
+ * Session row's `encryptedData` blob. Per ADR-023 Class C convention,
+ * this schema is named after the auxiliary type (no `SessionEncryptedInputSchema`
+ * alias). The compile-time parity test in
+ * `__tests__/type-parity/session.type.test.ts` asserts
+ * `z.infer<typeof DeviceInfoSchema>` ≡ `DeviceInfo`.
+ */
+export const DeviceInfoSchema: z.ZodType<DeviceInfo> = z
+  .object({
+    platform: z.string(),
+    appVersion: z.string(),
+    deviceName: z.string(),
+  })
+  .readonly();

--- a/packages/validation/src/session.ts
+++ b/packages/validation/src/session.ts
@@ -9,6 +9,8 @@ import type { DeviceInfo } from "@pluralscape/types";
  * alias). The compile-time parity test in
  * `__tests__/type-parity/session.type.test.ts` asserts
  * `z.infer<typeof DeviceInfoSchema>` ≡ `DeviceInfo`.
+ *
+ * Currently a parity gate only — not yet wired to a runtime parse boundary.
  */
 export const DeviceInfoSchema: z.ZodType<DeviceInfo> = z
   .object({

--- a/packages/validation/src/snapshot.ts
+++ b/packages/validation/src/snapshot.ts
@@ -1,7 +1,24 @@
 import { z } from "zod/v4";
 
 import { brandedIdQueryParam } from "./branded-id.js";
+import { brandedNumber, brandedString } from "./branded.js";
+import { PlaintextSaturationLevelSchema, PlaintextTagSchema } from "./plaintext-shared.js";
+import { RELATIONSHIP_TYPES } from "./relationship.js";
 import { MAX_ENCRYPTED_DATA_SIZE } from "./validation.constants.js";
+
+import type {
+  SnapshotContent,
+  SnapshotGroup,
+  SnapshotInnerworldEntity,
+  SnapshotInnerworldRegion,
+  SnapshotMember,
+  SnapshotRelationship,
+  SnapshotStructureEntity,
+  SnapshotStructureEntityType,
+  SystemStructureEntityAssociation,
+  SystemStructureEntityLink,
+  SystemStructureEntityMemberLink,
+} from "@pluralscape/types";
 
 export const CreateSnapshotBodySchema = z
   .object({
@@ -13,5 +30,132 @@ export const CreateSnapshotBodySchema = z
 export const DuplicateSystemBodySchema = z
   .object({
     snapshotId: brandedIdQueryParam("snap_"),
+  })
+  .readonly();
+
+// ── Snapshot sub-types ────────────────────────────────────────────────
+
+const SnapshotMemberSchema: z.ZodType<SnapshotMember> = z
+  .object({
+    id: brandedString<"MemberId">(),
+    name: z.string(),
+    pronouns: z.array(z.string()).readonly(),
+    description: z.string().nullable(),
+    tags: z.array(PlaintextTagSchema).readonly(),
+    saturationLevel: PlaintextSaturationLevelSchema.nullable(),
+    archived: z.boolean(),
+  })
+  .readonly();
+
+const SnapshotStructureEntityTypeSchema: z.ZodType<SnapshotStructureEntityType> = z
+  .object({
+    id: brandedString<"SystemStructureEntityTypeId">(),
+    name: z.string(),
+    description: z.string().nullable(),
+  })
+  .readonly();
+
+const SnapshotStructureEntitySchema: z.ZodType<SnapshotStructureEntity> = z
+  .object({
+    id: brandedString<"SystemStructureEntityId">(),
+    entityTypeId: brandedString<"SystemStructureEntityTypeId">(),
+    name: z.string(),
+    description: z.string().nullable(),
+  })
+  .readonly();
+
+const SnapshotRelationshipSchema: z.ZodType<SnapshotRelationship> = z
+  .object({
+    sourceMemberId: brandedString<"MemberId">(),
+    targetMemberId: brandedString<"MemberId">(),
+    type: z.enum(RELATIONSHIP_TYPES),
+    bidirectional: z.boolean(),
+    label: z.string().nullable(),
+  })
+  .readonly();
+
+const SnapshotGroupSchema: z.ZodType<SnapshotGroup> = z
+  .object({
+    id: brandedString<"GroupId">(),
+    name: z.string(),
+    description: z.string().nullable(),
+    parentGroupId: brandedString<"GroupId">().nullable(),
+    memberIds: z.array(brandedString<"MemberId">()).readonly(),
+  })
+  .readonly();
+
+const SnapshotInnerworldRegionSchema: z.ZodType<SnapshotInnerworldRegion> = z
+  .object({
+    id: brandedString<"InnerWorldRegionId">(),
+    name: z.string(),
+    description: z.string().nullable(),
+    parentRegionId: brandedString<"InnerWorldRegionId">().nullable(),
+  })
+  .readonly();
+
+const SnapshotInnerworldEntitySchema: z.ZodType<SnapshotInnerworldEntity> = z
+  .object({
+    id: brandedString<"InnerWorldEntityId">(),
+    regionId: brandedString<"InnerWorldRegionId">().nullable(),
+    entityType: z.enum(["member", "landmark", "structure-entity"]),
+    name: z.string().nullable(),
+  })
+  .readonly();
+
+// ── Junction-record schemas ───────────────────────────────────────────
+
+const SystemStructureEntityLinkSchema: z.ZodType<SystemStructureEntityLink> = z
+  .object({
+    id: brandedString<"SystemStructureEntityLinkId">(),
+    systemId: brandedString<"SystemId">(),
+    entityId: brandedString<"SystemStructureEntityId">(),
+    parentEntityId: brandedString<"SystemStructureEntityId">().nullable(),
+    sortOrder: z.number(),
+    createdAt: brandedNumber<"UnixMillis">(),
+  })
+  .readonly();
+
+const SystemStructureEntityMemberLinkSchema: z.ZodType<SystemStructureEntityMemberLink> = z
+  .object({
+    id: brandedString<"SystemStructureEntityMemberLinkId">(),
+    systemId: brandedString<"SystemId">(),
+    parentEntityId: brandedString<"SystemStructureEntityId">().nullable(),
+    memberId: brandedString<"MemberId">(),
+    sortOrder: z.number(),
+    createdAt: brandedNumber<"UnixMillis">(),
+  })
+  .readonly();
+
+const SystemStructureEntityAssociationSchema: z.ZodType<SystemStructureEntityAssociation> = z
+  .object({
+    id: brandedString<"SystemStructureEntityAssociationId">(),
+    systemId: brandedString<"SystemId">(),
+    sourceEntityId: brandedString<"SystemStructureEntityId">(),
+    targetEntityId: brandedString<"SystemStructureEntityId">(),
+    createdAt: brandedNumber<"UnixMillis">(),
+  })
+  .readonly();
+
+/**
+ * Zod schema for `SnapshotContent` — the auxiliary type encrypted inside
+ * a SystemSnapshot row's `encryptedData` blob. Per ADR-023 Class C convention,
+ * this schema is named after the auxiliary type (no
+ * `SystemSnapshotEncryptedInputSchema` alias). Parity test:
+ * `__tests__/type-parity/system-snapshot.type.test.ts`.
+ */
+export const SnapshotContentSchema: z.ZodType<SnapshotContent> = z
+  .object({
+    name: z.string().nullable(),
+    description: z.string().nullable(),
+    members: z.array(SnapshotMemberSchema).readonly(),
+    structureEntityTypes: z.array(SnapshotStructureEntityTypeSchema).readonly(),
+    structureEntities: z.array(SnapshotStructureEntitySchema).readonly(),
+    structureEntityLinks: z.array(SystemStructureEntityLinkSchema).readonly(),
+    structureEntityMemberLinks: z.array(SystemStructureEntityMemberLinkSchema).readonly(),
+    structureEntityAssociations: z.array(SystemStructureEntityAssociationSchema).readonly(),
+    relationships: z.array(SnapshotRelationshipSchema).readonly(),
+    groups: z.array(SnapshotGroupSchema).readonly(),
+    innerworldRegions: z.array(SnapshotInnerworldRegionSchema).readonly(),
+    innerworldEntities: z.array(SnapshotInnerworldEntitySchema).readonly(),
   })
   .readonly();

--- a/packages/validation/src/snapshot.ts
+++ b/packages/validation/src/snapshot.ts
@@ -142,6 +142,8 @@ const SystemStructureEntityAssociationSchema: z.ZodType<SystemStructureEntityAss
  * this schema is named after the auxiliary type (no
  * `SystemSnapshotEncryptedInputSchema` alias). Parity test:
  * `__tests__/type-parity/system-snapshot.type.test.ts`.
+ *
+ * Currently a parity gate only — not yet wired to a runtime parse boundary.
  */
 export const SnapshotContentSchema: z.ZodType<SnapshotContent> = z
   .object({

--- a/scripts/openapi-wire-parity.type-test.ts
+++ b/scripts/openapi-wire-parity.type-test.ts
@@ -36,6 +36,7 @@
 import type { components } from "../packages/api-client/src/generated/api-types.js";
 import type {
   AcknowledgementRequestWire,
+  ApiKeyWire,
   AuditLogEntry,
   AuditLogEntryWire,
   BoardMessageWire,
@@ -238,6 +239,13 @@ expectTypeOf<
 expectTypeOf<
   Equal<components["schemas"]["AcknowledgementResponse"], AcknowledgementRequestWire>
 >().toEqualTypeOf<true>();
+
+// ApiKey: Class C entity. `ApiKeyWire = Serialize<ApiKeyServerVisible>` —
+// the wire surface is a positive `Pick` allowlist of the server-visible
+// columns (no `tokenHash`, no `encryptedData`, no `encryptedKeyMaterial`,
+// no `accountId`). Any drift between the OpenAPI spec and the allowlist
+// fails this gate.
+expectTypeOf<Equal<components["schemas"]["ApiKeyResponse"], ApiKeyWire>>().toEqualTypeOf<true>();
 
 // JournalEntryResponse and WikiPageResponse: canonical wire types exist
 // (`JournalEntryWire`, `WikiPageWire`) but no OpenAPI route schema is


### PR DESCRIPTION
## Summary

Closes ps-qmyt. PR3 of 5 in the M9a closeout (umbrella plan: `docs/superpowers/plans/2026-04-26-m9a-closeout-umbrella.md`).

Extends the canonical chain in ADR-023 to cover Class C entities (api-key, session, system-snapshot) where the encrypted blob holds an auxiliary type (not a `Pick<Entity, K>`). ADR-023 grows two new sections — Class C (divergent encrypted payload) and Class E (server-side T3 encryption) — so PR4 (ps-f3ox) can be doc-only.

- Auxiliary type names stay (`DeviceInfo`, `SnapshotContent`); new `ApiKeyEncryptedPayload` discriminated union for api-key
- Each gets `<AuxiliaryType>Schema` in `packages/validation/src/<entity>.ts` + parity test asserting `z.infer` ≡ auxiliary type
- SoT manifest grows entries for all three with `encryptedInput` slot pointing at the auxiliary type
- ApiKey is hybrid Class C + Class E; `encryptedKeyMaterial` documented as Class E exception
- `ApiKeyWire` audit yielded `Serialize<ApiKeyServerVisible>` where `ApiKeyServerVisible` is a `Pick`-allowlist of `ApiKeyServerMetadata` (fail-closed: new columns default to excluded)

Per pre-production policy: no aliases, no shims. The auxiliary type IS the EncryptedInput directly.

Follow-up bean opened: `types-8f84` (pre-existing snapshot junction-type projection mismatch surfaced by review).

## Test plan

- [x] `pnpm types:check-sot`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (zero warnings)
- [x] `pnpm test:unit`
- [x] `pnpm test:integration`
- [x] `pnpm test:e2e` (507 passed, 2 skipped)
- [ ] CI green