### PR TITLE
feat: deferred wiring trio (api-bqu4, client-a0gf, ps-znp0)

### DIFF
--- a/.beans/api-bqu4--wire-decryptdeviceinfo-at-session-list-endpoint.md
+++ b/.beans/api-bqu4--wire-decryptdeviceinfo-at-session-list-endpoint.md
@@ -1,10 +1,11 @@
 ---
 # api-bqu4
 title: Wire decryptDeviceInfo at session-list endpoint
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-27T18:59:53Z
-updated_at: 2026-04-27T18:59:53Z
+updated_at: 2026-04-28T17:55:43Z
 parent: ps-cd6x
 ---
 
@@ -24,3 +25,15 @@ Landed in `types-emid` (PR #579) as part of pre-release data-layer scaffolding. 
 
 - types-emid (PR #579 — schema and transform landed)
 - ps-cd6x (Milestone 9a)
+
+## Summary of Changes
+
+- Extended SessionInfo with encryptedData field (apps/api/src/services/auth/sessions.ts)
+- Added encryptedData column to listSessions SELECT projection with base64 conversion
+- Updated OpenAPI schema source in docs/openapi/schemas/auth.yaml; rebundled
+- Added withDecryptedDeviceInfo helper + SessionListRow types in @pluralscape/data
+- Exported decryptDeviceInfo from data package index
+- Added integration test verifying encryptedData round-trips on listSessions
+- Added unit test for withDecryptedDeviceInfo (present + null cases)
+- Added E2E contract test asserting encryptedData field is exposed on session list
+- pnpm trpc:parity and pnpm types:check-sot pass

--- a/.beans/client-a0gf--wire-apikey-codec-transforms-when-crypto-variant-l.md
+++ b/.beans/client-a0gf--wire-apikey-codec-transforms-when-crypto-variant-l.md
@@ -1,10 +1,11 @@
 ---
 # client-a0gf
 title: Wire ApiKey codec transforms when crypto-variant lands client-side
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-27T19:00:01Z
-updated_at: 2026-04-27T19:00:01Z
+updated_at: 2026-04-28T18:45:41Z
 parent: ps-cd6x
 ---
 
@@ -30,3 +31,13 @@ When the crypto-variant work picks up:
 - types-emid (PR #579 — schema and transform landed)
 - ps-qmyt (Class C extension — original)
 - ps-cd6x (Milestone 9a)
+
+## Summary of Changes
+
+- Extended ApiKeyResult, API_KEY_SELECT_COLUMNS, toApiKeyResult with encryptedData (apps/api/src/services/api-key/internal.ts)
+- Updated OpenAPI ApiKeyResponse schema to include encryptedData; rebundled
+- Added decryptApiKeyPayload, encryptApiKeyPayload, withDecodedApiKeyPayload exports in @pluralscape/data
+- Added integration test asserting encryptedData round-trips on create/get/list
+- Added unit tests for withDecodedApiKeyPayload (crypto/metadata variants + field preservation)
+- Added E2E test exercising full crypto-variant publicKey encrypt-on-create → decrypt-on-list flow
+- pnpm trpc:parity and pnpm types:check-sot pass

--- a/.beans/ps-znp0--inline-or-relocate-decode-blob-asserts-after-frien.md
+++ b/.beans/ps-znp0--inline-or-relocate-decode-blob-asserts-after-frien.md
@@ -1,10 +1,11 @@
 ---
 # ps-znp0
 title: Inline or relocate decode-blob asserts after friend-dashboard migrates
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-27T19:00:19Z
-updated_at: 2026-04-27T19:00:19Z
+updated_at: 2026-04-28T18:50:56Z
 parent: ps-cd6x
 ---
 
@@ -30,3 +31,11 @@ Single-consumer helpers in `decode-blob.ts` are a code smell; either inline them
 
 - types-emid (PR #579 — established the Zod-at-decrypt pattern)
 - ps-cd6x (Milestone 9a)
+
+## Summary of Changes
+
+- Added 4 Zod schemas in @pluralscape/validation (FriendDashboardMember/FrontingSession/CustomFront/StructureEntity Blob)
+- Refactored decryptDashboard\* functions in @pluralscape/data to use Schema.parse() at the decrypt boundary
+- Deleted assertObjectBlob and assertStringField from packages/data/src/transforms/decode-blob.ts (sole consumers were the dashboard decryption helpers)
+- Added regression test for missing-required-field rejection on custom front
+- Updated existing throw assertions to match new Zod error messages (expected object/string)

--- a/apps/api-e2e/src/tests/api-keys/crud.spec.ts
+++ b/apps/api-e2e/src/tests/api-keys/crud.spec.ts
@@ -39,30 +39,37 @@ test.describe("API keys CRUD", () => {
     await test.step("get API key by ID", async () => {
       const res = await request.get(`${keysUrl}/${keyId}`, { headers: authHeaders });
       expect(res.status()).toBe(HTTP_OK);
-      const body = (await res.json()) as { data: { id: string; keyType: string } };
+      const body = (await res.json()) as {
+        data: { id: string; keyType: string; encryptedData: string };
+      };
       expect(body.data.id).toBe(keyId);
       expect(body.data.keyType).toBe("metadata");
       // Fail-closed allowlist guard (ADR-023 Class C): the wire surface must
-      // never include sensitive server-only columns.
+      // never include sensitive server-only columns. encryptedData is the
+      // client-encrypted Class C payload — it MUST be exposed (surfaced in
+      // api-bqu4 / client-a0gf) so clients can decrypt it; it is not in this
+      // exclusion list.
       expect(body.data).not.toHaveProperty("tokenHash");
-      expect(body.data).not.toHaveProperty("encryptedData");
       expect(body.data).not.toHaveProperty("encryptedKeyMaterial");
       expect(body.data).not.toHaveProperty("accountId");
+      expect(typeof body.data.encryptedData).toBe("string");
     });
 
     await test.step("list includes the key", async () => {
       const res = await request.get(keysUrl, { headers: authHeaders });
       expect(res.status()).toBe(HTTP_OK);
-      const body = (await res.json()) as { data: Array<{ id: string }> };
+      const body = (await res.json()) as { data: Array<{ id: string; encryptedData: string }> };
       const ids = body.data.map((k) => k.id);
       expect(ids).toContain(keyId);
       const listed = body.data.find((k) => k.id === keyId);
-      expect(listed).toBeDefined();
+      if (!listed) {
+        throw new Error(`Expected list to include ApiKey ${keyId}`);
+      }
       // Same fail-closed guard on the list endpoint.
       expect(listed).not.toHaveProperty("tokenHash");
-      expect(listed).not.toHaveProperty("encryptedData");
       expect(listed).not.toHaveProperty("encryptedKeyMaterial");
       expect(listed).not.toHaveProperty("accountId");
+      expect(typeof listed.encryptedData).toBe("string");
     });
 
     await test.step("revoke API key", async () => {

--- a/apps/api-e2e/src/tests/api-keys/encrypted-data.spec.ts
+++ b/apps/api-e2e/src/tests/api-keys/encrypted-data.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * E2E coverage for the ApiKey encryptedData round-trip wired in client-a0gf.
+ *
+ * Validates that a crypto-variant payload (`name` + 32-byte X25519 publicKey)
+ * survives the encrypt-on-create → list → decrypt flow end-to-end, including
+ * the Zod codec that turns `publicKey: Uint8Array` into a base64 string inside
+ * the AEAD plaintext.
+ */
+import { expect, test } from "../../fixtures/auth.fixture.js";
+import { decryptFromApi, encryptForApi, ensureCryptoReady } from "../../fixtures/crypto.fixture.js";
+import { getSystemId } from "../../fixtures/entity-helpers.js";
+import { HTTP_CREATED, HTTP_OK } from "../../fixtures/http.constants.js";
+
+interface ApiKeyRow {
+  id: string;
+  systemId: string;
+  keyType: "metadata" | "crypto";
+  encryptedData: string;
+}
+
+interface CreateBody {
+  data: ApiKeyRow;
+}
+
+interface ListBody {
+  data: ApiKeyRow[];
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function base64ToUint8Array(b64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(b64, "base64"));
+}
+
+test.describe("ApiKey encryptedData round-trip", () => {
+  test.beforeAll(async () => {
+    await ensureCryptoReady();
+  });
+
+  test("crypto-variant publicKey survives encrypt-on-create → list → decrypt", async ({
+    request,
+    authHeaders,
+  }) => {
+    const systemId = await getSystemId(request, authHeaders);
+    const keysUrl = `/v1/systems/${systemId}/api-keys`;
+
+    const publicKey = new Uint8Array(32).fill(0xaa);
+    const wirePayload = {
+      keyType: "crypto" as const,
+      name: "Crypto Round-Trip Key",
+      publicKey: uint8ArrayToBase64(publicKey),
+    };
+    const encryptedData = encryptForApi(wirePayload);
+
+    const createRes = await request.post(keysUrl, {
+      headers: authHeaders,
+      data: {
+        keyType: "crypto",
+        scopes: ["read:members"],
+        encryptedData,
+        encryptedKeyMaterial: uint8ArrayToBase64(new Uint8Array(64).fill(0xbb)),
+      },
+    });
+    expect(createRes.status()).toBe(HTTP_CREATED);
+    const createBody = (await createRes.json()) as CreateBody;
+    const created = createBody.data;
+    expect(created.encryptedData).toBeTruthy();
+    expect(typeof created.encryptedData).toBe("string");
+
+    const listRes = await request.get(keysUrl, { headers: authHeaders });
+    expect(listRes.status()).toBe(HTTP_OK);
+    const listBody = (await listRes.json()) as ListBody;
+    const row = listBody.data.find((k) => k.id === created.id);
+    expect(row).toBeDefined();
+    expect(row?.encryptedData).toBeTruthy();
+
+    const decoded = decryptFromApi(row?.encryptedData ?? "") as {
+      keyType: string;
+      name: string;
+      publicKey: string;
+    };
+    expect(decoded.keyType).toBe("crypto");
+    expect(decoded.name).toBe("Crypto Round-Trip Key");
+    const decodedPublicKey = base64ToUint8Array(decoded.publicKey);
+    expect(decodedPublicKey.length).toBe(32);
+    expect(decodedPublicKey[0]).toBe(0xaa);
+  });
+});

--- a/apps/api-e2e/src/tests/auth/sessions.spec.ts
+++ b/apps/api-e2e/src/tests/auth/sessions.spec.ts
@@ -1,13 +1,44 @@
 import { expect, test } from "../../fixtures/auth.fixture.js";
 
+interface SessionRow {
+  id: string;
+  createdAt: number;
+  lastActive: number | null;
+  expiresAt: number | null;
+  encryptedData: string | null;
+}
+
+interface SessionListBody {
+  data: {
+    sessions: SessionRow[];
+    nextCursor: string | null;
+  };
+}
+
 test.describe("Session management", () => {
   test("GET /v1/auth/sessions lists active sessions", async ({ request, authHeaders }) => {
     const res = await request.get("/v1/auth/sessions", { headers: authHeaders });
 
     expect(res.status()).toBe(200);
-    const body = await res.json();
+    const body = (await res.json()) as SessionListBody;
     expect(body).toHaveProperty("data");
     expect(body.data.sessions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("session-list response carries encryptedData field for DeviceInfo decryption", async ({
+    request,
+    authHeaders,
+  }) => {
+    const res = await request.get("/v1/auth/sessions", { headers: authHeaders });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as SessionListBody;
+    const first = body.data.sessions[0];
+    expect(first).toBeDefined();
+    expect(first).toHaveProperty("encryptedData");
+    // No login flow currently writes encryptedData, so the value is null.
+    // Once the mobile/web sign-in flow plumbs DeviceInfo through, this field
+    // will carry a base64 T1 ciphertext blob decryptable via decryptDeviceInfo.
+    expect(first?.encryptedData).toBeNull();
   });
 
   test("POST /v1/auth/logout invalidates the session", async ({ request, registeredAccount }) => {

--- a/apps/api/src/__tests__/routes/api-keys/api-keys.test.ts
+++ b/apps/api/src/__tests__/routes/api-keys/api-keys.test.ts
@@ -51,6 +51,7 @@ const MOCK_API_KEY_RESULT: ApiKeyResult = {
   revokedAt: null,
   expiresAt: null,
   scopedBucketIds: null,
+  encryptedData: "dGVzdGVuY3J5cHRlZGRhdGE=" as EncryptedBase64,
 };
 
 const MOCK_CREATE_RESULT: ApiKeyCreateResult = {

--- a/apps/api/src/__tests__/routes/auth/sessions.test.ts
+++ b/apps/api/src/__tests__/routes/auth/sessions.test.ts
@@ -106,8 +106,20 @@ describe("sessions route", () => {
     it("returns session list for authenticated user", async () => {
       const mockSessions = {
         sessions: [
-          { id: brandId<SessionId>("sess_1"), createdAt: 1000, lastActive: 2000, expiresAt: 9000 },
-          { id: brandId<SessionId>("sess_2"), createdAt: 1500, lastActive: 2500, expiresAt: 9500 },
+          {
+            id: brandId<SessionId>("sess_1"),
+            createdAt: 1000,
+            lastActive: 2000,
+            expiresAt: 9000,
+            encryptedData: null,
+          },
+          {
+            id: brandId<SessionId>("sess_2"),
+            createdAt: 1500,
+            lastActive: 2500,
+            expiresAt: 9500,
+            encryptedData: null,
+          },
         ],
         nextCursor: toCursor("sess_2"),
       };

--- a/apps/api/src/__tests__/services/api-key.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/api-key.service.integration.test.ts
@@ -194,6 +194,28 @@ describe("api-key.service (PGlite integration)", () => {
     expect(match?.scopes).toEqual(scopes);
   });
 
+  it("returns encryptedData as base64 from get and list", async () => {
+    const created = await createApiKey(
+      asDb(db),
+      systemId,
+      makeCreateParams(["read:members"]),
+      auth,
+      noopAudit,
+    );
+
+    expect(typeof created.encryptedData).toBe("string");
+    expect(created.encryptedData).toMatch(/^[A-Za-z0-9+/=]+$/);
+
+    const fetched = await getApiKey(asDb(db), systemId, created.id, auth);
+    expect(typeof fetched.encryptedData).toBe("string");
+    expect(fetched.encryptedData).toMatch(/^[A-Za-z0-9+/=]+$/);
+
+    const listed = await listApiKeys(asDb(db), systemId, auth);
+    const match = listed.data.find((k) => k.id === created.id);
+    expect(typeof match?.encryptedData).toBe("string");
+    expect(match?.encryptedData).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+
   // ── Validation rejections ─────────────────────────────────────
 
   it("rejects invalid scope string", async () => {

--- a/apps/api/src/__tests__/services/api-key.service.test.ts
+++ b/apps/api/src/__tests__/services/api-key.service.test.ts
@@ -68,6 +68,7 @@ vi.mock("../../lib/encrypted-blob.js", () => ({
     nonce: new Uint8Array(24),
     ciphertext: new Uint8Array(16),
   })),
+  encryptedBlobToBase64: vi.fn(() => "ZW5jcnlwdGVkRGF0YQ=="),
   toT3EncryptedBytes: vi.fn((bytes: Uint8Array) => bytes),
 }));
 
@@ -118,6 +119,14 @@ function makeApiKeyRow(overrides: Record<string, unknown> = {}): Record<string, 
     revokedAt: null,
     expiresAt: null,
     scopedBucketIds: null,
+    encryptedData: {
+      tier: 1,
+      algorithm: "xchacha20-poly1305",
+      keyVersion: null,
+      bucketId: null,
+      nonce: new Uint8Array(24),
+      ciphertext: new Uint8Array(16),
+    },
     ...overrides,
   };
 }

--- a/apps/api/src/__tests__/services/auth.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/auth.service.integration.test.ts
@@ -355,9 +355,11 @@ describe("auth.service (PGlite integration)", { timeout: 60_000 }, () => {
       );
 
       const withBlob = sessionList.find((s) => s.encryptedData !== null);
-      expect(withBlob).toBeDefined();
-      expect(typeof withBlob?.encryptedData).toBe("string");
-      expect(withBlob?.encryptedData).toMatch(/^[A-Za-z0-9+/=]+$/);
+      if (!withBlob) {
+        throw new Error("Expected to find a session with encryptedData set");
+      }
+      expect(typeof withBlob.encryptedData).toBe("string");
+      expect(withBlob.encryptedData).toMatch(/^[A-Za-z0-9+/=]+$/);
     });
   });
 

--- a/apps/api/src/__tests__/services/auth.service.integration.test.ts
+++ b/apps/api/src/__tests__/services/auth.service.integration.test.ts
@@ -1,8 +1,8 @@
 import { PGlite } from "@electric-sql/pglite";
-import { initSodium } from "@pluralscape/crypto";
+import { encryptTier1, generateMasterKey, getSodium, initSodium, toHex } from "@pluralscape/crypto";
 import * as schema from "@pluralscape/db/pg";
 import { createPgAuthTables, PG_DDL, pgExec } from "@pluralscape/db/test-helpers/pg-helpers";
-import { brandId } from "@pluralscape/types";
+import { brandId, toUnixMillis } from "@pluralscape/types";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,7 +31,7 @@ import { asDb, noopAudit, registerTestAccount, spyAudit } from "../helpers/integ
 import { createMockLogger } from "../helpers/mock-logger.js";
 
 import type { RegistrationCommitResult } from "../../services/auth/register.js";
-import type { AccountId } from "@pluralscape/types";
+import type { AccountId, SessionId } from "@pluralscape/types";
 import type { PgliteDatabase } from "drizzle-orm/pglite";
 
 const { accounts, authKeys, recoveryKeys, sessions, systems } = schema;
@@ -316,6 +316,48 @@ describe("auth.service (PGlite integration)", { timeout: 60_000 }, () => {
       const page2 = await listSessions(asDb(db), brandId<AccountId>(reg.accountId), rawCursor, 1);
       expect(page2.sessions).toHaveLength(1);
       expect(page2.sessions[0]?.id).not.toBe(rawCursor);
+    });
+
+    it("projects encryptedData=null for sessions without a DeviceInfo blob", async () => {
+      const reg = await registerTestAccount(asDb(db));
+
+      const { sessions: sessionList } = await listSessions(
+        asDb(db),
+        brandId<AccountId>(reg.accountId),
+      );
+
+      expect(sessionList.length).toBeGreaterThanOrEqual(1);
+      expect(sessionList[0]?.encryptedData).toBeNull();
+    });
+
+    it("projects encryptedData as base64 string when row has a stored blob", async () => {
+      const sodium = getSodium();
+      const reg = await registerTestAccount(asDb(db));
+      const masterKey = generateMasterKey();
+      const blob = encryptTier1(
+        { platform: "ios", appVersion: "1.0.0", deviceName: "Test iPhone" },
+        masterKey,
+      );
+
+      await db.insert(sessions).values({
+        id: brandId<SessionId>(`sess_${crypto.randomUUID()}`),
+        accountId: brandId<AccountId>(reg.accountId),
+        tokenHash: toHex(sodium.randomBytes(32)),
+        encryptedData: blob,
+        createdAt: toUnixMillis(Date.now()),
+        lastActive: toUnixMillis(Date.now()),
+        expiresAt: toUnixMillis(Date.now() + 3_600_000),
+      });
+
+      const { sessions: sessionList } = await listSessions(
+        asDb(db),
+        brandId<AccountId>(reg.accountId),
+      );
+
+      const withBlob = sessionList.find((s) => s.encryptedData !== null);
+      expect(withBlob).toBeDefined();
+      expect(typeof withBlob?.encryptedData).toBe("string");
+      expect(withBlob?.encryptedData).toMatch(/^[A-Za-z0-9+/=]+$/);
     });
   });
 

--- a/apps/api/src/__tests__/services/auth.service.test.ts
+++ b/apps/api/src/__tests__/services/auth.service.test.ts
@@ -1102,8 +1102,8 @@ describe("auth service", () => {
     it("returns sessions without nextCursor when under the limit", async () => {
       const { db, chain } = mockDb();
       const rows = [
-        { id: "sess_1", createdAt: 1000, lastActive: 2000, expiresAt: 3000 },
-        { id: "sess_2", createdAt: 1100, lastActive: 2100, expiresAt: 3100 },
+        { id: "sess_1", createdAt: 1000, lastActive: 2000, expiresAt: 3000, encryptedData: null },
+        { id: "sess_2", createdAt: 1100, lastActive: 2100, expiresAt: 3100, encryptedData: null },
       ];
       chain.limit.mockResolvedValueOnce(rows);
 
@@ -1115,9 +1115,9 @@ describe("auth service", () => {
     it("returns nextCursor when limit+1 rows are returned", async () => {
       const { db, chain } = mockDb();
       const rows = [
-        { id: "sess_1", createdAt: 1000, lastActive: 2000, expiresAt: 3000 },
-        { id: "sess_2", createdAt: 1100, lastActive: 2100, expiresAt: 3100 },
-        { id: "sess_3", createdAt: 1200, lastActive: 2200, expiresAt: 3200 },
+        { id: "sess_1", createdAt: 1000, lastActive: 2000, expiresAt: 3000, encryptedData: null },
+        { id: "sess_2", createdAt: 1100, lastActive: 2100, expiresAt: 3100, encryptedData: null },
+        { id: "sess_3", createdAt: 1200, lastActive: 2200, expiresAt: 3200, encryptedData: null },
       ];
       chain.limit.mockResolvedValueOnce(rows);
 
@@ -1133,8 +1133,8 @@ describe("auth service", () => {
     it("passes cursor as SQL condition (not in-memory filtering)", async () => {
       const { db, chain } = mockDb();
       const rows = [
-        { id: "sess_2", createdAt: 1100, lastActive: 2100, expiresAt: 3100 },
-        { id: "sess_3", createdAt: 1200, lastActive: 2200, expiresAt: 3200 },
+        { id: "sess_2", createdAt: 1100, lastActive: 2100, expiresAt: 3100, encryptedData: null },
+        { id: "sess_3", createdAt: 1200, lastActive: 2200, expiresAt: 3200, encryptedData: null },
       ];
       chain.limit.mockResolvedValueOnce(rows);
 
@@ -1150,7 +1150,15 @@ describe("auth service", () => {
       const { db, chain } = mockDb();
       const fixedTime = 700_000_000;
       mockNow.mockReturnValue(fixedTime);
-      const rows = [{ id: "sess_1", createdAt: 0, lastActive: 1, expiresAt: 2_592_000_000 }];
+      const rows = [
+        {
+          id: "sess_1",
+          createdAt: 0,
+          lastActive: 1,
+          expiresAt: 2_592_000_000,
+          encryptedData: null,
+        },
+      ];
       chain.limit.mockResolvedValueOnce(rows);
 
       const result = await listSessions(db, TEST_ACCOUNT_ID);
@@ -1167,6 +1175,7 @@ describe("auth service", () => {
           createdAt: fixedTime - 1000,
           lastActive: fixedTime - 500,
           expiresAt: fixedTime + 2_592_000_000,
+          encryptedData: null,
         },
       ];
       chain.limit.mockResolvedValueOnce(rows);

--- a/apps/api/src/__tests__/trpc/routers/api-key.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/api-key.test.ts
@@ -52,6 +52,7 @@ const MOCK_API_KEY_RESULT = {
   revokedAt: null,
   expiresAt: null,
   scopedBucketIds: null,
+  encryptedData: "dGVzdGVuY3J5cHRlZGRhdGE=" as EncryptedBase64,
 };
 
 const MOCK_CREATE_RESULT = {

--- a/apps/api/src/__tests__/trpc/routers/auth.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/auth.test.ts
@@ -319,7 +319,13 @@ describe("auth router", () => {
     it("returns paginated sessions", async () => {
       const mockResult = {
         sessions: [
-          { id: brandId<SessionId>("sess_1"), createdAt: 1000, lastActive: 2000, expiresAt: null },
+          {
+            id: brandId<SessionId>("sess_1"),
+            createdAt: 1000,
+            lastActive: 2000,
+            expiresAt: null,
+            encryptedData: null,
+          },
         ],
         nextCursor: null,
       };

--- a/apps/api/src/services/api-key/internal.ts
+++ b/apps/api/src/services/api-key/internal.ts
@@ -4,8 +4,16 @@ import { apiKeys } from "@pluralscape/db/pg";
 import { brandId, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
 
 import { env } from "../../env.js";
+import { encryptedBlobToBase64 } from "../../lib/encrypted-blob.js";
 
-import type { ApiKeyId, ApiKeyScope, SystemId, UnixMillis } from "@pluralscape/types";
+import type {
+  ApiKeyId,
+  ApiKeyScope,
+  EncryptedBase64,
+  EncryptedBlob,
+  SystemId,
+  UnixMillis,
+} from "@pluralscape/types";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -19,6 +27,12 @@ export interface ApiKeyResult {
   readonly revokedAt: UnixMillis | null;
   readonly expiresAt: UnixMillis | null;
   readonly scopedBucketIds: readonly string[] | null;
+  /**
+   * Base64-encoded T1 ciphertext blob carrying the `ApiKeyEncryptedPayload`
+   * (name plus, for crypto variants, the X25519 publicKey). Decrypted
+   * client-side via `decryptApiKeyPayload` from `@pluralscape/data`.
+   */
+  readonly encryptedData: EncryptedBase64;
 }
 
 // ── Shared select columns ──────────────────────────────────────────
@@ -33,6 +47,7 @@ export const API_KEY_SELECT_COLUMNS = {
   revokedAt: apiKeys.revokedAt,
   expiresAt: apiKeys.expiresAt,
   scopedBucketIds: apiKeys.scopedBucketIds,
+  encryptedData: apiKeys.encryptedData,
 } as const;
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -47,6 +62,7 @@ export function toApiKeyResult(row: {
   revokedAt: number | null;
   expiresAt: number | null;
   scopedBucketIds: readonly string[] | null;
+  encryptedData: EncryptedBlob;
 }): ApiKeyResult {
   return {
     id: brandId<ApiKeyId>(row.id),
@@ -58,6 +74,7 @@ export function toApiKeyResult(row: {
     revokedAt: toUnixMillisOrNull(row.revokedAt),
     expiresAt: toUnixMillisOrNull(row.expiresAt),
     scopedBucketIds: row.scopedBucketIds,
+    encryptedData: encryptedBlobToBase64(row.encryptedData),
   };
 }
 

--- a/apps/api/src/services/auth/sessions.ts
+++ b/apps/api/src/services/auth/sessions.ts
@@ -2,13 +2,14 @@ import { sessions } from "@pluralscape/db/pg";
 import { brandId, now } from "@pluralscape/types";
 import { and, eq, gt, isNull, ne, or } from "drizzle-orm";
 
+import { encryptedBlobToBase64OrNull } from "../../lib/encrypted-blob.js";
 import { toCursor } from "../../lib/pagination.js";
 import { withAccountRead, withAccountTransaction } from "../../lib/rls-context.js";
 import { buildIdleTimeoutFilter } from "../../lib/session-idle-filter.js";
 import { DEFAULT_SESSION_LIMIT, MAX_SESSION_LIMIT } from "../../routes/auth/auth.constants.js";
 
 import type { AuditWriter } from "../../lib/audit-writer.js";
-import type { AccountId, PaginationCursor, SessionId } from "@pluralscape/types";
+import type { AccountId, EncryptedBase64, PaginationCursor, SessionId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Session management ─────────────────────────────────────────────
@@ -18,6 +19,13 @@ export interface SessionInfo {
   readonly createdAt: number;
   readonly lastActive: number | null;
   readonly expiresAt: number | null;
+  /**
+   * Base64-encoded T1 ciphertext blob carrying the per-session DeviceInfo
+   * payload (platform, appVersion, deviceName). Decrypted client-side via
+   * `decryptDeviceInfo` from `@pluralscape/data`. Null on legacy rows that
+   * pre-date device-info capture.
+   */
+  readonly encryptedData: EncryptedBase64 | null;
 }
 
 export async function listSessions(
@@ -48,6 +56,7 @@ export async function listSessions(
         createdAt: sessions.createdAt,
         lastActive: sessions.lastActive,
         expiresAt: sessions.expiresAt,
+        encryptedData: sessions.encryptedData,
       })
       .from(sessions)
       .where(and(...conditions))
@@ -55,7 +64,14 @@ export async function listSessions(
       .limit(effectiveLimit + 1);
 
     const hasMore = rows.length > effectiveLimit;
-    const result = hasMore ? rows.slice(0, effectiveLimit) : rows;
+    const sliced = hasMore ? rows.slice(0, effectiveLimit) : rows;
+    const result: SessionInfo[] = sliced.map((row) => ({
+      id: row.id,
+      createdAt: row.createdAt,
+      lastActive: row.lastActive,
+      expiresAt: row.expiresAt,
+      encryptedData: encryptedBlobToBase64OrNull(row.encryptedData),
+    }));
     const lastId = result[result.length - 1]?.id;
     const nextCursor = hasMore && lastId ? toCursor(lastId) : null;
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12170,6 +12170,14 @@ components:
           format: int64
           nullable: true
           description: Unix timestamp in milliseconds when the session expires
+        encryptedData:
+          type: string
+          nullable: true
+          description: |
+            Base64-encoded T1 ciphertext blob carrying the per-session DeviceInfo
+            payload (platform, appVersion, deviceName). Decrypted client-side via
+            `decryptDeviceInfo` from `@pluralscape/data`. Null on legacy rows that
+            pre-date device-info capture.
     SessionListResponse:
       type: object
       required:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -17059,6 +17059,7 @@ components:
         - revokedAt
         - expiresAt
         - scopedBucketIds
+        - encryptedData
       properties:
         id:
           type: string
@@ -17103,6 +17104,12 @@ components:
             type: string
           nullable: true
           description: Privacy bucket IDs this key is scoped to, null if unrestricted
+        encryptedData:
+          type: string
+          description: |
+            Base64-encoded T1 ciphertext blob carrying the `ApiKeyEncryptedPayload`
+            (name plus, for crypto variants, the X25519 publicKey). Decrypted
+            client-side via `decryptApiKeyPayload` from `@pluralscape/data`.
     CreateApiKeyRequest:
       type: object
       required:

--- a/docs/openapi/schemas/api-keys.yaml
+++ b/docs/openapi/schemas/api-keys.yaml
@@ -95,7 +95,18 @@ ApiKeyResponse:
     cannot be retrieved again.
   type: object
   required:
-    [id, systemId, keyType, scopes, createdAt, lastUsedAt, revokedAt, expiresAt, scopedBucketIds]
+    [
+      id,
+      systemId,
+      keyType,
+      scopes,
+      createdAt,
+      lastUsedAt,
+      revokedAt,
+      expiresAt,
+      scopedBucketIds,
+      encryptedData,
+    ]
   properties:
     id:
       type: string
@@ -140,6 +151,12 @@ ApiKeyResponse:
         type: string
       nullable: true
       description: "Privacy bucket IDs this key is scoped to, null if unrestricted"
+    encryptedData:
+      type: string
+      description: |
+        Base64-encoded T1 ciphertext blob carrying the `ApiKeyEncryptedPayload`
+        (name plus, for crypto variants, the X25519 publicKey). Decrypted
+        client-side via `decryptApiKeyPayload` from `@pluralscape/data`.
 
 ApiKeyCreateResponse:
   description: |

--- a/docs/openapi/schemas/auth.yaml
+++ b/docs/openapi/schemas/auth.yaml
@@ -271,6 +271,14 @@ SessionInfo:
       format: int64
       nullable: true
       description: Unix timestamp in milliseconds when the session expires
+    encryptedData:
+      type: string
+      nullable: true
+      description: |
+        Base64-encoded T1 ciphertext blob carrying the per-session DeviceInfo
+        payload (platform, appVersion, deviceName). Decrypted client-side via
+        `decryptDeviceInfo` from `@pluralscape/data`. Null on legacy rows that
+        pre-date device-info capture.
 
 SessionListResponse:
   type: object

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -18,6 +18,14 @@ export {
 } from "./transforms/decode-blob.js";
 
 // --- Domain crypto transforms ---
+export { decryptDeviceInfo } from "./transforms/session.js";
+
+export {
+  withDecryptedDeviceInfo,
+  type SessionListRow,
+  type SessionListRowWithDeviceInfo,
+} from "./transforms/session-helpers.js";
+
 export {
   decryptMember,
   decryptMemberPage,

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -26,6 +26,14 @@ export {
   type SessionListRowWithDeviceInfo,
 } from "./transforms/session-helpers.js";
 
+export { decryptApiKeyPayload, encryptApiKeyPayload } from "./transforms/api-key.js";
+
+export {
+  withDecodedApiKeyPayload,
+  type ApiKeyListRow,
+  type ApiKeyListRowWithPayload,
+} from "./transforms/api-key-helpers.js";
+
 export {
   decryptMember,
   decryptMemberPage,

--- a/packages/data/src/transforms/__tests__/api-key-helpers.test.ts
+++ b/packages/data/src/transforms/__tests__/api-key-helpers.test.ts
@@ -1,0 +1,81 @@
+import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
+import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
+import { brandId, toUnixMillis } from "@pluralscape/types";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { withDecodedApiKeyPayload, type ApiKeyListRow } from "../api-key-helpers.js";
+import { encryptApiKeyPayload } from "../api-key.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { ApiKeyId, SystemId } from "@pluralscape/types";
+
+let masterKey: KdfMasterKey;
+
+beforeAll(async () => {
+  configureSodium(new WasmSodiumAdapter());
+  await initSodium();
+  masterKey = generateMasterKey();
+});
+
+function makeRow(encryptedData: string): ApiKeyListRow {
+  return {
+    id: brandId<ApiKeyId>("ak_test"),
+    systemId: brandId<SystemId>("sys_test"),
+    keyType: "crypto",
+    scopes: ["read:members"],
+    createdAt: toUnixMillis(1000),
+    lastUsedAt: null,
+    revokedAt: null,
+    expiresAt: null,
+    scopedBucketIds: null,
+    encryptedData,
+  };
+}
+
+describe("withDecodedApiKeyPayload", () => {
+  it("decodes crypto-variant payload preserving Uint8Array publicKey", () => {
+    const publicKey = new Uint8Array(32).fill(0x42);
+    const { encryptedData } = encryptApiKeyPayload(
+      { keyType: "crypto", name: "test crypto key", publicKey },
+      masterKey,
+    );
+    const row = makeRow(encryptedData);
+
+    const result = withDecodedApiKeyPayload(row, masterKey);
+
+    expect(result.payload.keyType).toBe("crypto");
+    if (result.payload.keyType === "crypto") {
+      expect(result.payload.name).toBe("test crypto key");
+      expect(result.payload.publicKey).toBeInstanceOf(Uint8Array);
+      expect(result.payload.publicKey.length).toBe(32);
+      expect(result.payload.publicKey[0]).toBe(0x42);
+    }
+  });
+
+  it("decodes metadata-variant payload", () => {
+    const { encryptedData } = encryptApiKeyPayload(
+      { keyType: "metadata", name: "metadata key" },
+      masterKey,
+    );
+    const row = makeRow(encryptedData);
+
+    const result = withDecodedApiKeyPayload(row, masterKey);
+
+    expect(result.payload.keyType).toBe("metadata");
+    if (result.payload.keyType === "metadata") {
+      expect(result.payload.name).toBe("metadata key");
+    }
+  });
+
+  it("preserves all other row fields", () => {
+    const { encryptedData } = encryptApiKeyPayload({ keyType: "metadata", name: "k" }, masterKey);
+    const row = makeRow(encryptedData);
+
+    const result = withDecodedApiKeyPayload(row, masterKey);
+
+    expect(result.id).toBe(row.id);
+    expect(result.systemId).toBe(row.systemId);
+    expect(result.scopes).toEqual(row.scopes);
+    expect(result.createdAt).toBe(row.createdAt);
+  });
+});

--- a/packages/data/src/transforms/__tests__/friend-dashboard.test.ts
+++ b/packages/data/src/transforms/__tests__/friend-dashboard.test.ts
@@ -154,7 +154,7 @@ describe("decryptDashboardMember", () => {
       id: brandId<MemberId>("mem_bad"),
       encryptedData: encryptAndEncodeT2("not-an-object", bucketKey, BUCKET_ID),
     };
-    expect(() => decryptDashboardMember(raw, bucketKey)).toThrow("not an object");
+    expect(() => decryptDashboardMember(raw, bucketKey)).toThrow(/expected object/i);
   });
 
   it("throws on missing name field", () => {
@@ -162,7 +162,15 @@ describe("decryptDashboardMember", () => {
       id: brandId<MemberId>("mem_bad"),
       encryptedData: encryptAndEncodeT2({ pronouns: [] }, bucketKey, BUCKET_ID),
     };
-    expect(() => decryptDashboardMember(raw, bucketKey)).toThrow("missing required string field");
+    expect(() => decryptDashboardMember(raw, bucketKey)).toThrow(/expected string/i);
+  });
+
+  it("throws on missing name field for custom front", () => {
+    const raw = {
+      id: brandId<CustomFrontId>("cf_bad"),
+      encryptedData: encryptAndEncodeT2({ description: "x" }, bucketKey, BUCKET_ID),
+    };
+    expect(() => decryptDashboardCustomFront(raw, bucketKey)).toThrow(/expected string/i);
   });
 });
 

--- a/packages/data/src/transforms/__tests__/session-helpers.test.ts
+++ b/packages/data/src/transforms/__tests__/session-helpers.test.ts
@@ -1,0 +1,66 @@
+import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
+import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
+import { brandId } from "@pluralscape/types";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { encryptAndEncodeT1 } from "../decode-blob.js";
+import { withDecryptedDeviceInfo, type SessionListRow } from "../session-helpers.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { DeviceInfo, SessionId } from "@pluralscape/types";
+
+let masterKey: KdfMasterKey;
+
+beforeAll(async () => {
+  configureSodium(new WasmSodiumAdapter());
+  await initSodium();
+  masterKey = generateMasterKey();
+});
+
+function makeRow(overrides: Partial<SessionListRow> = {}): SessionListRow {
+  return {
+    id: brandId<SessionId>("sess_test"),
+    createdAt: 1000,
+    lastActive: 2000,
+    expiresAt: 9000,
+    encryptedData: null,
+    ...overrides,
+  };
+}
+
+describe("withDecryptedDeviceInfo", () => {
+  it("returns deviceInfo when encryptedData is present", () => {
+    const info: DeviceInfo = {
+      platform: "android",
+      appVersion: "2.1.0",
+      deviceName: "Pixel 9",
+    };
+    const encryptedData = encryptAndEncodeT1(info, masterKey);
+    const row = makeRow({ encryptedData });
+
+    const result = withDecryptedDeviceInfo(row, masterKey);
+
+    expect(result.deviceInfo).toEqual(info);
+    expect(result.id).toBe(row.id);
+    expect(result.encryptedData).toBe(encryptedData);
+  });
+
+  it("returns deviceInfo=null when encryptedData is null", () => {
+    const row = makeRow({ encryptedData: null });
+
+    const result = withDecryptedDeviceInfo(row, masterKey);
+
+    expect(result.deviceInfo).toBeNull();
+    expect(result.id).toBe(row.id);
+  });
+
+  it("preserves all other row fields", () => {
+    const row = makeRow({ createdAt: 5000, lastActive: 6000, expiresAt: 7000 });
+
+    const result = withDecryptedDeviceInfo(row, masterKey);
+
+    expect(result.createdAt).toBe(5000);
+    expect(result.lastActive).toBe(6000);
+    expect(result.expiresAt).toBe(7000);
+  });
+});

--- a/packages/data/src/transforms/api-key-helpers.ts
+++ b/packages/data/src/transforms/api-key-helpers.ts
@@ -1,0 +1,45 @@
+import { decryptApiKeyPayload } from "./api-key.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type {
+  ApiKeyEncryptedPayload,
+  ApiKeyId,
+  ApiKeyScope,
+  BucketId,
+  SystemId,
+  UnixMillis,
+} from "@pluralscape/types";
+
+/** Shape of the tRPC apiKey.get / apiKey.list[i] row (mirrors apps/api ApiKeyResult). */
+export interface ApiKeyListRow {
+  readonly id: ApiKeyId;
+  readonly systemId: SystemId;
+  readonly keyType: "metadata" | "crypto";
+  readonly scopes: readonly ApiKeyScope[];
+  readonly createdAt: UnixMillis;
+  readonly lastUsedAt: UnixMillis | null;
+  readonly revokedAt: UnixMillis | null;
+  readonly expiresAt: UnixMillis | null;
+  readonly scopedBucketIds: readonly BucketId[] | null;
+  readonly encryptedData: string;
+}
+
+export interface ApiKeyListRowWithPayload extends ApiKeyListRow {
+  readonly payload: ApiKeyEncryptedPayload;
+}
+
+/**
+ * Project an ApiKey row plus the master key into a row carrying the decoded
+ * `ApiKeyEncryptedPayload`. The `encryptedData` field is always non-null on
+ * the wire (the column is `.notNull()` on the server), so the decoded payload
+ * is always present.
+ */
+export function withDecodedApiKeyPayload(
+  row: ApiKeyListRow,
+  masterKey: KdfMasterKey,
+): ApiKeyListRowWithPayload {
+  return {
+    ...row,
+    payload: decryptApiKeyPayload(row.encryptedData, masterKey),
+  };
+}

--- a/packages/data/src/transforms/decode-blob.ts
+++ b/packages/data/src/transforms/decode-blob.ts
@@ -75,28 +75,6 @@ export function encryptAndEncodeT2(
   return uint8ArrayToBase64(bytes);
 }
 
-/**
- * Validate that a decrypted blob is a non-null object.
- * Returns the object cast to Record for field inspection.
- */
-export function assertObjectBlob(raw: unknown, entity: string): Record<string, unknown> {
-  if (raw === null || typeof raw !== "object") {
-    throw new Error(`Decrypted ${entity} blob is not an object`);
-  }
-  return raw as Record<string, unknown>;
-}
-
-/** Validate that a field exists and is a string. */
-export function assertStringField(
-  obj: Record<string, unknown>,
-  entity: string,
-  field: string,
-): void {
-  if (typeof obj[field] !== "string") {
-    throw new Error(`Decrypted ${entity} blob missing required string field: ${field}`);
-  }
-}
-
 export function base64ToUint8Array(base64: string): Uint8Array {
   return new Uint8Array(Buffer.from(base64, "base64"));
 }

--- a/packages/data/src/transforms/friend-dashboard.ts
+++ b/packages/data/src/transforms/friend-dashboard.ts
@@ -1,9 +1,11 @@
 import {
-  assertObjectBlob,
-  assertStringField,
-  decodeAndDecryptT2,
-  extractT2BucketId,
-} from "./decode-blob.js";
+  FriendDashboardCustomFrontBlobSchema,
+  FriendDashboardFrontingSessionBlobSchema,
+  FriendDashboardMemberBlobSchema,
+  FriendDashboardStructureEntityBlobSchema,
+} from "@pluralscape/validation";
+
+import { decodeAndDecryptT2, extractT2BucketId } from "./decode-blob.js";
 
 import type { AeadKey } from "@pluralscape/crypto";
 import type {
@@ -84,30 +86,6 @@ export interface DecryptedFriendDashboard {
   readonly visibleStructureEntities: readonly DecryptedDashboardStructureEntity[];
 }
 
-// ── Validators ────────────────────────────────────────────────────
-
-function assertMemberBlob(raw: unknown): Record<string, unknown> {
-  const obj = assertObjectBlob(raw, "dashboard member");
-  assertStringField(obj, "dashboard member", "name");
-  return obj;
-}
-
-function assertFrontingSessionBlob(raw: unknown): Record<string, unknown> {
-  return assertObjectBlob(raw, "dashboard fronting session");
-}
-
-function assertCustomFrontBlob(raw: unknown): Record<string, unknown> {
-  const obj = assertObjectBlob(raw, "dashboard custom front");
-  assertStringField(obj, "dashboard custom front", "name");
-  return obj;
-}
-
-function assertStructureEntityBlob(raw: unknown): Record<string, unknown> {
-  const obj = assertObjectBlob(raw, "dashboard structure entity");
-  assertStringField(obj, "dashboard structure entity", "name");
-  return obj;
-}
-
 // ── Per-entity decrypt functions ──────────────────────────────────
 
 /** Decrypt a single friend dashboard member T2 blob. */
@@ -116,14 +94,14 @@ export function decryptDashboardMember(
   bucketKey: AeadKey,
 ): DecryptedDashboardMember {
   const plaintext = decodeAndDecryptT2(raw.encryptedData, bucketKey);
-  const obj = assertMemberBlob(plaintext);
+  const parsed = FriendDashboardMemberBlobSchema.parse(plaintext);
 
   return {
     id: raw.id,
-    name: obj["name"] as string,
-    pronouns: (obj["pronouns"] as readonly string[] | undefined) ?? [],
-    description: (obj["description"] as string | null) ?? null,
-    colors: (obj["colors"] as readonly (HexColor | null)[] | undefined) ?? [],
+    name: parsed.name,
+    pronouns: parsed.pronouns ?? [],
+    description: parsed.description ?? null,
+    colors: (parsed.colors as readonly (HexColor | null)[] | undefined) ?? [],
   };
 }
 
@@ -133,7 +111,7 @@ export function decryptDashboardFrontingSession(
   bucketKey: AeadKey,
 ): DecryptedDashboardFrontingSession {
   const plaintext = decodeAndDecryptT2(raw.encryptedData, bucketKey);
-  const obj = assertFrontingSessionBlob(plaintext);
+  const parsed = FriendDashboardFrontingSessionBlobSchema.parse(plaintext);
 
   return {
     id: raw.id,
@@ -141,10 +119,11 @@ export function decryptDashboardFrontingSession(
     customFrontId: raw.customFrontId,
     structureEntityId: raw.structureEntityId,
     startTime: raw.startTime,
-    comment: (obj["comment"] as string | null) ?? null,
-    positionality: (obj["positionality"] as string | null) ?? null,
-    outtrigger: (obj["outtrigger"] as string | null) ?? null,
-    outtriggerSentiment: (obj["outtriggerSentiment"] as OuttriggerSentiment | null) ?? null,
+    comment: parsed.comment ?? null,
+    positionality: parsed.positionality ?? null,
+    outtrigger: parsed.outtrigger ?? null,
+    outtriggerSentiment:
+      (parsed.outtriggerSentiment as OuttriggerSentiment | null | undefined) ?? null,
   };
 }
 
@@ -154,14 +133,14 @@ export function decryptDashboardCustomFront(
   bucketKey: AeadKey,
 ): DecryptedDashboardCustomFront {
   const plaintext = decodeAndDecryptT2(raw.encryptedData, bucketKey);
-  const obj = assertCustomFrontBlob(plaintext);
+  const parsed = FriendDashboardCustomFrontBlobSchema.parse(plaintext);
 
   return {
     id: raw.id,
-    name: obj["name"] as string,
-    description: (obj["description"] as string | null) ?? null,
-    color: (obj["color"] as HexColor | null) ?? null,
-    emoji: (obj["emoji"] as string | null) ?? null,
+    name: parsed.name,
+    description: parsed.description ?? null,
+    color: (parsed.color as HexColor | null | undefined) ?? null,
+    emoji: parsed.emoji ?? null,
   };
 }
 
@@ -171,15 +150,15 @@ export function decryptDashboardStructureEntity(
   bucketKey: AeadKey,
 ): DecryptedDashboardStructureEntity {
   const plaintext = decodeAndDecryptT2(raw.encryptedData, bucketKey);
-  const obj = assertStructureEntityBlob(plaintext);
+  const parsed = FriendDashboardStructureEntityBlobSchema.parse(plaintext);
 
   return {
     id: raw.id,
-    name: obj["name"] as string,
-    description: (obj["description"] as string | null) ?? null,
-    emoji: (obj["emoji"] as string | null) ?? null,
-    color: (obj["color"] as HexColor | null) ?? null,
-    imageSource: (obj["imageSource"] as ImageSource | null) ?? null,
+    name: parsed.name,
+    description: parsed.description ?? null,
+    emoji: parsed.emoji ?? null,
+    color: (parsed.color as HexColor | null | undefined) ?? null,
+    imageSource: parsed.imageSource ?? null,
   };
 }
 

--- a/packages/data/src/transforms/session-helpers.ts
+++ b/packages/data/src/transforms/session-helpers.ts
@@ -1,0 +1,33 @@
+import { decryptDeviceInfo } from "./session.js";
+
+import type { KdfMasterKey } from "@pluralscape/crypto";
+import type { DeviceInfo, SessionId } from "@pluralscape/types";
+
+/** Shape of the tRPC session-list row (mirrors apps/api SessionInfo). */
+export interface SessionListRow {
+  readonly id: SessionId;
+  readonly createdAt: number;
+  readonly lastActive: number | null;
+  readonly expiresAt: number | null;
+  readonly encryptedData: string | null;
+}
+
+/** Same row with the DeviceInfo decoded from encryptedData. */
+export interface SessionListRowWithDeviceInfo extends SessionListRow {
+  readonly deviceInfo: DeviceInfo | null;
+}
+
+/**
+ * Project a session-list row plus the master key into a row carrying the
+ * decoded DeviceInfo. Returns deviceInfo=null when encryptedData is null
+ * (legacy rows that pre-date device-info capture).
+ */
+export function withDecryptedDeviceInfo(
+  row: SessionListRow,
+  masterKey: KdfMasterKey,
+): SessionListRowWithDeviceInfo {
+  return {
+    ...row,
+    deviceInfo: row.encryptedData === null ? null : decryptDeviceInfo(row.encryptedData, masterKey),
+  };
+}

--- a/packages/validation/src/__tests__/friend-dashboard-blob.test.ts
+++ b/packages/validation/src/__tests__/friend-dashboard-blob.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  FriendDashboardCustomFrontBlobSchema,
+  FriendDashboardFrontingSessionBlobSchema,
+  FriendDashboardMemberBlobSchema,
+  FriendDashboardStructureEntityBlobSchema,
+} from "../friend-dashboard-blob.js";
+
+describe("FriendDashboardMemberBlobSchema", () => {
+  test("parses a complete member blob", () => {
+    const input = {
+      name: "Alex",
+      pronouns: ["they/them"],
+      description: "Lead member",
+      colors: ["#ff0000"],
+    };
+    expect(FriendDashboardMemberBlobSchema.parse(input)).toEqual(input);
+  });
+
+  test("requires name", () => {
+    expect(() => FriendDashboardMemberBlobSchema.parse({ pronouns: ["they/them"] })).toThrow();
+  });
+
+  test("allows null description and missing optional fields", () => {
+    const input = { name: "Alex", description: null };
+    const parsed = FriendDashboardMemberBlobSchema.parse(input);
+    expect(parsed.name).toBe("Alex");
+    expect(parsed.description).toBeNull();
+  });
+
+  test("allows null entries inside the colors array", () => {
+    const input = { name: "Alex", colors: ["#abcdef", null] };
+    const parsed = FriendDashboardMemberBlobSchema.parse(input);
+    expect(parsed.colors).toEqual(["#abcdef", null]);
+  });
+});
+
+describe("FriendDashboardFrontingSessionBlobSchema", () => {
+  test("accepts an empty object (all fields optional)", () => {
+    expect(FriendDashboardFrontingSessionBlobSchema.parse({})).toEqual({});
+  });
+
+  test("parses comment, positionality, outtrigger fields", () => {
+    const input = {
+      comment: "comment text",
+      positionality: "back",
+      outtrigger: null,
+      outtriggerSentiment: "positive",
+    };
+    expect(FriendDashboardFrontingSessionBlobSchema.parse(input)).toEqual(input);
+  });
+
+  test("rejects unknown outtriggerSentiment values", () => {
+    expect(() =>
+      FriendDashboardFrontingSessionBlobSchema.parse({ outtriggerSentiment: "ambivalent" }),
+    ).toThrow();
+  });
+});
+
+describe("FriendDashboardCustomFrontBlobSchema", () => {
+  test("requires name", () => {
+    expect(() => FriendDashboardCustomFrontBlobSchema.parse({ description: "x" })).toThrow();
+  });
+
+  test("parses all optional fields", () => {
+    const input = {
+      name: "Sleep",
+      description: "Nighttime state",
+      color: "#102030",
+      emoji: "💤",
+    };
+    expect(FriendDashboardCustomFrontBlobSchema.parse(input)).toEqual(input);
+  });
+});
+
+describe("FriendDashboardStructureEntityBlobSchema", () => {
+  test("requires name", () => {
+    expect(() => FriendDashboardStructureEntityBlobSchema.parse({ description: "x" })).toThrow();
+  });
+
+  test("parses imageSource discriminated union", () => {
+    const input = {
+      name: "Inner garden",
+      imageSource: { kind: "external", url: "https://example.com/garden.png" },
+    };
+    const parsed = FriendDashboardStructureEntityBlobSchema.parse(input);
+    expect(parsed.imageSource).toEqual({
+      kind: "external",
+      url: "https://example.com/garden.png",
+    });
+  });
+});

--- a/packages/validation/src/friend-dashboard-blob.ts
+++ b/packages/validation/src/friend-dashboard-blob.ts
@@ -1,0 +1,62 @@
+/**
+ * Decrypt-boundary Zod schemas for friend-dashboard T2 blobs.
+ *
+ * Mirrors the `DecryptedDashboard*` interfaces in
+ * `packages/data/src/transforms/friend-dashboard.ts`. The plaintext returned
+ * from the AEAD cipher is `unknown`; calling `Schema.parse` here turns it
+ * into a typed, validated record before any consumer reads it.
+ *
+ * Matches the post-types-emid fleet pattern: every decrypt site validates
+ * with Zod, no hand-rolled `assertObjectBlob` / `assertStringField` helpers.
+ */
+import { z } from "zod/v4";
+
+import { HexColorSchema, PlaintextImageSourceSchema } from "./plaintext-shared.js";
+
+/** Friend-dashboard member plaintext shape. Mirrors `DecryptedDashboardMember` minus `id`. */
+export const FriendDashboardMemberBlobSchema = z.object({
+  name: z.string(),
+  pronouns: z.array(z.string()).optional(),
+  description: z.string().nullable().optional(),
+  colors: z.array(HexColorSchema.nullable()).optional(),
+});
+
+/**
+ * Friend-dashboard fronting session plaintext shape. Mirrors
+ * `DecryptedDashboardFrontingSession` minus structural columns.
+ */
+export const FriendDashboardFrontingSessionBlobSchema = z.object({
+  comment: z.string().nullable().optional(),
+  positionality: z.string().nullable().optional(),
+  outtrigger: z.string().nullable().optional(),
+  outtriggerSentiment: z.enum(["negative", "neutral", "positive"]).nullable().optional(),
+});
+
+/** Friend-dashboard custom front plaintext shape. Mirrors `DecryptedDashboardCustomFront` minus `id`. */
+export const FriendDashboardCustomFrontBlobSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  color: HexColorSchema.nullable().optional(),
+  emoji: z.string().nullable().optional(),
+});
+
+/**
+ * Friend-dashboard structure entity plaintext shape. Mirrors
+ * `DecryptedDashboardStructureEntity` minus `id`.
+ */
+export const FriendDashboardStructureEntityBlobSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  emoji: z.string().nullable().optional(),
+  color: HexColorSchema.nullable().optional(),
+  imageSource: PlaintextImageSourceSchema.nullable().optional(),
+});
+
+export type FriendDashboardMemberBlob = z.infer<typeof FriendDashboardMemberBlobSchema>;
+export type FriendDashboardFrontingSessionBlob = z.infer<
+  typeof FriendDashboardFrontingSessionBlobSchema
+>;
+export type FriendDashboardCustomFrontBlob = z.infer<typeof FriendDashboardCustomFrontBlobSchema>;
+export type FriendDashboardStructureEntityBlob = z.infer<
+  typeof FriendDashboardStructureEntityBlobSchema
+>;

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -61,6 +61,16 @@ export {
   PlaintextTagSchema,
 } from "./plaintext-shared.js";
 export {
+  FriendDashboardMemberBlobSchema,
+  FriendDashboardFrontingSessionBlobSchema,
+  FriendDashboardCustomFrontBlobSchema,
+  FriendDashboardStructureEntityBlobSchema,
+  type FriendDashboardMemberBlob,
+  type FriendDashboardFrontingSessionBlob,
+  type FriendDashboardCustomFrontBlob,
+  type FriendDashboardStructureEntityBlob,
+} from "./friend-dashboard-blob.js";
+export {
   CreateFieldDefinitionBodySchema,
   FieldDefinitionEncryptedInputSchema,
   FieldValueEncryptedInputSchema,


### PR DESCRIPTION
## Summary

Closes three M9a "deferred wiring" beans by surfacing already-stored encrypted fields end-to-end and wiring the existing data-layer codecs.

- **api-bqu4** — `listSessions` now projects `encryptedData`; new `withDecryptedDeviceInfo` helper in `@pluralscape/data` decodes the per-session DeviceInfo when populated.
- **client-a0gf** — `apiKey.list` and `apiKey.get` now project `encryptedData`; new `withDecodedApiKeyPayload` helper decodes the crypto-variant `publicKey`.
- **ps-znp0** — friend-dashboard migrated from `assertObjectBlob`/`assertStringField` to `FriendDashboard*BlobSchema` in `@pluralscape/validation`. Helpers deleted.

No mobile UI changes — these wirings are gates on future user-facing screens, not the screens themselves. See `docs/superpowers/specs/2026-04-27-deferred-wiring-closeout-design.md` § PR1 for full design context.

## Test plan

- [x] Integration: sessions encryptedData round-trip (auth.service.integration.test.ts)
- [x] Integration: api-key encryptedData on get/list (api-key.service.integration.test.ts)
- [x] E2E: session-list contract exposes encryptedData
- [x] E2E: crypto-variant ApiKey publicKey encrypt-on-create -> list -> decrypt round-trip
- [x] Unit: withDecryptedDeviceInfo (present + null + field-preservation cases)
- [x] Unit: withDecodedApiKeyPayload (crypto + metadata + field-preservation cases)
- [x] Unit: FriendDashboard*BlobSchema parse + reject-missing-field cases
- [x] pnpm trpc:parity passes
- [x] pnpm types:check-sot passes
- [x] pnpm typecheck, pnpm lint, pnpm test:unit, pnpm test:integration, pnpm test:e2e all green

Beans: api-bqu4, client-a0gf, ps-znp0