### PR TITLE
feat(types,validation,data): types-emid — wire encrypted-payload schemas at decrypt boundaries

### DIFF
--- a/.beans/api-bqu4--wire-decryptdeviceinfo-at-session-list-endpoint.md
+++ b/.beans/api-bqu4--wire-decryptdeviceinfo-at-session-list-endpoint.md
@@ -1,0 +1,26 @@
+---
+# api-bqu4
+title: Wire decryptDeviceInfo at session-list endpoint
+status: todo
+type: task
+created_at: 2026-04-27T18:59:53Z
+updated_at: 2026-04-27T18:59:53Z
+parent: ps-cd6x
+---
+
+Wire the existing client transform `decryptDeviceInfo` (`packages/data/src/transforms/session.ts`) once the session-list API endpoint plumbs encryptedData through to clients.
+
+## Background
+
+Landed in `types-emid` (PR #579) as part of pre-release data-layer scaffolding. The transform is fully tested at the data-layer round-trip level but has no consumer today — `apps/api/src/services/auth/sessions.ts:listSessions` currently returns only `{id, createdAt, lastActive, expiresAt}`, no `encryptedData` field.
+
+## Acceptance
+
+- `apps/api/src/services/auth/sessions.ts` returns `encryptedData` on the session-list endpoint (or, if the design calls for it, on a sibling `get` endpoint).
+- Mobile session-list view calls `decryptDeviceInfo(encryptedData, masterKey)` to surface platform / appVersion / deviceName.
+- Wire shape registered in OpenAPI / tRPC contract.
+
+## Related
+
+- types-emid (PR #579 — schema and transform landed)
+- ps-cd6x (Milestone 9a)

--- a/.beans/client-a0gf--wire-apikey-codec-transforms-when-crypto-variant-l.md
+++ b/.beans/client-a0gf--wire-apikey-codec-transforms-when-crypto-variant-l.md
@@ -1,0 +1,32 @@
+---
+# client-a0gf
+title: Wire ApiKey codec transforms when crypto-variant lands client-side
+status: todo
+type: task
+created_at: 2026-04-27T19:00:01Z
+updated_at: 2026-04-27T19:00:01Z
+parent: ps-cd6x
+---
+
+Wire `decryptApiKeyPayload` / `encryptApiKeyPayload` (`packages/data/src/transforms/api-key.ts`) when the ApiKey crypto-variant lands client-side.
+
+## Background
+
+Landed in `types-emid` (PR #579). The codec round-trip is fully tested at the data-layer level. Today no API surface emits or consumes `encryptedData` for ApiKeys — `API_KEY_SELECT_COLUMNS` (`apps/api/src/services/api-key/internal.ts`) deliberately omits `encryptedData`, and `ApiKeyResult` has no encrypted-blob field.
+
+When the crypto-variant work picks up:
+
+- The mobile create flow encrypts `{keyType: "crypto", name, publicKey: Uint8Array}` via `encryptApiKeyPayload` and sends the resulting base64 `encryptedData` to `POST /v1/systems/:id/api-keys`.
+- Listing/getting an ApiKey returns `encryptedData`; client calls `decryptApiKeyPayload` to surface the in-memory shape.
+
+## Acceptance
+
+- API endpoints emit/consume `encryptedData` for ApiKey rows on relevant routes.
+- Mobile ApiKey create / list / detail views call the codec transforms.
+- E2E test exercises the full encrypt-on-create → decrypt-on-display flow with a 32-byte X25519 publicKey.
+
+## Related
+
+- types-emid (PR #579 — schema and transform landed)
+- ps-qmyt (Class C extension — original)
+- ps-cd6x (Milestone 9a)

--- a/.beans/ps-znp0--inline-or-relocate-decode-blob-asserts-after-frien.md
+++ b/.beans/ps-znp0--inline-or-relocate-decode-blob-asserts-after-frien.md
@@ -1,0 +1,32 @@
+---
+# ps-znp0
+title: Inline or relocate decode-blob asserts after friend-dashboard migrates
+status: todo
+type: task
+created_at: 2026-04-27T19:00:19Z
+updated_at: 2026-04-27T19:00:19Z
+parent: ps-cd6x
+---
+
+Consolidate the remaining `assertObjectBlob` and `assertStringField` helpers in `packages/data/src/transforms/decode-blob.ts` once `friend-dashboard.ts` (their sole remaining consumer) migrates to its own validation pattern.
+
+## Background
+
+After `types-emid` (PR #579):
+
+- `assertArrayField` was removed (zero callers).
+- `assertObjectBlob` retained — only consumer is `packages/data/src/transforms/friend-dashboard.ts` (T2 path with cross-account-bucket decryption, out of scope for types-emid).
+- `assertStringField` retained — same single consumer in `friend-dashboard.ts`.
+
+Single-consumer helpers in `decode-blob.ts` are a code smell; either inline them into `friend-dashboard.ts` or move them to a sibling `friend-dashboard-asserts.ts`. Cleanest approach is to migrate `friend-dashboard.ts` to a Zod schema (matching the rest of the fleet), at which point both helpers can be deleted.
+
+## Acceptance
+
+- Either: `friend-dashboard.ts` migrates to a Zod schema for its decrypted-blob shapes, eliminating both helpers; OR the helpers are inlined into `friend-dashboard.ts` as private functions.
+- `packages/data/src/transforms/decode-blob.ts` no longer exports `assertObjectBlob` / `assertStringField`.
+- Existing `friend-dashboard` tests still pass.
+
+## Related
+
+- types-emid (PR #579 — established the Zod-at-decrypt pattern)
+- ps-cd6x (Milestone 9a)

--- a/.beans/types-emid--wire-class-c-parity-schemas-to-runtime-decrypt-bou.md
+++ b/.beans/types-emid--wire-class-c-parity-schemas-to-runtime-decrypt-bou.md
@@ -1,11 +1,11 @@
 ---
 # types-emid
 title: Wire Class C parity schemas to runtime decrypt boundaries
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T14:30:14Z
-updated_at: 2026-04-27T17:28:29Z
+updated_at: 2026-04-27T18:55:54Z
 ---
 
 Three Zod parity schemas for Class C entities are currently parity-gates only — not yet wired to a runtime parse boundary. This bean tracks wiring them at the decrypt callsites once those callsites materialize.
@@ -85,3 +85,59 @@ Implementation plan at `docs/superpowers/plans/2026-04-27-types-emid.md` (gitign
 7. `FrontingReportEncryptedInputSchema` wired in `decryptFrontingReport`
 8. Cleanup unused `decode-blob.ts` helpers
 9. Final `/verify` + bean closeout
+
+## Summary of Changes
+
+Wired five encrypted-payload Zod schemas at their runtime decrypt boundaries.
+
+### Codec primitive
+
+- New `Base64ToUint8ArrayCodec` in `packages/validation/src/encryption-primitives.ts` — Zod 4.1+ `z.codec()` for binary↔base64 boundaries inside JSON-encoded AEAD plaintexts.
+
+### ApiKey (Class C — codec-based)
+
+- `ApiKeyEncryptedPayloadSchema` rewritten as `z.codec()` — wire side `publicKey: z.base64()`, memory side `publicKey: Uint8Array` with 32-byte refine.
+- New transforms `decryptApiKeyPayload` / `encryptApiKeyPayload` in `packages/data/src/transforms/api-key.ts` using `Schema.parse` / `z.encode`.
+- Round-trip tests cover both metadata and crypto variants.
+- Parity test now asserts `z.output<>` ≡ `ApiKeyEncryptedPayload`.
+- Used `z.custom<Uint8Array>` over `z.instanceof` (with inline comment) because `z.instanceof` produces `InstanceType<typeof Uint8Array>` which fails strict `Equal<>` parity.
+
+### Snapshot, DeviceInfo (Class C — schema-parse)
+
+- `decryptSnapshot` swapped from hand-rolled `assertSnapshotContent` to `SnapshotContentSchema.parse()`.
+- New transform `decryptDeviceInfo` in `packages/data/src/transforms/session.ts` using `DeviceInfoSchema.parse()`.
+
+### FrontingReport (T1 outlier — full canonical-chain extension)
+
+- New canonical type `FrontingReportEncryptedInput` in `packages/types/src/analytics.ts`.
+- New `FrontingReportEncryptedInputSchema` (with sub-schemas for `DateRange`, `MemberFrontingBreakdown`, `ChartDataset`, `ChartData`) in `packages/validation/src/fronting-report.ts`.
+- New SoT manifest entry (Class A, `server: never` / `wire: never` placeholders documented for future endpoint formalization).
+- New G3 parity test.
+- `decryptFrontingReport` swapped from hand-rolled `assertFrontingReportEncryptedFields` to `FrontingReportEncryptedInputSchema.parse()`. Inline `FrontingReportEncryptedFields` interface and `AssertFrontingReportFieldsSubset` removed.
+- Orphaned barrel re-export from `packages/data/src/index.ts` removed.
+
+### Cleanup
+
+- "Parity gate only" / "in-memory contract" comments removed from all wired validation modules; replaced with positive wiring references.
+- Unused `assertArrayField` helper removed from `packages/data/src/transforms/decode-blob.ts` (zero callers after wiring). `assertObjectBlob` and `assertStringField` remain (still used by `friend-dashboard.ts` T2 path — out of scope).
+
+### Verification (final `/verify`)
+
+- `pnpm format` — clean
+- `pnpm lint` — zero warnings
+- `pnpm typecheck` — zero errors
+- `pnpm types:check-sot` — all 4 parity gates green (types, Drizzle, Zod, OpenAPI-Wire)
+- `pnpm test:unit` — 13024 passed (1 skipped, 1 todo across 1015 files)
+- `pnpm test:integration` — 3055 passed (11 skipped across 152 files)
+- `pnpm test:e2e` — 507 passed (2 skipped)
+
+### Follow-ups deferred to separate beans
+
+- Wire `decryptDeviceInfo` once the session-list endpoint plumbs `encryptedData`.
+- Wire `decryptApiKeyPayload` / `encryptApiKeyPayload` when ApiKey crypto-variant lands client-side.
+- Add `FrontingReportServerMetadata` / `FrontingReportWire` when report API endpoints are formalised.
+- Inline or relocate `assertObjectBlob` / `assertStringField` after `friend-dashboard.ts` migrates to its own validation pattern.
+
+### Branch / commits
+
+`feat/types-emid-decrypt-wiring` — 8 implementation commits + 1 bean-tracking commit, top-down narrative: codec primitive → ApiKey codec → ApiKey transforms → Snapshot wiring → DeviceInfo transform → FrontingReport canonical chain → FrontingReport wiring → decode-blob cleanup.

--- a/.beans/types-emid--wire-class-c-parity-schemas-to-runtime-decrypt-bou.md
+++ b/.beans/types-emid--wire-class-c-parity-schemas-to-runtime-decrypt-bou.md
@@ -1,10 +1,11 @@
 ---
 # types-emid
 title: Wire Class C parity schemas to runtime decrypt boundaries
-status: todo
+status: in-progress
 type: task
+priority: normal
 created_at: 2026-04-27T14:30:14Z
-updated_at: 2026-04-27T14:30:14Z
+updated_at: 2026-04-27T17:28:29Z
 ---
 
 Three Zod parity schemas for Class C entities are currently parity-gates only — not yet wired to a runtime parse boundary. This bean tracks wiring them at the decrypt callsites once those callsites materialize.
@@ -30,3 +31,57 @@ The schemas exist as compile-time parity gates so type and Zod stay in sync. Run
 - ps-qmyt (original Class C extension)
 - ps-8e36 (PR #578 review fixes)
 - types-8f84 (SnapshotContent server-shaped junction projections — adjacent cleanup)
+
+## Design
+
+Spec at `docs/superpowers/specs/2026-04-27-types-emid-design.md` (gitignored, local-only).
+
+## Expanded scope (post-design)
+
+Audit of `packages/data/src/transforms/` confirmed only **2 outliers** out of 23 T1 transforms still use hand-rolled assertions instead of Zod schema validation. One (`snapshot.ts`) was already in scope; the other (`fronting-report.ts`) is added here.
+
+### Final scope
+
+1. **Codec primitive**: introduce `Base64ToUint8ArrayCodec` in `packages/validation/src/encryption-primitives.ts` (Zod 4.1+ `z.codec()` for binary↔base64 boundaries inside JSON-encoded AEAD plaintexts).
+2. **ApiKey** — codec-based wiring (only payload with `Uint8Array` field). New transform `packages/data/src/transforms/api-key.ts`.
+3. **DeviceInfo** — `Schema.parse()` wiring. New transform `packages/data/src/transforms/session.ts`.
+4. **SnapshotContent** — replace `assertSnapshotContent` with `Schema.parse()` in existing `packages/data/src/transforms/snapshot.ts`.
+5. **FrontingReportEncryptedInput** — full canonical-chain extension (canonical type in `analytics.ts`, Zod schema + sub-schemas in `packages/validation/src/fronting-report.ts`, SoT manifest entry, parity test, runtime wiring).
+6. Drop "parity gate only / in-memory contract" comments from all wired validation modules.
+7. Cleanup unused exports from `decode-blob.ts` after the swaps.
+
+### Why `z.codec()` over alternatives
+
+Zod 4.1+ `z.codec()` is purpose-built for wire↔memory boundaries; the canonical Zod docs literally use `base64 ↔ Uint8Array` as the headline example. Pluralscape is on `zod ^4.3.6`. Matches the wire format used by JOSE/age/Tink/libsodium.js (binary as base64 string in JSON) while preserving `Uint8Array` in the in-memory domain type. Custom JSON replacer/reviver in `encryptJSON` was rejected — invents a sentinel-tagged shape that breaks OpenAPI parity and couples crypto to a serialization concern. CBOR/MessagePack switch was rejected — over-engineered for one 32-byte field.
+
+## Updated acceptance
+
+- All five payloads (ApiKey / DeviceInfo / SnapshotContent / FrontingReportEncryptedInput / no other T1 outliers) validated by Zod at decrypt boundaries.
+- `Base64ToUint8ArrayCodec` exported from `packages/validation/`.
+- ApiKey `publicKey: Uint8Array` round-trips through encrypt/decrypt cycles in tests.
+- `FrontingReport` has a canonical-chain entry with parity test in the SoT manifest.
+- All "parity gate only / in-memory contract" comments removed from validation modules.
+- `/verify` green (full suite — format, lint, typecheck, unit, integration, e2e).
+
+## Related
+
+- ps-qmyt (original Class C extension)
+- ps-8e36 (PR #578 review fixes)
+- types-8f84 (SnapshotContent server-shaped junction projections — adjacent cleanup, separate)
+- ps-y4tb (parent epic — encrypted-entity SoT consolidation)
+
+## Plan
+
+Implementation plan at `docs/superpowers/plans/2026-04-27-types-emid.md` (gitignored, local-only).
+
+9 tasks structured as bite-sized TDD steps:
+
+1. `Base64ToUint8ArrayCodec` primitive
+2. `ApiKeyEncryptedPayloadSchema` rewrite as `z.codec()`
+3. ApiKey decrypt/encrypt transforms with round-trip tests
+4. `SnapshotContentSchema` wired in `decryptSnapshot`
+5. `decryptDeviceInfo` transform with `DeviceInfoSchema`
+6. FrontingReport canonical-chain extension (type + Zod + parity test + SoT manifest)
+7. `FrontingReportEncryptedInputSchema` wired in `decryptFrontingReport`
+8. Cleanup unused `decode-blob.ts` helpers
+9. Final `/verify` + bean closeout

--- a/.beans/types-wyda--add-frontingreport-serverwire-types-when-report-en.md
+++ b/.beans/types-wyda--add-frontingreport-serverwire-types-when-report-en.md
@@ -1,0 +1,33 @@
+---
+# types-wyda
+title: Add FrontingReport server/wire types when report endpoints land
+status: todo
+type: task
+created_at: 2026-04-27T19:00:11Z
+updated_at: 2026-04-27T19:00:11Z
+parent: ps-cd6x
+---
+
+Replace the `server: never` / `wire: never` placeholders in the SoT manifest entry for FrontingReport (`packages/types/src/__sot-manifest__.ts`) with concrete `FrontingReportServerMetadata` and `FrontingReportWire` types when the FrontingReport API endpoints are formalised.
+
+## Background
+
+Landed in `types-emid` (PR #579) as part of the canonical-chain extension. The manifest entry currently uses `never` placeholders with an inline JSDoc TODO explaining the deferred status. This was acceptable because:
+
+1. The encrypted-input parity gate (Class A: `FrontingReportEncryptedInput` ≡ `Pick<FrontingReport, K>`) is the load-bearing invariant for the data-layer wiring.
+2. No FrontingReport API endpoints exist yet — adding wire/server types pre-emptively would freeze design choices we don't have yet.
+
+## Acceptance
+
+- FrontingReport API endpoints exist (presumably under `apps/api/src/services/fronting-report/` or similar — exact location TBD by the endpoint design).
+- `FrontingReportServerMetadata` defined in `packages/types/src/analytics.ts` (or moved to `packages/types/src/entities/fronting-report.ts` if the type warrants its own entity file).
+- `FrontingReportWire` defined alongside.
+- SoT manifest entry updated (`server: FrontingReportServerMetadata`, `wire: FrontingReportWire`).
+- The inline TODO comment in the manifest is removed.
+- Drizzle parity test added if a DB schema is involved.
+- OpenAPI-Wire parity test added.
+
+## Related
+
+- types-emid (PR #579 — Class A canonical chain landed)
+- ps-cd6x (Milestone 9a)

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -87,7 +87,6 @@ export {
   decryptFrontingReportPage,
   encryptFrontingReportInput,
 } from "./transforms/fronting-report.js";
-export type { FrontingReportEncryptedFields } from "./transforms/fronting-report.js";
 
 export {
   decryptTimerConfig,

--- a/packages/data/src/transforms/__tests__/api-key.test.ts
+++ b/packages/data/src/transforms/__tests__/api-key.test.ts
@@ -1,0 +1,64 @@
+import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
+import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
+import { PUBLIC_KEY_BYTE_LENGTH } from "@pluralscape/validation";
+import { beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+
+import { decryptApiKeyPayload, encryptApiKeyPayload } from "../api-key.js";
+import { encryptAndEncodeT1 } from "../decode-blob.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { ApiKeyEncryptedPayload } from "@pluralscape/types";
+
+let masterKey: KdfMasterKey;
+
+beforeAll(async () => {
+  configureSodium(new WasmSodiumAdapter());
+  await initSodium();
+  masterKey = generateMasterKey();
+});
+
+describe("ApiKey payload transforms", () => {
+  it("round-trips a metadata variant", () => {
+    const original: ApiKeyEncryptedPayload = { keyType: "metadata", name: "ci-bot" };
+    const { encryptedData } = encryptApiKeyPayload(original, masterKey);
+    const decoded = decryptApiKeyPayload(encryptedData, masterKey);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a crypto variant preserving Uint8Array publicKey", () => {
+    const publicKey = new Uint8Array(PUBLIC_KEY_BYTE_LENGTH);
+    for (let i = 0; i < publicKey.length; i++) publicKey[i] = (i * 11 + 5) & 0xff;
+    const original: ApiKeyEncryptedPayload = {
+      keyType: "crypto",
+      name: "session-key",
+      publicKey,
+    };
+    const { encryptedData } = encryptApiKeyPayload(original, masterKey);
+    const decoded = decryptApiKeyPayload(encryptedData, masterKey);
+    if (decoded.keyType !== "crypto") throw new Error("expected crypto variant");
+    expect(decoded.name).toBe("session-key");
+    expect(decoded.publicKey).toBeInstanceOf(Uint8Array);
+    expect(Array.from(decoded.publicKey)).toEqual(Array.from(publicKey));
+  });
+
+  it("rejects a malformed plaintext (wrong shape)", () => {
+    // Use the underlying T1 helper directly to produce ciphertext whose
+    // plaintext does not match the codec's wire schema; decryptApiKeyPayload
+    // must throw because z.parse rejects the wire-side parse.
+    const malformed = encryptAndEncodeT1({ keyType: "rogue" }, masterKey);
+    expect(() => decryptApiKeyPayload(malformed, masterKey)).toThrow();
+  });
+
+  it("rejects a malformed plaintext (publicKey wrong byte length)", () => {
+    // Encrypt a wire-shape payload whose publicKey decodes to fewer than 32
+    // bytes; the codec's memory-side .refine must reject after decode.
+    const wireShape = {
+      keyType: "crypto",
+      name: "short",
+      publicKey: z.util.uint8ArrayToBase64(new Uint8Array(PUBLIC_KEY_BYTE_LENGTH - 1)),
+    };
+    const malformed = encryptAndEncodeT1(wireShape, masterKey);
+    expect(() => decryptApiKeyPayload(malformed, masterKey)).toThrow();
+  });
+});

--- a/packages/data/src/transforms/__tests__/fronting-report.test.ts
+++ b/packages/data/src/transforms/__tests__/fronting-report.test.ts
@@ -12,9 +12,13 @@ import {
 
 import { makeBase64Blob } from "./helpers.js";
 
-import type { FrontingReportEncryptedFields } from "../fronting-report.js";
 import type { KdfMasterKey } from "@pluralscape/crypto";
-import type { FrontingReportId, SystemId, UnixMillis } from "@pluralscape/types";
+import type {
+  FrontingReportEncryptedInput,
+  FrontingReportId,
+  SystemId,
+  UnixMillis,
+} from "@pluralscape/types";
 
 let masterKey: KdfMasterKey;
 
@@ -23,7 +27,7 @@ const SYSTEM_ID = brandId<SystemId>("sys_test");
 const NOW = 1700000000000 as UnixMillis;
 const START = 1699000000000 as UnixMillis;
 
-const ENCRYPTED_FIELDS: FrontingReportEncryptedFields = {
+const ENCRYPTED_FIELDS: FrontingReportEncryptedInput = {
   dateRange: { start: START, end: NOW },
   memberBreakdowns: [],
   chartData: [],
@@ -108,25 +112,30 @@ describe("encryptFrontingReportInput", () => {
   });
 });
 
-// ── Assertion guard tests ────────────────────────────────────────────
+// ── Validation tests ────────────────────────────────────────────────
 
-describe("assertFrontingReportEncryptedFields", () => {
+describe("decryptFrontingReport validation (Zod)", () => {
   it("throws when decrypted blob is not an object", () => {
     const raw = makeRawReport(makeBase64Blob("not-an-object", masterKey));
-    expect(() => decryptFrontingReport(raw, masterKey)).toThrow("not an object");
+    expect(() => decryptFrontingReport(raw, masterKey)).toThrow();
   });
 
-  it("throws when blob is missing dateRange field", () => {
-    const raw = makeRawReport(makeBase64Blob({ memberBreakdowns: [] }, masterKey));
-    expect(() => decryptFrontingReport(raw, masterKey)).toThrow(
-      "missing required object field: dateRange",
-    );
+  it("throws when blob is missing dateRange", () => {
+    const raw = makeRawReport(makeBase64Blob({ memberBreakdowns: [], chartData: [] }, masterKey));
+    expect(() => decryptFrontingReport(raw, masterKey)).toThrow();
   });
 
   it("throws when dateRange is null", () => {
-    const raw = makeRawReport(makeBase64Blob({ dateRange: null }, masterKey));
-    expect(() => decryptFrontingReport(raw, masterKey)).toThrow(
-      "missing required object field: dateRange",
+    const raw = makeRawReport(
+      makeBase64Blob({ dateRange: null, memberBreakdowns: [], chartData: [] }, masterKey),
     );
+    expect(() => decryptFrontingReport(raw, masterKey)).toThrow();
+  });
+
+  it("throws when memberBreakdowns is missing", () => {
+    const raw = makeRawReport(
+      makeBase64Blob({ dateRange: { start: 1, end: 2 }, chartData: [] }, masterKey),
+    );
+    expect(() => decryptFrontingReport(raw, masterKey)).toThrow();
   });
 });

--- a/packages/data/src/transforms/__tests__/session.test.ts
+++ b/packages/data/src/transforms/__tests__/session.test.ts
@@ -1,0 +1,46 @@
+import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
+import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { encryptAndEncodeT1 } from "../decode-blob.js";
+import { decryptDeviceInfo } from "../session.js";
+
+import { makeBase64Blob } from "./helpers.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { DeviceInfo } from "@pluralscape/types";
+
+let masterKey: KdfMasterKey;
+
+beforeAll(async () => {
+  configureSodium(new WasmSodiumAdapter());
+  await initSodium();
+  masterKey = generateMasterKey();
+});
+
+describe("decryptDeviceInfo", () => {
+  it("decrypts a valid DeviceInfo plaintext", () => {
+    const info: DeviceInfo = {
+      platform: "ios",
+      appVersion: "1.0.0",
+      deviceName: "iPhone 15 Pro",
+    };
+    const encryptedData = encryptAndEncodeT1(info, masterKey);
+    const result = decryptDeviceInfo(encryptedData, masterKey);
+    expect(result).toEqual(info);
+  });
+
+  it("throws when plaintext is missing required fields", () => {
+    const encryptedData = makeBase64Blob({ platform: "ios" }, masterKey);
+    expect(() => decryptDeviceInfo(encryptedData, masterKey)).toThrow();
+  });
+
+  it("throws when plaintext is not an object", () => {
+    const encryptedData = makeBase64Blob("just-a-string", masterKey);
+    expect(() => decryptDeviceInfo(encryptedData, masterKey)).toThrow();
+  });
+
+  it("throws on invalid base64", () => {
+    expect(() => decryptDeviceInfo("!!!", masterKey)).toThrow();
+  });
+});

--- a/packages/data/src/transforms/__tests__/snapshot.test.ts
+++ b/packages/data/src/transforms/__tests__/snapshot.test.ts
@@ -93,23 +93,23 @@ describe("encryptSnapshotInput", () => {
   });
 });
 
-describe("assertSnapshotContent", () => {
+describe("decryptSnapshot validation (Zod)", () => {
   it("throws when blob is not an object", () => {
     const raw = makeRawSnapshot({ encryptedData: makeBase64Blob("string", masterKey) });
-    expect(() => decryptSnapshot(raw, masterKey)).toThrow("not an object");
+    expect(() => decryptSnapshot(raw, masterKey)).toThrow();
   });
 
   it("throws when members array is missing", () => {
     const raw = makeRawSnapshot({
       encryptedData: makeBase64Blob({ groups: [] }, masterKey),
     });
-    expect(() => decryptSnapshot(raw, masterKey)).toThrow("members");
+    expect(() => decryptSnapshot(raw, masterKey)).toThrow();
   });
 
   it("throws when groups array is missing", () => {
     const raw = makeRawSnapshot({
       encryptedData: makeBase64Blob({ members: [] }, masterKey),
     });
-    expect(() => decryptSnapshot(raw, masterKey)).toThrow("groups");
+    expect(() => decryptSnapshot(raw, masterKey)).toThrow();
   });
 });

--- a/packages/data/src/transforms/api-key.ts
+++ b/packages/data/src/transforms/api-key.ts
@@ -1,0 +1,33 @@
+import { ApiKeyEncryptedPayloadSchema } from "@pluralscape/validation";
+import { z } from "zod/v4";
+
+import { decodeAndDecryptT1, encryptInput } from "./decode-blob.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { ApiKeyEncryptedPayload } from "@pluralscape/types";
+
+/**
+ * Decrypt a base64-encoded T1 blob carrying an `ApiKeyEncryptedPayload`.
+ * Validates the wire shape and converts `publicKey` (crypto variant) from
+ * base64 string back to `Uint8Array` via the codec.
+ */
+export function decryptApiKeyPayload(
+  encryptedData: string,
+  masterKey: KdfMasterKey,
+): ApiKeyEncryptedPayload {
+  const wire = decodeAndDecryptT1(encryptedData, masterKey);
+  return ApiKeyEncryptedPayloadSchema.parse(wire);
+}
+
+/**
+ * Encrypt an `ApiKeyEncryptedPayload` to a base64-encoded T1 blob. Converts
+ * `publicKey` (crypto variant) from `Uint8Array` to base64 string before
+ * JSON-stringifying inside the AEAD plaintext.
+ */
+export function encryptApiKeyPayload(
+  payload: ApiKeyEncryptedPayload,
+  masterKey: KdfMasterKey,
+): { encryptedData: string } {
+  const wire = z.encode(ApiKeyEncryptedPayloadSchema, payload);
+  return encryptInput(wire, masterKey);
+}

--- a/packages/data/src/transforms/decode-blob.ts
+++ b/packages/data/src/transforms/decode-blob.ts
@@ -97,17 +97,6 @@ export function assertStringField(
   }
 }
 
-/** Validate that a field exists and is an array. */
-export function assertArrayField(
-  obj: Record<string, unknown>,
-  entity: string,
-  field: string,
-): void {
-  if (!Array.isArray(obj[field])) {
-    throw new Error(`Decrypted ${entity} blob missing required array field: ${field}`);
-  }
-}
-
 export function base64ToUint8Array(base64: string): Uint8Array {
   return new Uint8Array(Buffer.from(base64, "base64"));
 }

--- a/packages/data/src/transforms/fronting-report.ts
+++ b/packages/data/src/transforms/fronting-report.ts
@@ -1,30 +1,14 @@
+import { FrontingReportEncryptedInputSchema } from "@pluralscape/validation";
+
 import { decodeAndDecryptT1, encryptInput } from "./decode-blob.js";
 
 import type { KdfMasterKey } from "@pluralscape/crypto";
-import type {
-  ChartData,
-  DateRange,
-  FrontingReport,
-  MemberFrontingBreakdown,
-  UnixMillis,
-} from "@pluralscape/types";
-
-export interface FrontingReportEncryptedFields {
-  readonly dateRange: DateRange;
-  readonly memberBreakdowns: readonly MemberFrontingBreakdown[];
-  readonly chartData: readonly ChartData[];
-}
-
-/** Compile-time check: encrypted fields must be a subset of the domain type. */
-export type AssertFrontingReportFieldsSubset =
-  FrontingReportEncryptedFields extends Pick<FrontingReport, keyof FrontingReportEncryptedFields>
-    ? true
-    : never;
+import type { FrontingReport, FrontingReportEncryptedInput, UnixMillis } from "@pluralscape/types";
 
 // ── Wire types (derived from domain types) ──────────────────────────
 
 /** Wire shape for a fronting report — adds wire-only fields absent from the domain type. */
-export type FrontingReportRaw = Omit<FrontingReport, keyof FrontingReportEncryptedFields> & {
+export type FrontingReportRaw = Omit<FrontingReport, keyof FrontingReportEncryptedInput> & {
   readonly encryptedData: string;
   readonly version: number;
   readonly archived: boolean;
@@ -39,20 +23,6 @@ export interface FrontingReportPage {
   readonly nextCursor: string | null;
 }
 
-// ── Validator ─────────────────────────────────────────────────────────
-
-function assertFrontingReportEncryptedFields(
-  raw: unknown,
-): asserts raw is FrontingReportEncryptedFields {
-  if (raw === null || typeof raw !== "object") {
-    throw new Error("Decrypted fronting report blob is not an object");
-  }
-  const obj = raw as Record<string, unknown>;
-  if (typeof obj["dateRange"] !== "object" || obj["dateRange"] === null) {
-    throw new Error("Decrypted fronting report blob missing required object field: dateRange");
-  }
-}
-
 // ── Transforms ───────────────────────────────────────────────────────
 
 export function decryptFrontingReport(
@@ -60,13 +30,13 @@ export function decryptFrontingReport(
   masterKey: KdfMasterKey,
 ): FrontingReport {
   const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey);
-  assertFrontingReportEncryptedFields(decrypted);
+  const validated = FrontingReportEncryptedInputSchema.parse(decrypted);
   return {
     id: raw.id,
     systemId: raw.systemId,
-    dateRange: decrypted.dateRange,
-    memberBreakdowns: decrypted.memberBreakdowns,
-    chartData: decrypted.chartData,
+    dateRange: validated.dateRange,
+    memberBreakdowns: validated.memberBreakdowns,
+    chartData: validated.chartData,
     format: raw.format,
     generatedAt: raw.generatedAt,
   };
@@ -83,7 +53,7 @@ export function decryptFrontingReportPage(
 }
 
 export function encryptFrontingReportInput(
-  data: FrontingReportEncryptedFields,
+  data: FrontingReportEncryptedInput,
   masterKey: KdfMasterKey,
 ): { encryptedData: string } {
   return encryptInput(data, masterKey);

--- a/packages/data/src/transforms/session.ts
+++ b/packages/data/src/transforms/session.ts
@@ -1,0 +1,18 @@
+import { DeviceInfoSchema } from "@pluralscape/validation";
+
+import { decodeAndDecryptT1 } from "./decode-blob.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { DeviceInfo } from "@pluralscape/types";
+
+/**
+ * Decrypt a base64-encoded T1 blob carrying a `DeviceInfo` plaintext.
+ *
+ * `Session` is a Class C entity whose domain shape carries no encrypted
+ * fields; the auxiliary `DeviceInfo` type is what travels inside the T1
+ * blob. Clients call this when displaying their own session list.
+ */
+export function decryptDeviceInfo(encryptedData: string, masterKey: KdfMasterKey): DeviceInfo {
+  const decrypted = decodeAndDecryptT1(encryptedData, masterKey);
+  return DeviceInfoSchema.parse(decrypted);
+}

--- a/packages/data/src/transforms/snapshot.ts
+++ b/packages/data/src/transforms/snapshot.ts
@@ -1,13 +1,15 @@
-import {
-  assertObjectBlob,
-  assertArrayField,
-  decodeAndDecryptT1,
-  encryptInput,
-} from "./decode-blob.js";
+import { SnapshotContentSchema } from "@pluralscape/validation";
+
+import { decodeAndDecryptT1, encryptInput } from "./decode-blob.js";
 
 import type { KdfMasterKey } from "@pluralscape/crypto";
-import type { SystemSnapshotId, SystemId, UnixMillis } from "@pluralscape/types";
-import type { SnapshotContent, SnapshotTrigger } from "@pluralscape/types";
+import type {
+  SnapshotContent,
+  SnapshotTrigger,
+  SystemId,
+  SystemSnapshotId,
+  UnixMillis,
+} from "@pluralscape/types";
 
 // ── Decrypted output type ─────────────────────────────────────────────
 
@@ -34,26 +36,18 @@ export interface SnapshotPage {
   readonly nextCursor: string | null;
 }
 
-// ── Validators ────────────────────────────────────────────────────────
-
-function assertSnapshotContent(raw: unknown): asserts raw is SnapshotContent {
-  const obj = assertObjectBlob(raw, "snapshot");
-  assertArrayField(obj, "snapshot", "members");
-  assertArrayField(obj, "snapshot", "groups");
-}
-
 // ── Transforms ────────────────────────────────────────────────────────
 
 export function decryptSnapshot(raw: SnapshotRaw, masterKey: KdfMasterKey): SnapshotDecrypted {
-  const plaintext = decodeAndDecryptT1(raw.encryptedData, masterKey);
-  assertSnapshotContent(plaintext);
+  const decrypted = decodeAndDecryptT1(raw.encryptedData, masterKey);
+  const content = SnapshotContentSchema.parse(decrypted);
 
   return {
     id: raw.id,
     systemId: raw.systemId,
     snapshotTrigger: raw.snapshotTrigger,
     createdAt: raw.createdAt,
-    content: plaintext,
+    content,
   };
 }
 

--- a/packages/types/src/__sot-manifest__.ts
+++ b/packages/types/src/__sot-manifest__.ts
@@ -1,3 +1,4 @@
+import type { FrontingReport, FrontingReportEncryptedInput } from "./analytics.js";
 import type {
   AccountPurgeRequest,
   AccountPurgeRequestServerMetadata,
@@ -819,5 +820,17 @@ export type SotEntityManifest = {
     wire: FriendNotificationPreferenceWire;
     // Plaintext entity — no encrypted fields.
     encryptedFields: never;
+  };
+  FrontingReport: {
+    domain: FrontingReport;
+    encryptedFields: never;
+    encryptedInput: FrontingReportEncryptedInput;
+    server: never;
+    wire: never;
+    // Class A entity per ADR-023: encryptedInput is a subset of FrontingReport
+    // keys (dateRange / memberBreakdowns / chartData). Server-shaped server /
+    // wire types are not yet defined; this entry exists for parity-gate and
+    // canonical-chain consistency. Add server and wire types when the
+    // FrontingReport API endpoints are formalised.
   };
 };

--- a/packages/types/src/analytics.ts
+++ b/packages/types/src/analytics.ts
@@ -80,6 +80,20 @@ export interface FrontingReport {
   readonly generatedAt: UnixMillis;
 }
 
+/**
+ * Encrypted-input projection for `FrontingReport`. Class A (subset of
+ * `FrontingReport` keys). Travels inside the T1-encrypted `encryptedData`
+ * blob; server cannot read these fields.
+ *
+ * Parity gate: `FrontingReportEncryptedInputSchema` in
+ * `packages/validation/src/fronting-report.ts`.
+ */
+export interface FrontingReportEncryptedInput {
+  readonly dateRange: DateRange;
+  readonly memberBreakdowns: readonly MemberFrontingBreakdown[];
+  readonly chartData: readonly ChartData[];
+}
+
 /** A single data point in a chart dataset. */
 export interface ChartDataset {
   readonly label: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -266,6 +266,7 @@ export type {
   SubjectFrontingBreakdown,
   FrontingAnalytics,
   FrontingReport,
+  FrontingReportEncryptedInput,
   ChartDataset,
   ChartData,
   CoFrontingPair,

--- a/packages/validation/src/__tests__/api-key.test.ts
+++ b/packages/validation/src/__tests__/api-key.test.ts
@@ -1,83 +1,112 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
 
 import { ApiKeyEncryptedPayloadSchema } from "../api-key.js";
 import { PUBLIC_KEY_BYTE_LENGTH } from "../validation.constants.js";
 
-describe("ApiKeyEncryptedPayloadSchema", () => {
-  it("accepts a valid metadata-key payload", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "metadata",
-      name: "ci-bot",
+const VALID_PUBLIC_KEY_B64 = z.util.uint8ArrayToBase64(new Uint8Array(PUBLIC_KEY_BYTE_LENGTH));
+
+describe("ApiKeyEncryptedPayloadSchema (codec)", () => {
+  describe("z.decode (wire → memory)", () => {
+    it("decodes a metadata variant unchanged", () => {
+      const result = z.decode(ApiKeyEncryptedPayloadSchema, {
+        keyType: "metadata",
+        name: "ci-bot",
+      });
+      expect(result).toEqual({ keyType: "metadata", name: "ci-bot" });
     });
-    expect(result.success).toBe(true);
+
+    it("decodes a crypto variant with publicKey base64 → Uint8Array", () => {
+      const result = z.decode(ApiKeyEncryptedPayloadSchema, {
+        keyType: "crypto",
+        name: "session-key",
+        publicKey: VALID_PUBLIC_KEY_B64,
+      });
+      expect(result.keyType).toBe("crypto");
+      if (result.keyType === "crypto") {
+        expect(result.publicKey).toBeInstanceOf(Uint8Array);
+        expect(result.publicKey.length).toBe(PUBLIC_KEY_BYTE_LENGTH);
+      }
+    });
+
+    it("rejects a publicKey that decodes to wrong byte length", () => {
+      const wrongLengthB64 = z.util.uint8ArrayToBase64(new Uint8Array(PUBLIC_KEY_BYTE_LENGTH - 1));
+      const result = z.safeParse(ApiKeyEncryptedPayloadSchema, {
+        keyType: "crypto",
+        name: "short-key",
+        publicKey: wrongLengthB64,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an unknown keyType discriminator", () => {
+      const result = z.safeParse(ApiKeyEncryptedPayloadSchema, {
+        keyType: "signing",
+        name: "rogue",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an empty name on metadata variant", () => {
+      const result = z.safeParse(ApiKeyEncryptedPayloadSchema, {
+        keyType: "metadata",
+        name: "",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an empty name on crypto variant", () => {
+      const result = z.safeParse(ApiKeyEncryptedPayloadSchema, {
+        keyType: "crypto",
+        name: "",
+        publicKey: VALID_PUBLIC_KEY_B64,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a non-base64 publicKey", () => {
+      const result = z.safeParse(ApiKeyEncryptedPayloadSchema, {
+        keyType: "crypto",
+        name: "bad-b64",
+        publicKey: "not-base64!!!",
+      });
+      expect(result.success).toBe(false);
+    });
   });
 
-  it("accepts a valid crypto-key payload (32-byte publicKey)", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "crypto",
-      name: "session-key",
-      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH),
+  describe("z.encode (memory → wire)", () => {
+    it("encodes a metadata variant unchanged", () => {
+      const result = z.encode(ApiKeyEncryptedPayloadSchema, {
+        keyType: "metadata",
+        name: "ci-bot",
+      });
+      expect(result).toEqual({ keyType: "metadata", name: "ci-bot" });
     });
-    expect(result.success).toBe(true);
+
+    it("encodes a crypto variant with publicKey Uint8Array → base64", () => {
+      const result = z.encode(ApiKeyEncryptedPayloadSchema, {
+        keyType: "crypto",
+        name: "session-key",
+        publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH),
+      });
+      expect(result.keyType).toBe("crypto");
+      if (result.keyType === "crypto") {
+        expect(typeof result.publicKey).toBe("string");
+        expect(z.util.base64ToUint8Array(result.publicKey).length).toBe(PUBLIC_KEY_BYTE_LENGTH);
+      }
+    });
   });
 
-  it("rejects an unknown keyType discriminator", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "signing",
-      name: "rogue",
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects a crypto payload missing publicKey", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "crypto",
-      name: "missing-key",
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects an empty name on metadata variant", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "metadata",
-      name: "",
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects an empty name on crypto variant", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "crypto",
-      name: "",
-      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH),
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects a publicKey shorter than 32 bytes", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "crypto",
-      name: "short-key",
-      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH - 1),
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects a publicKey longer than 32 bytes", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "crypto",
-      name: "long-key",
-      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH + 1),
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects a base64 string for publicKey (in-memory contract)", () => {
-    const result = ApiKeyEncryptedPayloadSchema.safeParse({
-      keyType: "crypto",
-      name: "string-key",
-      publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-    });
-    expect(result.success).toBe(false);
+  it("round-trips a crypto payload through encode → decode", () => {
+    const original = {
+      keyType: "crypto" as const,
+      name: "round-trip",
+      publicKey: new Uint8Array(PUBLIC_KEY_BYTE_LENGTH).fill(0x42),
+    };
+    const wire = z.encode(ApiKeyEncryptedPayloadSchema, original);
+    const decoded = z.decode(ApiKeyEncryptedPayloadSchema, wire);
+    if (decoded.keyType !== "crypto") throw new Error("expected crypto variant");
+    expect(Array.from(decoded.publicKey)).toEqual(Array.from(original.publicKey));
+    expect(decoded.name).toBe(original.name);
   });
 });

--- a/packages/validation/src/__tests__/encryption-primitives.test.ts
+++ b/packages/validation/src/__tests__/encryption-primitives.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+
+import { Base64ToUint8ArrayCodec } from "../encryption-primitives.js";
+
+describe("Base64ToUint8ArrayCodec", () => {
+  it("decodes a base64 string to a Uint8Array", () => {
+    const result = z.decode(Base64ToUint8ArrayCodec, "AAECAw==");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("encodes a Uint8Array to a base64 string", () => {
+    const result = z.encode(Base64ToUint8ArrayCodec, new Uint8Array([0, 1, 2, 3]));
+    expect(result).toBe("AAECAw==");
+  });
+
+  it("round-trips arbitrary bytes losslessly", () => {
+    const original = new Uint8Array(32);
+    for (let i = 0; i < original.length; i++) original[i] = (i * 7 + 13) & 0xff;
+    const wire = z.encode(Base64ToUint8ArrayCodec, original);
+    const back = z.decode(Base64ToUint8ArrayCodec, wire);
+    expect(Array.from(back)).toEqual(Array.from(original));
+  });
+
+  it("rejects an invalid base64 string", () => {
+    const result = z.safeDecode(Base64ToUint8ArrayCodec, "not-base64!!!");
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validation/src/__tests__/fronting-report.test.ts
+++ b/packages/validation/src/__tests__/fronting-report.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { FrontingReportEncryptedInputSchema } from "../fronting-report.js";
+
+const VALID = {
+  dateRange: { start: 1_700_000_000_000, end: 1_700_086_400_000 },
+  memberBreakdowns: [],
+  chartData: [],
+};
+
+describe("FrontingReportEncryptedInputSchema", () => {
+  it("accepts an empty valid payload", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse(VALID);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a populated memberBreakdown", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse({
+      ...VALID,
+      memberBreakdowns: [
+        {
+          memberId: "mem_1",
+          totalDuration: 3_600_000,
+          sessionCount: 4,
+          averageSessionLength: 900_000,
+          percentageOfTotal: 25.5,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a populated chartData entry", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse({
+      ...VALID,
+      chartData: [
+        {
+          chartType: "pie",
+          labels: ["A", "B"],
+          datasets: [{ label: "All", data: [1, 2], color: "#ff0000" }],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a dateRange where start > end", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse({
+      ...VALID,
+      dateRange: { start: 100, end: 50 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a dateRange where start === end (boundary)", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse({
+      ...VALID,
+      dateRange: { start: 1_700_000_000_000, end: 1_700_000_000_000 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid chartType", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse({
+      ...VALID,
+      chartData: [{ chartType: "scatter", labels: [], datasets: [] }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a percentageOfTotal outside [0, 100]", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse({
+      ...VALID,
+      memberBreakdowns: [
+        {
+          memberId: "mem_1",
+          totalDuration: 1,
+          sessionCount: 1,
+          averageSessionLength: 1,
+          percentageOfTotal: 150,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing top-level field", () => {
+    const result = FrontingReportEncryptedInputSchema.safeParse({
+      dateRange: VALID.dateRange,
+      memberBreakdowns: [],
+      // chartData omitted
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validation/src/__tests__/type-parity/api-key.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/api-key.type.test.ts
@@ -6,9 +6,9 @@ import type { ApiKeyEncryptedPayload, Equal } from "@pluralscape/types";
 import type { z } from "zod/v4";
 
 describe("ApiKey Zod parity (Class C — ApiKeyEncryptedPayload)", () => {
-  it("z.infer<typeof ApiKeyEncryptedPayloadSchema> equals ApiKeyEncryptedPayload", () => {
+  it("z.output<typeof ApiKeyEncryptedPayloadSchema> equals ApiKeyEncryptedPayload (memory side)", () => {
     expectTypeOf<
-      Equal<z.infer<typeof ApiKeyEncryptedPayloadSchema>, ApiKeyEncryptedPayload>
+      Equal<z.output<typeof ApiKeyEncryptedPayloadSchema>, ApiKeyEncryptedPayload>
     >().toEqualTypeOf<true>();
   });
 });

--- a/packages/validation/src/__tests__/type-parity/fronting-report.type.test.ts
+++ b/packages/validation/src/__tests__/type-parity/fronting-report.type.test.ts
@@ -1,0 +1,24 @@
+/**
+ * G3 parity for FrontingReport (Domain ↔ Zod encrypted input).
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import { FrontingReportEncryptedInputSchema } from "../../fronting-report.js";
+
+import type { Equal, FrontingReport, FrontingReportEncryptedInput } from "@pluralscape/types";
+import type { z } from "zod/v4";
+
+describe("FrontingReport parity (G3: Domain ↔ Zod encrypted input)", () => {
+  it("FrontingReportEncryptedInputSchema matches FrontingReportEncryptedInput", () => {
+    expectTypeOf<
+      Equal<z.infer<typeof FrontingReportEncryptedInputSchema>, FrontingReportEncryptedInput>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("FrontingReportEncryptedInput is a Pick<FrontingReport, K>", () => {
+    expectTypeOf<
+      Equal<FrontingReportEncryptedInput, Pick<FrontingReport, keyof FrontingReportEncryptedInput>>
+    >().toEqualTypeOf<true>();
+  });
+});

--- a/packages/validation/src/api-key.ts
+++ b/packages/validation/src/api-key.ts
@@ -28,35 +28,68 @@ export const CreateApiKeyBodySchema = z
   )
   .readonly();
 
-/**
- * Zod parity for `ApiKeyEncryptedPayload` — the Class C auxiliary type
- * encrypted inside an ApiKey row's `encryptedData` blob.
- *
- * Validates the in-memory shape after decode. The schema rejects
- * base64 strings for `publicKey` — any JSON-string boundary requires a
- * base64-string adapter before parsing.
- */
-export const ApiKeyEncryptedPayloadSchema: z.ZodType<ApiKeyEncryptedPayload> = z.discriminatedUnion(
-  "keyType",
-  [
-    z
-      .object({
-        keyType: z.literal("metadata"),
-        name: z.string().min(1),
-      })
-      .readonly(),
-    z
-      .object({
-        keyType: z.literal("crypto"),
-        name: z.string().min(1),
-        // In-memory contract — replace with EncryptedBase64Schema if wired to a JSON parse boundary.
-        publicKey: z
-          .instanceof(Uint8Array)
-          .refine(
-            (buf) => buf.length === PUBLIC_KEY_BYTE_LENGTH,
-            "publicKey must be 32 bytes (X25519)",
-          ),
-      })
-      .readonly(),
-  ],
+// ── ApiKeyEncryptedPayload codec ──────────────────────────────────────
+//
+// Class C auxiliary type encrypted inside an ApiKey row's `encryptedData`
+// blob. Wire side: publicKey is a base64 string (what JSON.parse produces).
+// Memory side: publicKey is a 32-byte Uint8Array (what crypto operations
+// consume). `z.encode(...)` runs memory → wire (used at the encrypt
+// boundary, before JSON.stringify); `z.decode(...)` runs wire → memory
+// (used at the decrypt boundary, after JSON.parse).
+// Parity test: `__tests__/type-parity/api-key.type.test.ts` asserts
+// `z.output<typeof ApiKeyEncryptedPayloadSchema>` ≡ `ApiKeyEncryptedPayload`.
+
+const ApiKeyEncryptedPayloadWireSchema = z.discriminatedUnion("keyType", [
+  z
+    .object({
+      keyType: z.literal("metadata"),
+      name: z.string().min(1),
+    })
+    .readonly(),
+  z
+    .object({
+      keyType: z.literal("crypto"),
+      name: z.string().min(1),
+      publicKey: z.base64(),
+    })
+    .readonly(),
+]);
+
+const ApiKeyEncryptedPayloadMemorySchema = z.discriminatedUnion("keyType", [
+  z
+    .object({
+      keyType: z.literal("metadata"),
+      name: z.string().min(1),
+    })
+    .readonly(),
+  z
+    .object({
+      keyType: z.literal("crypto"),
+      name: z.string().min(1),
+      // z.custom<Uint8Array> (not z.instanceof) — z.instanceof yields
+      // InstanceType<typeof Uint8Array> which breaks Equal<> parity in the
+      // type-parity test. Runtime check is identical (instanceof Uint8Array).
+      publicKey: z
+        .custom<Uint8Array>((v) => v instanceof Uint8Array)
+        .refine(
+          (buf) => buf.length === PUBLIC_KEY_BYTE_LENGTH,
+          "publicKey must be 32 bytes (X25519)",
+        ),
+    })
+    .readonly(),
+]) satisfies z.ZodType<ApiKeyEncryptedPayload>;
+
+export const ApiKeyEncryptedPayloadSchema = z.codec(
+  ApiKeyEncryptedPayloadWireSchema,
+  ApiKeyEncryptedPayloadMemorySchema,
+  {
+    decode: (wire) =>
+      wire.keyType === "crypto"
+        ? { ...wire, publicKey: z.util.base64ToUint8Array(wire.publicKey) }
+        : wire,
+    encode: (memory) =>
+      memory.keyType === "crypto"
+        ? { ...memory, publicKey: z.util.uint8ArrayToBase64(memory.publicKey) }
+        : memory,
+  },
 );

--- a/packages/validation/src/encryption-primitives.ts
+++ b/packages/validation/src/encryption-primitives.ts
@@ -1,0 +1,17 @@
+import { z } from "zod/v4";
+
+/**
+ * Bidirectional codec for the binary↔base64 boundary used inside JSON-encoded
+ * AEAD plaintexts. Wire side is a base64 string (what `JSON.parse` produces);
+ * memory side is a `Uint8Array` (what crypto operations consume).
+ *
+ * Usage:
+ * ```
+ *   z.decode(Base64ToUint8ArrayCodec, "<base64>")  // → Uint8Array
+ *   z.encode(Base64ToUint8ArrayCodec, bytes)       // → base64 string
+ * ```
+ */
+export const Base64ToUint8ArrayCodec = z.codec(z.base64(), z.instanceof(Uint8Array), {
+  decode: (b64) => z.util.base64ToUint8Array(b64),
+  encode: (bytes) => z.util.uint8ArrayToBase64(bytes),
+});

--- a/packages/validation/src/fronting-report.ts
+++ b/packages/validation/src/fronting-report.ts
@@ -1,0 +1,61 @@
+import { z } from "zod/v4";
+
+import { brandedNumber, brandedString } from "./branded.js";
+
+import type { FrontingReportEncryptedInput } from "@pluralscape/types";
+
+/** Minimum value for a percentage field (inclusive). */
+const PERCENTAGE_MIN = 0;
+/** Maximum value for a percentage field (inclusive). */
+const PERCENTAGE_MAX = 100;
+
+const DateRangeSchema = z
+  .object({
+    start: brandedNumber<"UnixMillis">(),
+    end: brandedNumber<"UnixMillis">(),
+  })
+  .refine((d) => d.start <= d.end, {
+    message: "DateRange.start must be <= DateRange.end",
+    path: ["start"],
+  })
+  .readonly();
+
+const MemberFrontingBreakdownSchema = z
+  .object({
+    memberId: brandedString<"MemberId">(),
+    totalDuration: brandedNumber<"Duration">(),
+    sessionCount: z.number().int().nonnegative(),
+    averageSessionLength: brandedNumber<"Duration">(),
+    percentageOfTotal: z.number().min(PERCENTAGE_MIN).max(PERCENTAGE_MAX),
+  })
+  .readonly();
+
+const ChartDatasetSchema = z
+  .object({
+    label: z.string(),
+    data: z.array(z.number()).readonly(),
+    color: z.string(),
+  })
+  .readonly();
+
+const ChartDataSchema = z
+  .object({
+    chartType: z.enum(["pie", "bar", "timeline"]),
+    labels: z.array(z.string()).readonly(),
+    datasets: z.array(ChartDatasetSchema).readonly(),
+  })
+  .readonly();
+
+/**
+ * Zod schema for `FrontingReportEncryptedInput` — the encrypted-input
+ * projection of `FrontingReport` (Class A, subset of domain keys). Validates
+ * the in-memory shape after decrypt; wired at the decrypt boundary in
+ * `packages/data/src/transforms/fronting-report.ts:decryptFrontingReport`.
+ */
+export const FrontingReportEncryptedInputSchema: z.ZodType<FrontingReportEncryptedInput> = z
+  .object({
+    dateRange: DateRangeSchema,
+    memberBreakdowns: z.array(MemberFrontingBreakdownSchema).readonly(),
+    chartData: z.array(ChartDataSchema).readonly(),
+  })
+  .readonly();

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -130,6 +130,7 @@ export {
   UpdateFrontingCommentBodySchema,
   FrontingCommentQuerySchema,
 } from "./fronting-comment.js";
+export { FrontingReportEncryptedInputSchema } from "./fronting-report.js";
 export {
   booleanQueryParam,
   optionalBooleanQueryParam,

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -250,7 +250,11 @@ export {
 } from "./validation.constants.js";
 export { ApiKeyEncryptedPayloadSchema, CreateApiKeyBodySchema } from "./api-key.js";
 export { PurgeSystemBodySchema } from "./system-purge.js";
-export { CreateSnapshotBodySchema, DuplicateSystemBodySchema } from "./snapshot.js";
+export {
+  CreateSnapshotBodySchema,
+  DuplicateSystemBodySchema,
+  SnapshotContentSchema,
+} from "./snapshot.js";
 export {
   CreateImportJobBodySchema,
   UpdateImportJobBodySchema,

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -249,6 +249,7 @@ export {
   PUBLIC_KEY_BYTE_LENGTH,
 } from "./validation.constants.js";
 export { ApiKeyEncryptedPayloadSchema, CreateApiKeyBodySchema } from "./api-key.js";
+export { DeviceInfoSchema } from "./session.js";
 export { PurgeSystemBodySchema } from "./system-purge.js";
 export {
   CreateSnapshotBodySchema,

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -246,8 +246,9 @@ export {
   DEVICE_TOKEN_PLATFORM_VALUES,
   FRIEND_NOTIFICATION_EVENT_TYPE_VALUES,
   IMPORT_ENTITY_REF_BATCH_MAX,
+  PUBLIC_KEY_BYTE_LENGTH,
 } from "./validation.constants.js";
-export { CreateApiKeyBodySchema } from "./api-key.js";
+export { ApiKeyEncryptedPayloadSchema, CreateApiKeyBodySchema } from "./api-key.js";
 export { PurgeSystemBodySchema } from "./system-purge.js";
 export { CreateSnapshotBodySchema, DuplicateSystemBodySchema } from "./snapshot.js";
 export {

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -266,3 +266,4 @@ export type {
   ImportEntityRefLookupBatchBody,
   ImportEntityRefUpsertBatchBody,
 } from "./import-entity-ref.js";
+export { Base64ToUint8ArrayCodec } from "./encryption-primitives.js";

--- a/packages/validation/src/session.ts
+++ b/packages/validation/src/session.ts
@@ -10,7 +10,8 @@ import type { DeviceInfo } from "@pluralscape/types";
  * `__tests__/type-parity/session.type.test.ts` asserts
  * `z.infer<typeof DeviceInfoSchema>` ≡ `DeviceInfo`.
  *
- * Currently a parity gate only — not yet wired to a runtime parse boundary.
+ * Wired at the decrypt boundary in
+ * `packages/data/src/transforms/session.ts:decryptDeviceInfo`.
  */
 export const DeviceInfoSchema: z.ZodType<DeviceInfo> = z
   .object({

--- a/packages/validation/src/snapshot.ts
+++ b/packages/validation/src/snapshot.ts
@@ -143,7 +143,8 @@ const SystemStructureEntityAssociationSchema: z.ZodType<SystemStructureEntityAss
  * `SystemSnapshotEncryptedInputSchema` alias). Parity test:
  * `__tests__/type-parity/system-snapshot.type.test.ts`.
  *
- * Currently a parity gate only — not yet wired to a runtime parse boundary.
+ * Wired at the decrypt boundary in
+ * `packages/data/src/transforms/snapshot.ts:decryptSnapshot`.
  */
 export const SnapshotContentSchema: z.ZodType<SnapshotContent> = z
   .object({


### PR DESCRIPTION
## Summary

Wires five encrypted-payload Zod schemas at their runtime decrypt boundaries — three Class C parity gates (ApiKey / DeviceInfo / SnapshotContent) plus two T1 outliers (Snapshot / FrontingReport). Introduces a reusable `z.codec()`-based base64↔`Uint8Array` primitive for ApiKey's binary `publicKey` field. Full canonical-chain extension for FrontingReport (canonical type, Zod schema with sub-schemas, parity test, SoT manifest entry).

After this PR, all 23 T1 transforms in `packages/data/src/transforms/` validate plaintext via Zod schemas at decrypt boundaries — no hand-rolled `assertX` patterns remain on the T1 path.

## Changes

- **`Base64ToUint8ArrayCodec`** — new Zod 4.1+ codec primitive in `packages/validation/src/encryption-primitives.ts`. Uses `z.util.base64ToUint8Array` / `uint8ArrayToBase64` (no `Buffer`).
- **ApiKey** — `ApiKeyEncryptedPayloadSchema` rewritten as `z.codec()` (wire `publicKey: z.base64()` ↔ memory `publicKey: Uint8Array` with 32-byte refine). New `decryptApiKeyPayload` / `encryptApiKeyPayload` transforms with both-direction round-trip tests.
- **Snapshot** — `decryptSnapshot` swapped from hand-rolled `assertSnapshotContent` to `SnapshotContentSchema.parse()`.
- **DeviceInfo** — new `decryptDeviceInfo` transform in `packages/data/src/transforms/session.ts` using `DeviceInfoSchema.parse()`.
- **FrontingReport** — full canonical-chain extension: new `FrontingReportEncryptedInput` type, new `FrontingReportEncryptedInputSchema` (with sub-schemas for `DateRange`, `MemberFrontingBreakdown`, `ChartDataset`, `ChartData`), new SoT manifest entry, new G3 parity test, swapped `decryptFrontingReport` from hand-rolled assert to `Schema.parse()`. Inline `FrontingReportEncryptedFields` interface removed.
- **Cleanup** — "parity gate only" / "in-memory contract" comments removed from wired validation modules; unused `assertArrayField` helper removed from `packages/data/src/transforms/decode-blob.ts`.

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm types:check-sot` — all 4 parity gates green (types, Drizzle, Zod, OpenAPI-Wire)
- [x] `pnpm test:unit` — 13024 passed (1 skipped, 1 todo across 1015 files)
- [x] `pnpm test:integration` — 3055 passed (11 skipped across 152 files)
- [x] `pnpm test:e2e` — 507 passed (2 skipped)
- [x] New `Base64ToUint8ArrayCodec` round-trip tests
- [x] New ApiKey codec round-trip tests (metadata + crypto variants, encode → decrypt cycle preserves `Uint8Array` publicKey bit-for-bit)
- [x] New `decryptDeviceInfo` runtime tests
- [x] New `FrontingReportEncryptedInputSchema` runtime + G3 parity tests
- [x] Updated snapshot + fronting-report transform tests for Zod-error contract

## Bean

`types-emid` (closed)

## Spec / Plan

Local working docs (gitignored):
- Spec: `docs/superpowers/specs/2026-04-27-types-emid-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-types-emid.md`