### PR TITLE
feat(types,validation,data): M9a brand closeout — same-entity-peer brands (4 tasks)

### DIFF
--- a/.beans/ps-0vwf--closeout-quick-wins.md
+++ b/.beans/ps-0vwf--closeout-quick-wins.md
@@ -1,11 +1,11 @@
 ---
 # ps-0vwf
 title: Closeout quick wins
-status: in-progress
+status: completed
 type: epic
 priority: normal
 created_at: 2026-04-21T13:54:51Z
-updated_at: 2026-04-21T17:31:55Z
+updated_at: 2026-04-29T04:11:44Z
 parent: ps-cd6x
 ---
 
@@ -39,3 +39,16 @@ docs/superpowers/specs/2026-04-21-m9a-closeout-hardening-design.md
 - db-4pir — RLS lint rule + unset-context integration test (commit 63db35fe)
 
 Deferred: ps-lg9y (blocked by api-6l1q service refactor epic; lands after that completes).
+
+## Summary of Changes
+
+All 8 children completed:
+
+- api-e3li — typed JobQueue mock
+- ps-g5dl — local audit archive
+- ps-sg0u — ADR supersession fields + backfills
+- mobile-8ovj — shared mobile test factories
+- api-6d0l — dev-only crypto constants module
+- api-lm4o — Hono AuthEnv typing + CONTRIBUTING doc
+- db-4pir — RLS lint rule + unset-context integration test
+- ps-lg9y — CI/pre-commit LOC cap on apps/api/src/services/\*_/_.ts (landed after api-6l1q service refactor epic completed)

--- a/.beans/ps-toyo--address-pr-586-review-feedback-empty-string-bounda.md
+++ b/.beans/ps-toyo--address-pr-586-review-feedback-empty-string-bounda.md
@@ -1,10 +1,11 @@
 ---
 # ps-toyo
 title: "Address PR #586 review feedback — empty-string boundary, max-50 enforcement, JSDoc cleanup, brand-type assertions"
-status: in-progress
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-29T08:41:51Z
-updated_at: 2026-04-29T08:41:51Z
+updated_at: 2026-04-29T09:37:12Z
 parent: ps-cd6x
 ---
 
@@ -64,3 +65,17 @@ under `scripts/.sp-test-*.json`).
 
 Verification: typecheck, lint, types:check-sot, unit (13194 passed),
 integration (3063 passed), e2e (509 passed) all green; format:fix clean.
+
+### Commit 6 (227e3d5b)
+
+Encoded the 50-character limit on FrontingSession.comment via a Zod refine that preserves the FrontingSessionComment brand. Introduced MAX_FRONTING_COMMENT_LENGTH in new packages/types/src/fronting.constants.ts; the entity-level field declaration retains its existing constraint marker.
+
+### Commit 7 (04524590)
+
+Added expectTypeOf brand assertions for Note/Poll/FieldDefinition mirroring the FrontingSession precedent — locks in compile-time brand identity for the canonical chain projections.
+
+### Commit 8 (this commit)
+
+Removed all references to docs/local-audits/2026-04-27-free-text-label-brand-audit.md from packages/types/src/value-types.ts (6 sites) and from the 4 brand-task bean bodies (types-cdr5, types-09m5, types-e6n9, types-gkhk). Replaced audit-citing preambles with self-contained one-line rationale text. Aligned peer brand JSDoc (NoteContent, PollOptionLabel, FrontingSessionPositionality, FrontingSessionOuttrigger) to the existing LifecycleEventName one-line peer-delegation precedent. Fixed PollTitle grammar ambiguity. Named FieldDefinition's same-entity peer (description) explicitly. Verified zero local-audits references remain in packages/, .beans/, apps/.
+
+Verification: format, lint, typecheck, types:check-sot, unit (13204 passed), integration (3063 passed), e2e (509 passed) all green.

--- a/.beans/ps-toyo--address-pr-586-review-feedback-empty-string-bounda.md
+++ b/.beans/ps-toyo--address-pr-586-review-feedback-empty-string-bounda.md
@@ -1,0 +1,66 @@
+---
+# ps-toyo
+title: "Address PR #586 review feedback — empty-string boundary, max-50 enforcement, JSDoc cleanup, brand-type assertions"
+status: in-progress
+type: task
+created_at: 2026-04-29T08:41:51Z
+updated_at: 2026-04-29T08:41:51Z
+parent: ps-cd6x
+---
+
+Multi-agent review of PR #586 (M9a brand closeout) surfaced 4 important issues and 8 suggestions. This bean tracks the follow-up commits on the same branch:
+
+- Commit 5: SP mapper empty-string boundary handling + per-schema empty-string-rejection tests (4 validation test files; 1 created)
+- Commit 6: Encode 50-char limit on FrontingSession.comment via Zod refine + new MAX_FRONTING_COMMENT_LENGTH constant
+- Commit 7: expectTypeOf brand assertions for Note/Poll/FieldDefinition
+- Commit 8: JSDoc cleanup in value-types.ts + bean-body cleanup (drop local-audit references everywhere)
+
+Out of scope per user direction: do not commit or reference the local audit doc anywhere; do not introduce a brandedStringAllowEmpty<B> helper now.
+
+Plan: ~/.claude/plans/fix-all-of-the-typed-newell.md (local only)
+
+## Summary of Changes
+
+### Commit 5 (this commit)
+
+Fixed runtime regression risk at the SP-import boundary for the brand-tightened
+fields introduced by the four earlier brand-introduction commits.
+
+- `packages/import-sp/src/mappers/fronting-session.mapper.ts` — coerce empty
+  `sp.customStatus` to `null` for `FrontingSessionComment` (nullable target)
+  using the cleaner `?.length` guard.
+- `packages/import-sp/src/mappers/journal-entry.mapper.ts` — guard empty
+  `sp.title` and `sp.note` and return `failed({ kind: "empty-name", ... })`
+  with `targetField` set to `title` or `content`.
+- `packages/import-sp/src/mappers/poll.mapper.ts` — guard empty `sp.name` and
+  any option with empty `name` before the option-mapping `.map()`; both return
+  `failed({ kind: "empty-name", ... })`.
+- `packages/import-sp/src/mappers/field-definition.mapper.ts` — guard empty
+  `sp.name` and return `failed({ kind: "empty-name", ... })`.
+
+Added empty-string handling tests in each affected mapper test file plus
+per-schema empty-string-rejection tests in:
+
+- `packages/validation/src/__tests__/note.test.ts` (NoteEncryptedInputSchema)
+- `packages/validation/src/__tests__/poll.test.ts` (PollEncryptedInputSchema,
+  validates option label/id rejection through the parent schema since
+  `PollOptionSchema` is module-private)
+- `packages/validation/src/__tests__/fronting-session.test.ts`
+  (FrontingSessionEncryptedInputSchema — accepts null and non-empty strings,
+  rejects empty strings on each of comment, positionality, outtrigger)
+- `packages/validation/src/__tests__/custom-fields.test.ts` (newly created;
+  FieldDefinitionEncryptedInputSchema)
+
+Used the existing `"empty-name"` `ImportFailureKind` literal across all the
+required-non-empty boundaries — semantically the closest match and already
+in use by the shared `requireName()` helper in
+`packages/import-sp/src/mappers/helpers.ts`.
+
+The pre-existing journal-entry test that asserted "allows empty body" was
+inverted (no migration concerns: the codebase is pre-production with no
+prod data). The local SP adversarial fixture's `note.emptytitle` entry was
+removed from both the local-only export and manifest JSONs (gitignored
+under `scripts/.sp-test-*.json`).
+
+Verification: typecheck, lint, types:check-sot, unit (13194 passed),
+integration (3063 passed), e2e (509 passed) all green; format:fix clean.

--- a/.beans/ps-toyo--address-pr-586-review-feedback-empty-string-bounda.md
+++ b/.beans/ps-toyo--address-pr-586-review-feedback-empty-string-bounda.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-29T08:41:51Z
-updated_at: 2026-04-29T09:37:12Z
+updated_at: 2026-04-29T09:39:43Z
 parent: ps-cd6x
 ---
 
@@ -76,6 +76,6 @@ Added expectTypeOf brand assertions for Note/Poll/FieldDefinition mirroring the 
 
 ### Commit 8 (this commit)
 
-Removed all references to docs/local-audits/2026-04-27-free-text-label-brand-audit.md from packages/types/src/value-types.ts (6 sites) and from the 4 brand-task bean bodies (types-cdr5, types-09m5, types-e6n9, types-gkhk). Replaced audit-citing preambles with self-contained one-line rationale text. Aligned peer brand JSDoc (NoteContent, PollOptionLabel, FrontingSessionPositionality, FrontingSessionOuttrigger) to the existing LifecycleEventName one-line peer-delegation precedent. Fixed PollTitle grammar ambiguity. Named FieldDefinition's same-entity peer (description) explicitly. Verified zero local-audits references remain in packages/, .beans/, apps/.
+Removed all local-audit path references from packages/types/src/value-types.ts (6 sites) and from the 4 brand-task bean bodies (types-cdr5, types-09m5, types-e6n9, types-gkhk). Replaced audit-citing preambles with self-contained one-line rationale text. Aligned peer brand JSDoc (NoteContent, PollOptionLabel, FrontingSessionPositionality, FrontingSessionOuttrigger) to the existing LifecycleEventName one-line peer-delegation precedent. Fixed PollTitle grammar ambiguity. Named FieldDefinition's same-entity peer (description) explicitly. Verified zero local-audits references remain in packages/, .beans/, apps/.
 
 Verification: format, lint, typecheck, types:check-sot, unit (13204 passed), integration (3063 passed), e2e (509 passed) all green.

--- a/.beans/types-09m5--brand-frontingsessioncomment-positionality-and-out.md
+++ b/.beans/types-09m5--brand-frontingsessioncomment-positionality-and-out.md
@@ -5,11 +5,11 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T21:25:50Z
-updated_at: 2026-04-29T07:28:11Z
+updated_at: 2026-04-29T09:27:16Z
 parent: ps-cd6x
 ---
 
-Per types-t3tn audit (2026-04-27): Three same-entity free-text peers on FrontingSession with concrete cross-field swap risk — all three are short user-typed strings sharing one encrypted blob and one set of fronting-rendering helpers. Brand FrontingSessionComment, FrontingSessionPositionality, FrontingSessionOuttrigger to lock relative positions. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+Three same-entity free-text peers on FrontingSession with concrete cross-field swap risk — all three are short user-typed strings sharing one encrypted blob. Brand FrontingSessionComment, FrontingSessionPositionality, FrontingSessionOuttrigger to lock relative positions.
 
 ## Summary of Changes
 

--- a/.beans/types-09m5--brand-frontingsessioncomment-positionality-and-out.md
+++ b/.beans/types-09m5--brand-frontingsessioncomment-positionality-and-out.md
@@ -1,11 +1,16 @@
 ---
 # types-09m5
 title: Brand FrontingSession.comment, .positionality, and .outtrigger
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-27T21:25:50Z
-updated_at: 2026-04-27T21:25:50Z
+updated_at: 2026-04-29T07:28:11Z
 parent: ps-cd6x
 ---
 
 Per types-t3tn audit (2026-04-27): Three same-entity free-text peers on FrontingSession with concrete cross-field swap risk — all three are short user-typed strings sharing one encrypted blob and one set of fronting-rendering helpers. Brand FrontingSessionComment, FrontingSessionPositionality, FrontingSessionOuttrigger to lock relative positions. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+
+## Summary of Changes
+
+Defined FrontingSessionComment, FrontingSessionPositionality, and FrontingSessionOuttrigger brands in packages/types/src/value-types.ts as a three-way same-entity peer cluster. Re-exported from packages/types/src/index.ts. Applied to FrontingSession.comment, .positionality, .outtrigger (all nullable). Updated FrontingSessionEncryptedInputSchema in packages/validation/src/fronting-session.ts to use brandedString().nullable() for each. Canonical chain inherits brands via existing Pick/Omit projections; null-passthrough preserved through Zod's .nullable() and entity-level | null union. Empty-non-null strings now reject — must be null instead — matching the lifecycle-event branding precedent.

--- a/.beans/types-cdr5--brand-notetitle-and-notecontent.md
+++ b/.beans/types-cdr5--brand-notetitle-and-notecontent.md
@@ -1,11 +1,16 @@
 ---
 # types-cdr5
 title: Brand Note.title and Note.content
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-27T21:25:44Z
-updated_at: 2026-04-27T21:25:44Z
+updated_at: 2026-04-29T06:49:38Z
 parent: ps-cd6x
 ---
 
 Per types-t3tn audit (2026-04-27): Note has both title and content as same-entity free-text peers with symmetric swap risk. Brand NoteTitle and NoteContent as phantom brands so render pipelines (truncation/tooltip vs rich-block) can't accept the wrong field. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+
+## Summary of Changes
+
+Defined NoteTitle and NoteContent brands in packages/types/src/value-types.ts as same-entity peers and applied them to Note.title and Note.content. Re-exported from packages/types/src/index.ts. Updated NoteEncryptedInputSchema in packages/validation/src/note.ts to use brandedString for both fields. Canonical chain inherits brands via existing Pick/Omit projections. Note.content was previously typed z.string() (allowed empty); brandedString tightens to non-empty — no callers or tests depended on empty content.

--- a/.beans/types-cdr5--brand-notetitle-and-notecontent.md
+++ b/.beans/types-cdr5--brand-notetitle-and-notecontent.md
@@ -5,11 +5,11 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T21:25:44Z
-updated_at: 2026-04-29T06:49:38Z
+updated_at: 2026-04-29T09:27:14Z
 parent: ps-cd6x
 ---
 
-Per types-t3tn audit (2026-04-27): Note has both title and content as same-entity free-text peers with symmetric swap risk. Brand NoteTitle and NoteContent as phantom brands so render pipelines (truncation/tooltip vs rich-block) can't accept the wrong field. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+Note has both title and content as same-entity free-text peers with symmetric swap risk. Brand NoteTitle and NoteContent as phantom brands to prevent cross-field assignment between the two.
 
 ## Summary of Changes
 

--- a/.beans/types-e6n9--brand-polltitle-and-polloptionlabel.md
+++ b/.beans/types-e6n9--brand-polltitle-and-polloptionlabel.md
@@ -5,11 +5,11 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T21:25:41Z
-updated_at: 2026-04-29T07:07:30Z
+updated_at: 2026-04-29T09:27:18Z
 parent: ps-cd6x
 ---
 
-Per types-t3tn audit (2026-04-27): Poll.title and PollOption.label are sibling free-text fields across the parent/child relationship; cross-field swap risk is concrete in option-edit forms. Brand PollTitle and PollOptionLabel as separate phantom brands. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+Poll.title and PollOption.label are sibling free-text fields across the parent/child relationship; cross-field swap risk is concrete in option-edit forms. Brand PollTitle and PollOptionLabel as separate phantom brands.
 
 ## Summary of Changes
 

--- a/.beans/types-e6n9--brand-polltitle-and-polloptionlabel.md
+++ b/.beans/types-e6n9--brand-polltitle-and-polloptionlabel.md
@@ -1,11 +1,16 @@
 ---
 # types-e6n9
 title: Brand Poll.title and PollOption.label
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-27T21:25:41Z
-updated_at: 2026-04-27T21:25:41Z
+updated_at: 2026-04-29T07:07:30Z
 parent: ps-cd6x
 ---
 
 Per types-t3tn audit (2026-04-27): Poll.title and PollOption.label are sibling free-text fields across the parent/child relationship; cross-field swap risk is concrete in option-edit forms. Brand PollTitle and PollOptionLabel as separate phantom brands. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+
+## Summary of Changes
+
+Defined PollTitle and PollOptionLabel brands in packages/types/src/value-types.ts and applied them to Poll.title and PollOption.label. Re-exported from packages/types/src/index.ts. Updated PollEncryptedInputSchema and the nested PollOptionSchema in packages/validation/src/poll.ts to use brandedString for both fields. Canonical chain inherits brands via existing Pick/Omit projections; the array projection of PollOption inside PollEncryptedInput propagates the option-label brand through Zod inference. Both fields previously required min(1); brandedString preserves that semantic via its length > 0 predicate.

--- a/.beans/types-f3fk--brand-fleet-expansion-membername-memberpronouns-gr.md
+++ b/.beans/types-f3fk--brand-fleet-expansion-membername-memberpronouns-gr.md
@@ -5,8 +5,8 @@ status: todo
 type: task
 priority: normal
 created_at: 2026-04-27T04:54:07Z
-updated_at: 2026-04-27T21:27:05Z
-parent: ps-cd6x
+updated_at: 2026-04-29T04:26:01Z
+parent: ps-9u4w
 ---
 
 Per types-yxgc spec (2026-04-26): expand non-ID branded value types to fleet display labels. Pattern: define brands in packages/types/src/value-types.ts, apply to domain types, update Zod schemas to brandedString, brand at transform construction. Cross-link: docs/superpowers/specs/2026-04-26-m9a-closeout-design.md

--- a/.beans/types-f3fk--brand-fleet-expansion-membername-memberpronouns-gr.md
+++ b/.beans/types-f3fk--brand-fleet-expansion-membername-memberpronouns-gr.md
@@ -5,15 +5,15 @@ status: todo
 type: task
 priority: normal
 created_at: 2026-04-27T04:54:07Z
-updated_at: 2026-04-29T04:26:01Z
+updated_at: 2026-04-29T09:39:16Z
 parent: ps-9u4w
 ---
 
 Per types-yxgc spec (2026-04-26): expand non-ID branded value types to fleet display labels. Pattern: define brands in packages/types/src/value-types.ts, apply to domain types, update Zod schemas to brandedString, brand at transform construction. Cross-link: docs/superpowers/specs/2026-04-26-m9a-closeout-design.md
 
-## Audit fold-ins from types-t3tn (2026-04-27)
+## Fold-ins from sibling brand work
 
-The types-t3tn audit doc (at docs/local-audits/2026-04-27-free-text-label-brand-audit.md, gitignored) folded these scope items into types-f3fk rather than filing separate beans:
+The following scope items are folded into types-f3fk rather than filed as separate beans:
 
 **Direct fold-ins (when implementing types-f3fk, also brand these):**
 

--- a/.beans/types-gkhk--brand-fielddefinitionname-as-fielddefinitionlabel.md
+++ b/.beans/types-gkhk--brand-fielddefinitionname-as-fielddefinitionlabel.md
@@ -5,11 +5,11 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-04-27T21:25:37Z
-updated_at: 2026-04-29T06:29:52Z
+updated_at: 2026-04-29T09:27:20Z
 parent: ps-cd6x
 ---
 
-Per types-t3tn audit (2026-04-27): FieldDefinition.name is the field's display label (e.g. "Pronouns", "Age", "Job"). Sibling free-text "description" creates same-entity swap risk; further, the field is widely used as a UI label key with high confusion risk against content strings. Brand FieldDefinitionLabel = Brand<string, "FieldDefinitionLabel">. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+FieldDefinition.name is the field's display label (e.g. "Pronouns", "Age", "Job"). Sibling free-text "description" creates same-entity swap risk; further, the field is widely used as a UI label key with high confusion risk against content strings. Brand FieldDefinitionLabel as a phantom brand.
 
 ## Summary of Changes
 

--- a/.beans/types-gkhk--brand-fielddefinitionname-as-fielddefinitionlabel.md
+++ b/.beans/types-gkhk--brand-fielddefinitionname-as-fielddefinitionlabel.md
@@ -1,11 +1,16 @@
 ---
 # types-gkhk
 title: Brand FieldDefinition.name as FieldDefinitionLabel
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-04-27T21:25:37Z
-updated_at: 2026-04-27T21:25:37Z
+updated_at: 2026-04-29T06:29:52Z
 parent: ps-cd6x
 ---
 
 Per types-t3tn audit (2026-04-27): FieldDefinition.name is the field's display label (e.g. "Pronouns", "Age", "Job"). Sibling free-text "description" creates same-entity swap risk; further, the field is widely used as a UI label key with high confusion risk against content strings. Brand FieldDefinitionLabel = Brand<string, "FieldDefinitionLabel">. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+
+## Summary of Changes
+
+Defined FieldDefinitionLabel brand in packages/types/src/value-types.ts and applied it to FieldDefinition.name. Updated FieldDefinitionEncryptedInputSchema in packages/validation/src/custom-fields.ts to use brandedString<"FieldDefinitionLabel">(). Updated FieldDefinitionDecrypted.name in packages/data/src/transforms/custom-field.ts to use the brand. Canonical chain (FieldDefinitionEncryptedInput → ServerMetadata → Result → Wire) inherits the brand via existing Pick/Omit projections; Serialize<T> strips brands at the wire boundary.

--- a/.beans/types-t3tn--audit-free-text-display-labels-for-branded-value-c.md
+++ b/.beans/types-t3tn--audit-free-text-display-labels-for-branded-value-c.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: low
 created_at: 2026-04-27T04:54:10Z
-updated_at: 2026-04-27T21:26:15Z
+updated_at: 2026-04-29T09:39:41Z
 parent: ps-cd6x
 ---
 
@@ -13,17 +13,6 @@ Per types-yxgc spec (2026-04-26): inventory remaining free-text fields across th
 
 ## Summary of Changes
 
-Audit document at docs/local-audits/2026-04-27-free-text-label-brand-audit.md
-covering 33 candidate fields across packages/types/src/entities/ outside the
-lifecycle-event scope (types-yxgc) and Member/Group/Channel name (types-f3fk).
+Audit completed: 33 candidate fields surveyed across packages/types/src/entities/ outside the lifecycle-event scope (types-yxgc) and Member/Group/Channel name (types-f3fk).
 
-Decisions: 5 brand candidates filed as follow-up beans (types-gkhk, types-e6n9,
-types-cdr5, types-x37g, types-09m5), 9 don't-brand singletons with one-line
-rationale, 3 deferred clusters (EntityDescription cluster, System.name vs
-displayName, NotificationPayload templating). Two clusters (CustomFront.name +
-the entity-display-names cluster) folded into types-f3fk's scope rather than
-filing separate beans, plus two design questions (EntityDescription strategy,
-System.name vs displayName) folded into types-f3fk for resolution before any
-description / system-name follow-ups are filed.
-
-See audit doc for the full table.
+Decisions: 5 brand candidates filed as follow-up beans (types-gkhk, types-e6n9, types-cdr5, types-x37g, types-09m5), 9 don't-brand singletons with one-line rationale, 3 deferred clusters (EntityDescription cluster, System.name vs displayName, NotificationPayload templating). Two clusters (CustomFront.name + the entity-display-names cluster) folded into types-f3fk's scope rather than filing separate beans, plus two design questions (EntityDescription strategy, System.name vs displayName) folded into types-f3fk for resolution before any description / system-name follow-ups are filed.

--- a/.beans/types-x37g--brand-journalentrytitle-and-wikipagetitle.md
+++ b/.beans/types-x37g--brand-journalentrytitle-and-wikipagetitle.md
@@ -3,9 +3,10 @@
 title: Brand JournalEntry.title and WikiPage.title
 status: todo
 type: task
+priority: normal
 created_at: 2026-04-27T21:25:47Z
-updated_at: 2026-04-27T21:25:47Z
-parent: ps-cd6x
+updated_at: 2026-04-29T04:26:00Z
+parent: ps-9u4w
 ---
 
 Per types-t3tn audit (2026-04-27): Both entities expose title: string fields that flow through shared title-display helpers across long-form-content UIs. Brand JournalEntryTitle and WikiPageTitle to lock the cross-entity title slots against accidental member-name/etc. assignment. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.

--- a/.beans/types-x37g--brand-journalentrytitle-and-wikipagetitle.md
+++ b/.beans/types-x37g--brand-journalentrytitle-and-wikipagetitle.md
@@ -5,8 +5,8 @@ status: todo
 type: task
 priority: normal
 created_at: 2026-04-27T21:25:47Z
-updated_at: 2026-04-29T04:26:00Z
+updated_at: 2026-04-29T09:39:14Z
 parent: ps-9u4w
 ---
 
-Per types-t3tn audit (2026-04-27): Both entities expose title: string fields that flow through shared title-display helpers across long-form-content UIs. Brand JournalEntryTitle and WikiPageTitle to lock the cross-entity title slots against accidental member-name/etc. assignment. See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+Both JournalEntry and WikiPage expose title: string fields that flow through shared title-display helpers across long-form-content UIs. Brand JournalEntryTitle and WikiPageTitle to lock the cross-entity title slots against accidental member-name/etc. assignment.

--- a/apps/mobile/src/__tests__/factories.ts
+++ b/apps/mobile/src/__tests__/factories.ts
@@ -71,6 +71,8 @@ import type {
   MemberId,
   MemberWire,
   EncryptedBase64,
+  NoteContent,
+  NoteTitle,
   NoteWire,
   PollOptionId,
   PollVoteWire,
@@ -537,7 +539,11 @@ export function makeRawMessage(
 
 export function makeRawNote(id: string, overrides?: Partial<NoteWire>): NoteWire {
   const encrypted = encryptNoteInput(
-    { title: "Note", content: "Body", backgroundColor: null },
+    {
+      title: brandValue<NoteTitle>("Note"),
+      content: brandValue<NoteContent>("Body"),
+      backgroundColor: null,
+    },
     TEST_MASTER_KEY,
   );
   return {

--- a/apps/mobile/src/__tests__/factories.ts
+++ b/apps/mobile/src/__tests__/factories.ts
@@ -35,7 +35,7 @@ import {
   encryptSystemSettingsUpdate,
 } from "@pluralscape/data/transforms/system-settings";
 import { encryptTimerConfigInput } from "@pluralscape/data/transforms/timer-check-in";
-import { brandId } from "@pluralscape/types";
+import { brandId, brandValue } from "@pluralscape/types";
 
 import { TEST_MASTER_KEY, TEST_SYSTEM_ID } from "../hooks/__tests__/helpers/test-crypto.js";
 
@@ -55,6 +55,7 @@ import type {
   ChatMessageWire,
   CheckInRecordId,
   CustomFrontWire,
+  FieldDefinitionLabel,
   FieldDefinitionWire,
   FieldValueWire,
   FrontingCommentWire,
@@ -170,7 +171,11 @@ export function makeRawFieldDefinition(
   overrides?: Partial<FieldDefinitionWire>,
 ): FieldDefinitionWire {
   const encrypted = encryptFieldDefinitionInput(
-    { name: `Field ${id}`, description: "A test field", options: null },
+    {
+      name: brandValue<FieldDefinitionLabel>(`Field ${id}`),
+      description: "A test field",
+      options: null,
+    },
     TEST_MASTER_KEY,
   );
   return {

--- a/apps/mobile/src/__tests__/factories.ts
+++ b/apps/mobile/src/__tests__/factories.ts
@@ -75,6 +75,8 @@ import type {
   NoteTitle,
   NoteWire,
   PollOptionId,
+  PollOptionLabel,
+  PollTitle,
   PollVoteWire,
   PollWire,
   RelationshipType,
@@ -566,12 +568,12 @@ export function makeRawNote(id: string, overrides?: Partial<NoteWire>): NoteWire
 export function makeRawPoll(id: string, overrides?: Partial<PollWire>): PollWire {
   const encrypted = encryptPollInput(
     {
-      title: `Poll ${id}`,
+      title: brandValue<PollTitle>(`Poll ${id}`),
       description: null,
       options: [
         {
           id: brandId<PollOptionId>("opt-1"),
-          label: "Yes",
+          label: brandValue<PollOptionLabel>("Yes"),
           voteCount: 0,
           color: null,
           emoji: null,

--- a/apps/mobile/src/__tests__/factories.ts
+++ b/apps/mobile/src/__tests__/factories.ts
@@ -60,7 +60,9 @@ import type {
   FieldValueWire,
   FrontingCommentWire,
   FrontingReportWire,
+  FrontingSessionComment,
   FrontingSessionId,
+  FrontingSessionPositionality,
   FrontingSessionWire,
   GroupWire,
   InnerWorldCanvasWire,
@@ -306,8 +308,8 @@ export function makeRawFrontingSession(
 ): FrontingSessionWire {
   const encrypted = encryptFrontingSessionInput(
     {
-      comment: `Session ${id}`,
-      positionality: "close",
+      comment: brandValue<FrontingSessionComment>(`Session ${id}`),
+      positionality: brandValue<FrontingSessionPositionality>("close"),
       outtrigger: null,
       outtriggerSentiment: null,
     },

--- a/apps/mobile/src/data/row-transforms/communication.ts
+++ b/apps/mobile/src/data/row-transforms/communication.ts
@@ -1,4 +1,4 @@
-import { brandId } from "@pluralscape/types";
+import { brandId, brandValue } from "@pluralscape/types";
 
 import {
   guardedNum,
@@ -32,6 +32,8 @@ import type {
   MemberId,
   Note,
   NoteAuthorEntityType,
+  NoteContent,
+  NoteTitle,
   Poll,
   SystemStructureEntityId,
   WikiPage,
@@ -312,8 +314,8 @@ export function rowToNote(row: Record<string, unknown>): Note | Archived<Note> {
     id: guardedStr(row["id"], "notes", "id", id) as Note["id"],
     systemId: guardedStr(row["system_id"], "notes", "system_id", id) as Note["systemId"],
     author,
-    title: guardedStr(row["title"], "notes", "title", id),
-    content: guardedStr(row["content"], "notes", "content", id),
+    title: brandValue<NoteTitle>(guardedStr(row["title"], "notes", "title", id)),
+    content: brandValue<NoteContent>(guardedStr(row["content"], "notes", "content", id)),
     backgroundColor: strOrNull(
       row["background_color"],
       "notes",

--- a/apps/mobile/src/data/row-transforms/communication.ts
+++ b/apps/mobile/src/data/row-transforms/communication.ts
@@ -35,6 +35,7 @@ import type {
   NoteContent,
   NoteTitle,
   Poll,
+  PollTitle,
   SystemStructureEntityId,
   WikiPage,
 } from "@pluralscape/types";
@@ -148,7 +149,7 @@ export function rowToPoll(row: Record<string, unknown>): Poll | ArchivedPoll {
       "created_by_member_id",
       id,
     ) as Poll["createdByMemberId"],
-    title: guardedStr(row["title"], "polls", "title", id),
+    title: brandValue<PollTitle>(guardedStr(row["title"], "polls", "title", id)),
     description: strOrNull(row["description"], "polls", "description", id),
     kind: guardedStr(row["kind"], "polls", "kind", id) as Poll["kind"],
     options: [] as Poll["options"],

--- a/apps/mobile/src/data/row-transforms/fronting.ts
+++ b/apps/mobile/src/data/row-transforms/fronting.ts
@@ -1,3 +1,5 @@
+import { brandValue } from "@pluralscape/types";
+
 import {
   guardedStr,
   guardedToMs,
@@ -15,6 +17,9 @@ import type {
   CustomFront,
   FrontingComment,
   FrontingSession,
+  FrontingSessionComment,
+  FrontingSessionOuttrigger,
+  FrontingSessionPositionality,
 } from "@pluralscape/types";
 
 export function rowToCustomFront(row: Record<string, unknown>): CustomFront | ArchivedCustomFront {
@@ -48,6 +53,14 @@ export function rowToFrontingSession(
   const archived = intToBool(row["archived"]);
   const updatedAt = guardedToMs(row["updated_at"], "fronting_sessions", "updated_at", id);
   const endTime = toMsOrNull(row["end_time"], "fronting_sessions", "end_time", id);
+  const commentRaw = strOrNull(row["comment"], "fronting_sessions", "comment", id);
+  const positionalityRaw = strOrNull(
+    row["positionality"],
+    "fronting_sessions",
+    "positionality",
+    id,
+  );
+  const outtriggerRaw = strOrNull(row["outtrigger"], "fronting_sessions", "outtrigger", id);
   const baseCommon = {
     id: guardedStr(row["id"], "fronting_sessions", "id", id) as FrontingSession["id"],
     systemId: guardedStr(
@@ -63,7 +76,7 @@ export function rowToFrontingSession(
       id,
     ) as FrontingSession["memberId"],
     startTime: guardedToMs(row["start_time"], "fronting_sessions", "start_time", id),
-    comment: strOrNull(row["comment"], "fronting_sessions", "comment", id),
+    comment: commentRaw === null ? null : brandValue<FrontingSessionComment>(commentRaw),
     customFrontId: strOrNull(
       row["custom_front_id"],
       "fronting_sessions",
@@ -76,8 +89,10 @@ export function rowToFrontingSession(
       "structure_entity_id",
       id,
     ) as FrontingSession["structureEntityId"],
-    positionality: strOrNull(row["positionality"], "fronting_sessions", "positionality", id),
-    outtrigger: strOrNull(row["outtrigger"], "fronting_sessions", "outtrigger", id),
+    positionality:
+      positionalityRaw === null ? null : brandValue<FrontingSessionPositionality>(positionalityRaw),
+    outtrigger:
+      outtriggerRaw === null ? null : brandValue<FrontingSessionOuttrigger>(outtriggerRaw),
     outtriggerSentiment: strOrNull(
       row["outtrigger_sentiment"],
       "fronting_sessions",

--- a/apps/mobile/src/data/row-transforms/privacy.ts
+++ b/apps/mobile/src/data/row-transforms/privacy.ts
@@ -1,3 +1,5 @@
+import { brandValue } from "@pluralscape/types";
+
 import {
   guardedNum,
   guardedStr,
@@ -17,6 +19,7 @@ import type {
 } from "@pluralscape/data/transforms/custom-field";
 import type {
   ArchivedPrivacyBucket,
+  FieldDefinitionLabel,
   FieldValueUnion,
   PrivacyBucket,
   SystemId,
@@ -58,7 +61,9 @@ export function rowToFieldDefinition(row: Record<string, unknown>): FieldDefinit
       "system_id",
       id,
     ) as FieldDefinitionDecrypted["systemId"],
-    name: guardedStr(row["name"], "field_definitions", "name", id),
+    name: brandValue<FieldDefinitionLabel>(
+      guardedStr(row["name"], "field_definitions", "name", id),
+    ),
     description: strOrNull(row["description"], "field_definitions", "description", id),
     fieldType: guardedStr(
       row["field_type"],

--- a/packages/data/src/transforms/__tests__/custom-field.test.ts
+++ b/packages/data/src/transforms/__tests__/custom-field.test.ts
@@ -1,7 +1,7 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
 import { brandId, brandValue } from "@pluralscape/types";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 
 import {
   decryptFieldDefinition,
@@ -14,9 +14,14 @@ import {
 
 import { makeBase64Blob } from "./helpers.js";
 
-import type { FieldDefinitionEncryptedInput, FieldValueDecrypted } from "../custom-field.js";
+import type {
+  FieldDefinitionDecrypted,
+  FieldDefinitionEncryptedInput,
+  FieldValueDecrypted,
+} from "../custom-field.js";
 import type { KdfMasterKey } from "@pluralscape/crypto";
 import type {
+  FieldDefinition,
   FieldDefinitionId,
   FieldDefinitionLabel,
   FieldValueId,
@@ -465,5 +470,16 @@ describe("FieldValueDecrypted shape", () => {
     expect(result.systemId).toBe(BASE_VALUE_RESULT.systemId);
     expect(result.groupId).toBeNull();
     expect(result.structureEntityId).toBeNull();
+  });
+});
+
+// ── brand types ───────────────────────────────────────────────────────
+
+describe("brand types", () => {
+  it("FieldDefinition.name is branded as FieldDefinitionLabel", () => {
+    expectTypeOf<FieldDefinition["name"]>().toEqualTypeOf<FieldDefinitionLabel>();
+  });
+  it("FieldDefinitionDecrypted.name is branded as FieldDefinitionLabel", () => {
+    expectTypeOf<FieldDefinitionDecrypted["name"]>().toEqualTypeOf<FieldDefinitionLabel>();
   });
 });

--- a/packages/data/src/transforms/__tests__/custom-field.test.ts
+++ b/packages/data/src/transforms/__tests__/custom-field.test.ts
@@ -1,6 +1,6 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
-import { brandId } from "@pluralscape/types";
+import { brandId, brandValue } from "@pluralscape/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -16,7 +16,12 @@ import { makeBase64Blob } from "./helpers.js";
 
 import type { FieldDefinitionEncryptedInput, FieldValueDecrypted } from "../custom-field.js";
 import type { KdfMasterKey } from "@pluralscape/crypto";
-import type { FieldDefinitionId, FieldValueId, SystemId } from "@pluralscape/types";
+import type {
+  FieldDefinitionId,
+  FieldDefinitionLabel,
+  FieldValueId,
+  SystemId,
+} from "@pluralscape/types";
 
 // ── Test helpers ──────────────────────────────────────────────────────
 
@@ -58,7 +63,7 @@ const BASE_VALUE_RESULT = {
 describe("decryptFieldDefinition", () => {
   it("decrypts name, description, and options from the encrypted blob", () => {
     const encrypted: FieldDefinitionEncryptedInput = {
-      name: "Pronoun",
+      name: brandValue<FieldDefinitionLabel>("Pronoun"),
       description: "Preferred pronoun",
       options: null,
     };
@@ -82,7 +87,7 @@ describe("decryptFieldDefinition", () => {
 
   it("decrypts select field with options array", () => {
     const encrypted: FieldDefinitionEncryptedInput = {
-      name: "Role",
+      name: brandValue<FieldDefinitionLabel>("Role"),
       description: null,
       options: ["host", "protector", "gatekeeper"],
     };
@@ -107,7 +112,7 @@ describe("decryptFieldDefinition", () => {
   it("throws when blob was encrypted with a different key", () => {
     const otherKey = generateMasterKey();
     const encrypted: FieldDefinitionEncryptedInput = {
-      name: "X",
+      name: brandValue<FieldDefinitionLabel>("X"),
       description: null,
       options: null,
     };
@@ -121,7 +126,7 @@ describe("decryptFieldDefinition", () => {
 describe("decryptFieldDefinitionPage", () => {
   it("decrypts all items and passes through nextCursor", () => {
     const encrypted: FieldDefinitionEncryptedInput = {
-      name: "Field A",
+      name: brandValue<FieldDefinitionLabel>("Field A"),
       description: null,
       options: null,
     };
@@ -149,12 +154,12 @@ describe("decryptFieldDefinitionPage", () => {
 
   it("decrypts multiple items", () => {
     const enc1: FieldDefinitionEncryptedInput = {
-      name: "Alpha",
+      name: brandValue<FieldDefinitionLabel>("Alpha"),
       description: "First",
       options: null,
     };
     const enc2: FieldDefinitionEncryptedInput = {
-      name: "Beta",
+      name: brandValue<FieldDefinitionLabel>("Beta"),
       description: null,
       options: ["a", "b"],
     };
@@ -189,7 +194,7 @@ describe("decryptFieldDefinitionPage", () => {
 describe("encryptFieldDefinitionInput", () => {
   it("returns an object with encryptedData string", () => {
     const data: FieldDefinitionEncryptedInput = {
-      name: "Height",
+      name: brandValue<FieldDefinitionLabel>("Height"),
       description: "Member height",
       options: null,
     };
@@ -202,7 +207,7 @@ describe("encryptFieldDefinitionInput", () => {
 
   it("round-trips: decryptFieldDefinition recovers original fields", () => {
     const data: FieldDefinitionEncryptedInput = {
-      name: "Mood",
+      name: brandValue<FieldDefinitionLabel>("Mood"),
       description: null,
       options: ["happy", "calm", "anxious"],
     };

--- a/packages/data/src/transforms/__tests__/fronting-session.test.ts
+++ b/packages/data/src/transforms/__tests__/fronting-session.test.ts
@@ -1,6 +1,6 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
-import { brandId } from "@pluralscape/types";
+import { brandId, brandValue } from "@pluralscape/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -15,8 +15,11 @@ import { makeBase64Blob } from "./helpers.js";
 import type { KdfMasterKey } from "@pluralscape/crypto";
 import type {
   EncryptedBase64,
+  FrontingSessionComment,
   FrontingSessionEncryptedInput,
   FrontingSessionId,
+  FrontingSessionOuttrigger,
+  FrontingSessionPositionality,
   MemberId,
   PaginationCursor,
   SystemId,
@@ -41,9 +44,9 @@ function makeRawSession(
   }> = {},
 ) {
   const fields: FrontingSessionEncryptedInput = overrides.encryptedFields ?? {
-    comment: "feeling good",
-    positionality: "close",
-    outtrigger: "stress",
+    comment: brandValue<FrontingSessionComment>("feeling good"),
+    positionality: brandValue<FrontingSessionPositionality>("close"),
+    outtrigger: brandValue<FrontingSessionOuttrigger>("stress"),
     outtriggerSentiment: "negative",
   };
   return {
@@ -170,9 +173,9 @@ describe("decryptFrontingSessionPage", () => {
 describe("encryptFrontingSessionInput", () => {
   it("encrypts fields and returns encryptedData string", () => {
     const fields: FrontingSessionEncryptedInput = {
-      comment: "hello",
+      comment: brandValue<FrontingSessionComment>("hello"),
       positionality: null,
-      outtrigger: "joy",
+      outtrigger: brandValue<FrontingSessionOuttrigger>("joy"),
       outtriggerSentiment: "positive",
     };
     const result = encryptFrontingSessionInput(fields, masterKey);
@@ -183,8 +186,8 @@ describe("encryptFrontingSessionInput", () => {
 
   it("round-trips: encrypted data can be decrypted back", () => {
     const fields: FrontingSessionEncryptedInput = {
-      comment: "round-trip",
-      positionality: "far",
+      comment: brandValue<FrontingSessionComment>("round-trip"),
+      positionality: brandValue<FrontingSessionPositionality>("far"),
       outtrigger: null,
       outtriggerSentiment: null,
     };
@@ -202,7 +205,7 @@ describe("encryptFrontingSessionInput", () => {
 describe("encryptFrontingSessionUpdate", () => {
   it("encrypts fields and includes version", () => {
     const fields: FrontingSessionEncryptedInput = {
-      comment: "updated",
+      comment: brandValue<FrontingSessionComment>("updated"),
       positionality: null,
       outtrigger: null,
       outtriggerSentiment: null,
@@ -215,9 +218,9 @@ describe("encryptFrontingSessionUpdate", () => {
 
   it("round-trips: update data can be decrypted back", () => {
     const fields: FrontingSessionEncryptedInput = {
-      comment: "updated comment",
-      positionality: "very close",
-      outtrigger: "music",
+      comment: brandValue<FrontingSessionComment>("updated comment"),
+      positionality: brandValue<FrontingSessionPositionality>("very close"),
+      outtrigger: brandValue<FrontingSessionOuttrigger>("music"),
       outtriggerSentiment: "positive",
     };
     const { encryptedData, version } = encryptFrontingSessionUpdate(fields, 3, masterKey);

--- a/packages/data/src/transforms/__tests__/note.test.ts
+++ b/packages/data/src/transforms/__tests__/note.test.ts
@@ -1,6 +1,6 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
-import { toUnixMillis, brandId } from "@pluralscape/types";
+import { toUnixMillis, brandId, brandValue } from "@pluralscape/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { encryptAndEncodeT1 } from "../decode-blob.js";
@@ -12,8 +12,10 @@ import type { KdfMasterKey } from "@pluralscape/crypto";
 import type {
   HexColor,
   NoteAuthorEntityType,
+  NoteContent,
   NoteEncryptedInput,
   NoteId,
+  NoteTitle,
   SystemId,
   UnixMillis,
 } from "@pluralscape/types";
@@ -28,8 +30,8 @@ beforeAll(async () => {
 
 function makeEncryptedFields(): NoteEncryptedInput {
   return {
-    title: "My Note",
-    content: "Note content goes here.",
+    title: brandValue<NoteTitle>("My Note"),
+    content: brandValue<NoteContent>("Note content goes here."),
     backgroundColor: "#ffffff" as HexColor,
   };
 }

--- a/packages/data/src/transforms/__tests__/note.test.ts
+++ b/packages/data/src/transforms/__tests__/note.test.ts
@@ -1,7 +1,7 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
 import { toUnixMillis, brandId, brandValue } from "@pluralscape/types";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 
 import { encryptAndEncodeT1 } from "../decode-blob.js";
 import { decryptNote, decryptNotePage, encryptNoteInput, encryptNoteUpdate } from "../note.js";
@@ -11,6 +11,7 @@ import { makeBase64Blob } from "./helpers.js";
 import type { KdfMasterKey } from "@pluralscape/crypto";
 import type {
   HexColor,
+  Note,
   NoteAuthorEntityType,
   NoteContent,
   NoteEncryptedInput,
@@ -208,5 +209,16 @@ describe("NoteEncryptedInputSchema validation", () => {
       encryptedData: makeBase64Blob({ title: "My Note" }, masterKey),
     };
     expect(() => decryptNote(raw, masterKey)).toThrow(/content/);
+  });
+});
+
+// ── brand types ───────────────────────────────────────────────────────
+
+describe("brand types", () => {
+  it("Note.title is branded as NoteTitle", () => {
+    expectTypeOf<Note["title"]>().toEqualTypeOf<NoteTitle>();
+  });
+  it("Note.content is branded as NoteContent", () => {
+    expectTypeOf<Note["content"]>().toEqualTypeOf<NoteContent>();
   });
 });

--- a/packages/data/src/transforms/__tests__/poll.test.ts
+++ b/packages/data/src/transforms/__tests__/poll.test.ts
@@ -1,7 +1,7 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
 import { toUnixMillis, brandId, brandValue } from "@pluralscape/types";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 
 import { encryptAndEncodeT1 } from "../decode-blob.js";
 import {
@@ -20,6 +20,7 @@ import type {
   EntityReference,
   HexColor,
   MemberId,
+  Poll,
   PollEncryptedInput,
   PollId,
   PollKind,
@@ -326,5 +327,16 @@ describe("PollEncryptedInputSchema validation", () => {
       encryptedData: makeBase64Blob({ title: "A poll" }, masterKey),
     };
     expect(() => decryptPoll(raw, masterKey)).toThrow(/options/);
+  });
+});
+
+// ── brand types ───────────────────────────────────────────────────────
+
+describe("brand types", () => {
+  it("Poll.title is branded as PollTitle", () => {
+    expectTypeOf<Poll["title"]>().toEqualTypeOf<PollTitle>();
+  });
+  it("PollOption.label is branded as PollOptionLabel", () => {
+    expectTypeOf<PollOption["label"]>().toEqualTypeOf<PollOptionLabel>();
   });
 });

--- a/packages/data/src/transforms/__tests__/poll.test.ts
+++ b/packages/data/src/transforms/__tests__/poll.test.ts
@@ -1,6 +1,6 @@
 import { configureSodium, generateMasterKey, initSodium } from "@pluralscape/crypto";
 import { WasmSodiumAdapter } from "@pluralscape/crypto/wasm";
-import { toUnixMillis, brandId } from "@pluralscape/types";
+import { toUnixMillis, brandId, brandValue } from "@pluralscape/types";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { encryptAndEncodeT1 } from "../decode-blob.js";
@@ -25,7 +25,9 @@ import type {
   PollKind,
   PollOption,
   PollOptionId,
+  PollOptionLabel,
   PollStatus,
+  PollTitle,
   PollVoteEncryptedInput,
   PollVoteId,
   SystemId,
@@ -45,7 +47,7 @@ beforeAll(async () => {
 function makePollOption(id: string): PollOption {
   return {
     id: brandId<PollOptionId>(id),
-    label: `Option ${id}`,
+    label: brandValue<PollOptionLabel>(`Option ${id}`),
     voteCount: 0,
     color: "#aabbcc" as HexColor,
     emoji: null,
@@ -54,7 +56,7 @@ function makePollOption(id: string): PollOption {
 
 function makePollEncryptedInput(): PollEncryptedInput {
   return {
-    title: "Best snack?",
+    title: brandValue<PollTitle>("Best snack?"),
     description: "Vote for your favourite.",
     options: [makePollOption("opt_001"), makePollOption("opt_002")],
   };
@@ -143,7 +145,11 @@ describe("decryptPoll", () => {
   });
 
   it("handles null description", () => {
-    const fields: PollEncryptedInput = { title: "Yes/No?", description: null, options: [] };
+    const fields: PollEncryptedInput = {
+      title: brandValue<PollTitle>("Yes/No?"),
+      description: null,
+      options: [],
+    };
     const result = decryptPoll(makeServerPoll(fields), masterKey);
     expect(result.description).toBeNull();
     expect(result.options).toEqual([]);

--- a/packages/data/src/transforms/custom-field.ts
+++ b/packages/data/src/transforms/custom-field.ts
@@ -11,6 +11,7 @@ import type {
   FieldDefinition,
   FieldDefinitionEncryptedFields,
   FieldDefinitionId,
+  FieldDefinitionLabel,
   FieldDefinitionWire,
   FieldType,
   FieldValueId,
@@ -46,7 +47,7 @@ export type FieldValueEncryptedInput = FieldValueUnion;
 export interface FieldDefinitionDecrypted {
   readonly id: FieldDefinitionId;
   readonly systemId: SystemId;
-  readonly name: string;
+  readonly name: FieldDefinitionLabel;
   readonly description: string | null;
   readonly fieldType: FieldType;
   readonly options: readonly string[] | null;

--- a/packages/import-sp/src/__tests__/mappers/field-definition.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/field-definition.mapper.test.ts
@@ -91,6 +91,17 @@ describe("mapFieldDefinition", () => {
     }
   });
 
+  it("rejects empty name with kind empty-name targeting name", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    const sp: SPCustomField = { _id: "f_empty", name: "", type: 0, order: "0" };
+    const result = mapFieldDefinition(sp, ctx);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("empty-name");
+      expect(result.targetField).toBe("name");
+    }
+  });
+
   it("unparseable order emits a warning and returns 0", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     const sp: SPCustomField = { _id: "f4", name: "Bad", type: 0, order: "!!!" };

--- a/packages/import-sp/src/__tests__/mappers/fronting-session.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/fronting-session.mapper.test.ts
@@ -167,6 +167,29 @@ describe("mapFrontingSession", () => {
     }
   });
 
+  it("coerces empty customStatus to null comment", () => {
+    // SP often emits an empty-string `customStatus` for sessions with no
+    // user-entered note. The FrontingSessionComment brand requires a
+    // non-empty value when present, so the mapper normalizes "" to null
+    // at the boundary instead of letting it reach the persister.
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    ctx.register("member", "src_m1", "ps_m1");
+    const sp: SPFrontHistory = {
+      _id: "fh_empty_status",
+      member: "src_m1",
+      custom: false,
+      live: false,
+      startTime: 1,
+      endTime: 2,
+      customStatus: "",
+    };
+    const result = mapFrontingSession(sp, ctx);
+    expect(result.status).toBe("mapped");
+    if (result.status === "mapped") {
+      expect(result.payload.encrypted.comment).toBeNull();
+    }
+  });
+
   it("non-live session with omitted endTime produces endTime: null", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     ctx.register("member", "src_m1", "ps_m1");

--- a/packages/import-sp/src/__tests__/mappers/journal-entry.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/journal-entry.mapper.test.ts
@@ -43,20 +43,39 @@ describe("mapJournalEntry", () => {
     }
   });
 
-  it("allows empty body (empty content string)", () => {
+  it("rejects empty content with kind empty-name targeting content", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     ctx.register("member", "src_m1", "ps_m1");
     const sp: SPNote = {
       _id: "n3",
-      title: "Blank",
+      title: "Blank body",
       note: "",
       date: 1,
       member: "src_m1",
     };
     const result = mapJournalEntry(sp, ctx);
-    expect(result.status).toBe("mapped");
-    if (result.status === "mapped") {
-      expect(result.payload.encrypted.content).toBe("");
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("empty-name");
+      expect(result.targetField).toBe("content");
+    }
+  });
+
+  it("rejects empty title with kind empty-name targeting title", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    ctx.register("member", "src_m1", "ps_m1");
+    const sp: SPNote = {
+      _id: "n3b",
+      title: "",
+      note: "Body without title",
+      date: 1,
+      member: "src_m1",
+    };
+    const result = mapJournalEntry(sp, ctx);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("empty-name");
+      expect(result.targetField).toBe("title");
     }
   });
 

--- a/packages/import-sp/src/__tests__/mappers/poll.mapper.test.ts
+++ b/packages/import-sp/src/__tests__/mappers/poll.mapper.test.ts
@@ -128,6 +128,40 @@ describe("mapPoll", () => {
     expect(result.status).toBe("mapped");
   });
 
+  it("rejects empty poll name with kind empty-name targeting name", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    const sp: SPPoll = {
+      _id: "p_empty_name",
+      name: "",
+      options: [{ id: "o1", name: "Yes" }],
+    };
+    const result = mapPoll(sp, ctx);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("empty-name");
+      expect(result.targetField).toBe("name");
+    }
+  });
+
+  it("rejects empty option label with kind empty-name targeting options", () => {
+    const ctx = createMappingContext({ sourceMode: "fake" });
+    const sp: SPPoll = {
+      _id: "p_empty_opt",
+      name: "Pick one",
+      options: [
+        { id: "o1", name: "Yes" },
+        { id: "o2", name: "" },
+      ],
+    };
+    const result = mapPoll(sp, ctx);
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("empty-name");
+      expect(result.targetField).toBe("options");
+      expect(result.message).toContain("index 1");
+    }
+  });
+
   it("maps custom kind and flags, preserves desc and endTime", () => {
     const ctx = createMappingContext({ sourceMode: "fake" });
     const sp: SPPoll = {

--- a/packages/import-sp/src/mappers/field-definition.mapper.ts
+++ b/packages/import-sp/src/mappers/field-definition.mapper.ts
@@ -25,7 +25,7 @@ import {
   SP_FIELD_TYPE_YEAR,
 } from "../import-sp.constants.js";
 
-import { mapped, type MapperResult } from "./mapper-result.js";
+import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPCustomField, SPCustomFieldType } from "../sources/sp-types.js";
@@ -101,6 +101,16 @@ export function mapFieldDefinition(
   sp: SPCustomField,
   ctx: MappingContext,
 ): MapperResult<MappedFieldDefinition> {
+  // FieldDefinitionLabel brand rejects empty strings; guard at the SP
+  // boundary so a malformed source custom-field becomes a non-fatal import
+  // failure instead of a downstream Zod parse error.
+  if (sp.name.length === 0) {
+    return failed({
+      kind: "empty-name",
+      message: `field-definition "${sp._id}" has empty name`,
+      targetField: "name",
+    });
+  }
   const fieldType = spTypeToFieldType(sp.type);
   const orderResult = fractionalIndexToOrder(sp.order);
   if (!orderResult.ok) {

--- a/packages/import-sp/src/mappers/field-definition.mapper.ts
+++ b/packages/import-sp/src/mappers/field-definition.mapper.ts
@@ -12,6 +12,8 @@
  * prefix decode — sufficient for small field sets and lets users fine-tune
  * ordering after import.
  */
+import { brandValue } from "@pluralscape/types";
+
 import {
   SP_FIELD_TYPE_COLOR,
   SP_FIELD_TYPE_DATE,
@@ -28,7 +30,7 @@ import { mapped, type MapperResult } from "./mapper-result.js";
 import type { MappingContext } from "./context.js";
 import type { SPCustomField, SPCustomFieldType } from "../sources/sp-types.js";
 import type { FieldDefinitionEncryptedInput } from "@pluralscape/data";
-import type { FieldType } from "@pluralscape/types";
+import type { FieldDefinitionLabel, FieldType } from "@pluralscape/types";
 import type { CreateFieldDefinitionBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -109,7 +111,7 @@ export function mapFieldDefinition(
     });
   }
   const encrypted: FieldDefinitionEncryptedInput = {
-    name: sp.name,
+    name: brandValue<FieldDefinitionLabel>(sp.name),
     description: null,
     options: null,
   };

--- a/packages/import-sp/src/mappers/fronting-session.mapper.ts
+++ b/packages/import-sp/src/mappers/fronting-session.mapper.ts
@@ -10,13 +10,18 @@
  * moves on (sessions whose referenced member was skipped upstream simply
  * can't be materialised).
  */
-import { brandId } from "@pluralscape/types";
+import { brandId, brandValue } from "@pluralscape/types";
 
 import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPFrontHistory } from "../sources/sp-types.js";
-import type { CustomFrontId, FrontingSessionEncryptedInput, MemberId } from "@pluralscape/types";
+import type {
+  CustomFrontId,
+  FrontingSessionComment,
+  FrontingSessionEncryptedInput,
+  MemberId,
+} from "@pluralscape/types";
 import type { CreateFrontingSessionBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -46,7 +51,10 @@ export function mapFrontingSession(
   const endTime = sp.live ? null : (sp.endTime ?? null);
 
   const encrypted: FrontingSessionEncryptedInput = {
-    comment: sp.customStatus ?? null,
+    comment:
+      sp.customStatus === undefined || sp.customStatus === null
+        ? null
+        : brandValue<FrontingSessionComment>(sp.customStatus),
     positionality: null,
     outtrigger: null,
     outtriggerSentiment: null,

--- a/packages/import-sp/src/mappers/fronting-session.mapper.ts
+++ b/packages/import-sp/src/mappers/fronting-session.mapper.ts
@@ -51,10 +51,10 @@ export function mapFrontingSession(
   const endTime = sp.live ? null : (sp.endTime ?? null);
 
   const encrypted: FrontingSessionEncryptedInput = {
-    comment:
-      sp.customStatus === undefined || sp.customStatus === null
-        ? null
-        : brandValue<FrontingSessionComment>(sp.customStatus),
+    // SP source may carry an empty `customStatus` string for sessions with no
+    // user-entered note. The Pluralscape brand requires non-empty when present,
+    // so coerce empty/missing alike to null at the boundary.
+    comment: sp.customStatus?.length ? brandValue<FrontingSessionComment>(sp.customStatus) : null,
     positionality: null,
     outtrigger: null,
     outtriggerSentiment: null,

--- a/packages/import-sp/src/mappers/journal-entry.mapper.ts
+++ b/packages/import-sp/src/mappers/journal-entry.mapper.ts
@@ -37,6 +37,24 @@ export function mapJournalEntry(sp: SPNote, ctx: MappingContext): MapperResult<M
     });
   }
 
+  // The Pluralscape NoteTitle/NoteContent brands reject empty strings. Stop
+  // them at the SP boundary so a malformed source note becomes a non-fatal
+  // import failure instead of a downstream Zod parse error.
+  if (sp.title.length === 0) {
+    return failed({
+      kind: "empty-name",
+      message: `note "${sp._id}" has empty title`,
+      targetField: "title",
+    });
+  }
+  if (sp.note.length === 0) {
+    return failed({
+      kind: "empty-name",
+      message: `note "${sp._id}" has empty content`,
+      targetField: "content",
+    });
+  }
+
   if (sp.supportMarkdown !== undefined) {
     ctx.addWarningOnce("journal-entry.supportMarkdown-dropped", {
       entityType: "journal-entry",

--- a/packages/import-sp/src/mappers/journal-entry.mapper.ts
+++ b/packages/import-sp/src/mappers/journal-entry.mapper.ts
@@ -10,12 +10,14 @@
  *
  * Fails when the author FK can't be resolved.
  */
+import { brandValue } from "@pluralscape/types";
+
 import { parseHexColor } from "./helpers.js";
 import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPNote } from "../sources/sp-types.js";
-import type { NoteEncryptedInput } from "@pluralscape/types";
+import type { NoteContent, NoteEncryptedInput, NoteTitle } from "@pluralscape/types";
 import type { CreateNoteBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -53,8 +55,8 @@ export function mapJournalEntry(sp: SPNote, ctx: MappingContext): MapperResult<M
   }
 
   const encrypted: NoteEncryptedInput = {
-    title: sp.title,
-    content: sp.note,
+    title: brandValue<NoteTitle>(sp.title),
+    content: brandValue<NoteContent>(sp.note),
     backgroundColor,
   };
 

--- a/packages/import-sp/src/mappers/poll.mapper.ts
+++ b/packages/import-sp/src/mappers/poll.mapper.ts
@@ -43,11 +43,32 @@ export type MappedPoll = Omit<z.infer<typeof CreatePollBodySchema>, "encryptedDa
 };
 
 export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPoll> {
+  // The PollTitle and PollOptionLabel brands reject empty strings. Guard
+  // both at the SP boundary before any downstream branding so a malformed
+  // source poll becomes a non-fatal import failure instead of a Zod parse
+  // error inside the persister.
+  if (sp.name.length === 0) {
+    return failed({
+      kind: "empty-name",
+      message: `poll "${sp._id}" has empty name`,
+      targetField: "name",
+    });
+  }
+  const sourceOptions = sp.options ?? [];
+  const emptyLabelIndex = sourceOptions.findIndex((o) => o.name.length === 0);
+  if (emptyLabelIndex !== -1) {
+    return failed({
+      kind: "empty-name",
+      message: `poll "${sp._id}" option at index ${String(emptyLabelIndex)} has empty label`,
+      targetField: "options",
+    });
+  }
+
   // SP poll options have an optional `id` field — freshly-created polls ship
   // options without ids. Fall back to a stable positional synthetic id so
   // downstream votes can still reference them by position even without a
   // server-assigned id.
-  const options = (sp.options ?? []).map((o, idx) => ({
+  const options = sourceOptions.map((o, idx) => ({
     id: brandId<PollOptionId>(o.id ?? `${sp._id}_opt_${String(idx)}`),
     label: brandValue<PollOptionLabel>(o.name),
     voteCount: 0,
@@ -55,7 +76,7 @@ export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPol
     emoji: null,
   }));
 
-  const hasInvalidOptionColor = (sp.options ?? []).some(
+  const hasInvalidOptionColor = sourceOptions.some(
     (o) =>
       o.color !== undefined &&
       o.color !== null &&

--- a/packages/import-sp/src/mappers/poll.mapper.ts
+++ b/packages/import-sp/src/mappers/poll.mapper.ts
@@ -14,14 +14,19 @@
  * can't be resolved become `{memberId: null, isVeto: false}` with a warning —
  * the vote is still preserved, just unattributed.
  */
-import { brandId } from "@pluralscape/types";
+import { brandId, brandValue } from "@pluralscape/types";
 
 import { parseHexColor } from "./helpers.js";
 import { failed, mapped, type MapperResult } from "./mapper-result.js";
 
 import type { MappingContext } from "./context.js";
 import type { SPPoll } from "../sources/sp-types.js";
-import type { PollEncryptedInput, PollOptionId } from "@pluralscape/types";
+import type {
+  PollEncryptedInput,
+  PollOptionId,
+  PollOptionLabel,
+  PollTitle,
+} from "@pluralscape/types";
 import type { CreatePollBodySchema } from "@pluralscape/validation";
 import type { z } from "zod/v4";
 
@@ -44,7 +49,7 @@ export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPol
   // server-assigned id.
   const options = (sp.options ?? []).map((o, idx) => ({
     id: brandId<PollOptionId>(o.id ?? `${sp._id}_opt_${String(idx)}`),
-    label: o.name,
+    label: brandValue<PollOptionLabel>(o.name),
     voteCount: 0,
     color: parseHexColor(o.color),
     emoji: null,
@@ -100,7 +105,7 @@ export function mapPoll(sp: SPPoll, ctx: MappingContext): MapperResult<MappedPol
   }
 
   const encrypted: PollEncryptedInput = {
-    title: sp.name,
+    title: brandValue<PollTitle>(sp.name),
     description: sp.desc ?? null,
     options,
   };

--- a/packages/types/src/__tests__/fronting.test.ts
+++ b/packages/types/src/__tests__/fronting.test.ts
@@ -21,6 +21,11 @@ import type {
 } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { AuditMetadata } from "../utility.js";
+import type {
+  FrontingSessionComment,
+  FrontingSessionOuttrigger,
+  FrontingSessionPositionality,
+} from "../value-types.js";
 
 describe("FrontingSession", () => {
   it("discriminates on endTime — null narrows to ActiveFrontingSession", () => {
@@ -40,10 +45,14 @@ describe("FrontingSession", () => {
     expectTypeOf<ActiveFrontingSession["systemId"]>().toEqualTypeOf<SystemId>();
     expectTypeOf<ActiveFrontingSession["memberId"]>().toEqualTypeOf<MemberId | null>();
     expectTypeOf<ActiveFrontingSession["startTime"]>().toEqualTypeOf<UnixMillis>();
-    expectTypeOf<ActiveFrontingSession["comment"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<ActiveFrontingSession["comment"]>().toEqualTypeOf<FrontingSessionComment | null>();
     expectTypeOf<ActiveFrontingSession["customFrontId"]>().toEqualTypeOf<CustomFrontId | null>();
-    expectTypeOf<ActiveFrontingSession["positionality"]>().toEqualTypeOf<string | null>();
-    expectTypeOf<ActiveFrontingSession["outtrigger"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<
+      ActiveFrontingSession["positionality"]
+    >().toEqualTypeOf<FrontingSessionPositionality | null>();
+    expectTypeOf<
+      ActiveFrontingSession["outtrigger"]
+    >().toEqualTypeOf<FrontingSessionOuttrigger | null>();
     expectTypeOf<
       ActiveFrontingSession["outtriggerSentiment"]
     >().toEqualTypeOf<OuttriggerSentiment | null>();
@@ -55,10 +64,16 @@ describe("FrontingSession", () => {
     expectTypeOf<CompletedFrontingSession["memberId"]>().toEqualTypeOf<MemberId | null>();
     expectTypeOf<CompletedFrontingSession["startTime"]>().toEqualTypeOf<UnixMillis>();
     expectTypeOf<CompletedFrontingSession["endTime"]>().toEqualTypeOf<UnixMillis>();
-    expectTypeOf<CompletedFrontingSession["comment"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<
+      CompletedFrontingSession["comment"]
+    >().toEqualTypeOf<FrontingSessionComment | null>();
     expectTypeOf<CompletedFrontingSession["customFrontId"]>().toEqualTypeOf<CustomFrontId | null>();
-    expectTypeOf<CompletedFrontingSession["positionality"]>().toEqualTypeOf<string | null>();
-    expectTypeOf<CompletedFrontingSession["outtrigger"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<
+      CompletedFrontingSession["positionality"]
+    >().toEqualTypeOf<FrontingSessionPositionality | null>();
+    expectTypeOf<
+      CompletedFrontingSession["outtrigger"]
+    >().toEqualTypeOf<FrontingSessionOuttrigger | null>();
     expectTypeOf<
       CompletedFrontingSession["outtriggerSentiment"]
     >().toEqualTypeOf<OuttriggerSentiment | null>();

--- a/packages/types/src/entities/field-definition.ts
+++ b/packages/types/src/entities/field-definition.ts
@@ -4,6 +4,7 @@ import type { BucketId, FieldDefinitionId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
 import type { Archived, AuditMetadata } from "../utility.js";
+import type { FieldDefinitionLabel } from "../value-types.js";
 
 /** The supported field types for custom fields (single source of truth). */
 export const FIELD_TYPES = [
@@ -29,7 +30,7 @@ export interface FieldBucketVisibility {
 export interface FieldDefinition extends AuditMetadata {
   readonly id: FieldDefinitionId;
   readonly systemId: SystemId;
-  readonly name: string;
+  readonly name: FieldDefinitionLabel;
   readonly description: string | null;
   readonly fieldType: FieldType;
   /** Valid options for select / multi-select fields. Null for other types. */

--- a/packages/types/src/entities/fronting-session.ts
+++ b/packages/types/src/entities/fronting-session.ts
@@ -10,6 +10,11 @@ import type {
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
 import type { Archived, AuditMetadata } from "../utility.js";
+import type {
+  FrontingSessionComment,
+  FrontingSessionOuttrigger,
+  FrontingSessionPositionality,
+} from "../value-types.js";
 
 /** Sentiment classification for an outtrigger reason. */
 export type OuttriggerSentiment = "negative" | "neutral" | "positive";
@@ -21,14 +26,14 @@ interface FrontingSessionBase extends AuditMetadata {
   readonly memberId: MemberId | null;
   readonly startTime: UnixMillis;
   /** Free-text status comment on this session. Max 50 characters (runtime enforced). SP-compatible. */
-  readonly comment: string | null;
+  readonly comment: FrontingSessionComment | null;
   readonly customFrontId: CustomFrontId | null;
   /** FK to linked structure entity. */
   readonly structureEntityId: SystemStructureEntityId | null;
   /** Free-text description of fronting positionality (e.g. close vs far, height). */
-  readonly positionality: string | null;
+  readonly positionality: FrontingSessionPositionality | null;
   /** Free-text reason describing what caused the fronting change. Stored in T1 encrypted blob. */
-  readonly outtrigger: string | null;
+  readonly outtrigger: FrontingSessionOuttrigger | null;
   /** Sentiment classification for the outtrigger reason. Stored in T1 encrypted blob. */
   readonly outtriggerSentiment: OuttriggerSentiment | null;
   readonly archived: false;

--- a/packages/types/src/entities/note.ts
+++ b/packages/types/src/entities/note.ts
@@ -4,6 +4,7 @@ import type { AnyBrandedId, HexColor, NoteId, SystemId } from "../ids.js";
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
 import type { Archived, AuditMetadata, EntityReference } from "../utility.js";
+import type { NoteContent, NoteTitle } from "../value-types.js";
 
 /** Valid entity types that can author a note. */
 export type NoteAuthorEntityType = "member" | "structure-entity";
@@ -19,8 +20,8 @@ export interface Note extends AuditMetadata {
   readonly id: NoteId;
   readonly systemId: SystemId;
   readonly author: EntityReference<NoteAuthorEntityType> | null;
-  readonly title: string;
-  readonly content: string;
+  readonly title: NoteTitle;
+  readonly content: NoteContent;
   readonly backgroundColor: HexColor | null;
   readonly archived: false;
 }

--- a/packages/types/src/entities/poll.ts
+++ b/packages/types/src/entities/poll.ts
@@ -4,11 +4,12 @@ import type { HexColor, MemberId, PollId, PollOptionId, SystemId } from "../ids.
 import type { UnixMillis } from "../timestamps.js";
 import type { Serialize } from "../type-assertions.js";
 import type { Archived, AuditMetadata } from "../utility.js";
+import type { PollOptionLabel, PollTitle } from "../value-types.js";
 
 /** A single option within a poll. */
 export interface PollOption {
   readonly id: PollOptionId;
-  readonly label: string;
+  readonly label: PollOptionLabel;
   readonly voteCount: number;
   readonly color: HexColor | null;
   readonly emoji: string | null;
@@ -32,7 +33,7 @@ export interface Poll extends AuditMetadata {
   readonly systemId: SystemId;
   /** Member who created the poll. null when imported from a source system (e.g., Simply Plural) that has no per-poll creator concept. */
   readonly createdByMemberId: MemberId | null;
-  readonly title: string;
+  readonly title: PollTitle;
   readonly description: string | null;
   readonly kind: PollKind;
   readonly options: readonly PollOption[];

--- a/packages/types/src/fronting.constants.ts
+++ b/packages/types/src/fronting.constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Maximum length of FrontingSession.comment in characters.
+ *
+ * Constraint origin: Simply Plural's customStatus field is capped at
+ * 50 characters; preserving compatibility with that schema makes
+ * round-tripping SP exports lossless. Enforced at the
+ * FrontingSessionEncryptedInputSchema validation boundary via Zod
+ * refine; the brand carries the type, the schema carries the runtime
+ * check.
+ */
+export const MAX_FRONTING_COMMENT_LENGTH = 50;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -103,7 +103,11 @@ export { brandId } from "./brand-utils.js";
 export { assertBrandedTargetId, InvalidBrandedIdError } from "./assert-branded.js";
 
 // ── Branded value types (non-ID display labels) ──────────────────
-export type { LifecycleEventForm, LifecycleEventName } from "./value-types.js";
+export type {
+  FieldDefinitionLabel,
+  LifecycleEventForm,
+  LifecycleEventName,
+} from "./value-types.js";
 export { brandValue } from "./value-types.js";
 
 // ── Checksum ─────────────────────────────────────────────────────

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -109,6 +109,8 @@ export type {
   LifecycleEventName,
   NoteContent,
   NoteTitle,
+  PollOptionLabel,
+  PollTitle,
 } from "./value-types.js";
 export { brandValue } from "./value-types.js";
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -105,6 +105,9 @@ export { assertBrandedTargetId, InvalidBrandedIdError } from "./assert-branded.j
 // ── Branded value types (non-ID display labels) ──────────────────
 export type {
   FieldDefinitionLabel,
+  FrontingSessionComment,
+  FrontingSessionOuttrigger,
+  FrontingSessionPositionality,
   LifecycleEventForm,
   LifecycleEventName,
   NoteContent,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -117,6 +117,9 @@ export type {
 } from "./value-types.js";
 export { brandValue } from "./value-types.js";
 
+// ── Fronting constants ───────────────────────────────────────────
+export { MAX_FRONTING_COMMENT_LENGTH } from "./fronting.constants.js";
+
 // ── Checksum ─────────────────────────────────────────────────────
 export { toChecksumHex } from "./checksum.js";
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -107,6 +107,8 @@ export type {
   FieldDefinitionLabel,
   LifecycleEventForm,
   LifecycleEventName,
+  NoteContent,
+  NoteTitle,
 } from "./value-types.js";
 export { brandValue } from "./value-types.js";
 

--- a/packages/types/src/value-types.ts
+++ b/packages/types/src/value-types.ts
@@ -51,6 +51,25 @@ export type NoteTitle = Brand<string, "NoteTitle">;
  */
 export type NoteContent = Brand<string, "NoteContent">;
 
+/**
+ * Free-text user-supplied poll title.
+ *
+ * Branded distinct from {@link PollOptionLabel} to prevent
+ * cross-field assignment between parent and child option labels in
+ * poll-edit forms — Poll.title and PollOption.label are both
+ * user-typed strings on the same entity tree. See
+ * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ */
+export type PollTitle = Brand<string, "PollTitle">;
+
+/**
+ * Free-text user-supplied poll-option label.
+ *
+ * Branded distinct from {@link PollTitle} (parent/child peer). See
+ * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ */
+export type PollOptionLabel = Brand<string, "PollOptionLabel">;
+
 /** Constraint for {@link brandValue} — any string-backed phantom brand. */
 type AnyBrandedValue = Brand<string, string>;
 

--- a/packages/types/src/value-types.ts
+++ b/packages/types/src/value-types.ts
@@ -70,6 +70,36 @@ export type PollTitle = Brand<string, "PollTitle">;
  */
 export type PollOptionLabel = Brand<string, "PollOptionLabel">;
 
+/**
+ * Free-text user-supplied fronting-session status comment.
+ * Max 50 characters (runtime enforced separately). SP-compatible.
+ *
+ * Branded distinct from {@link FrontingSessionPositionality} and
+ * {@link FrontingSessionOuttrigger} — three same-entity peers all
+ * stored in the FrontingSession encrypted blob with concrete
+ * cross-field swap risk through shared fronting-rendering helpers.
+ * See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ */
+export type FrontingSessionComment = Brand<string, "FrontingSessionComment">;
+
+/**
+ * Free-text user-supplied fronting-session positionality (e.g. close
+ * vs far, height).
+ *
+ * Branded distinct from {@link FrontingSessionComment} and
+ * {@link FrontingSessionOuttrigger} (same-entity peers).
+ */
+export type FrontingSessionPositionality = Brand<string, "FrontingSessionPositionality">;
+
+/**
+ * Free-text user-supplied fronting-session outtrigger reason —
+ * what caused the fronting change. Stored in the T1 encrypted blob.
+ *
+ * Branded distinct from {@link FrontingSessionComment} and
+ * {@link FrontingSessionPositionality} (same-entity peers).
+ */
+export type FrontingSessionOuttrigger = Brand<string, "FrontingSessionOuttrigger">;
+
 /** Constraint for {@link brandValue} — any string-backed phantom brand. */
 type AnyBrandedValue = Brand<string, string>;
 

--- a/packages/types/src/value-types.ts
+++ b/packages/types/src/value-types.ts
@@ -24,10 +24,10 @@ export type LifecycleEventName = Brand<string, "LifecycleEventName">;
  * Examples: "Pronouns", "Age", "Job".
  *
  * Branded so a `FieldDefinition.name` value cannot accidentally be
- * assigned to other free-text slots — `FieldDefinition.name` is the
- * field's display label and is widely passed as a UI label key, with
- * high confusion risk against content strings. See
- * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ * assigned to the sibling `description` field, or to other UI-label
+ * slots — `FieldDefinition.name` is the field's display label and is
+ * widely passed as a UI label key, with high confusion risk against
+ * content strings.
  */
 export type FieldDefinitionLabel = Brand<string, "FieldDefinitionLabel">;
 
@@ -36,18 +36,15 @@ export type FieldDefinitionLabel = Brand<string, "FieldDefinitionLabel">;
  *
  * Branded distinct from {@link NoteContent} to prevent cross-field
  * assignment between same-entity peers — Note has both `title` and
- * `content` as user-typed strings. Render pipelines treat them
- * differently (titles get truncation/tooltip; content gets rich-block
- * rendering). See
- * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ * `content` as user-typed strings.
  */
 export type NoteTitle = Brand<string, "NoteTitle">;
 
 /**
  * Free-text user-supplied note body.
+ * Examples: "Met with therapist today...", "Reminder: pick up groceries".
  *
- * Branded distinct from {@link NoteTitle} (same-entity peer). See
- * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ * See {@link NoteTitle} for rationale.
  */
 export type NoteContent = Brand<string, "NoteContent">;
 
@@ -55,30 +52,26 @@ export type NoteContent = Brand<string, "NoteContent">;
  * Free-text user-supplied poll title.
  *
  * Branded distinct from {@link PollOptionLabel} to prevent
- * cross-field assignment between parent and child option labels in
- * poll-edit forms — Poll.title and PollOption.label are both
- * user-typed strings on the same entity tree. See
- * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ * cross-field assignment between the parent poll title and child
+ * option labels in poll-edit forms — Poll.title and PollOption.label
+ * are both user-typed strings on the same entity tree.
  */
 export type PollTitle = Brand<string, "PollTitle">;
 
 /**
  * Free-text user-supplied poll-option label.
  *
- * Branded distinct from {@link PollTitle} (parent/child peer). See
- * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ * See {@link PollTitle} for rationale.
  */
 export type PollOptionLabel = Brand<string, "PollOptionLabel">;
 
 /**
  * Free-text user-supplied fronting-session status comment.
- * Max 50 characters (runtime enforced). SP-compatible.
  *
  * Branded distinct from {@link FrontingSessionPositionality} and
  * {@link FrontingSessionOuttrigger} — three same-entity peers all
  * stored in the FrontingSession encrypted blob with concrete
- * cross-field swap risk through shared fronting-rendering helpers.
- * See docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ * cross-field swap risk.
  */
 export type FrontingSessionComment = Brand<string, "FrontingSessionComment">;
 
@@ -86,17 +79,15 @@ export type FrontingSessionComment = Brand<string, "FrontingSessionComment">;
  * Free-text user-supplied fronting-session positionality (e.g. close
  * vs far, height).
  *
- * Branded distinct from {@link FrontingSessionComment} and
- * {@link FrontingSessionOuttrigger} (same-entity peers).
+ * See {@link FrontingSessionComment} for rationale.
  */
 export type FrontingSessionPositionality = Brand<string, "FrontingSessionPositionality">;
 
 /**
- * Free-text user-supplied fronting-session outtrigger reason —
- * what caused the fronting change. Stored in the T1 encrypted blob.
+ * Free-text user-supplied fronting-session outtrigger reason — what
+ * caused the fronting change.
  *
- * Branded distinct from {@link FrontingSessionComment} and
- * {@link FrontingSessionPositionality} (same-entity peers).
+ * See {@link FrontingSessionComment} for rationale.
  */
 export type FrontingSessionOuttrigger = Brand<string, "FrontingSessionOuttrigger">;
 

--- a/packages/types/src/value-types.ts
+++ b/packages/types/src/value-types.ts
@@ -19,6 +19,18 @@ export type LifecycleEventForm = Brand<string, "LifecycleEventForm">;
  */
 export type LifecycleEventName = Brand<string, "LifecycleEventName">;
 
+/**
+ * Free-text user-supplied field-definition display label.
+ * Examples: "Pronouns", "Age", "Job".
+ *
+ * Branded so a `FieldDefinition.name` value cannot accidentally be
+ * assigned to other free-text slots — `FieldDefinition.name` is the
+ * field's display label and is widely passed as a UI label key, with
+ * high confusion risk against content strings. See
+ * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ */
+export type FieldDefinitionLabel = Brand<string, "FieldDefinitionLabel">;
+
 /** Constraint for {@link brandValue} — any string-backed phantom brand. */
 type AnyBrandedValue = Brand<string, string>;
 

--- a/packages/types/src/value-types.ts
+++ b/packages/types/src/value-types.ts
@@ -72,7 +72,7 @@ export type PollOptionLabel = Brand<string, "PollOptionLabel">;
 
 /**
  * Free-text user-supplied fronting-session status comment.
- * Max 50 characters (runtime enforced separately). SP-compatible.
+ * Max 50 characters (runtime enforced). SP-compatible.
  *
  * Branded distinct from {@link FrontingSessionPositionality} and
  * {@link FrontingSessionOuttrigger} — three same-entity peers all

--- a/packages/types/src/value-types.ts
+++ b/packages/types/src/value-types.ts
@@ -31,6 +31,26 @@ export type LifecycleEventName = Brand<string, "LifecycleEventName">;
  */
 export type FieldDefinitionLabel = Brand<string, "FieldDefinitionLabel">;
 
+/**
+ * Free-text user-supplied note title.
+ *
+ * Branded distinct from {@link NoteContent} to prevent cross-field
+ * assignment between same-entity peers — Note has both `title` and
+ * `content` as user-typed strings. Render pipelines treat them
+ * differently (titles get truncation/tooltip; content gets rich-block
+ * rendering). See
+ * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ */
+export type NoteTitle = Brand<string, "NoteTitle">;
+
+/**
+ * Free-text user-supplied note body.
+ *
+ * Branded distinct from {@link NoteTitle} (same-entity peer). See
+ * docs/local-audits/2026-04-27-free-text-label-brand-audit.md.
+ */
+export type NoteContent = Brand<string, "NoteContent">;
+
 /** Constraint for {@link brandValue} — any string-backed phantom brand. */
 type AnyBrandedValue = Brand<string, string>;
 

--- a/packages/validation/src/__tests__/custom-fields.test.ts
+++ b/packages/validation/src/__tests__/custom-fields.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { FieldDefinitionEncryptedInputSchema } from "../custom-fields.js";
+
+// ── FieldDefinitionEncryptedInputSchema ─────────────────────────
+
+describe("FieldDefinitionEncryptedInputSchema", () => {
+  it("accepts a non-empty name with null description and options", () => {
+    const result = FieldDefinitionEncryptedInputSchema.safeParse({
+      name: "Likes",
+      description: null,
+      options: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    // The FieldDefinitionLabel brand requires a non-empty string. The SP
+    // import boundary now guards this, but the schema must also reject it
+    // independently to catch future callers that bypass the boundary.
+    const result = FieldDefinitionEncryptedInputSchema.safeParse({
+      name: "",
+      description: null,
+      options: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a list of option strings", () => {
+    const result = FieldDefinitionEncryptedInputSchema.safeParse({
+      name: "Role",
+      description: "Member role",
+      options: ["lead", "support"],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/validation/src/__tests__/fronting-session.test.ts
+++ b/packages/validation/src/__tests__/fronting-session.test.ts
@@ -216,6 +216,44 @@ describe("FrontingSessionEncryptedInputSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  // ── 50-char limit on comment (SP compatibility) ──────────────────
+
+  it("accepts a 1-character comment (sanity)", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      comment: "a",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a comment of exactly 50 characters (boundary)", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      comment: "a".repeat(50),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a comment of 51 characters (just over the limit)", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      comment: "a".repeat(51),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join(" ");
+      expect(messages).toContain("50 characters");
+    }
+  });
+
+  it("accepts comment: null (limit only applies to non-null values)", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      comment: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects empty-string positionality when non-null", () => {
     const result = FrontingSessionEncryptedInputSchema.safeParse({
       ...allNull,

--- a/packages/validation/src/__tests__/fronting-session.test.ts
+++ b/packages/validation/src/__tests__/fronting-session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   CreateFrontingSessionBodySchema,
+  FrontingSessionEncryptedInputSchema,
   UpdateFrontingSessionBodySchema,
   EndFrontingSessionBodySchema,
   FrontingSessionQuerySchema,
@@ -165,6 +166,70 @@ describe("CreateFrontingSessionBodySchema", () => {
     if (result.success) {
       expect("admin" in result.data).toBe(false);
     }
+  });
+});
+
+// ── FrontingSessionEncryptedInputSchema ─────────────────────────────
+
+describe("FrontingSessionEncryptedInputSchema", () => {
+  const allNull = {
+    comment: null,
+    positionality: null,
+    outtrigger: null,
+    outtriggerSentiment: null,
+  } as const;
+
+  it("accepts all-null encrypted fields", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse(allNull);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts non-empty comment", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      comment: "feeling blurry",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts non-empty positionality", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      positionality: "co-conscious",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts non-empty outtrigger", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      outtrigger: "loud noise",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty-string comment when non-null", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      comment: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty-string positionality when non-null", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      positionality: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty-string outtrigger when non-null", () => {
+    const result = FrontingSessionEncryptedInputSchema.safeParse({
+      ...allNull,
+      outtrigger: "",
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/validation/src/__tests__/note.test.ts
+++ b/packages/validation/src/__tests__/note.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { CreateNoteBodySchema, NoteQuerySchema, UpdateNoteBodySchema } from "../note.js";
+import {
+  CreateNoteBodySchema,
+  NoteEncryptedInputSchema,
+  NoteQuerySchema,
+  UpdateNoteBodySchema,
+} from "../note.js";
 import { MAX_ENCRYPTED_DATA_SIZE } from "../validation.constants.js";
 
 describe("CreateNoteBodySchema", () => {
@@ -132,6 +137,35 @@ describe("UpdateNoteBodySchema", () => {
 
   it("rejects missing encryptedData", () => {
     const result = UpdateNoteBodySchema.safeParse({ version: 1 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("NoteEncryptedInputSchema", () => {
+  it("accepts non-empty title and content with null backgroundColor", () => {
+    const result = NoteEncryptedInputSchema.safeParse({
+      title: "Morning thoughts",
+      content: "Woke up fronting.",
+      backgroundColor: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty title", () => {
+    const result = NoteEncryptedInputSchema.safeParse({
+      title: "",
+      content: "x",
+      backgroundColor: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty content", () => {
+    const result = NoteEncryptedInputSchema.safeParse({
+      title: "x",
+      content: "",
+      backgroundColor: null,
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/packages/validation/src/__tests__/poll.test.ts
+++ b/packages/validation/src/__tests__/poll.test.ts
@@ -3,11 +3,20 @@ import { describe, expect, it } from "vitest";
 import {
   CastVoteBodySchema,
   CreatePollBodySchema,
+  PollEncryptedInputSchema,
   PollQuerySchema,
   PollVoteQuerySchema,
   UpdatePollBodySchema,
 } from "../poll.js";
 import { MAX_ENCRYPTED_DATA_SIZE } from "../validation.constants.js";
+
+const VALID_POLL_OPTION = {
+  id: "popt_abc",
+  label: "Yes",
+  voteCount: 0,
+  color: null,
+  emoji: null,
+} as const;
 
 /** Remove a key from an object (lint-safe alternative to destructuring with _). */
 function omit<T extends Record<string, unknown>, K extends keyof T>(obj: T, key: K): Omit<T, K> {
@@ -274,6 +283,46 @@ describe("CastVoteBodySchema", () => {
     if (result.success) {
       expect("extra" in result.data).toBe(false);
     }
+  });
+});
+
+// ── PollEncryptedInputSchema ─────────────────────────────────────
+
+describe("PollEncryptedInputSchema", () => {
+  it("accepts non-empty title with a single valid option", () => {
+    const result = PollEncryptedInputSchema.safeParse({
+      title: "Lunch?",
+      description: null,
+      options: [VALID_POLL_OPTION],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty title", () => {
+    const result = PollEncryptedInputSchema.safeParse({
+      title: "",
+      description: null,
+      options: [VALID_POLL_OPTION],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an option with empty label (validated through PollEncryptedInputSchema)", () => {
+    const result = PollEncryptedInputSchema.safeParse({
+      title: "Lunch?",
+      description: null,
+      options: [{ ...VALID_POLL_OPTION, label: "" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an option with empty id (validated through PollEncryptedInputSchema)", () => {
+    const result = PollEncryptedInputSchema.safeParse({
+      title: "Lunch?",
+      description: null,
+      options: [{ ...VALID_POLL_OPTION, id: "" }],
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/validation/src/custom-fields.ts
+++ b/packages/validation/src/custom-fields.ts
@@ -1,6 +1,7 @@
 import { FIELD_TYPES } from "@pluralscape/types";
 import { z } from "zod/v4";
 
+import { brandedString } from "./branded.js";
 import {
   MAX_ENCRYPTED_FIELD_DATA_SIZE,
   MAX_ENCRYPTED_FIELD_VALUE_SIZE,
@@ -18,7 +19,7 @@ const FieldTypeSchema = z.enum(FIELD_TYPES);
  */
 export const FieldDefinitionEncryptedInputSchema = z
   .object({
-    name: z.string().min(1),
+    name: brandedString<"FieldDefinitionLabel">(),
     description: z.string().nullable(),
     options: z.array(z.string()).readonly().nullable(),
   })

--- a/packages/validation/src/fronting-session.ts
+++ b/packages/validation/src/fronting-session.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 
 import { optionalBrandedId, requireSubject, REQUIRE_SUBJECT_MESSAGE } from "./branded-id.js";
+import { brandedString } from "./branded.js";
 import { booleanQueryParam } from "./query-params.js";
 import { MAX_ENCRYPTED_DATA_SIZE } from "./validation.constants.js";
 
@@ -14,9 +15,9 @@ import { MAX_ENCRYPTED_DATA_SIZE } from "./validation.constants.js";
  */
 export const FrontingSessionEncryptedInputSchema = z
   .object({
-    comment: z.string().nullable(),
-    positionality: z.string().nullable(),
-    outtrigger: z.string().nullable(),
+    comment: brandedString<"FrontingSessionComment">().nullable(),
+    positionality: brandedString<"FrontingSessionPositionality">().nullable(),
+    outtrigger: brandedString<"FrontingSessionOuttrigger">().nullable(),
     outtriggerSentiment: z.enum(["negative", "neutral", "positive"]).nullable(),
   })
   .readonly();

--- a/packages/validation/src/fronting-session.ts
+++ b/packages/validation/src/fronting-session.ts
@@ -1,3 +1,4 @@
+import { MAX_FRONTING_COMMENT_LENGTH } from "@pluralscape/types";
 import { z } from "zod/v4";
 
 import { optionalBrandedId, requireSubject, REQUIRE_SUBJECT_MESSAGE } from "./branded-id.js";
@@ -15,7 +16,11 @@ import { MAX_ENCRYPTED_DATA_SIZE } from "./validation.constants.js";
  */
 export const FrontingSessionEncryptedInputSchema = z
   .object({
-    comment: brandedString<"FrontingSessionComment">().nullable(),
+    comment: brandedString<"FrontingSessionComment">()
+      .refine((v) => v.length <= MAX_FRONTING_COMMENT_LENGTH, {
+        message: `comment must be at most ${String(MAX_FRONTING_COMMENT_LENGTH)} characters`,
+      })
+      .nullable(),
     positionality: brandedString<"FrontingSessionPositionality">().nullable(),
     outtrigger: brandedString<"FrontingSessionOuttrigger">().nullable(),
     outtriggerSentiment: z.enum(["negative", "neutral", "positive"]).nullable(),

--- a/packages/validation/src/note.ts
+++ b/packages/validation/src/note.ts
@@ -1,6 +1,7 @@
 import { NOTE_AUTHOR_ENTITY_TYPES } from "@pluralscape/types";
 import { z } from "zod/v4";
 
+import { brandedString } from "./branded.js";
 import { HexColorSchema } from "./plaintext-shared.js";
 import { booleanQueryParam } from "./query-params.js";
 import { MAX_ENCRYPTED_DATA_SIZE, MAX_QUERY_PARAM_STRING_LENGTH } from "./validation.constants.js";
@@ -14,8 +15,8 @@ import { MAX_ENCRYPTED_DATA_SIZE, MAX_QUERY_PARAM_STRING_LENGTH } from "./valida
  */
 export const NoteEncryptedInputSchema = z
   .object({
-    title: z.string().min(1),
-    content: z.string(),
+    title: brandedString<"NoteTitle">(),
+    content: brandedString<"NoteContent">(),
     backgroundColor: HexColorSchema.nullable(),
   })
   .readonly();

--- a/packages/validation/src/poll.ts
+++ b/packages/validation/src/poll.ts
@@ -15,7 +15,7 @@ export const POLL_VOTER_ENTITY_TYPES = ["member", "structure-entity"] as const;
 const PollOptionSchema = z
   .object({
     id: brandedString<"PollOptionId">(),
-    label: z.string().min(1),
+    label: brandedString<"PollOptionLabel">(),
     voteCount: z.number().int().min(0),
     color: HexColorSchema.nullable(),
     emoji: z.string().nullable(),
@@ -29,7 +29,7 @@ const PollOptionSchema = z
  */
 export const PollEncryptedInputSchema = z
   .object({
-    title: z.string().min(1),
+    title: brandedString<"PollTitle">(),
     description: z.string().nullable(),
     options: z.array(PollOptionSchema).readonly(),
   })


### PR DESCRIPTION
## Summary

Closes the same-entity-peer branding thread under M9a (`ps-cd6x`) by branding 8 user-typed display strings across 4 entities. Each commit is mechanically independent; commit order is simplest-to-most-complex for reviewer calibration.

| Bean | Brands | Entity |
|---|---|---|
| types-gkhk | FieldDefinitionLabel | FieldDefinition.name |
| types-cdr5 | NoteTitle, NoteContent | Note.title, Note.content |
| types-e6n9 | PollTitle, PollOptionLabel | Poll.title, PollOption.label |
| types-09m5 | FrontingSessionComment, FrontingSessionPositionality, FrontingSessionOuttrigger | FrontingSession.{comment,positionality,outtrigger} |

Pattern follows `types-yxgc` (PR #571) verbatim: phantom brand → entity update → Zod `brandedString<...>()` → Zod inference flows through to the data transform → `Serialize<T>` strips brands at the wire boundary, so OpenAPI parity is preserved without changes.

The two deferred branding beans (`types-x37g` for WikiPage/JournalEntry titles and `types-f3fk` for the entity-display-name fleet) were reparented to Milestone 15 — weaker swap-risk evidence and unresolved design questions made them poor M9a closeout candidates.

Runtime semantic change: empty-non-null strings now reject for `Note.content` and the FrontingSession trio. `brandedString` enforces `length > 0` internally; matches the lifecycle-event precedent (`types-yxgc`). No callers or tests depended on empty content.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint` (zero warnings)
- [x] `pnpm typecheck`
- [x] `pnpm types:check-sot` (4 parity gates)
- [x] `pnpm test:unit` (13172 passed)
- [x] `pnpm test:integration` (3063 passed)
- [x] `pnpm test:e2e` (509 passed)

Each commit independently passed the full gate before being committed.