### PR TITLE
fix(ci,deps): install node-gyp, bump postcss, reorder null narrowing

### DIFF
--- a/.beans/infra-jqr1--fix-ci-node-gyp-flake-3-securitycodeql-alerts.md
+++ b/.beans/infra-jqr1--fix-ci-node-gyp-flake-3-securitycodeql-alerts.md
@@ -1,0 +1,18 @@
+---
+# infra-jqr1
+title: Fix CI node-gyp flake + 3 security/CodeQL alerts
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-04-28T11:16:53Z
+updated_at: 2026-04-28T11:16:53Z
+---
+
+Branch: fix/ci-node-gyp-and-deps
+
+## Changes
+
+1. setup-pnpm: install `node-gyp` globally so cache-miss postinstall builds (e.g., better-sqlite3-multiple-ciphers when no prebuilt) don't fail with `sh: 1: node-gyp: not found`.
+2. CodeQL #40 (extract-entities.ts:88): reorder narrowing — `raw === null` first, then `typeof !== "object"`, to silence js/comparison-between-incompatible-types. Apply to all 3 occurrences (lines 58/73/88).
+3. Dependabot #42 (postcss < 8.5.10): add `pnpm.overrides.postcss: >=8.5.10`. Transitive via @redocly/cli → styled-components.
+4. Dependabot #41 (fast-xml-parser CVE-2026-41650 / GHSA-gh4j-gqv2-49f6): no code change. Already documented as unreachable in a95c19de — AWS XML-Builder uses XMLParser API only; CVE is in XMLBuilder. CVE listed in pnpm.auditConfig.ignoreCves. Dismiss the GitHub UI alert post-merge with reason "tolerable_risk: documented unreachable, see a95c19de".

--- a/.beans/ps-nbvm--merge-open-renovate-prs-10.md
+++ b/.beans/ps-nbvm--merge-open-renovate-prs-10.md
@@ -1,0 +1,59 @@
+---
+# ps-nbvm
+title: Merge open Renovate PRs (10)
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-28T08:10:48Z
+updated_at: 2026-04-28T10:44:16Z
+---
+
+Process all 10 open Renovate PRs:
+
+- #573 github actions
+- #569 nodemailer 8.0.7
+- #566 hono 4.12.15
+- #567 i18next 26.0.8
+- #570 dev-dependencies (patch/minor)
+- #577 @journeyapps/wa-sqlite 1.7.0
+- #576 @electric-sql/pglite 0.4.5
+- #575 aws-sdk-js-v3 monorepo 3.1038.0
+- #574 tanstack-query monorepo 5.100.5
+- #572 expo monorepo
+
+Workflow per PR:
+
+1. gh pr update-branch (rebase to main)
+2. gh pr review --approve
+3. gh pr merge --auto --squash --delete-branch
+4. wait for merged state
+
+## Merge order
+
+- [x] #573 github actions
+- [x] #569 nodemailer 8.0.7
+- [x] #566 hono 4.12.15
+- [x] #567 i18next 26.0.8
+- [x] #570 dev-dependencies (patch/minor)
+- [x] #577 wa-sqlite 1.7.0
+- [x] #576 pglite 0.4.5
+- [x] #575 aws-sdk-js-v3 3.1038.0
+- [x] #574 tanstack-query 5.100.5
+- [x] #572 expo monorepo
+
+## Summary of Changes
+
+Merged all 10 Renovate dependency PRs:
+
+- #566 hono 4.12.15
+- #576 @electric-sql/pglite 0.4.5
+- #573 github actions
+- #569 nodemailer 8.0.7
+- #567 i18next 26.0.8
+- #570 dev-dependencies (patch/minor)
+- #577 @journeyapps/wa-sqlite 1.7.0
+- #574 tanstack-query 5.100.5
+- #575 aws-sdk-js-v3 3.1038.0
+- #572 expo monorepo
+
+Workflow per PR: rebase via `gh api -X PUT .../update-branch`, re-approve (dismiss_stale_reviews_on_push fires after each push), auto-merge --squash --delete-branch. Repeated until all merged. Encountered intermittent `sh: 1: node-gyp: not found` install flakes on the Scope Coverage Check job (likely cache-miss + missing prebuilt for node 24.15.0); resolved via `gh run rerun <run-id> --failed`.

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -11,5 +11,9 @@ runs:
         node-version: 24
         cache: pnpm
 
+    - name: Ensure node-gyp on PATH
+      shell: bash
+      run: npm install -g node-gyp
+
     - shell: bash
       run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
       "esbuild": ">=0.25.0",
       "fast-xml-parser": ">=5.7.0",
       "@aws-sdk/xml-builder>fast-xml-parser": "5.5.8",
+      "postcss": ">=8.5.10",
       "flatted": ">=3.4.2",
       "brace-expansion": ">=5.0.5",
       "picomatch": ">=4.0.4",

--- a/packages/sync/src/materializer/materializers/extract-entities.ts
+++ b/packages/sync/src/materializer/materializers/extract-entities.ts
@@ -55,7 +55,7 @@ function extractByStorageType(
 
 /** lww-map and append-lww: Record<entityId, entityObject> */
 function extractMapEntities(raw: unknown, columnNames: readonly string[]): EntityRow[] {
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return [];
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return [];
   const rows: EntityRow[] = [];
   for (const [entityId, entity] of Object.entries(raw as Record<string, unknown>)) {
     if (typeof entity !== "object" || entity === null || Array.isArray(entity)) continue;
@@ -70,7 +70,7 @@ function extractSingletonEntity(
   raw: unknown,
   columnNames: readonly string[],
 ): EntityRow[] {
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return [];
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return [];
   const entity = raw as Record<string, unknown>;
   const id = typeof entity["id"] === "string" ? entity["id"] : entityType;
   return [entityToRow(id, entity, columnNames)];
@@ -85,7 +85,7 @@ function extractSingletonEntity(
  * extractor share this convention; both must change together.
  */
 function extractJunctionEntities(raw: unknown, columnNames: readonly string[]): EntityRow[] {
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return [];
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return [];
   const rows: EntityRow[] = [];
   const nonIdColumns = columnNames.filter((c) => c !== "id");
   for (const compoundKey of Object.keys(raw as Record<string, unknown>)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,7 @@ overrides:
   esbuild: '>=0.25.0'
   fast-xml-parser: '>=5.7.0'
   '@aws-sdk/xml-builder>fast-xml-parser': 5.5.8
+  postcss: '>=8.5.10'
   flatted: '>=3.4.2'
   brace-expansion: '>=5.0.5'
   picomatch: '>=4.0.4'
@@ -998,7 +999,7 @@ importers:
         version: 0.45.2(@electric-sql/pglite@0.4.5)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3-multiple-ciphers@12.8.0)(bun-types@1.3.13)(expo-sqlite@55.0.15(expo@55.0.17)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(postgres@3.4.9)
       vitest:
         specifier: '>=4.0.0'
-        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       '@pluralscape/crypto':
         specifier: workspace:*
@@ -6162,10 +6163,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.49:
-    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6870,11 +6867,6 @@ packages:
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
-
-  terser@5.46.1:
-    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   terser@5.46.2:
     resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
@@ -8897,7 +8889,7 @@ snapshots:
       jsc-safe-url: 0.2.4
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.4.49
+      postcss: 8.5.12
       resolve-from: 5.0.0
     optionalDependencies:
       expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
@@ -10668,13 +10660,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -13411,12 +13403,6 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.49:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
@@ -14130,7 +14116,7 @@ snapshots:
       '@types/stylis': 4.2.7
       css-to-react-native: 3.2.0
       csstype: 3.2.3
-      postcss: 8.4.49
+      postcss: 8.5.12
       react: 19.2.5
       shallowequal: 1.1.0
       stylis: 4.3.6
@@ -14203,14 +14189,6 @@ snapshots:
     dependencies:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
-
-  terser@5.46.1:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    optional: true
 
   terser@5.46.2:
     dependencies:
@@ -14430,22 +14408,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.12
-      rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.6.0
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.1
-      tsx: 4.21.0
-      yaml: 2.8.3
-
   vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -14468,10 +14430,10 @@ snapshots:
       typescript: 6.0.3
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
-  vitest@4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -14488,7 +14450,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary

Three independent fixes bundled to clear open security/quality alerts and a recurring CI flake (bean infra-jqr1).

## What changed

| Fix | Detail | Resolves |
|---|---|---|
| `setup-pnpm` action | `npm i -g node-gyp` before `pnpm install` so postinstall scripts that fall back to source-build (e.g., `better-sqlite3-multiple-ciphers` when no prebuilt exists for the runner's node patch) don't fail with `sh: 1: node-gyp: not found` | Recurring CI flake (hit 4 times in last Renovate batch) |
| `pnpm.overrides.postcss: ">=8.5.10"` | Dedupes transitive `postcss@8.4.49` pulled by `@redocly/cli → styled-components` onto the patched line | Dependabot #42 (XSS via unescaped `</style>`) |
| `extract-entities.ts` | Reorder `typeof !== "object" \|\| raw === null` → `raw === null \|\| typeof !== "object"` in 3 junction/keyed-map guards. Behaviour identical (`typeof null === "object"`) | CodeQL #40 (`js/comparison-between-incompatible-types`) |

## Dependabot #41 (fast-xml-parser, GHSA-gh4j-gqv2-49f6)

Not changed — already documented unreachable in commit a95c19de:

> AWS SDK only uses the XMLParser API, so GHSA-gh4j-gqv2-49f6 (a CDATA injection flaw in XMLBuilder) is unreachable through this code path.

The CVE is listed in `pnpm.auditConfig.ignoreCves`. The GitHub UI alert should be dismissed post-merge with reason "tolerable_risk: documented unreachable, see a95c19de" — recommend doing this manually rather than via CI to keep the audit trail visible.

## Test plan

- [x] `pnpm lint` (0 errors)
- [x] `pnpm typecheck` (0 errors)
- [x] `pnpm scope:check`
- [x] `pnpm vitest run --project sync` (951 passed)
- [ ] Full CI on PR