### PR TITLE
feat: wire materializer subscriber to SyncEngine (sync-xjfi)

### DIFF
--- a/.beans/ps-4mv5--pr-584-review-remediation-sync-xjfi.md
+++ b/.beans/ps-4mv5--pr-584-review-remediation-sync-xjfi.md
@@ -1,11 +1,11 @@
 ---
 # ps-4mv5
 title: "PR #584 review remediation (sync-xjfi)"
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-28T21:03:38Z
-updated_at: 2026-04-28T21:35:19Z
+updated_at: 2026-04-28T21:44:59Z
 ---
 
 Address all critical, important, and suggestion findings from the multi-agent review of PR #584 per plan at .claude/plans/woolly-roaming-nova.md. 9 commits planned.
@@ -22,3 +22,26 @@ Address all critical, important, and suggestion findings from the multi-agent re
 - [x] Commit 9 — test: branch coverage, disposal-order, lock/unlock, registry isolation (S1 + S12)
 
 Plan reference: /home/theprismsystem/.claude/plans/woolly-roaming-nova.md
+
+## Summary of Changes
+
+Addresses all critical, important, and suggestion findings from the multi-agent review of PR #584. 7 commits on top of the 7 sync-xjfi commits already on the branch:
+
+- **3aae5dc4** — I2: brand `documentId` on `SyncChangesMergedEvent` / `SyncSnapshotAppliedEvent`; reword `dirtyEntityTypes` JSDoc.
+- **5eeeea17** — I6: tighten `MaterializerDb.queryAll` / `execute` to `readonly MaterializerBindValue[]`; add `toBindValue` runtime guard. Drop `as SQLiteBindParams` casts in the expo-sqlite adapter.
+- **2dad9123** — F1 + I1 + I3 + S2 + S4 + S5 + S8: subscriber wraps `engine.getDocumentSnapshot` in try/catch (silent skip on `NoActiveSessionError`, `sync:error` on anything else); wraps `materializer.materialize` in `materializerDb.transaction(...)` for true per-merge atomicity (transaction wrap removed from `applyDiff`); emits `sync:error` on materializer write failure; renames `materialise` → `materialize`; drops `isRecordSnapshot`.
+- **b9ad1bc4** — I7: replace `materializerDb: MaterializerDb | null` with discriminated `PlatformStorage` union (`sqlite-sync` | `sqlite-async` | `indexeddb`); add `isSqliteBackend` type guard. All consumers (DataLayerProvider, useQuerySource, SyncProvider, fixtures) propagated.
+- **ca9e5dd7** — I4 + S6 + S10 + S11: SyncProvider catch branch now mirrors success path (`setEngine(null)` + `setIsBootstrapped(false)`); ref clears consolidated to single source of truth; `bus` alias inlined.
+- **15195bbb** — I5: `logger.warn` on the SQLCipher wipe path before `deleteDatabaseSync`. S7 (runStatement helper) skipped — TRow generic preservation made the deduped helper less clear than the duplication.
+- **da9c591a** — S1 + S12: branch coverage tests for F1/I1/I3 paths in materializer-subscriber; queryAll-throw test in materializer-db-adapter; subscriber-disposal-order, lock→unlock re-creation, and SyncEngine-construction-throw tests in SyncProvider; materializer registry save+restore isolation in `beforeEach`/`afterEach`.
+
+## Test counts
+
+- Unit: 13147 passed (+~17 new tests)
+- Integration: 3060 passed
+- E2E: 507 passed (2 skipped)
+
+## Out of scope
+
+- S9 (shared `makeMockMaterializerDb` fixture in `tooling/test-utils`) deferred — current duplication is small (one fn each in two test files) and lifting now would require a publishing change to test-utils. Worth revisiting only if a third caller appears.
+- Option B for I6 (tighten `EntityRow` value type to `MaterializerBindValue`) — too invasive across all materializers; chosen Option A (`toBindValue` boundary guard) instead.

--- a/.beans/ps-4mv5--pr-584-review-remediation-sync-xjfi.md
+++ b/.beans/ps-4mv5--pr-584-review-remediation-sync-xjfi.md
@@ -1,0 +1,24 @@
+---
+# ps-4mv5
+title: "PR #584 review remediation (sync-xjfi)"
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-04-28T21:03:38Z
+updated_at: 2026-04-28T21:35:19Z
+---
+
+Address all critical, important, and suggestion findings from the multi-agent review of PR #584 per plan at .claude/plans/woolly-roaming-nova.md. 9 commits planned.
+
+## Implementation checklist
+
+- [x] Commit 1 — fix(sync): brand documentId in event-map (I2) [3aae5dc4]
+- [x] Commit 2 — refactor(sync): tighten MaterializerDb param types (I6) [5eeeea17]
+- [x] Commit 3+4 — refactor(sync, data): move transaction wrap to subscriber, F1 NoActiveSessionError handling, I3 sync:error on materialize throw, S2/S4/S5/S8 cleanup [2dad9123]
+- [x] Commit 5 — refactor(mobile): discriminated PlatformStorage + isSqliteBackend helper (I7) [b9ad1bc4]
+- [x] Commit 6 — fix(mobile): SyncProvider catch clears engine state + comment + ref consolidation + bus inlining (I4 + S6 + S10 + S11) [ca9e5dd7]
+- [x] Commit 7 — fix(mobile): logger.warn on SQLCipher wipe (I5) [15195bbb]; S7 (runStatement) skipped — see commit body
+- [x] Commit 8 — docs(mobile): reworded adapter transaction JSDoc (I1 docs + S3) [folded into commit 5eeeea17]
+- [x] Commit 9 — test: branch coverage, disposal-order, lock/unlock, registry isolation (S1 + S12)
+
+Plan reference: /home/theprismsystem/.claude/plans/woolly-roaming-nova.md

--- a/.beans/sync-xjfi--wire-materializerregistrymaterialize-into-data-lay.md
+++ b/.beans/sync-xjfi--wire-materializerregistrymaterialize-into-data-lay.md
@@ -1,12 +1,23 @@
 ---
 # sync-xjfi
 title: Wire materializerRegistry.materialize into data-layer write path
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-21T03:02:54Z
-updated_at: 2026-04-27T20:28:57Z
+updated_at: 2026-04-28T20:26:14Z
 parent: ps-cd6x
 ---
 
 PR #531 added dirtyEntityTypes scaffolding to materializeDocument / materializer.materialize(), but no production code invokes either — the materializer is only exercised in tests. Wire into the production data-layer write path (likely in @pluralscape/data or wherever materialized:document events should be emitted). Until done, the sync-f4ma perf gain is unreachable.
+
+## Summary of Changes
+
+- Extended `SyncChangesMergedEvent` with `dirtyEntityTypes: ReadonlySet<SyncedEntityType>` so subscribers can use the perf gain from sync-f4ma.
+- Updated both engine emit sites in `SyncEngine.applyEncryptedChanges` and `mergeChangesEnvelope` to forward the dirty set already computed locally.
+- Added `createMaterializerSubscriber({engine, materializerDb, eventBus})` in `@pluralscape/data`. Subscribes to `sync:changes-merged` and `sync:snapshot-applied`; calls `engine.getDocumentSnapshot`, looks up the registered materializer, runs it. Skips silently when the snapshot is evicted or no materializer is registered.
+- Built a `MaterializerDb` adapter over expo-sqlite's sync APIs in `apps/mobile/src/data/materializer-db-adapter.ts` — wraps `prepareSync`/`executeSync`/`finalizeSync` and `withTransactionSync`.
+- Refactored `createExpoSqliteDriver` to also expose a `materializerDb` adapter sharing the same SQLCipher connection. Threaded `materializerDb: MaterializerDb | null` through the platform storage type.
+- Wired the subscriber inside `SyncProvider.tsx` alongside the engine, with proper dispose order on auth-state transitions and unmount.
+- Added a smoke test in `SyncProvider.test.tsx` proving the subscriber is wired (engine.getDocumentSnapshot → registered materializer.materialize) and disposed correctly.
+- All `/verify` gates pass (format, lint, typecheck, types:check-sot, unit, integration, e2e — 13136 unit, 3060 integration, 507 e2e).

--- a/apps/mobile/src/data/DataLayerProvider.tsx
+++ b/apps/mobile/src/data/DataLayerProvider.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { createContext, useContext, useEffect, useRef } from "react";
 
 import { usePlatform } from "../platform/PlatformProvider.js";
+import { isSqliteBackend } from "../platform/types.js";
 
 import { createLocalDatabase } from "./local-database.js";
 import { createQueryInvalidator } from "./query-invalidator.js";
@@ -33,7 +34,7 @@ export function DataLayerProvider({
   eventBusRef.current ??= createEventBus<DataLayerEventMap>();
 
   const localDbRef = useRef<LocalDatabase | null>(null);
-  if (localDbRef.current === null && platform.storage.backend === "sqlite") {
+  if (localDbRef.current === null && isSqliteBackend(platform.storage)) {
     const db = createLocalDatabase(platform.storage.driver);
     // Fire-and-forget: initialize() runs CREATE TABLE DDL asynchronously.
     // Failures surface via the event bus as `data:error` for UI to observe.

--- a/apps/mobile/src/data/__tests__/DataLayerProvider.test.tsx
+++ b/apps/mobile/src/data/__tests__/DataLayerProvider.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../../platform/PlatformProvider.js", () => ({
       hasNativeMemzero: false,
       storageBackend: "sqlite" as const,
     },
-    storage: { backend: "sqlite" as const, driver: mockDriver },
+    storage: { backend: "sqlite-async" as const, driver: mockDriver },
     crypto: {},
   }),
 }));

--- a/apps/mobile/src/data/__tests__/materializer-db-adapter.test.ts
+++ b/apps/mobile/src/data/__tests__/materializer-db-adapter.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock, type MockProxy } from "vitest-mock-extended";
+
+import {
+  createMaterializerDbAdapter,
+  type ExecuteSyncResult,
+  type SqliteStatementHandle,
+  type SqliteSyncDatabase,
+} from "../materializer-db-adapter.js";
+
+interface TestRow {
+  readonly id: string;
+}
+
+function setupMocks(rows: TestRow[]): {
+  db: MockProxy<SqliteSyncDatabase>;
+  stmt: MockProxy<SqliteStatementHandle>;
+  result: MockProxy<ExecuteSyncResult<TestRow>>;
+} {
+  const result = mock<ExecuteSyncResult<TestRow>>();
+  result.getAllSync.mockReturnValue(rows);
+
+  const stmt = mock<SqliteStatementHandle>();
+  stmt.executeSync.mockReturnValue(result);
+
+  const db = mock<SqliteSyncDatabase>();
+  db.prepareSync.mockReturnValue(stmt);
+  db.withTransactionSync.mockImplementation((fn: () => void) => {
+    fn();
+  });
+
+  return { db, stmt, result };
+}
+
+describe("createMaterializerDbAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queryAll prepares the SQL, executes with params, and returns rows", () => {
+    const rows: TestRow[] = [{ id: "m1" }, { id: "m2" }];
+    const { db, stmt, result } = setupMocks(rows);
+    const adapter = createMaterializerDbAdapter(db);
+
+    const returned = adapter.queryAll<TestRow>("SELECT id FROM members WHERE id = ?", ["m1"]);
+
+    expect(db.prepareSync).toHaveBeenCalledWith("SELECT id FROM members WHERE id = ?");
+    expect(stmt.executeSync).toHaveBeenCalledWith(["m1"]);
+    expect(stmt.finalizeSync).toHaveBeenCalledTimes(1);
+    expect(result.getAllSync).toHaveBeenCalledTimes(1);
+    expect(returned).toEqual(rows);
+  });
+
+  it("execute prepares the SQL, executes with params, and finalises the statement", () => {
+    const { db, stmt } = setupMocks([]);
+    const adapter = createMaterializerDbAdapter(db);
+
+    adapter.execute("INSERT INTO members (id) VALUES (?)", ["m_1"]);
+
+    expect(db.prepareSync).toHaveBeenCalledWith("INSERT INTO members (id) VALUES (?)");
+    expect(stmt.executeSync).toHaveBeenCalledWith(["m_1"]);
+    expect(stmt.finalizeSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("finalises the statement even when executeSync throws", () => {
+    const { db, stmt } = setupMocks([]);
+    stmt.executeSync.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const adapter = createMaterializerDbAdapter(db);
+
+    expect(() => {
+      adapter.execute("INSERT INTO members (id) VALUES (?)", ["m_1"]);
+    }).toThrow("boom");
+    expect(stmt.finalizeSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("transaction wraps the callback in withTransactionSync and propagates the return value", () => {
+    const { db } = setupMocks([]);
+    const adapter = createMaterializerDbAdapter(db);
+
+    const value = adapter.transaction(() => 42);
+
+    expect(db.withTransactionSync).toHaveBeenCalledTimes(1);
+    expect(value).toBe(42);
+  });
+
+  it("transaction propagates errors thrown inside the callback", () => {
+    const { db } = setupMocks([]);
+    const adapter = createMaterializerDbAdapter(db);
+
+    expect(() =>
+      adapter.transaction(() => {
+        throw new Error("tx-boom");
+      }),
+    ).toThrow("tx-boom");
+    expect(db.withTransactionSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/data/__tests__/materializer-db-adapter.test.ts
+++ b/apps/mobile/src/data/__tests__/materializer-db-adapter.test.ts
@@ -62,7 +62,7 @@ describe("createMaterializerDbAdapter", () => {
     expect(stmt.finalizeSync).toHaveBeenCalledTimes(1);
   });
 
-  it("finalises the statement even when executeSync throws", () => {
+  it("finalises the statement even when executeSync throws on execute", () => {
     const { db, stmt } = setupMocks([]);
     stmt.executeSync.mockImplementation(() => {
       throw new Error("boom");
@@ -72,6 +72,19 @@ describe("createMaterializerDbAdapter", () => {
     expect(() => {
       adapter.execute("INSERT INTO members (id) VALUES (?)", ["m_1"]);
     }).toThrow("boom");
+    expect(stmt.finalizeSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("finalises the statement even when executeSync throws on queryAll", () => {
+    const { db, stmt } = setupMocks([]);
+    stmt.executeSync.mockImplementation(() => {
+      throw new Error("query-boom");
+    });
+    const adapter = createMaterializerDbAdapter(db);
+
+    expect(() => {
+      adapter.queryAll<TestRow>("SELECT id FROM members WHERE id = ?", ["m1"]);
+    }).toThrow("query-boom");
     expect(stmt.finalizeSync).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/mobile/src/data/friend-indexer.ts
+++ b/apps/mobile/src/data/friend-indexer.ts
@@ -3,10 +3,11 @@ import {
   FRIEND_EXPORTABLE_ENTITY_TYPES,
   entityToRow,
   getTableMetadataForEntityType,
+  toBindValue,
 } from "@pluralscape/sync/materializer";
 
 import type { DataLayerEventMap, EventBus, SyncedEntityType } from "@pluralscape/sync";
-import type { MaterializerDb } from "@pluralscape/sync/materializer";
+import type { MaterializerBindValue, MaterializerDb } from "@pluralscape/sync/materializer";
 
 // ── Public types ──────────────────────────────────────────────────────
 
@@ -75,9 +76,9 @@ async function indexFriend(connectionId: string, config: FriendIndexerConfig): P
       const presentColumns = ["connection_id", ...columnNames.filter((col) => col in row)];
       const placeholders = presentColumns.map(() => "?").join(", ");
       const sql = `INSERT OR REPLACE INTO ${friendTableName} (${presentColumns.join(", ")}) VALUES (${placeholders})`;
-      const params: unknown[] = [
+      const params: MaterializerBindValue[] = [
         connectionId,
-        ...columnNames.filter((col) => col in row).map((col) => row[col] ?? null),
+        ...columnNames.filter((col) => col in row).map((col) => toBindValue(row[col] ?? null)),
       ];
 
       db.execute(sql, params);

--- a/apps/mobile/src/data/materializer-db-adapter.ts
+++ b/apps/mobile/src/data/materializer-db-adapter.ts
@@ -1,5 +1,4 @@
-import type { MaterializerDb } from "@pluralscape/sync/materializer";
-import type { SQLiteBindParams } from "expo-sqlite";
+import type { MaterializerBindValue, MaterializerDb } from "@pluralscape/sync/materializer";
 
 /**
  * Subset of expo-sqlite's `SQLiteExecuteSyncResult` we exercise. The
@@ -17,9 +16,13 @@ export interface ExecuteSyncResult<T> {
  * Methods are declared as arrow-function properties so consumers can pass
  * them around without binding gymnastics — keeps test mocks free of
  * unbound-method lint noise.
+ *
+ * `executeSync` accepts `MaterializerBindValue[]` (a structural subset of
+ * `SQLiteBindValue[]`), so passing the materializer's bound params straight
+ * through requires no cast at the call site.
  */
 export interface SqliteStatementHandle {
-  readonly executeSync: <T>(params: SQLiteBindParams) => ExecuteSyncResult<T>;
+  readonly executeSync: <T>(params: MaterializerBindValue[]) => ExecuteSyncResult<T>;
   readonly finalizeSync: () => void;
 }
 
@@ -39,32 +42,32 @@ export interface SqliteSyncDatabase {
 
 /**
  * Adapter wrapping `expo-sqlite`'s synchronous JSI APIs into the
- * `MaterializerDb` interface used by the materializer.
+ * `MaterializerDb` interface used by the materializer subscriber.
  *
  * The materializer issues dynamic INSERT OR REPLACE statements with positional
- * parameters; this adapter forwards them to `prepareSync` / `executeSync` and
- * runs `withTransactionSync` to batch a merge's writes into a single SQLite
- * transaction (per local-first consensus — synchronous in-transaction
- * materialization, no concurrent writers under WAL).
+ * parameters; this adapter forwards them to `prepareSync` / `executeSync`. It
+ * also exposes `transaction()` so the subscriber can wrap one full
+ * materialisation pass (all entity-type projections for one merge) inside a
+ * single BEGIN/COMMIT — keeping a merge atomic from a reader's perspective.
  *
  * Statement handles are finalised in `finally` to avoid native leaks if the
  * caller throws.
  */
 export function createMaterializerDbAdapter(db: SqliteSyncDatabase): MaterializerDb {
   return {
-    queryAll<T>(sql: string, params: unknown[]): T[] {
+    queryAll<T>(sql: string, params: MaterializerBindValue[]): T[] {
       const stmt = db.prepareSync(sql);
       try {
-        const result = stmt.executeSync<T>(params as SQLiteBindParams);
+        const result = stmt.executeSync<T>(params);
         return result.getAllSync();
       } finally {
         stmt.finalizeSync();
       }
     },
-    execute(sql: string, params: unknown[]): void {
+    execute(sql: string, params: MaterializerBindValue[]): void {
       const stmt = db.prepareSync(sql);
       try {
-        stmt.executeSync(params as SQLiteBindParams);
+        stmt.executeSync(params);
       } finally {
         stmt.finalizeSync();
       }

--- a/apps/mobile/src/data/materializer-db-adapter.ts
+++ b/apps/mobile/src/data/materializer-db-adapter.ts
@@ -1,0 +1,83 @@
+import type { MaterializerDb } from "@pluralscape/sync/materializer";
+import type { SQLiteBindParams } from "expo-sqlite";
+
+/**
+ * Subset of expo-sqlite's `SQLiteExecuteSyncResult` we exercise. The
+ * materializer reads rows back via `getAllSync`; the other surface methods
+ * (`getFirstSync`, `resetSync`, etc.) are out of scope.
+ */
+export interface ExecuteSyncResult<T> {
+  readonly getAllSync: () => T[];
+}
+
+/**
+ * Subset of expo-sqlite's `SQLiteStatement` we exercise. The two methods
+ * mirror the prepare/finalize half of the JSI-prepared-statement lifecycle.
+ *
+ * Methods are declared as arrow-function properties so consumers can pass
+ * them around without binding gymnastics — keeps test mocks free of
+ * unbound-method lint noise.
+ */
+export interface SqliteStatementHandle {
+  readonly executeSync: <T>(params: SQLiteBindParams) => ExecuteSyncResult<T>;
+  readonly finalizeSync: () => void;
+}
+
+/**
+ * Minimal expo-sqlite database surface the materializer needs. Defining the
+ * interface here (rather than importing `SQLiteDatabase`) keeps the adapter
+ * decoupled from expo-sqlite's much larger public type and lets tests pass
+ * lightweight mocks without `as unknown as` gymnastics.
+ *
+ * Real callers pass an `SQLiteDatabase` opened via `openDatabaseSync`; the
+ * structural subset is satisfied automatically.
+ */
+export interface SqliteSyncDatabase {
+  readonly prepareSync: (sql: string) => SqliteStatementHandle;
+  readonly withTransactionSync: (fn: () => void) => void;
+}
+
+/**
+ * Adapter wrapping `expo-sqlite`'s synchronous JSI APIs into the
+ * `MaterializerDb` interface used by the materializer.
+ *
+ * The materializer issues dynamic INSERT OR REPLACE statements with positional
+ * parameters; this adapter forwards them to `prepareSync` / `executeSync` and
+ * runs `withTransactionSync` to batch a merge's writes into a single SQLite
+ * transaction (per local-first consensus — synchronous in-transaction
+ * materialization, no concurrent writers under WAL).
+ *
+ * Statement handles are finalised in `finally` to avoid native leaks if the
+ * caller throws.
+ */
+export function createMaterializerDbAdapter(db: SqliteSyncDatabase): MaterializerDb {
+  return {
+    queryAll<T>(sql: string, params: unknown[]): T[] {
+      const stmt = db.prepareSync(sql);
+      try {
+        const result = stmt.executeSync<T>(params as SQLiteBindParams);
+        return result.getAllSync();
+      } finally {
+        stmt.finalizeSync();
+      }
+    },
+    execute(sql: string, params: unknown[]): void {
+      const stmt = db.prepareSync(sql);
+      try {
+        stmt.executeSync(params as SQLiteBindParams);
+      } finally {
+        stmt.finalizeSync();
+      }
+    },
+    transaction<T>(fn: () => T): T {
+      // `withTransactionSync` invokes its callback synchronously inside BEGIN
+      // and rethrows if `fn` does — so when this assignment lands here, `result`
+      // has been set or the line below never runs.
+      let result!: T;
+      db.withTransactionSync(() => {
+        result = fn();
+      });
+      return result;
+    },
+  };
+}

--- a/apps/mobile/src/hooks/__tests__/helpers/render-hook-with-providers.tsx
+++ b/apps/mobile/src/hooks/__tests__/helpers/render-hook-with-providers.tsx
@@ -99,9 +99,8 @@ const STUB_LOCAL_PLATFORM: PlatformContext = {
     storageBackend: "sqlite",
   },
   storage: {
-    backend: "sqlite",
+    backend: "sqlite-async",
     driver: {} as SqliteDriver,
-    materializerDb: null,
   },
   crypto: STUB_SODIUM,
 };

--- a/apps/mobile/src/hooks/__tests__/helpers/render-hook-with-providers.tsx
+++ b/apps/mobile/src/hooks/__tests__/helpers/render-hook-with-providers.tsx
@@ -101,6 +101,7 @@ const STUB_LOCAL_PLATFORM: PlatformContext = {
   storage: {
     backend: "sqlite",
     driver: {} as SqliteDriver,
+    materializerDb: null,
   },
   crypto: STUB_SODIUM,
 };

--- a/apps/mobile/src/hooks/__tests__/use-query-source.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-query-source.test.ts
@@ -26,6 +26,7 @@ import type { PlatformContext } from "../../platform/types.js";
 import type { SyncContextValue } from "../../sync/sync-context.js";
 import type { SodiumAdapter } from "@pluralscape/crypto";
 import type { SqliteDriver } from "@pluralscape/sync/adapters";
+import type { MaterializerDb } from "@pluralscape/sync/materializer";
 
 const mockUsePlatform = vi.mocked(usePlatform);
 const mockUseSync = vi.mocked(useSync);
@@ -42,9 +43,9 @@ function makePlatform(backend: "sqlite" | "indexeddb"): PlatformContext {
         storageBackend: "sqlite",
       },
       storage: {
-        backend: "sqlite",
+        backend: "sqlite-sync",
         driver: mock<SqliteDriver>(),
-        materializerDb: null,
+        materializerDb: mock<MaterializerDb>(),
       },
       crypto: mock<SodiumAdapter>(),
     };

--- a/apps/mobile/src/hooks/__tests__/use-query-source.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-query-source.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 vi.mock("../../platform/PlatformProvider.js", () => ({
   usePlatform: vi.fn(),
@@ -23,6 +24,8 @@ import { useLocalDb, useQuerySource } from "../use-query-source.js";
 import type { DataLayerContextValue } from "../../data/DataLayerProvider.js";
 import type { PlatformContext } from "../../platform/types.js";
 import type { SyncContextValue } from "../../sync/sync-context.js";
+import type { SodiumAdapter } from "@pluralscape/crypto";
+import type { SqliteDriver } from "@pluralscape/sync/adapters";
 
 const mockUsePlatform = vi.mocked(usePlatform);
 const mockUseSync = vi.mocked(useSync);
@@ -38,8 +41,12 @@ function makePlatform(backend: "sqlite" | "indexeddb"): PlatformContext {
         hasNativeMemzero: false,
         storageBackend: "sqlite",
       },
-      storage: { backend: "sqlite", driver: {} as never },
-      crypto: {} as never,
+      storage: {
+        backend: "sqlite",
+        driver: mock<SqliteDriver>(),
+        materializerDb: null,
+      },
+      crypto: mock<SodiumAdapter>(),
     };
   }
   return {

--- a/apps/mobile/src/hooks/use-query-source.ts
+++ b/apps/mobile/src/hooks/use-query-source.ts
@@ -1,5 +1,6 @@
 import { useDataLayerOptional } from "../data/DataLayerProvider.js";
 import { usePlatform } from "../platform/PlatformProvider.js";
+import { isSqliteBackend } from "../platform/types.js";
 import { useSync } from "../sync/sync-context.js";
 
 import type { LocalDatabase } from "../data/local-database.js";
@@ -14,7 +15,7 @@ export function useQuerySource(): QuerySource {
   const platform = usePlatform();
   const sync = useSync();
   if (sync.fallbackToRemote) return "remote";
-  return platform.storage.backend === "sqlite" && sync.isBootstrapped ? "local" : "remote";
+  return isSqliteBackend(platform.storage) && sync.isBootstrapped ? "local" : "remote";
 }
 
 /**

--- a/apps/mobile/src/platform/__tests__/detect.test.ts
+++ b/apps/mobile/src/platform/__tests__/detect.test.ts
@@ -85,7 +85,7 @@ describe("detectPlatform — web + OPFS available", () => {
     });
     const ctx = await detectPlatform();
     expect(ctx.capabilities.storageBackend).toBe("sqlite");
-    expect(ctx.storage.backend).toBe("sqlite");
+    expect(ctx.storage.backend).toBe("sqlite-async");
   });
 });
 

--- a/apps/mobile/src/platform/detect.ts
+++ b/apps/mobile/src/platform/detect.ts
@@ -59,7 +59,10 @@ async function detectWeb(): Promise<PlatformContext> {
           hasNativeMemzero: false,
           storageBackend: "sqlite",
         },
-        storage: { backend: "sqlite", driver },
+        // OPFS exposes only async APIs (worker-backed) — no sync materializer
+        // adapter is wired here. The subscriber is a no-op on web until a sync
+        // path lands (e.g., wa-sqlite synchronous mode).
+        storage: { backend: "sqlite", driver, materializerDb: null },
         crypto,
       };
     } catch (err: unknown) {
@@ -93,7 +96,7 @@ async function detectNative(): Promise<PlatformContext> {
   await crypto.init();
 
   const { createExpoSqliteDriver } = await import("./drivers/expo-sqlite-driver.js");
-  const driver = await createExpoSqliteDriver();
+  const { driver, materializerDb } = await createExpoSqliteDriver();
 
   return {
     capabilities: {
@@ -103,7 +106,7 @@ async function detectNative(): Promise<PlatformContext> {
       hasNativeMemzero: nativeMemzero !== undefined,
       storageBackend: "sqlite",
     },
-    storage: { backend: "sqlite", driver },
+    storage: { backend: "sqlite", driver, materializerDb },
     crypto,
   };
 }

--- a/apps/mobile/src/platform/detect.ts
+++ b/apps/mobile/src/platform/detect.ts
@@ -62,7 +62,7 @@ async function detectWeb(): Promise<PlatformContext> {
         // OPFS exposes only async APIs (worker-backed) — no sync materializer
         // adapter is wired here. The subscriber is a no-op on web until a sync
         // path lands (e.g., wa-sqlite synchronous mode).
-        storage: { backend: "sqlite", driver, materializerDb: null },
+        storage: { backend: "sqlite-async", driver },
         crypto,
       };
     } catch (err: unknown) {
@@ -106,7 +106,7 @@ async function detectNative(): Promise<PlatformContext> {
       hasNativeMemzero: nativeMemzero !== undefined,
       storageBackend: "sqlite",
     },
-    storage: { backend: "sqlite", driver, materializerDb },
+    storage: { backend: "sqlite-sync", driver, materializerDb },
     crypto,
   };
 }

--- a/apps/mobile/src/platform/drivers/__tests__/expo-sqlite-driver.test.ts
+++ b/apps/mobile/src/platform/drivers/__tests__/expo-sqlite-driver.test.ts
@@ -11,6 +11,7 @@ const {
   mockCloseSync,
   mockDeleteDatabaseSync,
   mockOpenDatabaseSync,
+  mockLoggerWarn,
 } = vi.hoisted(() => {
   const mockFinalizeSync = vi.fn();
   const mockGetFirstSync = vi.fn<() => Record<string, unknown> | null>(() => null);
@@ -31,6 +32,7 @@ const {
     execSync: mockExecSync,
     closeSync: mockCloseSync,
   }));
+  const mockLoggerWarn = vi.fn();
 
   return {
     mockFinalizeSync,
@@ -42,12 +44,22 @@ const {
     mockCloseSync,
     mockDeleteDatabaseSync,
     mockOpenDatabaseSync,
+    mockLoggerWarn,
   };
 });
 
 vi.mock("expo-sqlite", () => ({
   openDatabaseSync: mockOpenDatabaseSync,
   deleteDatabaseSync: mockDeleteDatabaseSync,
+}));
+
+vi.mock("../../../lib/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+  },
 }));
 
 import {
@@ -251,6 +263,28 @@ describe("createExpoSqliteDriver", () => {
       expect(mockDeleteDatabaseSync).toHaveBeenCalledWith("pluralscape-sync.db");
       // openDatabaseSync called twice: initial open + reopen after delete
       expect(mockOpenDatabaseSync).toHaveBeenCalledTimes(2);
+    });
+
+    it("logs a warning when wiping an unencrypted DB so the destructive branch is observable", async () => {
+      let execCallCount = 0;
+      mockExecSync.mockImplementation((sql: string) => {
+        execCallCount++;
+        if (execCallCount === 2 && sql.includes("sqlite_master")) {
+          throw new Error("file is not a database");
+        }
+      });
+
+      await createExpoSqliteDriver({ encryptionKeyHex: TEST_KEY_HEX });
+
+      expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+      const [message, context] = mockLoggerWarn.mock.calls[0] ?? [];
+      expect(message).toContain("unencrypted DB detected");
+      expect(context).toEqual({ dbName: "pluralscape-sync.db" });
+    });
+
+    it("does not log when encrypted open succeeds on first attempt", async () => {
+      await createExpoSqliteDriver({ encryptionKeyHex: TEST_KEY_HEX });
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
     });
 
     it("does not delete DB when encrypted open succeeds", async () => {

--- a/apps/mobile/src/platform/drivers/__tests__/expo-sqlite-driver.test.ts
+++ b/apps/mobile/src/platform/drivers/__tests__/expo-sqlite-driver.test.ts
@@ -63,7 +63,7 @@ describe("createExpoSqliteDriver", () => {
   });
 
   it("returns an object implementing SqliteDriver", async () => {
-    const driver = await createExpoSqliteDriver();
+    const { driver } = await createExpoSqliteDriver();
     expect(driver).toHaveProperty("prepare");
     expect(driver).toHaveProperty("exec");
     expect(driver).toHaveProperty("transaction");
@@ -71,7 +71,7 @@ describe("createExpoSqliteDriver", () => {
   });
 
   it("prepare returns a statement with run, all, get methods", async () => {
-    const driver = await createExpoSqliteDriver();
+    const { driver } = await createExpoSqliteDriver();
     const stmt = driver.prepare("SELECT 1");
     expect(stmt).toHaveProperty("run");
     expect(stmt).toHaveProperty("all");
@@ -80,7 +80,7 @@ describe("createExpoSqliteDriver", () => {
 
   describe("exec()", () => {
     it("delegates to db.execSync()", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       await driver.exec("CREATE TABLE t (id INTEGER)");
       expect(mockExecSync).toHaveBeenCalledWith("CREATE TABLE t (id INTEGER)");
     });
@@ -88,7 +88,7 @@ describe("createExpoSqliteDriver", () => {
 
   describe("close()", () => {
     it("delegates to db.closeSync()", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       await driver.close();
       expect(mockCloseSync).toHaveBeenCalledOnce();
     });
@@ -96,7 +96,7 @@ describe("createExpoSqliteDriver", () => {
 
   describe("transaction()", () => {
     it("issues BEGIN/COMMIT and returns fn result on success", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const result = await driver.transaction(() => Promise.resolve(42));
       expect(mockExecSync).toHaveBeenCalledWith("BEGIN");
       expect(mockExecSync).toHaveBeenCalledWith("COMMIT");
@@ -105,7 +105,7 @@ describe("createExpoSqliteDriver", () => {
     });
 
     it("issues ROLLBACK and rethrows when fn throws", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const failure = new Error("fn failed");
       await expect(driver.transaction(() => Promise.reject(failure))).rejects.toBe(failure);
       expect(mockExecSync).toHaveBeenCalledWith("BEGIN");
@@ -114,7 +114,7 @@ describe("createExpoSqliteDriver", () => {
     });
 
     it("throws AggregateError when both fn and ROLLBACK throw", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const failure = new Error("fn failed");
       const rollbackFailure = new Error("rollback failed");
       mockExecSync.mockImplementation((sql: string) => {
@@ -129,7 +129,7 @@ describe("createExpoSqliteDriver", () => {
     });
 
     it("propagates COMMIT failure and attempts a ROLLBACK", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const commitFailure = new Error("commit failed");
       mockExecSync.mockImplementation((sql: string) => {
         if (sql === "COMMIT") throw commitFailure;
@@ -142,7 +142,7 @@ describe("createExpoSqliteDriver", () => {
     });
 
     it("wraps COMMIT and ROLLBACK errors in AggregateError when both fail", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const commitFailure = new Error("commit failed");
       const rollbackFailure = new Error("rollback failed");
       mockExecSync.mockImplementation((sql: string) => {
@@ -159,7 +159,7 @@ describe("createExpoSqliteDriver", () => {
     it("rejects nested transactions with a clear error", async () => {
       // Reset any lingering mockImplementation from preceding error-path tests
       mockExecSync.mockImplementation(() => {});
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       await expect(
         driver.transaction(async () => {
           await driver.transaction(() => Promise.resolve("inner"));
@@ -170,7 +170,7 @@ describe("createExpoSqliteDriver", () => {
 
   describe("prepare().run()", () => {
     it("prepares, executes, and finalizes the statement", async () => {
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       await driver.prepare("INSERT INTO t VALUES (?)").run(1);
       expect(mockPrepareSync).toHaveBeenCalledWith("INSERT INTO t VALUES (?)");
       expect(mockExecuteSync).toHaveBeenCalledWith([1]);
@@ -182,7 +182,7 @@ describe("createExpoSqliteDriver", () => {
     it("returns all rows and finalizes the statement", async () => {
       const rows = [{ id: 1 }, { id: 2 }];
       mockGetAllSync.mockReturnValueOnce(rows);
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const result = await driver.prepare("SELECT * FROM t").all();
       expect(result).toEqual(rows);
       expect(mockFinalizeSync).toHaveBeenCalledOnce();
@@ -192,7 +192,7 @@ describe("createExpoSqliteDriver", () => {
   describe("prepare().get()", () => {
     it("returns the first row when present", async () => {
       mockGetFirstSync.mockReturnValueOnce({ id: 1 });
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const result = await driver.prepare("SELECT * FROM t WHERE id = ?").get(1);
       expect(result).toEqual({ id: 1 });
       expect(mockFinalizeSync).toHaveBeenCalledOnce();
@@ -200,7 +200,7 @@ describe("createExpoSqliteDriver", () => {
 
     it("returns undefined (not null) when no row is found", async () => {
       mockGetFirstSync.mockReturnValueOnce(null);
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       const result = await driver.prepare("SELECT * FROM t WHERE id = ?").get(999);
       expect(result).toBeUndefined();
       expect(mockFinalizeSync).toHaveBeenCalledOnce();
@@ -212,7 +212,7 @@ describe("createExpoSqliteDriver", () => {
       mockExecuteSync.mockImplementationOnce(() => {
         throw new Error("db error");
       });
-      const driver = await createExpoSqliteDriver();
+      const { driver } = await createExpoSqliteDriver();
       expect(() => driver.prepare("SELECT 1").run()).toThrow("db error");
       expect(mockFinalizeSync).toHaveBeenCalledOnce();
     });

--- a/apps/mobile/src/platform/drivers/expo-sqlite-driver.ts
+++ b/apps/mobile/src/platform/drivers/expo-sqlite-driver.ts
@@ -6,7 +6,10 @@ import {
   type SQLiteDatabase,
 } from "expo-sqlite";
 
+import { createMaterializerDbAdapter } from "../../data/materializer-db-adapter.js";
+
 import type { SqliteDriver, SqliteStatement } from "@pluralscape/sync/adapters";
+import type { MaterializerDb } from "@pluralscape/sync/materializer";
 
 const DB_NAME = "pluralscape-sync.db";
 
@@ -26,6 +29,18 @@ export interface ExpoSqliteDriverOptions {
    * `DB_ENCRYPTION_KDF_CONTEXT` and `DB_ENCRYPTION_SUBKEY_ID` constants).
    */
   readonly encryptionKeyHex?: string;
+}
+
+/**
+ * Pair returned by {@link createExpoSqliteDriver}: the async {@link SqliteDriver}
+ * used by the storage adapter and the synchronous {@link MaterializerDb} used
+ * by the materializer subscriber. Both wrap the same underlying expo-sqlite
+ * connection so writes from each side share the SQLCipher session and a single
+ * WAL.
+ */
+export interface ExpoSqliteAdapters {
+  readonly driver: SqliteDriver;
+  readonly materializerDb: MaterializerDb;
 }
 
 /**
@@ -65,7 +80,11 @@ function isDatabaseAccessible(db: SQLiteDatabase): boolean {
 }
 
 /**
- * Wraps expo-sqlite into the SqliteDriver interface used by @pluralscape/sync adapters.
+ * Wraps expo-sqlite into the SqliteDriver interface used by @pluralscape/sync adapters
+ * AND the synchronous {@link MaterializerDb} interface used by the materializer
+ * subscriber. Both are backed by the same underlying expo-sqlite connection so writes
+ * from each side share the SQLCipher session and a single WAL.
+ *
  * expo-sqlite uses a synchronous API under the hood (JSI), wrapped in our interface.
  *
  * When `encryptionKeyHex` is provided, the driver:
@@ -79,7 +98,7 @@ function isDatabaseAccessible(db: SQLiteDatabase): boolean {
  */
 export function createExpoSqliteDriver(
   options: ExpoSqliteDriverOptions = {},
-): Promise<SqliteDriver> {
+): Promise<ExpoSqliteAdapters> {
   const { encryptionKeyHex } = options;
 
   let db: SQLiteDatabase = openDatabaseSync(DB_NAME);
@@ -160,5 +179,7 @@ export function createExpoSqliteDriver(
     },
   };
 
-  return Promise.resolve(driver);
+  const materializerDb = createMaterializerDbAdapter(db);
+
+  return Promise.resolve({ driver, materializerDb });
 }

--- a/apps/mobile/src/platform/drivers/expo-sqlite-driver.ts
+++ b/apps/mobile/src/platform/drivers/expo-sqlite-driver.ts
@@ -7,6 +7,7 @@ import {
 } from "expo-sqlite";
 
 import { createMaterializerDbAdapter } from "../../data/materializer-db-adapter.js";
+import { logger } from "../../lib/logger.js";
 
 import type { SqliteDriver, SqliteStatement } from "@pluralscape/sync/adapters";
 import type { MaterializerDb } from "@pluralscape/sync/materializer";
@@ -108,8 +109,15 @@ export function createExpoSqliteDriver(
     db.execSync(`PRAGMA key = "x'${encryptionKeyHex}'"`);
 
     if (!isDatabaseAccessible(db)) {
-      // Database exists but was created without encryption (pre-production migration).
-      // Close, delete the unencrypted file, and recreate with encryption.
+      // Database exists but was created without encryption (pre-production
+      // migration). Close, delete the unencrypted file, and recreate with
+      // encryption. Logged so the wipe is observable in production diagnostics
+      // — once the DB is encrypted, the branch never matches again, so this
+      // log fires at most once per device install.
+      logger.warn(
+        "[expo-sqlite-driver] unencrypted DB detected; deleting and recreating with encryption",
+        { dbName: DB_NAME },
+      );
       db.closeSync();
       deleteDatabaseSync(DB_NAME);
 

--- a/apps/mobile/src/platform/types.ts
+++ b/apps/mobile/src/platform/types.ts
@@ -20,20 +20,40 @@ export interface PlatformCapabilities {
 
 export type PlatformStorage =
   | {
-      readonly backend: "sqlite";
-      readonly driver: SqliteDriver;
       /**
-       * Synchronous DB handle the materializer subscriber writes through.
-       * Populated for sync-native backends (expo-sqlite); `null` for backends
-       * that only expose async APIs (OPFS over a Web Worker).
+       * Native sqlite (expo-sqlite). Exposes both the async {@link SqliteDriver}
+       * used by the engine's storage adapter and the synchronous
+       * {@link MaterializerDb} the materializer subscriber writes through.
        */
-      readonly materializerDb: MaterializerDb | null;
+      readonly backend: "sqlite-sync";
+      readonly driver: SqliteDriver;
+      readonly materializerDb: MaterializerDb;
+    }
+  | {
+      /**
+       * Web sqlite (OPFS over a Worker). Only exposes async APIs; no
+       * materializer subscriber wires up on this backend until a sync path
+       * lands (e.g. wa-sqlite synchronous mode).
+       */
+      readonly backend: "sqlite-async";
+      readonly driver: SqliteDriver;
     }
   | {
       readonly backend: "indexeddb";
       readonly storageAdapter: SyncStorageAdapter;
       readonly offlineQueueAdapter: OfflineQueueAdapter;
     };
+
+/**
+ * Type guard covering both sqlite variants (native sync + OPFS async). Use
+ * when consumers only need a {@link SqliteDriver} and don't care which
+ * platform produced it.
+ */
+export function isSqliteBackend(
+  s: PlatformStorage,
+): s is PlatformStorage & { driver: SqliteDriver } {
+  return s.backend === "sqlite-sync" || s.backend === "sqlite-async";
+}
 
 export interface PlatformContext {
   readonly capabilities: PlatformCapabilities;

--- a/apps/mobile/src/platform/types.ts
+++ b/apps/mobile/src/platform/types.ts
@@ -4,6 +4,7 @@ import type {
   SyncStorageAdapter,
   OfflineQueueAdapter,
 } from "@pluralscape/sync/adapters";
+import type { MaterializerDb } from "@pluralscape/sync/materializer";
 
 export type StorageBackend = "sqlite" | "indexeddb";
 
@@ -18,7 +19,16 @@ export interface PlatformCapabilities {
 }
 
 export type PlatformStorage =
-  | { readonly backend: "sqlite"; readonly driver: SqliteDriver }
+  | {
+      readonly backend: "sqlite";
+      readonly driver: SqliteDriver;
+      /**
+       * Synchronous DB handle the materializer subscriber writes through.
+       * Populated for sync-native backends (expo-sqlite); `null` for backends
+       * that only expose async APIs (OPFS over a Web Worker).
+       */
+      readonly materializerDb: MaterializerDb | null;
+    }
   | {
       readonly backend: "indexeddb";
       readonly storageAdapter: SyncStorageAdapter;

--- a/apps/mobile/src/sync/SyncProvider.tsx
+++ b/apps/mobile/src/sync/SyncProvider.tsx
@@ -1,4 +1,5 @@
 import { createBucketKeyCache } from "@pluralscape/crypto";
+import { createMaterializerSubscriber } from "@pluralscape/data";
 import { DocumentKeyResolver, SyncEngine } from "@pluralscape/sync";
 import { SqliteStorageAdapter } from "@pluralscape/sync/adapters";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -15,8 +16,10 @@ import { SyncCtx } from "./sync-context.js";
 import type { SyncContextValue } from "./sync-context.js";
 import type { WsManager } from "../connection/ws-manager.js";
 import type { BucketKeyCache, KdfMasterKey, SignKeypair, SodiumAdapter } from "@pluralscape/crypto";
+import type { MaterializerSubscriberHandle } from "@pluralscape/data";
 import type { DataLayerEventMap, EventBus, ReplicationProfile } from "@pluralscape/sync";
 import type { SqliteDriver } from "@pluralscape/sync/adapters";
+import type { MaterializerDb } from "@pluralscape/sync/materializer";
 import type { SystemId } from "@pluralscape/types";
 import type { ReactNode } from "react";
 
@@ -34,6 +37,11 @@ interface EngineReadyConfig {
   readonly masterKey: KdfMasterKey;
   readonly signingKeys: SignKeypair;
   readonly sqliteDriver: SqliteDriver;
+  /**
+   * Synchronous materializer DB handle. `null` on backends that only expose
+   * async APIs (web/OPFS); the subscriber is skipped in that case.
+   */
+  readonly materializerDb: MaterializerDb | null;
 }
 
 const Ctx = SyncCtx;
@@ -46,7 +54,9 @@ const Ctx = SyncCtx;
  * 2. Platform storage backend is "sqlite" (full device)
  *
  * Constructs: SqliteStorageAdapter, DocumentKeyResolver (with BucketKeyCache),
- * WsManager (WebSocket network adapter), and SyncEngine.
+ * WsManager (WebSocket network adapter), SyncEngine, and (when the platform
+ * exposes a synchronous DB handle) the materializer subscriber that projects
+ * merged CRDT state into local SQLite cache tables.
  *
  * Bootstraps sync when the SSE connection reports "connected", then exposes
  * engine and bootstrap state via context. Retries up to MAX_BOOTSTRAP_ATTEMPTS
@@ -91,6 +101,8 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
   const signingKeys =
     auth.snapshot.state === "unlocked" ? auth.snapshot.session.identityKeys.sign : null;
   const sqliteDriver = platform.storage.backend === "sqlite" ? platform.storage.driver : null;
+  const materializerDb =
+    platform.storage.backend === "sqlite" ? platform.storage.materializerDb : null;
 
   // Memoize engine creation config — excludes isConnected to avoid tearing
   // down and re-creating the engine on every connection status change.
@@ -114,10 +126,21 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
       masterKey,
       signingKeys,
       sqliteDriver,
+      materializerDb,
     };
     // storageBackend intentionally excluded: sqliteDriver is null on non-sqlite
     // platforms, so the null check above already gates on backend type.
-  }, [isUnlocked, systemId, sodium, eventBus, sessionToken, masterKey, signingKeys, sqliteDriver]);
+  }, [
+    isUnlocked,
+    systemId,
+    sodium,
+    eventBus,
+    sessionToken,
+    masterKey,
+    signingKeys,
+    sqliteDriver,
+    materializerDb,
+  ]);
 
   // Engine lifecycle effect — creates or tears down the sync pipeline.
   // Uses a ref-based cleanup strategy so state updates in the effect body
@@ -161,9 +184,13 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
       keyResolver?: DocumentKeyResolver;
       wsManager?: WsManager;
       engine?: SyncEngine;
+      materializerSubscriber?: MaterializerSubscriberHandle;
     } = {};
 
     const disposePartial = (): void => {
+      // Tear down in reverse construction order. Subscriber first so it
+      // stops consuming events the engine is about to stop emitting.
+      pipeline.materializerSubscriber?.dispose();
       pipeline.engine?.dispose();
       pipeline.keyResolver?.dispose();
       pipeline.wsManager?.disconnect();
@@ -224,6 +251,18 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
           disposePartial();
           return;
         }
+
+        // Wire the materializer subscriber once the engine exists, so merged
+        // CRDT state lands in the local SQLite cache. Skipped when the
+        // platform doesn't expose a synchronous DB handle (web/OPFS).
+        if (engineConfig.materializerDb !== null) {
+          pipeline.materializerSubscriber = createMaterializerSubscriber({
+            engine: pipeline.engine,
+            materializerDb: engineConfig.materializerDb,
+            eventBus: bus,
+          });
+        }
+
         setEngine(pipeline.engine);
 
         cleanup = () => {

--- a/apps/mobile/src/sync/SyncProvider.tsx
+++ b/apps/mobile/src/sync/SyncProvider.tsx
@@ -129,8 +129,9 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
       sqliteDriver,
       materializerDb,
     };
-    // storageBackend intentionally excluded: sqliteDriver is null on non-sqlite
-    // platforms, so the null check above already gates on backend type.
+    // storageBackend isn't a dep: `sqliteDriver` is null on non-sqlite platforms
+    // and `materializerDb` is null on async-only sqlite, so the null checks
+    // above already gate on backend variant.
   }, [
     isUnlocked,
     systemId,
@@ -196,9 +197,6 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
       pipeline.keyResolver?.dispose();
       pipeline.wsManager?.disconnect();
       pipeline.bucketKeyCache?.clearAll();
-      bucketKeyCacheRef.current = null;
-      keyResolverRef.current = null;
-      wsManagerRef.current = null;
     };
 
     void (async () => {
@@ -235,7 +233,6 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
 
         const profile: ReplicationProfile = { profileType: "owner-full" };
 
-        const bus = engineConfig.eventBus;
         pipeline.engine = new SyncEngine({
           networkAdapter,
           storageAdapter,
@@ -244,9 +241,9 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
           profile,
           systemId: engineConfig.systemId,
           onError: (message, error) => {
-            bus.emit("sync:error", { type: "sync:error", message, error });
+            engineConfig.eventBus.emit("sync:error", { type: "sync:error", message, error });
           },
-          eventBus: bus,
+          eventBus: engineConfig.eventBus,
         });
         if (isCancelled()) {
           disposePartial();
@@ -260,7 +257,7 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
           pipeline.materializerSubscriber = createMaterializerSubscriber({
             engine: pipeline.engine,
             materializerDb: engineConfig.materializerDb,
-            eventBus: bus,
+            eventBus: engineConfig.eventBus,
           });
         }
 
@@ -278,6 +275,11 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
           error,
         });
         disposePartial();
+        // Mirror the success-path cleanup: leaving stale engine state in React
+        // would cause the bootstrap effect to retry against a torn-down
+        // pipeline once the connection comes up.
+        setEngine(null);
+        setIsBootstrapped(false);
       }
     })();
 

--- a/apps/mobile/src/sync/SyncProvider.tsx
+++ b/apps/mobile/src/sync/SyncProvider.tsx
@@ -10,6 +10,7 @@ import { useConnection } from "../connection/index.js";
 import { createWsManager } from "../connection/ws-manager.js";
 import { useDataLayer } from "../data/DataLayerProvider.js";
 import { usePlatform } from "../platform/index.js";
+import { isSqliteBackend } from "../platform/types.js";
 
 import { SyncCtx } from "./sync-context.js";
 
@@ -100,9 +101,9 @@ export function SyncProvider({ children }: { readonly children: ReactNode }): Re
   const masterKey = auth.snapshot.state === "unlocked" ? auth.snapshot.session.masterKey : null;
   const signingKeys =
     auth.snapshot.state === "unlocked" ? auth.snapshot.session.identityKeys.sign : null;
-  const sqliteDriver = platform.storage.backend === "sqlite" ? platform.storage.driver : null;
+  const sqliteDriver = isSqliteBackend(platform.storage) ? platform.storage.driver : null;
   const materializerDb =
-    platform.storage.backend === "sqlite" ? platform.storage.materializerDb : null;
+    platform.storage.backend === "sqlite-sync" ? platform.storage.materializerDb : null;
 
   // Memoize engine creation config — excludes isConnected to avoid tearing
   // down and re-creating the engine on every connection status change.

--- a/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
+++ b/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
@@ -122,22 +122,29 @@ function makeSqliteDriver(
   opts: {
     materializerDb?: MaterializerDb | null;
   } = {},
-): PlatformStorage & { backend: "sqlite" } {
-  return {
-    backend: "sqlite" as const,
-    driver: {
-      exec: vi.fn(() => Promise.resolve()),
-      prepare: vi.fn(() => ({
-        all: vi.fn(() => Promise.resolve([])),
-        get: vi.fn(() => Promise.resolve(undefined)),
-        run: vi.fn(() => Promise.resolve()),
-      })),
-      transaction<T>(fn: () => Promise<T>): Promise<T> {
-        return fn();
-      },
-      close: vi.fn(() => Promise.resolve()),
+): PlatformStorage {
+  const driver = {
+    exec: vi.fn(() => Promise.resolve()),
+    prepare: vi.fn(() => ({
+      all: vi.fn(() => Promise.resolve([])),
+      get: vi.fn(() => Promise.resolve(undefined)),
+      run: vi.fn(() => Promise.resolve()),
+    })),
+    transaction<T>(fn: () => Promise<T>): Promise<T> {
+      return fn();
     },
-    materializerDb: opts.materializerDb ?? null,
+    close: vi.fn(() => Promise.resolve()),
+  };
+  // Default to "sqlite-sync" so existing tests that don't care about the
+  // subscriber wiring still get a fully-typed PlatformStorage. Pass
+  // `materializerDb: null` to opt into the async-only variant.
+  if (opts.materializerDb === null) {
+    return { backend: "sqlite-async" as const, driver };
+  }
+  return {
+    backend: "sqlite-sync" as const,
+    driver,
+    materializerDb: opts.materializerDb ?? makeMockMaterializerDb(),
   };
 }
 

--- a/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
+++ b/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
@@ -201,6 +201,12 @@ const mockGetMaterializer = vi.fn<
   materialize: mockMaterialize,
 }));
 
+// ── Hoisted subscriber-dispose spy (used by the disposal-order test) ──
+
+const { mockSubscriberDispose } = vi.hoisted(() => ({
+  mockSubscriberDispose: vi.fn(),
+}));
+
 // ── Mock DocumentKeyResolver ────────────────────────────────────────
 
 const mockKeyResolverDispose = vi.fn();
@@ -345,6 +351,28 @@ vi.mock("@pluralscape/sync/materializer", async (importOriginal) => {
   return {
     ...actual,
     getMaterializer: mockGetMaterializer,
+  };
+});
+
+// Wrap createMaterializerSubscriber so we can observe its dispose timing
+// against the engine's. The wrapper still delegates to the real subscriber so
+// the existing "materializer subscriber wiring" tests keep exercising the
+// real listener path.
+vi.mock("@pluralscape/data", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@pluralscape/data")>();
+  return {
+    ...actual,
+    createMaterializerSubscriber: (
+      deps: Parameters<typeof actual.createMaterializerSubscriber>[0],
+    ) => {
+      const real = actual.createMaterializerSubscriber(deps);
+      return {
+        dispose: () => {
+          mockSubscriberDispose();
+          real.dispose();
+        },
+      };
+    },
   };
 });
 
@@ -875,6 +903,91 @@ describe("SyncProvider", () => {
       });
 
       expect(mockMaterialize).not.toHaveBeenCalled();
+    });
+
+    it("disposes the subscriber before the engine on unmount", async () => {
+      setUnlocked();
+      mockConnectionStatus = "connected";
+
+      mockPlatformStorage = makeSqliteDriver({ materializerDb: makeMockMaterializerDb() });
+
+      const { unmount } = renderHook(() => useSync(), { wrapper: makeWrapper() });
+      await waitFor(() => {
+        expect(MockSyncEngine).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+
+      const subscriberOrder = mockSubscriberDispose.mock.invocationCallOrder[0];
+      const engineOrder = mockDispose.mock.invocationCallOrder[0];
+      // Vitest invocation order is monotonic and starts at 1; missing entries
+      // are undefined. Asserting > 0 doubles as a "was actually called" check.
+      expect(subscriberOrder).toBeGreaterThan(0);
+      expect(engineOrder).toBeGreaterThan(0);
+      // Subscriber must stop consuming events before the engine stops emitting.
+      expect(subscriberOrder).toBeLessThan(engineOrder ?? 0);
+    });
+
+    it("creates a fresh subscriber on lock→unlock cycle", async () => {
+      setUnlocked();
+      mockConnectionStatus = "connected";
+
+      mockPlatformStorage = makeSqliteDriver({ materializerDb: makeMockMaterializerDb() });
+
+      const { rerender } = renderHook(() => useSync(), { wrapper: makeWrapper() });
+      await waitFor(() => {
+        expect(MockSyncEngine).toHaveBeenCalledTimes(1);
+      });
+      expect(mockSubscriberDispose).not.toHaveBeenCalled();
+
+      // Lock — the subscriber for the first session must be disposed.
+      setUnauthenticated();
+      mockConnectionStatus = "disconnected";
+      rerender();
+
+      await waitFor(() => {
+        expect(mockSubscriberDispose).toHaveBeenCalledTimes(1);
+      });
+
+      // Unlock again — a NEW engine and subscriber are constructed.
+      setUnlocked();
+      mockConnectionStatus = "connected";
+      mockPlatformStorage = makeSqliteDriver({ materializerDb: makeMockMaterializerDb() });
+      rerender();
+
+      await waitFor(() => {
+        expect(MockSyncEngine).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("clears engine state when SyncEngine construction throws", async () => {
+      setUnlocked();
+      mockConnectionStatus = "connected";
+
+      const constructError = new Error("engine ctor failed");
+      MockSyncEngine.mockImplementationOnce(function FailingCtor() {
+        throw constructError;
+      });
+
+      const emitted: import("@pluralscape/sync").SyncErrorEvent[] = [];
+      mockEventBus.on("sync:error", (event) => {
+        emitted.push(event);
+      });
+
+      const { result } = renderHook(() => useSync(), { wrapper: makeWrapper() });
+
+      await waitFor(() => {
+        expect(emitted).toHaveLength(1);
+      });
+
+      expect(emitted[0]?.message).toContain("initialization failed");
+      expect(emitted[0]?.error).toBe(constructError);
+      expect(result.current.engine).toBeNull();
+      expect(result.current.isBootstrapped).toBe(false);
+      // Resources created BEFORE the throw must be torn down.
+      expect(mockKeyResolverDispose).toHaveBeenCalledTimes(1);
+      expect(mockClearAll).toHaveBeenCalledTimes(1);
+      expect(mockWsDisconnect).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
+++ b/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
@@ -20,7 +20,8 @@ import type {
   SignSecretKey,
 } from "@pluralscape/crypto";
 import type { ReplicationProfile } from "@pluralscape/sync";
-import type { AccountId, SystemId } from "@pluralscape/types";
+import type { MaterializerDb } from "@pluralscape/sync/materializer";
+import type { AccountId, SyncDocumentId, SystemId } from "@pluralscape/types";
 import type { ReactNode } from "react";
 
 // ── Branded type helpers (assertion-based, no double-cast) ──────────
@@ -105,7 +106,23 @@ let mockAuthState: AuthContextValue["snapshot"] = {
 
 let mockConnectionStatus: ConnectionContextValue["status"] = "disconnected";
 
-function makeSqliteDriver(): PlatformStorage & { backend: "sqlite" } {
+function makeMockMaterializerDb(): MaterializerDb {
+  // Note: `transaction` is generic, so we use a regular method declaration
+  // (preserves generic signature) rather than `vi.fn` (loses generic).
+  return {
+    queryAll: vi.fn(() => []),
+    execute: vi.fn(),
+    transaction<T>(fn: () => T): T {
+      return fn();
+    },
+  };
+}
+
+function makeSqliteDriver(
+  opts: {
+    materializerDb?: MaterializerDb | null;
+  } = {},
+): PlatformStorage & { backend: "sqlite" } {
   return {
     backend: "sqlite" as const,
     driver: {
@@ -120,7 +137,7 @@ function makeSqliteDriver(): PlatformStorage & { backend: "sqlite" } {
       },
       close: vi.fn(() => Promise.resolve()),
     },
-    materializerDb: null,
+    materializerDb: opts.materializerDb ?? null,
   };
 }
 
@@ -159,12 +176,23 @@ const mockSodium: PlatformContext["crypto"] = {
 
 const mockBootstrap = vi.fn(() => Promise.resolve());
 const mockDispose = vi.fn();
+const mockGetDocumentSnapshot = vi.fn<(id: string) => unknown>(() => null);
 
 // Use a function declaration so it can be called with `new`
 const MockSyncEngine = vi.fn(function MockSyncEngineImpl(this: Record<string, unknown>) {
   this.bootstrap = mockBootstrap;
   this.dispose = mockDispose;
+  this.getDocumentSnapshot = mockGetDocumentSnapshot;
 });
+
+// ── Mock materializer registry ──────────────────────────────────────
+
+const mockMaterialize = vi.fn();
+const mockGetMaterializer = vi.fn<
+  (docType: string) => { materialize: typeof mockMaterialize } | null
+>(() => ({
+  materialize: mockMaterialize,
+}));
 
 // ── Mock DocumentKeyResolver ────────────────────────────────────────
 
@@ -302,6 +330,14 @@ vi.mock("@pluralscape/sync/adapters", async (importOriginal) => {
   return {
     ...actual,
     SqliteStorageAdapter: MockSqliteStorageAdapter,
+  };
+});
+
+vi.mock("@pluralscape/sync/materializer", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@pluralscape/sync/materializer")>();
+  return {
+    ...actual,
+    getMaterializer: mockGetMaterializer,
   };
 });
 
@@ -712,6 +748,126 @@ describe("SyncProvider", () => {
       expect(emitted[0]?.error).toBe(initError);
       expect(MockSyncEngine).not.toHaveBeenCalled();
       expect(result.current.engine).toBeNull();
+    });
+  });
+
+  describe("materializer subscriber wiring", () => {
+    it("invokes the materializer when sync:changes-merged fires after engine creation", async () => {
+      setUnlocked();
+      mockConnectionStatus = "connected";
+
+      const materializerDb = makeMockMaterializerDb();
+      mockPlatformStorage = makeSqliteDriver({ materializerDb });
+
+      // Snapshot returned for the document under test
+      const docSnapshot = { members: { mem_1: { id: "mem_1", name: "Test" } } };
+      mockGetDocumentSnapshot.mockReturnValue(docSnapshot);
+
+      renderHook(() => useSync(), { wrapper: makeWrapper() });
+
+      // Wait for the engine (and subscriber) to be wired
+      await waitFor(() => {
+        expect(MockSyncEngine).toHaveBeenCalledTimes(1);
+      });
+
+      // Emit sync:changes-merged on the same eventBus the provider passes to
+      // the engine — the subscriber listens here.
+      const docId = brandId<SyncDocumentId>("system-core_sys_test123");
+      mockEventBus.emit("sync:changes-merged", {
+        type: "sync:changes-merged",
+        documentId: docId,
+        documentType: "system-core",
+        dirtyEntityTypes: new Set(["member"]),
+        conflicts: [],
+      });
+
+      expect(mockGetDocumentSnapshot).toHaveBeenCalledWith(docId);
+      expect(mockGetMaterializer).toHaveBeenCalledWith("system-core");
+      expect(mockMaterialize).toHaveBeenCalledTimes(1);
+      expect(mockMaterialize).toHaveBeenCalledWith(
+        docSnapshot,
+        materializerDb,
+        mockEventBus,
+        new Set(["member"]),
+      );
+    });
+
+    it("invokes the materializer with no dirty filter on sync:snapshot-applied", async () => {
+      setUnlocked();
+      mockConnectionStatus = "connected";
+
+      const materializerDb = makeMockMaterializerDb();
+      mockPlatformStorage = makeSqliteDriver({ materializerDb });
+      const docSnapshot = { members: {} };
+      mockGetDocumentSnapshot.mockReturnValue(docSnapshot);
+
+      renderHook(() => useSync(), { wrapper: makeWrapper() });
+      await waitFor(() => {
+        expect(MockSyncEngine).toHaveBeenCalledTimes(1);
+      });
+
+      const docId = brandId<SyncDocumentId>("system-core_sys_test123");
+      mockEventBus.emit("sync:snapshot-applied", {
+        type: "sync:snapshot-applied",
+        documentId: docId,
+        documentType: "system-core",
+      });
+
+      expect(mockMaterialize).toHaveBeenCalledTimes(1);
+      expect(mockMaterialize).toHaveBeenCalledWith(
+        docSnapshot,
+        materializerDb,
+        mockEventBus,
+        undefined,
+      );
+    });
+
+    it("does not wire a subscriber when materializerDb is null", async () => {
+      setUnlocked();
+      mockConnectionStatus = "connected";
+
+      mockPlatformStorage = makeSqliteDriver({ materializerDb: null });
+      mockGetDocumentSnapshot.mockReturnValue({ members: {} });
+
+      renderHook(() => useSync(), { wrapper: makeWrapper() });
+      await waitFor(() => {
+        expect(MockSyncEngine).toHaveBeenCalledTimes(1);
+      });
+
+      mockEventBus.emit("sync:changes-merged", {
+        type: "sync:changes-merged",
+        documentId: brandId<SyncDocumentId>("system-core_sys_test123"),
+        documentType: "system-core",
+        dirtyEntityTypes: new Set(["member"]),
+        conflicts: [],
+      });
+
+      expect(mockMaterialize).not.toHaveBeenCalled();
+    });
+
+    it("disposes the subscriber on unmount so later events are ignored", async () => {
+      setUnlocked();
+      mockConnectionStatus = "connected";
+
+      mockPlatformStorage = makeSqliteDriver({ materializerDb: makeMockMaterializerDb() });
+      mockGetDocumentSnapshot.mockReturnValue({ members: {} });
+
+      const { unmount } = renderHook(() => useSync(), { wrapper: makeWrapper() });
+      await waitFor(() => {
+        expect(MockSyncEngine).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+
+      mockEventBus.emit("sync:changes-merged", {
+        type: "sync:changes-merged",
+        documentId: brandId<SyncDocumentId>("system-core_sys_test123"),
+        documentType: "system-core",
+        dirtyEntityTypes: new Set(["member"]),
+        conflicts: [],
+      });
+
+      expect(mockMaterialize).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
+++ b/apps/mobile/src/sync/__tests__/SyncProvider.test.tsx
@@ -120,6 +120,7 @@ function makeSqliteDriver(): PlatformStorage & { backend: "sqlite" } {
       },
       close: vi.fn(() => Promise.resolve()),
     },
+    materializerDb: null,
   };
 }
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@pluralscape/api-client": "workspace:*",
     "@pluralscape/crypto": "workspace:*",
+    "@pluralscape/sync": "workspace:*",
     "@pluralscape/types": "workspace:*",
     "@pluralscape/validation": "workspace:*",
     "@tanstack/react-query": "catalog:"

--- a/packages/data/src/__tests__/materializer-subscriber.test.ts
+++ b/packages/data/src/__tests__/materializer-subscriber.test.ts
@@ -1,11 +1,17 @@
-import { createEventBus, type DataLayerEventMap, type EventBus } from "@pluralscape/sync";
+import {
+  createEventBus,
+  NoActiveSessionError,
+  type DataLayerEventMap,
+  type EventBus,
+} from "@pluralscape/sync";
 import {
   getMaterializer,
   registerMaterializer,
+  type DocumentMaterializer,
   type MaterializerDb,
 } from "@pluralscape/sync/materializer";
 import { brandId } from "@pluralscape/types";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { createMaterializerSubscriber } from "../materializer-subscriber.js";
 
@@ -16,19 +22,25 @@ function makeMockMaterializerDb(): MaterializerDb {
   return {
     queryAll: vi.fn(() => []),
     execute: vi.fn(),
-    transaction: <T>(fn: () => T): T => fn(),
+    transaction<T>(fn: () => T): T {
+      return fn();
+    },
   };
 }
 
-function makeMockEngine(snapshots: Record<string, unknown>): {
+function makeMockEngine(resolveSnapshot: (id: SyncDocumentId) => unknown): {
   engine: DocumentSnapshotProvider;
   spy: ReturnType<typeof vi.fn>;
 } {
-  const spy = vi.fn((id: SyncDocumentId) => snapshots[String(id)]);
-  return {
-    engine: { getDocumentSnapshot: spy },
-    spy,
-  };
+  const spy = vi.fn(resolveSnapshot);
+  return { engine: { getDocumentSnapshot: spy }, spy };
+}
+
+function snapshotsByDocId(snapshots: Record<string, unknown>): {
+  engine: DocumentSnapshotProvider;
+  spy: ReturnType<typeof vi.fn>;
+} {
+  return makeMockEngine((id) => snapshots[String(id)]);
 }
 
 function docId(raw: string): SyncDocumentId {
@@ -37,15 +49,26 @@ function docId(raw: string): SyncDocumentId {
 
 const TEST_DOC_TYPE = "system-core" as const;
 
+// ── Registry save/restore so the auto-registered system-core materializer is
+// reinstated between tests (registerMaterializer overwrites silently).
+let originalMaterializer: DocumentMaterializer | undefined;
+
+beforeEach(() => {
+  originalMaterializer = getMaterializer(TEST_DOC_TYPE);
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
+  if (originalMaterializer) {
+    registerMaterializer(originalMaterializer);
+  }
 });
 
 describe("createMaterializerSubscriber", () => {
   test("calls registered materializer on sync:changes-merged", () => {
     const id = docId("system-core_sys_test1");
     const docSnapshot = { members: {} };
-    const { engine, spy } = makeMockEngine({ [id]: docSnapshot });
+    const { engine, spy } = snapshotsByDocId({ [id]: docSnapshot });
     const materializerDb = makeMockMaterializerDb();
     const eventBus = createEventBus<DataLayerEventMap>();
 
@@ -77,10 +100,12 @@ describe("createMaterializerSubscriber", () => {
     handle.dispose();
   });
 
-  test("no-ops when getDocumentSnapshot returns undefined (session evicted)", () => {
-    const id = docId("system-core_sys_evicted");
-    const { engine } = makeMockEngine({});
+  test("wraps the materialize call in a single materializerDb.transaction", () => {
+    const id = docId("system-core_sys_tx");
+    const docSnapshot = { members: { mem_1: { id: "mem_1" } } };
+    const { engine } = snapshotsByDocId({ [id]: docSnapshot });
     const materializerDb = makeMockMaterializerDb();
+    const transactionSpy = vi.spyOn(materializerDb, "transaction");
     const eventBus = createEventBus<DataLayerEventMap>();
 
     const materializeSpy = vi.fn();
@@ -96,14 +121,112 @@ describe("createMaterializerSubscriber", () => {
       conflicts: [],
     });
 
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+    // The materialize callback ran inside the transaction's sync identity wrap.
+    expect(materializeSpy).toHaveBeenCalledTimes(1);
+    handle.dispose();
+  });
+
+  test("treats NoActiveSessionError as a benign skip without emitting sync:error", () => {
+    const id = docId("system-core_sys_evicted");
+    const { engine } = makeMockEngine(() => {
+      throw new NoActiveSessionError(String(id));
+    });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+    const errorEvents: unknown[] = [];
+    eventBus.on("sync:error", (e) => errorEvents.push(e));
+
+    const materializeSpy = vi.fn();
+    registerMaterializer({ documentType: TEST_DOC_TYPE, materialize: materializeSpy });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: id,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+
     expect(materializeSpy).not.toHaveBeenCalled();
+    expect(errorEvents).toHaveLength(0);
+    handle.dispose();
+  });
+
+  test("emits sync:error when getDocumentSnapshot throws something other than NoActiveSessionError", () => {
+    const id = docId("system-core_sys_disk");
+    const failure = new Error("disk read failed");
+    const { engine } = makeMockEngine(() => {
+      throw failure;
+    });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+    const errorEvents: { message: string; error: unknown }[] = [];
+    eventBus.on("sync:error", (e) => errorEvents.push({ message: e.message, error: e.error }));
+
+    const materializeSpy = vi.fn();
+    registerMaterializer({ documentType: TEST_DOC_TYPE, materialize: materializeSpy });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: id,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+
+    expect(materializeSpy).not.toHaveBeenCalled();
+    expect(errorEvents).toEqual([{ message: "materializer snapshot read failed", error: failure }]);
+    handle.dispose();
+  });
+
+  test("emits sync:error when materialize throws and continues handling subsequent emits", () => {
+    const id = docId("system-core_sys_writefail");
+    const docSnapshot = { members: {} };
+    const { engine } = snapshotsByDocId({ [id]: docSnapshot });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+    const errorEvents: { message: string; error: unknown }[] = [];
+    eventBus.on("sync:error", (e) => errorEvents.push({ message: e.message, error: e.error }));
+
+    const writeFailure = new Error("INSERT OR REPLACE failed");
+    let calls = 0;
+    const materializeSpy = vi.fn(() => {
+      calls += 1;
+      if (calls === 1) throw writeFailure;
+    });
+    registerMaterializer({ documentType: TEST_DOC_TYPE, materialize: materializeSpy });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+
+    // First emit triggers a throw inside materialize → sync:error
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: id,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+    // Second emit must still reach the materialize handler — listener didn't crash
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: id,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+
+    expect(materializeSpy).toHaveBeenCalledTimes(2);
+    expect(errorEvents).toEqual([{ message: "materializer write failed", error: writeFailure }]);
     handle.dispose();
   });
 
   test("invokes materializer with no dirty filter on sync:snapshot-applied", () => {
     const id = docId("system-core_sys_snap");
     const docSnapshot = { members: {} };
-    const { engine } = makeMockEngine({ [id]: docSnapshot });
+    const { engine } = snapshotsByDocId({ [id]: docSnapshot });
     const materializerDb = makeMockMaterializerDb();
     const eventBus = createEventBus<DataLayerEventMap>();
 
@@ -122,9 +245,34 @@ describe("createMaterializerSubscriber", () => {
     handle.dispose();
   });
 
+  test("skips silently when getDocumentSnapshot returns null", () => {
+    const id = docId("system-core_sys_null");
+    const { engine } = makeMockEngine(() => null);
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+    const errorEvents: unknown[] = [];
+    eventBus.on("sync:error", (e) => errorEvents.push(e));
+
+    const materializeSpy = vi.fn();
+    registerMaterializer({ documentType: TEST_DOC_TYPE, materialize: materializeSpy });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: id,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+
+    expect(materializeSpy).not.toHaveBeenCalled();
+    expect(errorEvents).toHaveLength(0);
+    handle.dispose();
+  });
+
   test("dispose unsubscribes both listeners", () => {
     const id = docId("system-core_sys_dispose");
-    const { engine } = makeMockEngine({ [id]: { members: {} } });
+    const { engine } = snapshotsByDocId({ [id]: { members: {} } });
     const materializerDb = makeMockMaterializerDb();
     const eventBus: EventBus<DataLayerEventMap> = createEventBus();
 
@@ -151,9 +299,20 @@ describe("createMaterializerSubscriber", () => {
     expect(materializeSpy).not.toHaveBeenCalled();
   });
 
+  test("dispose is idempotent — calling twice is safe", () => {
+    const id = docId("system-core_sys_idem");
+    const { engine } = snapshotsByDocId({ [id]: { members: {} } });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+    handle.dispose();
+    expect(() => { handle.dispose(); }).not.toThrow();
+  });
+
   test("skips silently when no materializer is registered for the document type", () => {
     const id = docId("system-core_sys_unknown");
-    const { engine } = makeMockEngine({ [id]: { members: {} } });
+    const { engine } = snapshotsByDocId({ [id]: { members: {} } });
     const materializerDb = makeMockMaterializerDb();
     const eventBus = createEventBus<DataLayerEventMap>();
 

--- a/packages/data/src/__tests__/materializer-subscriber.test.ts
+++ b/packages/data/src/__tests__/materializer-subscriber.test.ts
@@ -4,12 +4,13 @@ import {
   registerMaterializer,
   type MaterializerDb,
 } from "@pluralscape/sync/materializer";
+import { brandId } from "@pluralscape/types";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createMaterializerSubscriber } from "../materializer-subscriber.js";
 
 import type { DocumentSnapshotProvider } from "../crdt-query-bridge.js";
-import type { SyncDocumentId } from "@pluralscape/types";
+import type { SyncDocumentId, SyncDocumentType } from "@pluralscape/types";
 
 function makeMockMaterializerDb(): MaterializerDb {
   return {
@@ -30,6 +31,10 @@ function makeMockEngine(snapshots: Record<string, unknown>): {
   };
 }
 
+function docId(raw: string): SyncDocumentId {
+  return brandId<SyncDocumentId>(raw);
+}
+
 const TEST_DOC_TYPE = "system-core" as const;
 
 afterEach(() => {
@@ -38,9 +43,9 @@ afterEach(() => {
 
 describe("createMaterializerSubscriber", () => {
   test("calls registered materializer on sync:changes-merged", () => {
-    const docId = "system-core_sys_test1" as SyncDocumentId;
+    const id = docId("system-core_sys_test1");
     const docSnapshot = { members: {} };
-    const { engine, spy } = makeMockEngine({ [docId]: docSnapshot });
+    const { engine, spy } = makeMockEngine({ [id]: docSnapshot });
     const materializerDb = makeMockMaterializerDb();
     const eventBus = createEventBus<DataLayerEventMap>();
 
@@ -54,13 +59,13 @@ describe("createMaterializerSubscriber", () => {
 
     eventBus.emit("sync:changes-merged", {
       type: "sync:changes-merged",
-      documentId: docId,
+      documentId: id,
       documentType: TEST_DOC_TYPE,
       dirtyEntityTypes: new Set(["member"]),
       conflicts: [],
     });
 
-    expect(spy).toHaveBeenCalledWith(docId);
+    expect(spy).toHaveBeenCalledWith(id);
     expect(materializeSpy).toHaveBeenCalledTimes(1);
     expect(materializeSpy).toHaveBeenCalledWith(
       docSnapshot,
@@ -73,7 +78,7 @@ describe("createMaterializerSubscriber", () => {
   });
 
   test("no-ops when getDocumentSnapshot returns undefined (session evicted)", () => {
-    const docId = "system-core_sys_evicted" as SyncDocumentId;
+    const id = docId("system-core_sys_evicted");
     const { engine } = makeMockEngine({});
     const materializerDb = makeMockMaterializerDb();
     const eventBus = createEventBus<DataLayerEventMap>();
@@ -85,7 +90,7 @@ describe("createMaterializerSubscriber", () => {
 
     eventBus.emit("sync:changes-merged", {
       type: "sync:changes-merged",
-      documentId: docId,
+      documentId: id,
       documentType: TEST_DOC_TYPE,
       dirtyEntityTypes: new Set(["member"]),
       conflicts: [],
@@ -96,9 +101,9 @@ describe("createMaterializerSubscriber", () => {
   });
 
   test("invokes materializer with no dirty filter on sync:snapshot-applied", () => {
-    const docId = "system-core_sys_snap" as SyncDocumentId;
+    const id = docId("system-core_sys_snap");
     const docSnapshot = { members: {} };
-    const { engine } = makeMockEngine({ [docId]: docSnapshot });
+    const { engine } = makeMockEngine({ [id]: docSnapshot });
     const materializerDb = makeMockMaterializerDb();
     const eventBus = createEventBus<DataLayerEventMap>();
 
@@ -109,7 +114,7 @@ describe("createMaterializerSubscriber", () => {
 
     eventBus.emit("sync:snapshot-applied", {
       type: "sync:snapshot-applied",
-      documentId: docId,
+      documentId: id,
       documentType: TEST_DOC_TYPE,
     });
 
@@ -118,8 +123,8 @@ describe("createMaterializerSubscriber", () => {
   });
 
   test("dispose unsubscribes both listeners", () => {
-    const docId = "system-core_sys_dispose" as SyncDocumentId;
-    const { engine } = makeMockEngine({ [docId]: { members: {} } });
+    const id = docId("system-core_sys_dispose");
+    const { engine } = makeMockEngine({ [id]: { members: {} } });
     const materializerDb = makeMockMaterializerDb();
     const eventBus: EventBus<DataLayerEventMap> = createEventBus();
 
@@ -131,7 +136,7 @@ describe("createMaterializerSubscriber", () => {
 
     eventBus.emit("sync:changes-merged", {
       type: "sync:changes-merged",
-      documentId: docId,
+      documentId: id,
       documentType: TEST_DOC_TYPE,
       dirtyEntityTypes: new Set(["member"]),
       conflicts: [],
@@ -139,7 +144,7 @@ describe("createMaterializerSubscriber", () => {
 
     eventBus.emit("sync:snapshot-applied", {
       type: "sync:snapshot-applied",
-      documentId: docId,
+      documentId: id,
       documentType: TEST_DOC_TYPE,
     });
 
@@ -147,24 +152,29 @@ describe("createMaterializerSubscriber", () => {
   });
 
   test("skips silently when no materializer is registered for the document type", () => {
-    const docId = "system-core_sys_unknown" as SyncDocumentId;
-    const { engine } = makeMockEngine({ [docId]: { members: {} } });
+    const id = docId("system-core_sys_unknown");
+    const { engine } = makeMockEngine({ [id]: { members: {} } });
     const materializerDb = makeMockMaterializerDb();
     const eventBus = createEventBus<DataLayerEventMap>();
+
+    // A SyncDocumentType union is closed at compile time; pretend an unknown
+    // value via a typed local so we exercise the registry-miss branch without
+    // resorting to inline `as never` in test bodies.
+    const unknownDocType: SyncDocumentType = "nonexistent-doc-type" as SyncDocumentType;
 
     const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
 
     expect(() => {
       eventBus.emit("sync:changes-merged", {
         type: "sync:changes-merged",
-        documentId: docId,
-        documentType: "nonexistent-doc-type" as never,
+        documentId: id,
+        documentType: unknownDocType,
         dirtyEntityTypes: new Set(["member"]),
         conflicts: [],
       });
     }).not.toThrow();
 
-    expect(getMaterializer("nonexistent-doc-type" as never)).toBeUndefined();
+    expect(getMaterializer(unknownDocType)).toBeUndefined();
     handle.dispose();
   });
 });

--- a/packages/data/src/__tests__/materializer-subscriber.test.ts
+++ b/packages/data/src/__tests__/materializer-subscriber.test.ts
@@ -307,7 +307,9 @@ describe("createMaterializerSubscriber", () => {
 
     const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
     handle.dispose();
-    expect(() => { handle.dispose(); }).not.toThrow();
+    expect(() => {
+      handle.dispose();
+    }).not.toThrow();
   });
 
   test("skips silently when no materializer is registered for the document type", () => {

--- a/packages/data/src/__tests__/materializer-subscriber.test.ts
+++ b/packages/data/src/__tests__/materializer-subscriber.test.ts
@@ -1,0 +1,170 @@
+import { createEventBus, type DataLayerEventMap, type EventBus } from "@pluralscape/sync";
+import {
+  getMaterializer,
+  registerMaterializer,
+  type MaterializerDb,
+} from "@pluralscape/sync/materializer";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createMaterializerSubscriber } from "../materializer-subscriber.js";
+
+import type { DocumentSnapshotProvider } from "../crdt-query-bridge.js";
+import type { SyncDocumentId } from "@pluralscape/types";
+
+function makeMockMaterializerDb(): MaterializerDb {
+  return {
+    queryAll: vi.fn(() => []),
+    execute: vi.fn(),
+    transaction: <T>(fn: () => T): T => fn(),
+  };
+}
+
+function makeMockEngine(snapshots: Record<string, unknown>): {
+  engine: DocumentSnapshotProvider;
+  spy: ReturnType<typeof vi.fn>;
+} {
+  const spy = vi.fn((id: SyncDocumentId) => snapshots[String(id)]);
+  return {
+    engine: { getDocumentSnapshot: spy },
+    spy,
+  };
+}
+
+const TEST_DOC_TYPE = "system-core" as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createMaterializerSubscriber", () => {
+  test("calls registered materializer on sync:changes-merged", () => {
+    const docId = "system-core_sys_test1" as SyncDocumentId;
+    const docSnapshot = { members: {} };
+    const { engine, spy } = makeMockEngine({ [docId]: docSnapshot });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+
+    const materializeSpy = vi.fn();
+    registerMaterializer({
+      documentType: TEST_DOC_TYPE,
+      materialize: materializeSpy,
+    });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: docId,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+
+    expect(spy).toHaveBeenCalledWith(docId);
+    expect(materializeSpy).toHaveBeenCalledTimes(1);
+    expect(materializeSpy).toHaveBeenCalledWith(
+      docSnapshot,
+      materializerDb,
+      eventBus,
+      expect.any(Set),
+    );
+
+    handle.dispose();
+  });
+
+  test("no-ops when getDocumentSnapshot returns undefined (session evicted)", () => {
+    const docId = "system-core_sys_evicted" as SyncDocumentId;
+    const { engine } = makeMockEngine({});
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+
+    const materializeSpy = vi.fn();
+    registerMaterializer({ documentType: TEST_DOC_TYPE, materialize: materializeSpy });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: docId,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+
+    expect(materializeSpy).not.toHaveBeenCalled();
+    handle.dispose();
+  });
+
+  test("invokes materializer with no dirty filter on sync:snapshot-applied", () => {
+    const docId = "system-core_sys_snap" as SyncDocumentId;
+    const docSnapshot = { members: {} };
+    const { engine } = makeMockEngine({ [docId]: docSnapshot });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+
+    const materializeSpy = vi.fn();
+    registerMaterializer({ documentType: TEST_DOC_TYPE, materialize: materializeSpy });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+
+    eventBus.emit("sync:snapshot-applied", {
+      type: "sync:snapshot-applied",
+      documentId: docId,
+      documentType: TEST_DOC_TYPE,
+    });
+
+    expect(materializeSpy).toHaveBeenCalledWith(docSnapshot, materializerDb, eventBus, undefined);
+    handle.dispose();
+  });
+
+  test("dispose unsubscribes both listeners", () => {
+    const docId = "system-core_sys_dispose" as SyncDocumentId;
+    const { engine } = makeMockEngine({ [docId]: { members: {} } });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus: EventBus<DataLayerEventMap> = createEventBus();
+
+    const materializeSpy = vi.fn();
+    registerMaterializer({ documentType: TEST_DOC_TYPE, materialize: materializeSpy });
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+    handle.dispose();
+
+    eventBus.emit("sync:changes-merged", {
+      type: "sync:changes-merged",
+      documentId: docId,
+      documentType: TEST_DOC_TYPE,
+      dirtyEntityTypes: new Set(["member"]),
+      conflicts: [],
+    });
+
+    eventBus.emit("sync:snapshot-applied", {
+      type: "sync:snapshot-applied",
+      documentId: docId,
+      documentType: TEST_DOC_TYPE,
+    });
+
+    expect(materializeSpy).not.toHaveBeenCalled();
+  });
+
+  test("skips silently when no materializer is registered for the document type", () => {
+    const docId = "system-core_sys_unknown" as SyncDocumentId;
+    const { engine } = makeMockEngine({ [docId]: { members: {} } });
+    const materializerDb = makeMockMaterializerDb();
+    const eventBus = createEventBus<DataLayerEventMap>();
+
+    const handle = createMaterializerSubscriber({ engine, materializerDb, eventBus });
+
+    expect(() => {
+      eventBus.emit("sync:changes-merged", {
+        type: "sync:changes-merged",
+        documentId: docId,
+        documentType: "nonexistent-doc-type" as never,
+        dirtyEntityTypes: new Set(["member"]),
+        conflicts: [],
+      });
+    }).not.toThrow();
+
+    expect(getMaterializer("nonexistent-doc-type" as never)).toBeUndefined();
+    handle.dispose();
+  });
+});

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,6 +1,11 @@
 export { createAppQueryClient } from "./query-client.js";
 export { createCrdtQueryBridge } from "./crdt-query-bridge.js";
 export type { CrdtDocumentQueryOpts, DocumentSnapshotProvider } from "./crdt-query-bridge.js";
+export {
+  createMaterializerSubscriber,
+  type MaterializerSubscriberDeps,
+  type MaterializerSubscriberHandle,
+} from "./materializer-subscriber.js";
 export { ApiClientError } from "./api-client-error.js";
 export { createRestQueryFactory } from "./rest-query-factory.js";
 export type {

--- a/packages/data/src/materializer-subscriber.ts
+++ b/packages/data/src/materializer-subscriber.ts
@@ -1,0 +1,73 @@
+import { getMaterializer } from "@pluralscape/sync/materializer";
+
+import type { DocumentSnapshotProvider } from "./crdt-query-bridge.js";
+import type { DataLayerEventMap, EventBus, SyncedEntityType } from "@pluralscape/sync";
+import type { MaterializerDb } from "@pluralscape/sync/materializer";
+import type { SyncDocumentId, SyncDocumentType } from "@pluralscape/types";
+
+export interface MaterializerSubscriberDeps {
+  /** Source of CRDT document snapshots. SyncEngine implements this interface. */
+  readonly engine: DocumentSnapshotProvider;
+  /** Adapter over the local SQLite database where materialized rows are written. */
+  readonly materializerDb: MaterializerDb;
+  /** Event bus carrying sync:changes-merged and sync:snapshot-applied. */
+  readonly eventBus: EventBus<DataLayerEventMap>;
+}
+
+export interface MaterializerSubscriberHandle {
+  /** Unsubscribes both listeners. Idempotent. */
+  readonly dispose: () => void;
+}
+
+function isRecordSnapshot(doc: unknown): doc is Record<string, unknown> {
+  return doc !== null && typeof doc === "object";
+}
+
+/**
+ * Subscribes to engine merge events and runs the registered materializer
+ * for the affected document. On `sync:changes-merged`, materializes only
+ * the dirty entity types (perf gain landed in sync-f4ma). On
+ * `sync:snapshot-applied`, full materialisation (no dirty filter — fresh
+ * snapshot replaces the doc).
+ *
+ * Materialization runs synchronously inside the event-bus dispatch.
+ * After completion, the materializer emits `materialized:document` and
+ * `search:index-updated` itself — no double-emit needed here.
+ *
+ * Skips silently when the engine has evicted the session (snapshot is
+ * undefined) or no materializer is registered for the document type.
+ */
+export function createMaterializerSubscriber(
+  deps: MaterializerSubscriberDeps,
+): MaterializerSubscriberHandle {
+  const { engine, materializerDb, eventBus } = deps;
+
+  function materialise(
+    documentId: SyncDocumentId,
+    documentType: SyncDocumentType,
+    dirty: ReadonlySet<SyncedEntityType> | undefined,
+  ): void {
+    const doc = engine.getDocumentSnapshot(documentId);
+    if (!isRecordSnapshot(doc)) return;
+
+    const materializer = getMaterializer(documentType);
+    if (!materializer) return;
+
+    materializer.materialize(doc, materializerDb, eventBus, dirty);
+  }
+
+  const offMerged = eventBus.on("sync:changes-merged", (event) => {
+    materialise(event.documentId as SyncDocumentId, event.documentType, event.dirtyEntityTypes);
+  });
+
+  const offSnapshot = eventBus.on("sync:snapshot-applied", (event) => {
+    materialise(event.documentId as SyncDocumentId, event.documentType, undefined);
+  });
+
+  return {
+    dispose() {
+      offMerged();
+      offSnapshot();
+    },
+  };
+}

--- a/packages/data/src/materializer-subscriber.ts
+++ b/packages/data/src/materializer-subscriber.ts
@@ -57,11 +57,11 @@ export function createMaterializerSubscriber(
   }
 
   const offMerged = eventBus.on("sync:changes-merged", (event) => {
-    materialise(event.documentId as SyncDocumentId, event.documentType, event.dirtyEntityTypes);
+    materialise(event.documentId, event.documentType, event.dirtyEntityTypes);
   });
 
   const offSnapshot = eventBus.on("sync:snapshot-applied", (event) => {
-    materialise(event.documentId as SyncDocumentId, event.documentType, undefined);
+    materialise(event.documentId, event.documentType, undefined);
   });
 
   return {

--- a/packages/data/src/materializer-subscriber.ts
+++ b/packages/data/src/materializer-subscriber.ts
@@ -1,3 +1,4 @@
+import { NoActiveSessionError } from "@pluralscape/sync";
 import { getMaterializer } from "@pluralscape/sync/materializer";
 
 import type { DocumentSnapshotProvider } from "./crdt-query-bridge.js";
@@ -6,11 +7,8 @@ import type { MaterializerDb } from "@pluralscape/sync/materializer";
 import type { SyncDocumentId, SyncDocumentType } from "@pluralscape/types";
 
 export interface MaterializerSubscriberDeps {
-  /** Source of CRDT document snapshots. SyncEngine implements this interface. */
   readonly engine: DocumentSnapshotProvider;
-  /** Adapter over the local SQLite database where materialized rows are written. */
   readonly materializerDb: MaterializerDb;
-  /** Event bus carrying sync:changes-merged and sync:snapshot-applied. */
   readonly eventBus: EventBus<DataLayerEventMap>;
 }
 
@@ -19,49 +17,77 @@ export interface MaterializerSubscriberHandle {
   readonly dispose: () => void;
 }
 
-function isRecordSnapshot(doc: unknown): doc is Record<string, unknown> {
-  return doc !== null && typeof doc === "object";
-}
-
 /**
  * Subscribes to engine merge events and runs the registered materializer
  * for the affected document. On `sync:changes-merged`, materializes only
- * the dirty entity types (perf gain landed in sync-f4ma). On
- * `sync:snapshot-applied`, full materialisation (no dirty filter — fresh
- * snapshot replaces the doc).
+ * the dirty entity types. On `sync:snapshot-applied`, full materialisation
+ * (no dirty filter — fresh snapshot replaces the doc).
  *
- * Materialization runs synchronously inside the event-bus dispatch.
- * After completion, the materializer emits `materialized:document` and
- * `search:index-updated` itself — no double-emit needed here.
+ * Materialisation runs synchronously inside the event-bus dispatch and is
+ * wrapped in a single `materializerDb.transaction(...)` so all entity-type
+ * passes for one merge land atomically — readers never observe a half-merged
+ * state. After completion, the materializer emits `materialized:document`
+ * and `search:index-updated` itself.
  *
- * Skips silently when the engine has evicted the session (snapshot is
- * undefined) or no materializer is registered for the document type.
+ * Failure modes are surfaced through the event bus rather than thrown:
+ *
+ * - `NoActiveSessionError` from `engine.getDocumentSnapshot` is treated as a
+ *   benign race (session evicted before the listener fired) and skipped.
+ * - Any other snapshot read error or materializer write error is reported
+ *   via `sync:error` so observers can react; the listener does not crash
+ *   the bus dispatch (which would queueMicrotask the throw into an
+ *   unhandled rejection).
+ *
+ * Skips silently when no materializer is registered for the document type.
  */
 export function createMaterializerSubscriber(
   deps: MaterializerSubscriberDeps,
 ): MaterializerSubscriberHandle {
   const { engine, materializerDb, eventBus } = deps;
 
-  function materialise(
+  function materialize(
     documentId: SyncDocumentId,
     documentType: SyncDocumentType,
     dirty: ReadonlySet<SyncedEntityType> | undefined,
   ): void {
-    const doc = engine.getDocumentSnapshot(documentId);
-    if (!isRecordSnapshot(doc)) return;
+    let doc: unknown;
+    try {
+      doc = engine.getDocumentSnapshot(documentId);
+    } catch (err) {
+      if (err instanceof NoActiveSessionError) return;
+      eventBus.emit("sync:error", {
+        type: "sync:error",
+        message: "materializer snapshot read failed",
+        error: err,
+      });
+      return;
+    }
+
+    if (doc === null || typeof doc !== "object") return;
+    const snapshot = doc as Record<string, unknown>;
 
     const materializer = getMaterializer(documentType);
     if (!materializer) return;
 
-    materializer.materialize(doc, materializerDb, eventBus, dirty);
+    try {
+      materializerDb.transaction(() => {
+        materializer.materialize(snapshot, materializerDb, eventBus, dirty);
+      });
+    } catch (err) {
+      eventBus.emit("sync:error", {
+        type: "sync:error",
+        message: "materializer write failed",
+        error: err,
+      });
+    }
   }
 
   const offMerged = eventBus.on("sync:changes-merged", (event) => {
-    materialise(event.documentId, event.documentType, event.dirtyEntityTypes);
+    materialize(event.documentId, event.documentType, event.dirtyEntityTypes);
   });
 
   const offSnapshot = eventBus.on("sync:snapshot-applied", (event) => {
-    materialise(event.documentId, event.documentType, undefined);
+    materialize(event.documentId, event.documentType, undefined);
   });
 
   return {

--- a/packages/sync/src/engine/__tests__/sync-engine-events.test.ts
+++ b/packages/sync/src/engine/__tests__/sync-engine-events.test.ts
@@ -421,6 +421,7 @@ describe("SyncEngine event bus integration", () => {
           documentId: SYSTEM_CORE_DOC_ID,
           documentType: "system-core",
           conflicts: expect.any(Array) as unknown[],
+          dirtyEntityTypes: expect.any(Set) as unknown,
         }),
       );
 

--- a/packages/sync/src/engine/sync-engine.ts
+++ b/packages/sync/src/engine/sync-engine.ts
@@ -459,6 +459,7 @@ export class SyncEngine {
         type: "sync:changes-merged",
         documentId: docId,
         documentType,
+        dirtyEntityTypes: dirty,
         conflicts: postMergeResult.notifications,
       });
     }
@@ -578,6 +579,7 @@ export class SyncEngine {
           type: "sync:changes-merged",
           documentId: docId,
           documentType: docType,
+          dirtyEntityTypes: dirty,
           conflicts: postMergeResult.notifications,
         });
 

--- a/packages/sync/src/event-bus/event-map.ts
+++ b/packages/sync/src/event-bus/event-map.ts
@@ -1,6 +1,7 @@
 import type { SyncDocumentType } from "../document-types.js";
 import type { SyncedEntityType } from "../strategies/crdt-strategies.js";
 import type { ConflictNotification, EncryptedChangeEnvelope } from "../types.js";
+import type { SyncDocumentId } from "@pluralscape/types";
 
 // ── Transport events ────────────────────────────────────────────────
 
@@ -28,12 +29,14 @@ export interface WsNotificationEvent {
 
 export interface SyncChangesMergedEvent {
   readonly type: "sync:changes-merged";
-  readonly documentId: string;
+  readonly documentId: SyncDocumentId;
   readonly documentType: SyncDocumentType;
   /**
-   * Set of entity types whose CRDT shape changed during this merge. Consumed
-   * by the materializer subscriber to scope row-projection work to dirty
-   * entities only — the perf gain landed in sync-f4ma.
+   * Entity types whose CRDT shape changed during this merge. Consumed by the
+   * materializer subscriber to scope row projection to changed entities only
+   * — full-document materialisation scales with the total entity count, so a
+   * narrowed set keeps merge-time write amplification proportional to the
+   * actual delta.
    */
   readonly dirtyEntityTypes: ReadonlySet<SyncedEntityType>;
   readonly conflicts: readonly ConflictNotification[];
@@ -41,7 +44,7 @@ export interface SyncChangesMergedEvent {
 
 export interface SyncSnapshotAppliedEvent {
   readonly type: "sync:snapshot-applied";
-  readonly documentId: string;
+  readonly documentId: SyncDocumentId;
   readonly documentType: SyncDocumentType;
 }
 

--- a/packages/sync/src/event-bus/event-map.ts
+++ b/packages/sync/src/event-bus/event-map.ts
@@ -30,6 +30,12 @@ export interface SyncChangesMergedEvent {
   readonly type: "sync:changes-merged";
   readonly documentId: string;
   readonly documentType: SyncDocumentType;
+  /**
+   * Set of entity types whose CRDT shape changed during this merge. Consumed
+   * by the materializer subscriber to scope row-projection work to dirty
+   * entities only — the perf gain landed in sync-f4ma.
+   */
+  readonly dirtyEntityTypes: ReadonlySet<SyncedEntityType>;
   readonly conflicts: readonly ConflictNotification[];
 }
 

--- a/packages/sync/src/materializer/__tests__/base-materializer.test.ts
+++ b/packages/sync/src/materializer/__tests__/base-materializer.test.ts
@@ -235,7 +235,9 @@ describe("applyDiff", () => {
       { inserts: [insert], updates: [], deletes: [] },
       eventBus,
     );
-    expect(db.transactionCalled).toBe(true);
+    // applyDiff itself does not open a transaction — the caller (subscriber)
+    // wraps the whole merge so multi-entity-type merges land atomically.
+    expect(db.transactionCalled).toBe(false);
     expect(db.calls).toHaveLength(1);
     expect(db.calls[0]?.sql).toContain("INSERT OR REPLACE INTO");
     expect(db.calls[0]?.sql).toContain("members");
@@ -273,7 +275,7 @@ describe("applyDiff", () => {
     expect(db.calls[0]?.params).toEqual(["m_1"]);
   });
 
-  it("wraps all writes in a transaction", () => {
+  it("issues writes without opening its own transaction (caller owns transaction context)", () => {
     const db = makeDb();
     const eventBus = { emit: vi.fn(), on: vi.fn(), removeAll: vi.fn() };
     applyDiff(
@@ -288,7 +290,9 @@ describe("applyDiff", () => {
       },
       eventBus,
     );
-    expect(db.transactionCalled).toBe(true);
+    expect(db.transactionCalled).toBe(false);
+    // Both writes were issued anyway.
+    expect(db.calls).toHaveLength(2);
   });
 
   it("does not emit entity events for cold-path entities", () => {

--- a/packages/sync/src/materializer/base-materializer.ts
+++ b/packages/sync/src/materializer/base-materializer.ts
@@ -176,10 +176,15 @@ function emitEntityEvents(
  * - Skips if the diff is empty.
  * - Uses `INSERT OR REPLACE INTO` for inserts and updates.
  * - Uses `DELETE FROM … WHERE id = ?` for deletes.
- * - Wraps all writes in a single transaction.
  * - Emits `materialized:entity` events for each change when the entity
  *   type is hot-path (per `ENTITY_METADATA[entityType].hotPath`).
  *   Document-level events are NOT emitted here — the caller is responsible for that.
+ *
+ * Transaction boundary: this function does NOT open its own transaction. The
+ * caller (typically the materializer subscriber) wraps an entire merge's
+ * worth of `applyDiff` calls in one BEGIN/COMMIT so a multi-entity-type merge
+ * is atomic from a reader's perspective. Opening one here would conflict with
+ * the outer transaction (expo-sqlite's `withTransactionSync` is not nestable).
  */
 export function applyDiff(
   db: MaterializerDb,
@@ -195,17 +200,15 @@ export function applyDiff(
 
   const { tableName, columnNames } = meta;
 
-  db.transaction(() => {
-    for (const row of diff.inserts) {
-      upsertRow(db, tableName, columnNames, row);
-    }
-    for (const row of diff.updates) {
-      upsertRow(db, tableName, columnNames, row);
-    }
-    for (const id of diff.deletes) {
-      db.execute(`DELETE FROM ${tableName} WHERE id = ?`, [id]);
-    }
-  });
+  for (const row of diff.inserts) {
+    upsertRow(db, tableName, columnNames, row);
+  }
+  for (const row of diff.updates) {
+    upsertRow(db, tableName, columnNames, row);
+  }
+  for (const id of diff.deletes) {
+    db.execute(`DELETE FROM ${tableName} WHERE id = ?`, [id]);
+  }
 
   if (ENTITY_METADATA[entityType].hotPath) {
     emitEntityEvents(

--- a/packages/sync/src/materializer/base-materializer.ts
+++ b/packages/sync/src/materializer/base-materializer.ts
@@ -16,10 +16,38 @@ export interface DiffResult {
   readonly deletes: readonly string[];
 }
 
+/**
+ * Values bindable to a SQLite prepared statement. Mirrors the union accepted
+ * by `expo-sqlite`'s `SQLiteBindValue` and `bun:sqlite`'s parameter type so
+ * the materializer's interface narrows misuse (e.g., passing an object) into
+ * a TypeScript error rather than a native-bridge crash.
+ */
+export type MaterializerBindValue = string | number | boolean | null | Uint8Array;
+
 export interface MaterializerDb {
-  queryAll<T>(sql: string, params: unknown[]): T[];
-  execute(sql: string, params: unknown[]): void;
+  queryAll<T>(sql: string, params: MaterializerBindValue[]): T[];
+  execute(sql: string, params: MaterializerBindValue[]): void;
   transaction<T>(fn: () => T): T;
+}
+
+/**
+ * Narrow `unknown` (e.g. an EntityRow column value) to `MaterializerBindValue`.
+ * Throws on unsupported types so the caller fails fast at the materializer
+ * boundary instead of at the SQLite bridge.
+ */
+export function toBindValue(v: unknown): MaterializerBindValue {
+  if (
+    v === null ||
+    typeof v === "string" ||
+    typeof v === "number" ||
+    typeof v === "boolean" ||
+    v instanceof Uint8Array
+  ) {
+    return v;
+  }
+  throw new TypeError(
+    `materializer: unsupported bind value type ${v === undefined ? "undefined" : typeof v}`,
+  );
 }
 
 // ── diffEntities ──────────────────────────────────────────────────────
@@ -208,6 +236,6 @@ function upsertRow(
   const presentColumns = columnNames.filter((col) => col in row);
   const placeholders = presentColumns.map(() => "?").join(", ");
   const sql = `INSERT OR REPLACE INTO ${tableName} (${presentColumns.join(", ")}) VALUES (${placeholders})`;
-  const params = presentColumns.map((col) => row[col] ?? null);
+  const params = presentColumns.map((col) => toBindValue(row[col] ?? null));
   db.execute(sql, params);
 }

--- a/packages/sync/src/materializer/index.ts
+++ b/packages/sync/src/materializer/index.ts
@@ -7,9 +7,11 @@ export {
   diffEntities,
   applyDiff,
   entityToRow,
+  toBindValue,
   toSnakeCase,
   type EntityRow,
   type DiffResult,
+  type MaterializerBindValue,
   type MaterializerDb,
 } from "./base-materializer.js";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,6 +508,9 @@ importers:
       '@pluralscape/crypto':
         specifier: workspace:*
         version: link:../crypto
+      '@pluralscape/sync':
+        specifier: workspace:*
+        version: link:../sync
       '@pluralscape/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

Wires the materializer into the SyncEngine post-merge flow via a subscriber pattern. After this PR, every CRDT merge projects entities into local SQLite — the cache schemas added in PR2 finally hold rows, unlocking the perf gain landed in sync-f4ma.

- `SyncChangesMergedEvent` now carries `dirtyEntityTypes: ReadonlySet<SyncedEntityType>`. Both engine emit sites updated.
- `createMaterializerSubscriber({engine, materializerDb, eventBus})` lands in `@pluralscape/data`. Listens to `sync:changes-merged` and `sync:snapshot-applied`, fetches the doc snapshot, looks up the registered materializer, runs it. Skips silently when the snapshot is evicted or no materializer is registered.
- New `MaterializerDb` adapter on mobile wraps expo-sqlite's sync APIs (`prepareSync`/`executeSync`/`finalizeSync`/`withTransactionSync`).
- `createExpoSqliteDriver` now returns both the async `SqliteDriver` and the synchronous `MaterializerDb`, sharing the SQLCipher connection. `PlatformStorage` carries `materializerDb: MaterializerDb | null` (null on backends without sync APIs, e.g. OPFS).
- `SyncProvider.tsx` instantiates the subscriber alongside the engine and disposes it in reverse construction order on auth-state transitions / unmount.
- Subscriber is platform-conditional: web/OPFS sets `materializerDb: null`, so SyncProvider simply skips wiring.

Architecture justified by industry survey (Replicache, Electric, Triplit, Zero, PowerSync, automerge-repo, Yjs all use observer/subscription, none inline a materializer call). See `docs/superpowers/specs/2026-04-27-deferred-wiring-closeout-design.md` § PR3.

## Test plan

- [x] Engine emit sites assert `dirtyEntityTypes` is present in the event payload (sync engine tests)
- [x] Subscriber unit tests in `@pluralscape/data`: subscribes/disposes, materialises with the right dirty set, no-ops on evicted snapshot, no-ops on unknown doc type, full materialise on snapshot-applied
- [x] Mobile adapter unit tests: queryAll/execute/transaction delegate, statement is finalised even when executeSync throws, transaction propagates errors
- [x] Mobile integration smoke test in `SyncProvider.test.tsx`: subscriber wires when materializerDb is non-null, fires on `sync:changes-merged` / `sync:snapshot-applied`, no-ops when materializerDb is null, disposed on unmount
- [x] `/verify` all-green: format, lint, typecheck, types:check-sot, unit (13136), integration (3060), e2e (507)

Bean: sync-xjfi (M9a)
Closes the deferred-wiring closeout sequence (PR1 #583, PR2 #581, PR3 this).