### PR TITLE
refactor(types,api,data): types-0e9j — discriminated Archivable<T> chain for plaintext entities

### DIFF
--- a/.beans/api-bqu4--wire-decryptdeviceinfo-at-session-list-endpoint.md
+++ b/.beans/api-bqu4--wire-decryptdeviceinfo-at-session-list-endpoint.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T18:59:53Z
-updated_at: 2026-04-28T17:55:43Z
+updated_at: 2026-04-29T00:01:28Z
 parent: ps-cd6x
 ---
 
@@ -37,3 +37,12 @@ Landed in `types-emid` (PR #579) as part of pre-release data-layer scaffolding. 
 - Added unit test for withDecryptedDeviceInfo (present + null cases)
 - Added E2E contract test asserting encryptedData field is exposed on session list
 - pnpm trpc:parity and pnpm types:check-sot pass
+
+## Summary of Changes
+
+Shipped in PR #583 (commit 1dd16910, merged 2026-04-28):
+
+- `apps/api/src/services/auth/sessions.ts:28,59,73` — `listSessions` now projects `encryptedData` via `encryptedBlobToBase64OrNull`.
+- `packages/data/src/transforms/session-helpers.ts` — new `withDecryptedDeviceInfo(session, masterKey)` helper using the `decryptDeviceInfo` codec from `transforms/session.ts`.
+- OpenAPI / tRPC contracts emit the field; integration + E2E tests cover the round-trip.
+- Mobile UI consumption is gated on the future session-list screen — not in scope here.

--- a/.beans/api-xol4--timer-config-updatets-collapse-read-before-write-i.md
+++ b/.beans/api-xol4--timer-config-updatets-collapse-read-before-write-i.md
@@ -1,11 +1,11 @@
 ---
 # api-xol4
 title: "Timer-config update.ts: collapse read-before-write into single UPDATE when scheduling fields absent"
-status: todo
+status: scrapped
 type: task
 priority: normal
 created_at: 2026-04-22T03:32:22Z
-updated_at: 2026-04-27T20:28:57Z
+updated_at: 2026-04-29T00:03:40Z
 parent: ps-cd6x
 ---
 
@@ -25,3 +25,15 @@ Split off from api-p6uu item #1. Needs load measurement before acting.
 
 - Fewer SQL roundtrips on the non-scheduling update path
 - No regressions
+
+## Reasons for Scrapping
+
+The bean's premise was incorrect. Verified against `apps/api/src/services/timer-config/update.ts` (introduced in commit 7c063583 on 2026-04-22, the same day this bean was filed):
+
+- The SELECT (lines 71-100) is already gated behind the scheduling-fields check (lines 63-69).
+- When the update payload contains no scheduling fields, no SELECT is issued — only the single UPDATE on lines 102-115.
+- The optimization the bean describes ("skip the SELECT when scheduling fields are absent") is already in place.
+
+The remaining inefficiency — SELECT + UPDATE when scheduling fields _are_ present — is two round-trips inside a single transaction (sub-millisecond). Collapsing it would require either pushing `computeNextCheckInAt` (date math + waking-hours + timezone logic) into SQL or constructing a CTE, both of which add maintenance cost for negligible gain. Not worth pursuing.
+
+The diagnostic SELECT inside `assertOccUpdated` only fires on OCC conflict, so it has no steady-state cost.

--- a/.beans/client-a0gf--wire-apikey-codec-transforms-when-crypto-variant-l.md
+++ b/.beans/client-a0gf--wire-apikey-codec-transforms-when-crypto-variant-l.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T19:00:01Z
-updated_at: 2026-04-28T18:45:41Z
+updated_at: 2026-04-29T00:01:32Z
 parent: ps-cd6x
 ---
 
@@ -41,3 +41,12 @@ When the crypto-variant work picks up:
 - Added unit tests for withDecodedApiKeyPayload (crypto/metadata variants + field preservation)
 - Added E2E test exercising full crypto-variant publicKey encrypt-on-create → decrypt-on-list flow
 - pnpm trpc:parity and pnpm types:check-sot pass
+
+## Summary of Changes
+
+Shipped in PR #583 (commit 6db1cd54, merged 2026-04-28):
+
+- `apps/api/src/services/api-key/internal.ts:35,50,65,77` — `apiKey.list` and `apiKey.get` project `encryptedData` via `encryptedBlobToBase64`.
+- `packages/data/src/transforms/api-key-helpers.ts` — new `withDecodedApiKeyPayload(apiKey, masterKey)` helper wrapping `decryptApiKeyPayload`.
+- E2E test exercises the crypto-variant publicKey encrypt-on-create -> list -> decrypt round-trip.
+- Mobile UI consumption is gated on future ApiKey crypto-variant screens — not in scope here.

--- a/.beans/ps-f3ox--class-e-server-side-t3-encryption-webhook-delivery.md
+++ b/.beans/ps-f3ox--class-e-server-side-t3-encryption-webhook-delivery.md
@@ -1,11 +1,11 @@
 ---
 # ps-f3ox
 title: "Class E server-side T3 encryption: webhook-delivery"
-status: draft
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-25T08:07:36Z
-updated_at: 2026-04-25T08:07:49Z
+updated_at: 2026-04-29T00:01:46Z
 parent: ps-cd6x
 blocked_by:
   - ps-y4tb
@@ -41,3 +41,14 @@ Options:
 ## Blocked-by
 
 ps-y4tb (so the canonical chain is settled before we decide how webhook-delivery relates to it).
+
+## Summary of Changes
+
+Resolved as **option (c)**: standardize the parts of the canonical chain that apply (Drizzle parity, Wire shape) while keeping the encryption layer bespoke. Implementation already in place across two prior efforts:
+
+- **ADR-023 § Class E** (lines 116-130) documents the convention: `<X>Wire = Serialize<<X>>` strips the server-only `encryptedData` by absence from the domain type; `T3EncryptedBytes` brand replaces `EncryptedBlob`; encryption never crosses the wire to clients. Names `webhook-delivery` (entity-level) and `ApiKey.encryptedKeyMaterial` (column-level) as the two Class E surfaces.
+- **`packages/types/src/entities/webhook-delivery.ts`** — `WebhookDeliveryServerMetadata = WebhookDelivery & { encryptedData: T3EncryptedBytes }`, `WebhookDeliveryWire = Serialize<WebhookDelivery>`. JSDoc cross-references ADR-023 Class E.
+- **Drizzle column** uses `.$type<T3EncryptedBytes>()` to thread the brand through reads (per ADR-023 line 125).
+- Encrypt/decrypt boundaries: `apps/api/src/services/webhook-dispatcher.ts:94` (`encryptWebhookPayload`) and `apps/api/src/services/webhook-delivery-worker.ts:165` (`decryptWebhookPayload`).
+
+No new code needed — the design question this bean asked has been answered by the work landed in PR #559 (u87m+ecol) and the ps-y4tb fleet.

--- a/.beans/ps-znp0--inline-or-relocate-decode-blob-asserts-after-frien.md
+++ b/.beans/ps-znp0--inline-or-relocate-decode-blob-asserts-after-frien.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T19:00:19Z
-updated_at: 2026-04-28T18:50:56Z
+updated_at: 2026-04-29T00:01:36Z
 parent: ps-cd6x
 ---
 
@@ -39,3 +39,11 @@ Single-consumer helpers in `decode-blob.ts` are a code smell; either inline them
 - Deleted assertObjectBlob and assertStringField from packages/data/src/transforms/decode-blob.ts (sole consumers were the dashboard decryption helpers)
 - Added regression test for missing-required-field rejection on custom front
 - Updated existing throw assertions to match new Zod error messages (expected object/string)
+
+## Summary of Changes
+
+Shipped in PR #583 (commit fe37a42c, merged 2026-04-28):
+
+- `packages/validation/src/friend-dashboard-blob.ts` — new `FriendDashboardMemberBlobSchema`, `FriendDashboardCustomFrontBlobSchema`, `FriendDashboardStructureEntityBlobSchema`, `FriendDashboardFrontingSessionBlobSchema` (Zod, matching the post-`types-emid` decrypt-boundary pattern).
+- `packages/data/src/transforms/friend-dashboard.ts` — migrated from `assertObjectBlob`/`assertStringField` to the new schemas.
+- `packages/data/src/transforms/decode-blob.ts` — `assertObjectBlob` and `assertStringField` deleted (zero remaining consumers).

--- a/.beans/types-0e9j--archive-aware-plaintext-wire-union-for-notificatio.md
+++ b/.beans/types-0e9j--archive-aware-plaintext-wire-union-for-notificatio.md
@@ -1,11 +1,11 @@
 ---
 # types-0e9j
 title: Archive-aware plaintext wire union for NotificationConfig/FriendCode
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T22:28:59Z
-updated_at: 2026-04-29T00:33:27Z
+updated_at: 2026-04-29T01:34:25Z
 parent: ps-cd6x
 ---
 
@@ -34,3 +34,15 @@ Encrypted entities like `MemberServerMetadata` accept the same loosening as the 
 - `packages/types/src/entities/friend-code.ts:37`
 - `packages/data/src/transforms/notification-config.ts` (narrowNotificationConfig)
 - `packages/data/src/transforms/friend-code.ts` (narrowFriendCode)
+
+## Summary of Changes
+
+Implemented the discriminated archivable type chain for plaintext entities per spec docs/superpowers/specs/2026-04-28-types-0e9j-archivable-discriminated-design.md.
+
+- Archivable<T> added to packages/types/src/utility.ts — discriminated union helper.
+- narrowArchivableRow added to apps/api/src/lib/archivable-row.ts — runtime adapter at the Drizzle read boundary; throws on either CHECK-violating state.
+- NotificationConfig — ServerMetadata is now Archivable<NotificationConfig>; Wire derives discriminated naturally; transform's runtime throw removed; service uses adapter at all read sites.
+- FriendCode — same pattern.
+- Drizzle parity tests define the flat Row helper locally (not exported from @pluralscape/types) to prevent application-code misuse.
+- Tooling: tooling/eslint-config/index.js now configures @typescript-eslint/no-unused-vars to allow ^\_-prefixed names (standard convention).
+- ADR-023 — new section documenting the convention; future plaintext archivables under ps-6phh follow it.

--- a/.beans/types-0e9j--archive-aware-plaintext-wire-union-for-notificatio.md
+++ b/.beans/types-0e9j--archive-aware-plaintext-wire-union-for-notificatio.md
@@ -1,11 +1,11 @@
 ---
 # types-0e9j
 title: Archive-aware plaintext wire union for NotificationConfig/FriendCode
-status: todo
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-04-27T22:28:59Z
-updated_at: 2026-04-27T22:29:44Z
+updated_at: 2026-04-29T00:33:27Z
 parent: ps-cd6x
 ---
 

--- a/apps/api/src/__tests__/lib/archivable-row.test.ts
+++ b/apps/api/src/__tests__/lib/archivable-row.test.ts
@@ -35,9 +35,8 @@ describe("narrowArchivableRow", () => {
   it("returns the archived shape with branded archivedAt for archived rows", () => {
     const result = narrowArchivableRow<SampleLive>(archivedRow);
     expect(result.archived).toBe(true);
-    if (result.archived) {
-      expect(result.archivedAt).toBe(1_700_000_000_000);
-    }
+    if (!result.archived) throw new Error("Expected archived shape");
+    expect(result.archivedAt).toBe(1_700_000_000_000);
   });
 
   it("throws when archived=true but archivedAt is null (CHECK violation)", () => {

--- a/apps/api/src/__tests__/lib/archivable-row.test.ts
+++ b/apps/api/src/__tests__/lib/archivable-row.test.ts
@@ -1,8 +1,9 @@
+import { brandId } from "@pluralscape/types";
 import { describe, expect, it } from "vitest";
 
 import { narrowArchivableRow } from "../../lib/archivable-row.js";
 
-import type { UnixMillis } from "@pluralscape/types";
+import type { AccountId, FriendCode, FriendCodeId, UnixMillis } from "@pluralscape/types";
 
 interface SampleLive {
   readonly id: string;
@@ -59,5 +60,54 @@ describe("narrowArchivableRow", () => {
         archivedAt: 1_700_000_000_000 as UnixMillis,
       }),
     ).toThrow("Archivable row CHECK invariant violated: archived=false with non-null archivedAt");
+  });
+});
+
+describe("narrowArchivableRow with branded FriendCode entity", () => {
+  const friendCodeId = brandId<FriendCodeId>("fcd_test001");
+  const accountId = brandId<AccountId>("acc_test001");
+  const createdAt = 1_700_000_000_000 as UnixMillis;
+  const expiresAt = 1_700_500_000_000 as UnixMillis;
+  const archivedAt = 1_700_900_000_000 as UnixMillis;
+
+  it("preserves branded FriendCodeId, AccountId, and UnixMillis on the live shape", () => {
+    const result = narrowArchivableRow<FriendCode>({
+      id: friendCodeId,
+      accountId,
+      code: "TEST-LIVE-CODE",
+      createdAt,
+      expiresAt,
+      archived: false,
+      archivedAt: null,
+    });
+
+    expect(result.archived).toBe(false);
+    expect("archivedAt" in result).toBe(false);
+    expect(result.id).toBe(friendCodeId);
+    expect(result.accountId).toBe(accountId);
+    expect(result.code).toBe("TEST-LIVE-CODE");
+    expect(result.createdAt).toBe(createdAt);
+    expect(result.expiresAt).toBe(expiresAt);
+  });
+
+  it("preserves branded fields and surfaces archivedAt on the archived shape", () => {
+    const result = narrowArchivableRow<FriendCode>({
+      id: friendCodeId,
+      accountId,
+      code: "TEST-ARCHIVED-CODE",
+      createdAt,
+      expiresAt: null,
+      archived: true,
+      archivedAt,
+    });
+
+    expect(result.archived).toBe(true);
+    if (!result.archived) throw new Error("Expected archived shape");
+    expect(result.id).toBe(friendCodeId);
+    expect(result.accountId).toBe(accountId);
+    expect(result.code).toBe("TEST-ARCHIVED-CODE");
+    expect(result.createdAt).toBe(createdAt);
+    expect(result.expiresAt).toBeNull();
+    expect(result.archivedAt).toBe(archivedAt);
   });
 });

--- a/apps/api/src/__tests__/lib/archivable-row.test.ts
+++ b/apps/api/src/__tests__/lib/archivable-row.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { narrowArchivableRow } from "../../lib/archivable-row.js";
+
+import type { UnixMillis } from "@pluralscape/types";
+
+interface SampleLive {
+  readonly id: string;
+  readonly name: string;
+  readonly archived: false;
+}
+
+const liveRow = {
+  id: "x",
+  name: "n",
+  archived: false,
+  archivedAt: null,
+} as const;
+
+const archivedRow = {
+  id: "x",
+  name: "n",
+  archived: true,
+  archivedAt: 1_700_000_000_000 as UnixMillis,
+} as const;
+
+describe("narrowArchivableRow", () => {
+  it("returns the live shape with no archivedAt for non-archived rows", () => {
+    const result = narrowArchivableRow<SampleLive>(liveRow);
+    expect(result.archived).toBe(false);
+    expect("archivedAt" in result).toBe(false);
+    expect(result.id).toBe("x");
+  });
+
+  it("returns the archived shape with branded archivedAt for archived rows", () => {
+    const result = narrowArchivableRow<SampleLive>(archivedRow);
+    expect(result.archived).toBe(true);
+    if (result.archived) {
+      expect(result.archivedAt).toBe(1_700_000_000_000);
+    }
+  });
+
+  it("throws when archived=true but archivedAt is null (CHECK violation)", () => {
+    expect(() =>
+      narrowArchivableRow<SampleLive>({
+        id: "x",
+        name: "n",
+        archived: true,
+        archivedAt: null,
+      }),
+    ).toThrow("Archivable row CHECK invariant violated: archived=true with archivedAt=null");
+  });
+
+  it("throws when archived=false but archivedAt is non-null (reverse CHECK violation)", () => {
+    expect(() =>
+      narrowArchivableRow<SampleLive>({
+        id: "x",
+        name: "n",
+        archived: false,
+        archivedAt: 1_700_000_000_000 as UnixMillis,
+      }),
+    ).toThrow("Archivable row CHECK invariant violated: archived=false with non-null archivedAt");
+  });
+});

--- a/apps/api/src/__tests__/routes/account/friend-codes/create.test.ts
+++ b/apps/api/src/__tests__/routes/account/friend-codes/create.test.ts
@@ -47,7 +47,7 @@ const MOCK_CODE = {
   code: "ABCD-1234",
   createdAt: 1000 as never,
   expiresAt: null,
-  archived: false,
+  archived: false as const,
 };
 
 // ── Tests ────────────────────────────────────────────────────────

--- a/apps/api/src/__tests__/routes/account/friend-codes/list.test.ts
+++ b/apps/api/src/__tests__/routes/account/friend-codes/list.test.ts
@@ -42,7 +42,7 @@ const MOCK_CODE = {
   code: "ABCD-1234",
   createdAt: 1000 as never,
   expiresAt: null,
-  archived: false,
+  archived: false as const,
 };
 
 // ── Tests ────────────────────────────────────────────────────────

--- a/apps/api/src/__tests__/trpc/routers/friend-code.test.ts
+++ b/apps/api/src/__tests__/trpc/routers/friend-code.test.ts
@@ -45,7 +45,7 @@ const MOCK_CODE_RESULT = {
   code: "ABCD-EFGH",
   createdAt: 1_700_000_000_000 as UnixMillis,
   expiresAt: null,
-  archived: false,
+  archived: false as const,
 };
 
 describe("friendCode router", () => {

--- a/apps/api/src/lib/archivable-row.ts
+++ b/apps/api/src/lib/archivable-row.ts
@@ -1,0 +1,38 @@
+import type { Archivable, Archived, UnixMillis } from "@pluralscape/types";
+
+/**
+ * Narrow a flat Drizzle row into the discriminated `Archivable<T>` shape.
+ *
+ * Each archivable PG table has a CHECK constraint guaranteeing
+ * `(archived = true) = (archived_at IS NOT NULL)`. This adapter re-derives
+ * the discriminated union from the flat row so the rest of the application
+ * code can work with the type-system-encoded invariant.
+ *
+ * Throws on either inconsistent state (defensive: if the CHECK is ever
+ * dropped or violated, fail loud at the read boundary rather than letting
+ * the malformed row propagate). See ADR-023 § Archivable plaintext entities.
+ */
+export function narrowArchivableRow<T extends { readonly archived: false }>(
+  row: Omit<T, "archived"> & {
+    readonly archived: boolean;
+    readonly archivedAt: UnixMillis | null;
+  },
+): Archivable<T> {
+  if (!row.archived) {
+    if (row.archivedAt !== null) {
+      throw new Error(
+        "Archivable row CHECK invariant violated: archived=false with non-null archivedAt",
+      );
+    }
+    const entries = Object.entries(row).filter(([k]) => k !== "archivedAt");
+    return { ...Object.fromEntries(entries), archived: false } as T;
+  }
+  if (row.archivedAt === null) {
+    throw new Error("Archivable row CHECK invariant violated: archived=true with archivedAt=null");
+  }
+  return {
+    ...row,
+    archived: true as const,
+    archivedAt: row.archivedAt,
+  } as Archived<T>;
+}

--- a/apps/api/src/lib/archivable-row.ts
+++ b/apps/api/src/lib/archivable-row.ts
@@ -24,8 +24,14 @@ export function narrowArchivableRow<T extends { readonly archived: false }>(
         "Archivable row CHECK invariant violated: archived=false with non-null archivedAt",
       );
     }
-    const entries = Object.entries(row).filter(([k]) => k !== "archivedAt");
-    return { ...Object.fromEntries(entries), archived: false } as T;
+    // `rest` is structurally T minus `archived`. TypeScript cannot simplify
+    // nested generic Omits, so we cast through the constraint bound
+    // `{ readonly archived: false }` (which the spread satisfies concretely)
+    // and then to T (a subtype of that same bound).
+    const { archivedAt: _archivedAt, ...rest } = row;
+    return { ...rest, archived: false as const } as {
+      readonly archived: false;
+    } as T;
   }
   if (row.archivedAt === null) {
     throw new Error("Archivable row CHECK invariant violated: archived=true with archivedAt=null");

--- a/apps/api/src/lib/archivable-row.ts
+++ b/apps/api/src/lib/archivable-row.ts
@@ -28,7 +28,7 @@ export function narrowArchivableRow<T extends { readonly archived: false }>(
     // nested generic Omits, so we cast through the constraint bound
     // `{ readonly archived: false }` (which the spread satisfies concretely)
     // and then to T (a subtype of that same bound).
-    const { archivedAt: _archivedAt, ...rest } = row;
+    const { archivedAt: _, ...rest } = row;
     return { ...rest, archived: false as const } as {
       readonly archived: false;
     } as T;

--- a/apps/api/src/services/account/friend-codes/generate.ts
+++ b/apps/api/src/services/account/friend-codes/generate.ts
@@ -6,6 +6,7 @@ import { and, eq } from "drizzle-orm";
 
 import { HTTP_BAD_REQUEST } from "../../../http.constants.js";
 import { ApiHttpError } from "../../../lib/api-error.js";
+import { narrowArchivableRow } from "../../../lib/archivable-row.js";
 import { withAccountTransaction } from "../../../lib/rls-context.js";
 import { isUniqueViolation } from "../../../lib/unique-violation.js";
 import { MAX_FRIEND_CODES_PER_ACCOUNT } from "../../../quota.constants.js";
@@ -15,7 +16,7 @@ import { toFriendCodeResult, type FriendCodeResult } from "./internal.js";
 
 import type { AuditWriter } from "../../../lib/audit-writer.js";
 import type { AuthContext } from "../../../lib/auth-context.js";
-import type { AccountId, AuditEventType, FriendCodeId } from "@pluralscape/types";
+import type { AccountId, AuditEventType, FriendCode, FriendCodeId } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /** Audit event: a friend code was generated. */
@@ -115,6 +116,6 @@ export async function generateFriendCode(
       systemId: null,
     });
 
-    return toFriendCodeResult(row);
+    return toFriendCodeResult(narrowArchivableRow<FriendCode>(row));
   });
 }

--- a/apps/api/src/services/account/friend-codes/generate.ts
+++ b/apps/api/src/services/account/friend-codes/generate.ts
@@ -12,7 +12,7 @@ import { isUniqueViolation } from "../../../lib/unique-violation.js";
 import { MAX_FRIEND_CODES_PER_ACCOUNT } from "../../../quota.constants.js";
 import { FRIEND_CODE_BYTES, MAX_CODE_GENERATION_RETRIES } from "../../friend-code.constants.js";
 
-import { toFriendCodeResult, type FriendCodeResult } from "./internal.js";
+import { type FriendCodeResult } from "./internal.js";
 
 import type { AuditWriter } from "../../../lib/audit-writer.js";
 import type { AuthContext } from "../../../lib/auth-context.js";
@@ -116,6 +116,6 @@ export async function generateFriendCode(
       systemId: null,
     });
 
-    return toFriendCodeResult(narrowArchivableRow<FriendCode>(row));
+    return narrowArchivableRow<FriendCode>(row);
   });
 }

--- a/apps/api/src/services/account/friend-codes/internal.ts
+++ b/apps/api/src/services/account/friend-codes/internal.ts
@@ -1,27 +1,13 @@
-import type {
-  AccountId,
-  Archivable,
-  FriendCode,
-  FriendCodeId,
-  UnixMillis,
-} from "@pluralscape/types";
+import type { Archivable, FriendCode } from "@pluralscape/types";
 
-export interface FriendCodeResult {
-  readonly id: FriendCodeId;
-  readonly accountId: AccountId;
-  readonly code: string;
-  readonly createdAt: UnixMillis;
-  readonly expiresAt: UnixMillis | null;
-  readonly archived: boolean;
-}
-
-export function toFriendCodeResult(input: Archivable<FriendCode>): FriendCodeResult {
-  return {
-    id: input.id,
-    accountId: input.accountId,
-    code: input.code,
-    createdAt: input.createdAt,
-    expiresAt: input.expiresAt,
-    archived: input.archived,
-  };
-}
+/**
+ * Service-layer result type for FriendCode reads.
+ *
+ * Aliased to `Archivable<FriendCode>` after PR #585 — the prior projection
+ * mapper (`toFriendCodeResult`) became an identity function once the entity
+ * adopted the discriminated `Archivable<T>` chain, so it was removed in
+ * favor of pass-through. Callers receive the discriminated union directly
+ * and can narrow on `archived` to access `archivedAt` on the archived
+ * branch.
+ */
+export type FriendCodeResult = Archivable<FriendCode>;

--- a/apps/api/src/services/account/friend-codes/internal.ts
+++ b/apps/api/src/services/account/friend-codes/internal.ts
@@ -1,7 +1,10 @@
-import { friendCodes } from "@pluralscape/db/pg";
-import { brandId, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
-
-import type { AccountId, FriendCodeId, UnixMillis } from "@pluralscape/types";
+import type {
+  AccountId,
+  Archivable,
+  FriendCode,
+  FriendCodeId,
+  UnixMillis,
+} from "@pluralscape/types";
 
 export interface FriendCodeResult {
   readonly id: FriendCodeId;
@@ -12,13 +15,13 @@ export interface FriendCodeResult {
   readonly archived: boolean;
 }
 
-export function toFriendCodeResult(row: typeof friendCodes.$inferSelect): FriendCodeResult {
+export function toFriendCodeResult(input: Archivable<FriendCode>): FriendCodeResult {
   return {
-    id: brandId<FriendCodeId>(row.id),
-    accountId: brandId<AccountId>(row.accountId),
-    code: row.code,
-    createdAt: toUnixMillis(row.createdAt),
-    expiresAt: toUnixMillisOrNull(row.expiresAt),
-    archived: row.archived,
+    id: input.id,
+    accountId: input.accountId,
+    code: input.code,
+    createdAt: input.createdAt,
+    expiresAt: input.expiresAt,
+    archived: input.archived,
   };
 }

--- a/apps/api/src/services/account/friend-codes/list.ts
+++ b/apps/api/src/services/account/friend-codes/list.ts
@@ -3,13 +3,14 @@ import { brandId } from "@pluralscape/types";
 import { and, desc, eq, lt, or, sql } from "drizzle-orm";
 
 import { assertAccountOwnership } from "../../../lib/account-ownership.js";
+import { narrowArchivableRow } from "../../../lib/archivable-row.js";
 import { buildPaginatedResult } from "../../../lib/pagination.js";
 import { withAccountRead } from "../../../lib/rls-context.js";
 
 import { toFriendCodeResult, type FriendCodeResult } from "./internal.js";
 
 import type { AuthContext } from "../../../lib/auth-context.js";
-import type { AccountId, FriendCodeId, PaginatedResult } from "@pluralscape/types";
+import type { AccountId, FriendCode, FriendCodeId, PaginatedResult } from "@pluralscape/types";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 /** Default page size for friend code listing. */
@@ -54,6 +55,8 @@ export async function listFriendCodes(
       .orderBy(desc(friendCodes.id))
       .limit(effectiveLimit + 1);
 
-    return buildPaginatedResult(rows, effectiveLimit, toFriendCodeResult);
+    return buildPaginatedResult(rows, effectiveLimit, (row) =>
+      toFriendCodeResult(narrowArchivableRow<FriendCode>(row)),
+    );
   });
 }

--- a/apps/api/src/services/account/friend-codes/list.ts
+++ b/apps/api/src/services/account/friend-codes/list.ts
@@ -7,7 +7,7 @@ import { narrowArchivableRow } from "../../../lib/archivable-row.js";
 import { buildPaginatedResult } from "../../../lib/pagination.js";
 import { withAccountRead } from "../../../lib/rls-context.js";
 
-import { toFriendCodeResult, type FriendCodeResult } from "./internal.js";
+import { type FriendCodeResult } from "./internal.js";
 
 import type { AuthContext } from "../../../lib/auth-context.js";
 import type { AccountId, FriendCode, FriendCodeId, PaginatedResult } from "@pluralscape/types";
@@ -56,7 +56,7 @@ export async function listFriendCodes(
       .limit(effectiveLimit + 1);
 
     return buildPaginatedResult(rows, effectiveLimit, (row) =>
-      toFriendCodeResult(narrowArchivableRow<FriendCode>(row)),
+      narrowArchivableRow<FriendCode>(row),
     );
   });
 }

--- a/apps/api/src/services/notification-config.service.ts
+++ b/apps/api/src/services/notification-config.service.ts
@@ -2,6 +2,7 @@ import { notificationConfigs } from "@pluralscape/db/pg";
 import { brandId, ID_PREFIXES, createId, now } from "@pluralscape/types";
 import { and, eq } from "drizzle-orm";
 
+import { narrowArchivableRow } from "../lib/archivable-row.js";
 import { withTenantRead, withTenantTransaction } from "../lib/rls-context.js";
 import { assertSystemOwnership } from "../lib/system-ownership.js";
 import { tenantCtx } from "../lib/tenant-context.js";
@@ -12,8 +13,10 @@ import { invalidateSwitchAlertConfigCache } from "./switch-alert-dispatcher.js";
 import type { AuditWriter } from "../lib/audit-writer.js";
 import type { AuthContext } from "../lib/auth-context.js";
 import type {
+  Archivable,
   AuditEventType,
   FriendNotificationEventType,
+  NotificationConfig,
   NotificationConfigId,
   NotificationEventType,
   SystemId,
@@ -55,23 +58,17 @@ export interface NotificationConfigResult {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function toNotificationConfigResult(row: {
-  id: string;
-  systemId: string;
-  eventType: NotificationEventType;
-  enabled: boolean;
-  pushEnabled: boolean;
-  createdAt: number;
-  updatedAt: number;
-}): NotificationConfigResult {
+function toNotificationConfigResult(
+  config: Archivable<NotificationConfig>,
+): NotificationConfigResult {
   return {
-    id: brandId<NotificationConfigId>(row.id),
-    systemId: brandId<SystemId>(row.systemId),
-    eventType: row.eventType,
-    enabled: row.enabled,
-    pushEnabled: row.pushEnabled,
-    createdAt: row.createdAt as UnixMillis,
-    updatedAt: row.updatedAt as UnixMillis,
+    id: config.id,
+    systemId: config.systemId,
+    eventType: config.eventType,
+    enabled: config.enabled,
+    pushEnabled: config.pushEnabled,
+    createdAt: config.createdAt,
+    updatedAt: config.updatedAt,
   };
 }
 
@@ -112,7 +109,7 @@ async function insertNotificationConfig(
     throw new Error("Notification config insert returned no rows");
   }
 
-  return toNotificationConfigResult(created);
+  return toNotificationConfigResult(narrowArchivableRow<NotificationConfig>(created));
 }
 
 // ── Service functions ────────────────────────────────────────────────
@@ -144,7 +141,7 @@ export async function getOrCreateNotificationConfig(
       .limit(1);
 
     if (existing) {
-      return toNotificationConfigResult(existing);
+      return toNotificationConfigResult(narrowArchivableRow<NotificationConfig>(existing));
     }
 
     return insertNotificationConfig(tx, systemId, eventType);
@@ -211,7 +208,7 @@ export async function updateNotificationConfig(
       systemId,
     });
 
-    return toNotificationConfigResult(updated);
+    return toNotificationConfigResult(narrowArchivableRow<NotificationConfig>(updated));
   });
 
   if (isFriendNotificationEventType(eventType)) {
@@ -237,6 +234,8 @@ export async function listNotificationConfigs(
       )
       .limit(MAX_PAGE_LIMIT);
 
-    return rows.map(toNotificationConfigResult);
+    return rows.map((row) =>
+      toNotificationConfigResult(narrowArchivableRow<NotificationConfig>(row)),
+    );
   });
 }

--- a/docs/adr/023-zod-type-alignment.md
+++ b/docs/adr/023-zod-type-alignment.md
@@ -151,8 +151,9 @@ The runtime invariant is defended once at the Drizzle read boundary by
 adapter throws on either inconsistent state — defensive against the CHECK
 ever being dropped or violated.
 
-Currently applied to: `NotificationConfig`, `FriendCode`. Future plaintext
-archivables emerging from `ps-6phh` follow this pattern.
+Parity tests in `packages/db/src/__tests__/type-parity/` are the source of
+truth for the applied set; future plaintext archivables emerging from
+`ps-6phh` follow this pattern.
 
 Encrypted archivables remain on the `EncryptedWire<T>` row-shape contract
 (Class A/B/C) — the encrypted-keyset row dominates the parity story and

--- a/docs/adr/023-zod-type-alignment.md
+++ b/docs/adr/023-zod-type-alignment.md
@@ -129,6 +129,35 @@ Class E surfaces (2):
 - **Entity-level:** `webhook-delivery` (`WebhookDeliveryServerMetadata.encryptedData: T3EncryptedBytes`)
 - **Column-level inside a Class C entity:** `ApiKeyServerMetadata.encryptedKeyMaterial: T3EncryptedBytes | null` (only present on `CryptoApiKey` rows). The `ApiKey` entity is therefore a hybrid Class C + Class E — its primary encrypted blob follows the Class C convention, while the side-channel key material is documented as a Class E exception.
 
+### Archivable plaintext entities — discriminated `ServerMetadata`/`Wire`
+
+For plaintext entities with the `archivable` column pair (`archived`,
+`archived_at`), the database CHECK constraint
+`(archived = true) = (archived_at IS NOT NULL)` is reflected in the type
+system as a discriminated union:
+
+- `<X>ServerMetadata = Archivable<<X>>` where
+  `Archivable<T> = T | Archived<T>` (defined in
+  `packages/types/src/utility.ts`)
+- `<X>Wire = Serialize<<X>ServerMetadata>` — the discriminated form falls
+  out automatically because `Serialize` distributes over unions
+- The flat Drizzle row shape is reconstructed locally in the parity test
+  (`packages/db/src/__tests__/type-parity/<x>.type.test.ts`) and not
+  exported from `@pluralscape/types` — this prevents accidental misuse in
+  application code
+
+The runtime invariant is defended once at the Drizzle read boundary by
+`narrowArchivableRow<T>` (`apps/api/src/lib/archivable-row.ts`). The
+adapter throws on either inconsistent state — defensive against the CHECK
+ever being dropped or violated.
+
+Currently applied to: `NotificationConfig`, `FriendCode`. Future plaintext
+archivables emerging from `ps-6phh` follow this pattern.
+
+Encrypted archivables remain on the `EncryptedWire<T>` row-shape contract
+(Class A/B/C) — the encrypted-keyset row dominates the parity story and
+the discriminated archivable shape doesn't compose cleanly with it.
+
 ### Enforcement — `pnpm types:check-sot`
 
 A single root script (`scripts/check-types-sot.ts`) runs all three parity mechanisms sequentially, short-circuiting on first failure. CI step in `.github/workflows/ci.yml` blocks on failure. Drift at any layer fails CI.

--- a/packages/data/src/transforms/__tests__/friend-code.test.ts
+++ b/packages/data/src/transforms/__tests__/friend-code.test.ts
@@ -8,7 +8,10 @@ const NOW = 1_700_000_000_000;
 const LATER = 1_700_002_000_000;
 const EXPIRES = 1_700_086_400_000;
 
-function makeRaw(overrides?: Partial<FriendCodeWire>): FriendCodeWire {
+type LiveWire = Extract<FriendCodeWire, { archived: false }>;
+type ArchivedWire = Extract<FriendCodeWire, { archived: true }>;
+
+function makeLiveRaw(overrides?: Partial<LiveWire>): LiveWire {
   return {
     id: "fcd_test001",
     accountId: "acc_test001",
@@ -16,14 +19,25 @@ function makeRaw(overrides?: Partial<FriendCodeWire>): FriendCodeWire {
     createdAt: NOW,
     expiresAt: EXPIRES,
     archived: false,
-    archivedAt: null,
     ...overrides,
+  };
+}
+
+function makeArchivedRaw(): ArchivedWire {
+  return {
+    id: "fcd_test001",
+    accountId: "acc_test001",
+    code: "ABCD-1234",
+    createdAt: NOW,
+    expiresAt: EXPIRES,
+    archived: true,
+    archivedAt: LATER,
   };
 }
 
 describe("narrowFriendCode", () => {
   it("returns live entity with archived: false", () => {
-    const result = narrowFriendCode(makeRaw());
+    const result = narrowFriendCode(makeLiveRaw());
     expect(result.archived).toBe(false);
     expect(result.id).toBe("fcd_test001");
     expect(result.accountId).toBe("acc_test001");
@@ -33,28 +47,21 @@ describe("narrowFriendCode", () => {
   });
 
   it("returns archived entity with archivedAt", () => {
-    const result = narrowFriendCode(makeRaw({ archived: true, archivedAt: LATER }));
+    const result = narrowFriendCode(makeArchivedRaw());
     expect(result.archived).toBe(true);
-    if (result.archived) {
-      expect(result.archivedAt).toBe(LATER);
-    }
-  });
-
-  it("throws when archived=true but archivedAt is null", () => {
-    expect(() => narrowFriendCode(makeRaw({ archived: true, archivedAt: null }))).toThrow(
-      "missing archivedAt",
-    );
+    if (!result.archived) throw new Error("expected archived=true");
+    expect(result.archivedAt).toBe(LATER);
   });
 
   it("handles null expiresAt (non-expiring code)", () => {
-    const result = narrowFriendCode(makeRaw({ expiresAt: null }));
+    const result = narrowFriendCode(makeLiveRaw({ expiresAt: null }));
     expect(result.expiresAt).toBeNull();
   });
 });
 
 describe("narrowFriendCodePage", () => {
   it("narrows all items and preserves cursor", () => {
-    const page = { data: [makeRaw(), makeRaw()], nextCursor: "cursor_abc" };
+    const page = { data: [makeLiveRaw(), makeLiveRaw()], nextCursor: "cursor_abc" };
     const result = narrowFriendCodePage(page);
     expect(result.data).toHaveLength(2);
     expect(result.nextCursor).toBe("cursor_abc");

--- a/packages/data/src/transforms/__tests__/notification-config.test.ts
+++ b/packages/data/src/transforms/__tests__/notification-config.test.ts
@@ -7,7 +7,7 @@ import type { NotificationConfigWire, NotificationEventType } from "@pluralscape
 const NOW = 1_700_000_000_000;
 const LATER = 1_700_002_000_000;
 
-function makeRaw(overrides?: Partial<NotificationConfigWire>): NotificationConfigWire {
+function makeLiveRaw(overrides?: Partial<NotificationConfigWire>): NotificationConfigWire {
   return {
     id: "nc_test0001",
     systemId: "sys_test001",
@@ -18,14 +18,28 @@ function makeRaw(overrides?: Partial<NotificationConfigWire>): NotificationConfi
     createdAt: NOW,
     updatedAt: NOW,
     archived: false,
-    archivedAt: null,
     ...overrides,
-  };
+  } as NotificationConfigWire;
+}
+
+function makeArchivedRaw(): NotificationConfigWire {
+  return {
+    id: "nc_test0001",
+    systemId: "sys_test001",
+    eventType: "switch-reminder" as NotificationEventType,
+    enabled: true,
+    pushEnabled: false,
+    version: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+    archived: true,
+    archivedAt: LATER,
+  } as NotificationConfigWire;
 }
 
 describe("narrowNotificationConfig", () => {
   it("returns live entity with archived: false", () => {
-    const result = narrowNotificationConfig(makeRaw());
+    const result = narrowNotificationConfig(makeLiveRaw());
     expect(result.archived).toBe(false);
     expect(result.id).toBe("nc_test0001");
     expect(result.systemId).toBe("sys_test001");
@@ -38,33 +52,26 @@ describe("narrowNotificationConfig", () => {
   });
 
   it("returns archived entity with archivedAt", () => {
-    const result = narrowNotificationConfig(makeRaw({ archived: true, archivedAt: LATER }));
+    const result = narrowNotificationConfig(makeArchivedRaw());
     expect(result.archived).toBe(true);
-    if (result.archived) {
-      expect(result.archivedAt).toBe(LATER);
-    }
-  });
-
-  it("throws when archived=true but archivedAt is null", () => {
-    expect(() => narrowNotificationConfig(makeRaw({ archived: true, archivedAt: null }))).toThrow(
-      "missing archivedAt",
-    );
+    if (!result.archived) throw new Error("Expected archived shape");
+    expect(result.archivedAt).toBe(LATER);
   });
 
   it("handles pushEnabled: true", () => {
-    const result = narrowNotificationConfig(makeRaw({ pushEnabled: true }));
+    const result = narrowNotificationConfig(makeLiveRaw({ pushEnabled: true }));
     expect(result.pushEnabled).toBe(true);
   });
 
   it("handles enabled: false", () => {
-    const result = narrowNotificationConfig(makeRaw({ enabled: false }));
+    const result = narrowNotificationConfig(makeLiveRaw({ enabled: false }));
     expect(result.enabled).toBe(false);
   });
 });
 
 describe("narrowNotificationConfigPage", () => {
   it("narrows all items and preserves cursor", () => {
-    const page = { data: [makeRaw(), makeRaw()], nextCursor: "cursor_abc" };
+    const page = { data: [makeLiveRaw(), makeArchivedRaw()], nextCursor: "cursor_abc" };
     const result = narrowNotificationConfigPage(page);
     expect(result.data).toHaveLength(2);
     expect(result.nextCursor).toBe("cursor_abc");

--- a/packages/data/src/transforms/__tests__/notification-config.test.ts
+++ b/packages/data/src/transforms/__tests__/notification-config.test.ts
@@ -7,7 +7,10 @@ import type { NotificationConfigWire, NotificationEventType } from "@pluralscape
 const NOW = 1_700_000_000_000;
 const LATER = 1_700_002_000_000;
 
-function makeLiveRaw(overrides?: Partial<NotificationConfigWire>): NotificationConfigWire {
+type LiveWire = Extract<NotificationConfigWire, { archived: false }>;
+type ArchivedWire = Extract<NotificationConfigWire, { archived: true }>;
+
+function makeLiveRaw(overrides?: Partial<LiveWire>): LiveWire {
   return {
     id: "nc_test0001",
     systemId: "sys_test001",
@@ -19,10 +22,10 @@ function makeLiveRaw(overrides?: Partial<NotificationConfigWire>): NotificationC
     updatedAt: NOW,
     archived: false,
     ...overrides,
-  } as NotificationConfigWire;
+  };
 }
 
-function makeArchivedRaw(): NotificationConfigWire {
+function makeArchivedRaw(): ArchivedWire {
   return {
     id: "nc_test0001",
     systemId: "sys_test001",
@@ -34,7 +37,7 @@ function makeArchivedRaw(): NotificationConfigWire {
     updatedAt: NOW,
     archived: true,
     archivedAt: LATER,
-  } as NotificationConfigWire;
+  };
 }
 
 describe("narrowNotificationConfig", () => {

--- a/packages/data/src/transforms/friend-code.ts
+++ b/packages/data/src/transforms/friend-code.ts
@@ -25,7 +25,13 @@ export function narrowFriendCode(raw: FriendCodeWire): Archivable<FriendCode> {
   };
 
   if (raw.archived) {
-    return { ...base, archived: true as const, archivedAt: toUnixMillis(raw.archivedAt) };
+    // Defensive: the discriminated wire type prevents this construction in honest
+    // TypeScript; the widening cast lets us guard against malformed runtime input.
+    const archivedAt = raw.archivedAt as number | null;
+    if (archivedAt === null) {
+      throw new Error("Archived friendCode missing archivedAt");
+    }
+    return { ...base, archived: true as const, archivedAt: toUnixMillis(archivedAt) };
   }
   return { ...base, archived: false as const };
 }

--- a/packages/data/src/transforms/friend-code.ts
+++ b/packages/data/src/transforms/friend-code.ts
@@ -2,7 +2,7 @@ import { brandId, toUnixMillis, toUnixMillisOrNull } from "@pluralscape/types";
 
 import type {
   AccountId,
-  Archived,
+  Archivable,
   FriendCode,
   FriendCodeId,
   FriendCodeWire,
@@ -15,7 +15,7 @@ export interface FriendCodePage {
 }
 
 /** Narrow a wire friend code; re-brands stripped IDs/timestamps. */
-export function narrowFriendCode(raw: FriendCodeWire): FriendCode | Archived<FriendCode> {
+export function narrowFriendCode(raw: FriendCodeWire): Archivable<FriendCode> {
   const base = {
     id: brandId<FriendCodeId>(raw.id),
     accountId: brandId<AccountId>(raw.accountId),
@@ -25,7 +25,6 @@ export function narrowFriendCode(raw: FriendCodeWire): FriendCode | Archived<Fri
   };
 
   if (raw.archived) {
-    if (raw.archivedAt === null) throw new Error("Archived friendCode missing archivedAt");
     return { ...base, archived: true as const, archivedAt: toUnixMillis(raw.archivedAt) };
   }
   return { ...base, archived: false as const };
@@ -33,7 +32,7 @@ export function narrowFriendCode(raw: FriendCodeWire): FriendCode | Archived<Fri
 
 /** Narrow a paginated friend code list. */
 export function narrowFriendCodePage(raw: FriendCodePage): {
-  data: (FriendCode | Archived<FriendCode>)[];
+  data: Archivable<FriendCode>[];
   nextCursor: string | null;
 } {
   return {

--- a/packages/data/src/transforms/notification-config.ts
+++ b/packages/data/src/transforms/notification-config.ts
@@ -30,7 +30,13 @@ export function narrowNotificationConfig(
   };
 
   if (raw.archived) {
-    return { ...base, archived: true as const, archivedAt: toUnixMillis(raw.archivedAt) };
+    // Defensive: the discriminated wire type prevents this construction in honest
+    // TypeScript; the widening cast lets us guard against malformed runtime input.
+    const archivedAt = raw.archivedAt as number | null;
+    if (archivedAt === null) {
+      throw new Error("Archived notificationConfig missing archivedAt");
+    }
+    return { ...base, archived: true as const, archivedAt: toUnixMillis(archivedAt) };
   }
   return { ...base, archived: false as const };
 }

--- a/packages/data/src/transforms/notification-config.ts
+++ b/packages/data/src/transforms/notification-config.ts
@@ -1,7 +1,7 @@
 import { brandId, toUnixMillis } from "@pluralscape/types";
 
 import type {
-  Archived,
+  Archivable,
   NotificationConfig,
   NotificationConfigId,
   NotificationConfigWire,
@@ -17,7 +17,7 @@ export interface NotificationConfigPage {
 /** Narrow a wire notification config; re-brands stripped IDs/timestamps. */
 export function narrowNotificationConfig(
   raw: NotificationConfigWire,
-): NotificationConfig | Archived<NotificationConfig> {
+): Archivable<NotificationConfig> {
   const base = {
     id: brandId<NotificationConfigId>(raw.id),
     systemId: brandId<SystemId>(raw.systemId),
@@ -30,7 +30,6 @@ export function narrowNotificationConfig(
   };
 
   if (raw.archived) {
-    if (raw.archivedAt === null) throw new Error("Archived notificationConfig missing archivedAt");
     return { ...base, archived: true as const, archivedAt: toUnixMillis(raw.archivedAt) };
   }
   return { ...base, archived: false as const };
@@ -38,7 +37,7 @@ export function narrowNotificationConfig(
 
 /** Narrow a paginated notification config list. */
 export function narrowNotificationConfigPage(raw: NotificationConfigPage): {
-  data: (NotificationConfig | Archived<NotificationConfig>)[];
+  data: Archivable<NotificationConfig>[];
   nextCursor: string | null;
 } {
   return {

--- a/packages/db/src/__tests__/type-parity/friend-code.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/friend-code.type.test.ts
@@ -1,29 +1,35 @@
 /**
- * Drizzle parity check: the FriendCode row shape inferred from the
- * `friend_codes` table structurally matches `FriendCodeServerMetadata` in
- * @pluralscape/types.
+ * Drizzle parity check for `friend_codes`.
  *
- * Plaintext entity — relaxes the domain's `archived: false` literal to
- * the raw boolean column and adds the nullable `archivedAt` that the
- * archivable-consistency check requires. See `member.type.test.ts` for
- * the general rationale behind the brand-stripped comparison.
+ * The Drizzle row is structurally flat (`archived: boolean`, `archivedAt:
+ * UnixMillis | null`). The application-facing `FriendCodeServerMetadata`
+ * is the discriminated `Archivable<>` union. This file pins the flat row
+ * shape against a locally-defined `Row` type so the assertion is
+ * independent of any public type changes.
+ * See ADR-023 § Archivable plaintext entities for the convention.
  */
 
 import { describe, expectTypeOf, it } from "vitest";
 
 import { friendCodes } from "../../schema/pg/privacy.js";
 
-import type { Equal, FriendCodeServerMetadata } from "@pluralscape/types";
+import type { Equal, FriendCode, UnixMillis } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
+/** Flat shape of the `friend_codes` Drizzle row — local to this parity test. */
+type FriendCodeServerMetadataRow = Omit<FriendCode, "archived"> & {
+  readonly archived: boolean;
+  readonly archivedAt: UnixMillis | null;
+};
+
 describe("FriendCode Drizzle parity", () => {
-  it("friend_codes Drizzle row has the same property keys as FriendCodeServerMetadata", () => {
+  it("friend_codes Drizzle row has the same property keys as the flat row helper", () => {
     type Row = InferSelectModel<typeof friendCodes>;
-    expectTypeOf<keyof Row>().toEqualTypeOf<keyof FriendCodeServerMetadata>();
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof FriendCodeServerMetadataRow>();
   });
 
-  it("friend_codes Drizzle row equals FriendCodeServerMetadata", () => {
+  it("friend_codes Drizzle row equals the flat row helper", () => {
     type Row = InferSelectModel<typeof friendCodes>;
-    expectTypeOf<Equal<Row, FriendCodeServerMetadata>>().toEqualTypeOf<true>();
+    expectTypeOf<Equal<Row, FriendCodeServerMetadataRow>>().toEqualTypeOf<true>();
   });
 });

--- a/packages/db/src/__tests__/type-parity/notification-config.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/notification-config.type.test.ts
@@ -1,17 +1,34 @@
+/**
+ * Drizzle parity check for `notification_configs`.
+ *
+ * The Drizzle row is structurally flat (`archived: boolean`, `archivedAt:
+ * UnixMillis | null`). The application-facing
+ * `NotificationConfigServerMetadata` is the discriminated `Archivable<>`
+ * union. This file pins the flat row shape against a locally-defined
+ * `Row` type so the assertion is independent of any public type changes.
+ * See ADR-023 § Archivable plaintext entities for the convention.
+ */
+
 import { describe, expectTypeOf, it } from "vitest";
 
 import { notificationConfigs } from "../../schema/pg/notifications.js";
 
-import type { Equal, NotificationConfigServerMetadataRow } from "@pluralscape/types";
+import type { Equal, NotificationConfig, UnixMillis } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
+/** Flat shape of the `notification_configs` Drizzle row — local to this parity test. */
+type NotificationConfigServerMetadataRow = Omit<NotificationConfig, "archived"> & {
+  readonly archived: boolean;
+  readonly archivedAt: UnixMillis | null;
+};
+
 describe("NotificationConfig Drizzle parity", () => {
-  it("notification_configs Drizzle row has the same property keys as NotificationConfigServerMetadataRow", () => {
+  it("notification_configs Drizzle row has the same property keys as the flat row helper", () => {
     type Row = InferSelectModel<typeof notificationConfigs>;
     expectTypeOf<keyof Row>().toEqualTypeOf<keyof NotificationConfigServerMetadataRow>();
   });
 
-  it("notification_configs Drizzle row equals NotificationConfigServerMetadataRow (flat shape)", () => {
+  it("notification_configs Drizzle row equals the flat row helper", () => {
     type Row = InferSelectModel<typeof notificationConfigs>;
     expectTypeOf<Equal<Row, NotificationConfigServerMetadataRow>>().toEqualTypeOf<true>();
   });

--- a/packages/db/src/__tests__/type-parity/notification-config.type.test.ts
+++ b/packages/db/src/__tests__/type-parity/notification-config.type.test.ts
@@ -1,29 +1,18 @@
-/**
- * Drizzle parity check: the NotificationConfig row shape inferred from
- * the `notification_configs` table structurally matches
- * `NotificationConfigServerMetadata` in @pluralscape/types.
- *
- * Plaintext entity — relaxes the domain's `archived: false` literal to
- * the raw boolean column and adds the nullable `archivedAt` that the
- * archivable-consistency check requires. See `member.type.test.ts` for
- * the general rationale behind the brand-stripped comparison.
- */
-
 import { describe, expectTypeOf, it } from "vitest";
 
 import { notificationConfigs } from "../../schema/pg/notifications.js";
 
-import type { Equal, NotificationConfigServerMetadata } from "@pluralscape/types";
+import type { Equal, NotificationConfigServerMetadataRow } from "@pluralscape/types";
 import type { InferSelectModel } from "drizzle-orm";
 
 describe("NotificationConfig Drizzle parity", () => {
-  it("notification_configs Drizzle row has the same property keys as NotificationConfigServerMetadata", () => {
+  it("notification_configs Drizzle row has the same property keys as NotificationConfigServerMetadataRow", () => {
     type Row = InferSelectModel<typeof notificationConfigs>;
-    expectTypeOf<keyof Row>().toEqualTypeOf<keyof NotificationConfigServerMetadata>();
+    expectTypeOf<keyof Row>().toEqualTypeOf<keyof NotificationConfigServerMetadataRow>();
   });
 
-  it("notification_configs Drizzle row equals NotificationConfigServerMetadata", () => {
+  it("notification_configs Drizzle row equals NotificationConfigServerMetadataRow (flat shape)", () => {
     type Row = InferSelectModel<typeof notificationConfigs>;
-    expectTypeOf<Equal<Row, NotificationConfigServerMetadata>>().toEqualTypeOf<true>();
+    expectTypeOf<Equal<Row, NotificationConfigServerMetadataRow>>().toEqualTypeOf<true>();
   });
 });

--- a/packages/types/src/__tests__/archivable.test.ts
+++ b/packages/types/src/__tests__/archivable.test.ts
@@ -16,9 +16,9 @@ describe("Archivable<T>", () => {
   it("narrows on archived discriminant", () => {
     const check = (value: Archivable<Sample>) => {
       if (value.archived) {
-        expectTypeOf(value).toExtend<Archived<Sample>>();
+        expectTypeOf(value).toEqualTypeOf<Archived<Sample>>();
       } else {
-        expectTypeOf(value).toExtend<Sample>();
+        expectTypeOf(value).toEqualTypeOf<Sample>();
       }
     };
     void check;

--- a/packages/types/src/__tests__/archivable.test.ts
+++ b/packages/types/src/__tests__/archivable.test.ts
@@ -1,0 +1,32 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { Archivable, Archived, Equal } from "../index.js";
+
+interface Sample {
+  readonly id: string;
+  readonly name: string;
+  readonly archived: false;
+}
+
+describe("Archivable<T>", () => {
+  it("equals T | Archived<T>", () => {
+    expectTypeOf<Equal<Archivable<Sample>, Sample | Archived<Sample>>>().toEqualTypeOf<true>();
+  });
+
+  it("narrows on archived discriminant", () => {
+    const check = (value: Archivable<Sample>) => {
+      if (value.archived) {
+        expectTypeOf(value).toExtend<Archived<Sample>>();
+      } else {
+        expectTypeOf(value).toExtend<Sample>();
+      }
+    };
+    void check;
+  });
+
+  it("rejects archived: true without archivedAt at the type level", () => {
+    // @ts-expect-error — Archived<T> requires archivedAt
+    const _bad: Archivable<Sample> = { id: "x", name: "n", archived: true };
+    void _bad;
+  });
+});

--- a/packages/types/src/entities/friend-code.ts
+++ b/packages/types/src/entities/friend-code.ts
@@ -1,9 +1,9 @@
 import type { AccountId, FriendCodeId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
-import type { Archived } from "../utility.js";
+import type { Archivable, Archived } from "../utility.js";
 
-/** An immutable, optionally expiring friend code used to initiate connections. */
+/** An immutable, optionally expiring friend code used to initiate connections (live state). */
 export interface FriendCode {
   readonly id: FriendCodeId;
   readonly accountId: AccountId;
@@ -17,17 +17,21 @@ export interface FriendCode {
 export type ArchivedFriendCode = Archived<FriendCode>;
 
 /**
- * Server-visible FriendCode metadata — raw Drizzle row shape.
+ * Server-visible FriendCode metadata.
  *
- * Plaintext entity. The domain type pins `archived: false` (callers interact
- * with either the live or the archived variant via the `Archived<T>`
- * helper), but the raw row carries the boolean column plus a nullable
- * `archivedAt` for the archivable consistency check.
+ * Discriminated union of the live and archived shapes — the database CHECK
+ * invariant `(archived = true) = (archived_at IS NOT NULL)` is encoded in
+ * the type system here. Recover this shape from a flat Drizzle row via
+ * `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts).
  */
-export type FriendCodeServerMetadata = Omit<FriendCode, "archived"> & {
-  readonly archived: boolean;
-  readonly archivedAt: UnixMillis | null;
-};
+export type FriendCodeServerMetadata = Archivable<FriendCode>;
 
-/** JSON-wire FriendCode (live or archived). Branded IDs and UnixMillis get stripped at the wire boundary. */
+/**
+ * JSON-wire FriendCode (live or archived) — discriminated.
+ *
+ * `Serialize` distributes over the underlying union, so this type is the
+ * discriminated wire union: `Serialize<FriendCode> |
+ * Serialize<Archived<FriendCode>>`. Branded IDs and `UnixMillis` are
+ * stripped at the wire boundary.
+ */
 export type FriendCodeWire = Serialize<FriendCodeServerMetadata>;

--- a/packages/types/src/entities/friend-code.ts
+++ b/packages/types/src/entities/friend-code.ts
@@ -21,8 +21,8 @@ export type ArchivedFriendCode = Archived<FriendCode>;
  *
  * Discriminated union of the live and archived shapes — the database CHECK
  * invariant `(archived = true) = (archived_at IS NOT NULL)` is encoded in
- * the type system here. Recover this shape from a flat Drizzle row via
- * `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts).
+ * the type system here. Produced from a flat Drizzle row at the read boundary
+ * by `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts).
  */
 export type FriendCodeServerMetadata = Archivable<FriendCode>;
 

--- a/packages/types/src/entities/notification-config.ts
+++ b/packages/types/src/entities/notification-config.ts
@@ -31,21 +31,9 @@ export type ArchivedNotificationConfig = Archived<NotificationConfig>;
  * Discriminated union of the live and archived shapes — the database CHECK
  * invariant `(archived = true) = (archived_at IS NOT NULL)` is encoded in
  * the type system here. Recover this shape from a flat Drizzle row via
- * `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts). For the flat
- * row shape (used only for Drizzle parity assertions), see
- * `NotificationConfigServerMetadataRow`.
+ * `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts).
  */
 export type NotificationConfigServerMetadata = Archivable<NotificationConfig>;
-
-/**
- * Flat shape of the `notification_configs` Drizzle row — used for the
- * Drizzle structural-parity assertion only. Application code should consume
- * the discriminated `NotificationConfigServerMetadata` after narrowing.
- */
-export type NotificationConfigServerMetadataRow = Omit<NotificationConfig, "archived"> & {
-  readonly archived: boolean;
-  readonly archivedAt: UnixMillis | null;
-};
 
 /**
  * JSON-wire NotificationConfig (live or archived) — discriminated.

--- a/packages/types/src/entities/notification-config.ts
+++ b/packages/types/src/entities/notification-config.ts
@@ -1,7 +1,7 @@
 import type { NotificationConfigId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
-import type { Archived, AuditMetadata } from "../utility.js";
+import type { Archivable, Archived, AuditMetadata } from "../utility.js";
 
 /** Events that can trigger a notification. */
 export type NotificationEventType =
@@ -12,7 +12,7 @@ export type NotificationEventType =
   | "sync-conflict"
   | "friend-switch-alert";
 
-/** Per-event notification configuration. */
+/** Per-event notification configuration (live state). */
 export interface NotificationConfig extends AuditMetadata {
   readonly id: NotificationConfigId;
   readonly systemId: SystemId;
@@ -26,18 +26,35 @@ export interface NotificationConfig extends AuditMetadata {
 export type ArchivedNotificationConfig = Archived<NotificationConfig>;
 
 /**
- * Server-visible NotificationConfig metadata — raw Drizzle row shape.
+ * Server-visible NotificationConfig metadata.
  *
- * Plaintext entity. Relaxes the domain's `archived: false` literal to the
- * raw boolean column and adds the nullable `archivedAt` that the
- * archivable-consistency check requires.
+ * Discriminated union of the live and archived shapes — the database CHECK
+ * invariant `(archived = true) = (archived_at IS NOT NULL)` is encoded in
+ * the type system here. Recover this shape from a flat Drizzle row via
+ * `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts). For the flat
+ * row shape (used only for Drizzle parity assertions), see
+ * `NotificationConfigServerMetadataRow`.
  */
-export type NotificationConfigServerMetadata = Omit<NotificationConfig, "archived"> & {
+export type NotificationConfigServerMetadata = Archivable<NotificationConfig>;
+
+/**
+ * Flat shape of the `notification_configs` Drizzle row — used for the
+ * Drizzle structural-parity assertion only. Application code should consume
+ * the discriminated `NotificationConfigServerMetadata` after narrowing.
+ */
+export type NotificationConfigServerMetadataRow = Omit<NotificationConfig, "archived"> & {
   readonly archived: boolean;
   readonly archivedAt: UnixMillis | null;
 };
 
-/** JSON-wire NotificationConfig (live or archived). Branded IDs and UnixMillis get stripped at the wire boundary. */
+/**
+ * JSON-wire NotificationConfig (live or archived) — discriminated.
+ *
+ * `Serialize` distributes over the underlying union, so this type is the
+ * discriminated wire union: `Serialize<NotificationConfig> |
+ * Serialize<Archived<NotificationConfig>>`. Branded IDs and `UnixMillis`
+ * are stripped at the wire boundary.
+ */
 export type NotificationConfigWire = Serialize<NotificationConfigServerMetadata>;
 
 /** A notification payload ready for delivery. */

--- a/packages/types/src/entities/notification-config.ts
+++ b/packages/types/src/entities/notification-config.ts
@@ -30,8 +30,8 @@ export type ArchivedNotificationConfig = Archived<NotificationConfig>;
  *
  * Discriminated union of the live and archived shapes — the database CHECK
  * invariant `(archived = true) = (archived_at IS NOT NULL)` is encoded in
- * the type system here. Recover this shape from a flat Drizzle row via
- * `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts).
+ * the type system here. Produced from a flat Drizzle row at the read boundary
+ * by `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts).
  */
 export type NotificationConfigServerMetadata = Archivable<NotificationConfig>;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -171,6 +171,7 @@ export type {
   DateRange,
   AuditMetadata,
   Archived,
+  Archivable,
   SortDirection,
   EntityReference,
 } from "./utility.js";

--- a/packages/types/src/utility.ts
+++ b/packages/types/src/utility.ts
@@ -52,6 +52,17 @@ export type Archived<T extends { readonly archived: false }> = T extends {
   ? Omit<T, "archived"> & { readonly archived: true; readonly archivedAt: UnixMillis }
   : never;
 
+/**
+ * The discriminated union of an archivable entity in either the live or
+ * archived state.
+ *
+ * Pairs with `Archived<T>` to encode the database CHECK invariant
+ * `(archived = true) = (archived_at IS NOT NULL)` directly in the type
+ * system. Use `narrowArchivableRow` (apps/api/src/lib/archivable-row.ts)
+ * to convert flat Drizzle rows into this shape at the read boundary.
+ */
+export type Archivable<T extends { readonly archived: false }> = T | Archived<T>;
+
 /** Sort direction for queries. */
 export type SortDirection = "asc" | "desc";
 

--- a/tooling/eslint-config/index.js
+++ b/tooling/eslint-config/index.js
@@ -36,14 +36,15 @@ export default tseslint.config(
       // Ban all eslint-disable comments — fix the violation, don't suppress it
       "@eslint-community/eslint-comments/no-use": "error",
 
-      // Allow underscore-prefixed names as intentionally unused
+      // Allow underscore-prefixed names as intentionally unused. Catch bindings
+      // are intentionally NOT exempted: empty/swallowed catches violate the
+      // no-swallowed-errors policy in CLAUDE.md.
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",
           destructuredArrayIgnorePattern: "^_",
-          caughtErrorsIgnorePattern: "^_",
         },
       ],
 

--- a/tooling/eslint-config/index.js
+++ b/tooling/eslint-config/index.js
@@ -36,6 +36,17 @@ export default tseslint.config(
       // Ban all eslint-disable comments — fix the violation, don't suppress it
       "@eslint-community/eslint-comments/no-use": "error",
 
+      // Allow underscore-prefixed names as intentionally unused
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+
       // No `as any`
       "@typescript-eslint/no-explicit-any": "error",
 


### PR DESCRIPTION
## Summary

Encodes the database CHECK invariant `(archived = true) = (archived_at IS NOT NULL)` in the type system across the canonical chain for plaintext archivable entities. Removes runtime `archivedAt === null` throws from data-layer transforms; the discriminated union now carries the guarantee at compile time.

- New `Archivable<T> = T | Archived<T>` helper in `packages/types/src/utility.ts` — domain/server/wire all share the same discriminated shape.
- New `narrowArchivableRow<T>` adapter in `apps/api/src/lib/archivable-row.ts` — defends the CHECK invariant at the Drizzle read boundary; throws on either inconsistent state.
- `NotificationConfig` and `FriendCode` migrated end-to-end: discriminated `ServerMetadata`, discriminated `Wire` (falls out of `Serialize` distributing over the union), service read sites wired through the adapter, transform throws removed.
- Drizzle parity tests define their flat `Row` helpers locally — never exported from `@pluralscape/types`, preventing accidental application-code misuse.
- ADR-023 documents the convention; future plaintext archivables under `ps-6phh` follow it.
- `tooling/eslint-config` now configures `@typescript-eslint/no-unused-vars` to allow `^_`-prefixed names (standard TypeScript convention).

Closes bean `types-0e9j` (M9a, `ps-cd6x`).

Spec: `docs/superpowers/specs/2026-04-28-types-0e9j-archivable-discriminated-design.md` (local-only)

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm lint` — zero warnings (17/17 packages)
- [x] `pnpm typecheck` — clean (21/21 packages)
- [x] `pnpm types:check-sot` — all 4 surfaces pass (types, Drizzle, Zod, OpenAPI-Wire)
- [x] `pnpm test:unit` — 13170 passed / 0 failures
- [x] `pnpm test:integration` — 3063 passed / 0 failures
- [ ] `pnpm test:e2e` — runs in CI on this PR