### PR TITLE
chore(beans): restructure ps-36rg test-split epic with tiered children

### DIFF
--- a/.beans/api-4cmq--t2-api-wstrpc-test-splits-4-files-investigate-wsha.md
+++ b/.beans/api-4cmq--t2-api-wstrpc-test-splits-4-files-investigate-wsha.md
@@ -1,0 +1,32 @@
+---
+# api-4cmq
+title: "T2 api ws+trpc test splits: 4 files (investigate ws/handlers dup)"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:13Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+Four files in apps/api WS + tRPC layer. Investigate and resolve the two ws/handlers.test.ts duplicates as part of this PR.
+
+## Files
+
+- [ ] **tests**/ws/handlers.test.ts (1,042) — investigate vs the second handlers.test.ts; dedupe if confirmed duplicate
+- [ ] ws/**tests**/handlers.test.ts (928) — investigate vs first
+- [ ] **tests**/ws/message-router.test.ts (1,406)
+- [ ] **tests**/trpc/routers/structure.test.ts (875)
+
+## Acceptance
+
+- pnpm vitest run --project api passes
+- Duplicate handlers.test.ts resolved with explanation in PR description
+
+## Out of scope
+
+- WS protocol changes, tRPC router changes

--- a/.beans/api-rh0a--t2-api-services-test-splits-16-files-mirroring-api.md
+++ b/.beans/api-rh0a--t2-api-services-test-splits-16-files-mirroring-api.md
@@ -1,0 +1,45 @@
+---
+# api-rh0a
+title: "T2 api services test splits: 16 files mirroring api-6l1q verb structure"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:13Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+Sixteen service test files in apps/api/src/**tests**/services/. Mirror the verb-file split structure from the api-6l1q service refactor (services/<domain>/{create,update,...}.ts).
+
+## Files
+
+- [ ] auth.service.test.ts (1,454)
+- [ ] analytics.service.test.ts (1,245)
+- [ ] member.service.integration.test.ts (1,122)
+- [ ] key-rotation.service.integration.test.ts (955)
+- [ ] fronting-session.service.integration.test.ts (945)
+- [ ] board-message.service.integration.test.ts (879)
+- [ ] check-in-record.service.test.ts (874)
+- [ ] fronting-session.service.test.ts (862)
+- [ ] timer-config.service.test.ts (856)
+- [ ] group.service.test.ts (848)
+- [ ] member.service.test.ts (813)
+- [ ] import-job.service.integration.test.ts (796)
+- [ ] field-value.service.test.ts (790)
+- [ ] webhook-config.service.test.ts (789)
+- [ ] fronting-comment.service.test.ts (778)
+- [ ] switch-alert-dispatcher.integration.test.ts (762)
+
+## Acceptance
+
+- pnpm vitest run --project api passes (unit)
+- pnpm vitest run --project api-integration passes
+- Coverage unchanged or higher
+
+## Out of scope
+
+- Service code changes (all api-6l1q service refactors already merged)

--- a/.beans/crypto-mdzz--t2-crypto-test-split-key-lifecycletestts.md
+++ b/.beans/crypto-mdzz--t2-crypto-test-split-key-lifecycletestts.md
@@ -1,0 +1,25 @@
+---
+# crypto-mdzz
+title: "T2 crypto test split: key-lifecycle.test.ts"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:13Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+One file in packages/crypto.
+
+## Files
+
+- [ ] key-lifecycle.test.ts (1,021)
+
+## Acceptance
+
+- pnpm vitest run --project crypto passes
+- Coverage unchanged or higher

--- a/.beans/db-5bu5--split-rls-policiesintegrationtestts-2470-loc-by-ta.md
+++ b/.beans/db-5bu5--split-rls-policiesintegrationtestts-2470-loc-by-ta.md
@@ -3,8 +3,9 @@
 title: Split rls-policies.integration.test.ts (2,470 LOC) by table group
 status: todo
 type: task
+priority: normal
 created_at: 2026-04-21T13:57:36Z
-updated_at: 2026-04-21T13:57:36Z
+updated_at: 2026-04-30T05:00:05Z
 parent: ps-36rg
 ---
 
@@ -18,7 +19,7 @@ The RLS migration covers 70 tables with five distinct scoping patterns: account 
 
 - [ ] Split into rls-account-isolation.integration.test.ts, rls-system-isolation.integration.test.ts, rls-dual-tenant.integration.test.ts, rls-systems-pk.integration.test.ts, rls-audit-log.integration.test.ts, rls-key-grants.integration.test.ts
 - [ ] Extract shared setup into packages/db/src/**tests**/helpers/rls-test-helpers.ts
-- [ ] Each resulting file ≤500 LOC
+- [ ] Each resulting file ≤500 LOC (stretch 350)
 - [ ] Every existing test case preserved — count before and after match
 
 ## Out of scope
@@ -31,3 +32,7 @@ The RLS migration covers 70 tables with five distinct scoping patterns: account 
 - pnpm vitest run --project db-integration passes
 - Coverage unchanged or higher
 - Original file deleted
+
+## DRY pass
+
+While extracting helpers, scan sibling integration tests in packages/db for the same RLS-context boilerplate and consolidate when clear. Don't refactor any RLS policy. Per 2026-04-29 re-scope spec.

--- a/.beans/db-im18--t2-db-pg-test-splits-10-schema-files-pg-helpers-sc.md
+++ b/.beans/db-im18--t2-db-pg-test-splits-10-schema-files-pg-helpers-sc.md
@@ -1,0 +1,41 @@
+---
+# db-im18
+title: "T2 db pg test splits: 10 schema files + pg-helpers + schema-type-parity"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:12Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+Twelve files in packages/db (pg scope) ≥750 LOC. See spec PR 6.
+
+## Files
+
+- [ ] helpers/pg-helpers.ts (963)
+- [ ] schema-pg-structure.integration.test.ts (1,668)
+- [ ] schema-pg-communication.integration.test.ts (1,573)
+- [ ] schema-pg-custom-fields.integration.test.ts (1,250)
+- [ ] schema-pg-fronting.integration.test.ts (1,163)
+- [ ] schema-pg-privacy.integration.test.ts (1,162)
+- [ ] schema-pg-auth.integration.test.ts (1,016)
+- [ ] schema-pg-import-export.integration.test.ts (1,014)
+- [ ] schema-pg-notifications.integration.test.ts (809)
+- [ ] schema-pg-timers.integration.test.ts (761)
+- [ ] schema-pg-views.integration.test.ts (752)
+- [ ] schema-type-parity.test.ts (909)
+
+## Acceptance
+
+- pnpm vitest run --project db-integration passes
+- Coverage unchanged or higher
+
+## Out of scope
+
+- Schema or migration changes
+- sqlite-side files

--- a/.beans/db-oll6--t2-db-sqlite-test-splits-9-schema-files-sqlite-hel.md
+++ b/.beans/db-oll6--t2-db-sqlite-test-splits-9-schema-files-sqlite-hel.md
@@ -1,0 +1,40 @@
+---
+# db-oll6
+title: "T2 db sqlite test splits: 9 schema files + sqlite-helpers"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:12Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+Ten files in packages/db (sqlite scope) ≥750 LOC. See spec PR 5.
+
+## Files (current LOC → target ≤500)
+
+- [ ] helpers/sqlite-helpers.ts (1,893) — split by responsibility (schema init / fixture factory / transaction helpers)
+- [ ] schema-sqlite-structure.integration.test.ts (1,795)
+- [ ] schema-sqlite-communication.integration.test.ts (1,519)
+- [ ] schema-sqlite-custom-fields.integration.test.ts (1,386)
+- [ ] schema-sqlite-privacy.integration.test.ts (1,335)
+- [ ] schema-sqlite-fronting.integration.test.ts (1,171)
+- [ ] schema-sqlite-auth.integration.test.ts (1,106)
+- [ ] schema-sqlite-notifications.integration.test.ts (914)
+- [ ] schema-sqlite-import-export.integration.test.ts (911)
+- [ ] schema-sqlite-timers.integration.test.ts (859)
+
+## Acceptance
+
+- pnpm vitest run --project db-integration passes
+- Coverage unchanged or higher
+- Every new file ≤500 LOC
+
+## Out of scope
+
+- Schema or migration changes
+- pg-side files (separate bean)

--- a/.beans/mobile-jxox--t2-mobile-test-splits-row-transforms-factories-syn.md
+++ b/.beans/mobile-jxox--t2-mobile-test-splits-row-transforms-factories-syn.md
@@ -1,0 +1,30 @@
+---
+# mobile-jxox
+title: "T2 mobile test splits: row-transforms, factories, SyncProvider, opfs-worker, trpc-persister-api, import.hooks"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:13Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+Six files in apps/mobile.
+
+## Files
+
+- [ ] data/row-transforms.test.ts (2,011)
+- [ ] **tests**/factories.ts (909) helper — split by entity factory family
+- [ ] sync/SyncProvider.test.tsx (993)
+- [ ] platform/drivers/opfs-worker.test.ts (857)
+- [ ] features/import-sp/trpc-persister-api.test.ts (1,213)
+- [ ] features/import-sp/import.hooks.test.tsx (757)
+
+## Acceptance
+
+- pnpm vitest run --project mobile passes
+- Coverage unchanged or higher

--- a/.beans/ps-6phh--plaintextspecial-entity-type-sot-consolidation.md
+++ b/.beans/ps-6phh--plaintextspecial-entity-type-sot-consolidation.md
@@ -1,11 +1,11 @@
 ---
 # ps-6phh
 title: Plaintext/special entity type SoT consolidation
-status: in-progress
+status: completed
 type: epic
 priority: normal
 created_at: 2026-04-25T08:02:48Z
-updated_at: 2026-04-30T00:46:47Z
+updated_at: 2026-04-30T03:39:54Z
 parent: ps-cd6x
 blocked_by:
   - ps-y4tb

--- a/.beans/ps-ga25--split-import-enginetestts-2195-loc-by-phase.md
+++ b/.beans/ps-ga25--split-import-enginetestts-2195-loc-by-phase.md
@@ -3,8 +3,9 @@
 title: Split import-engine.test.ts (2,195 LOC) by phase
 status: todo
 type: task
+priority: normal
 created_at: 2026-04-21T13:57:36Z
-updated_at: 2026-04-21T13:57:36Z
+updated_at: 2026-04-30T05:00:06Z
 parent: ps-36rg
 ---
 
@@ -18,7 +19,7 @@ import-core's engine covers several phases: input parsing, entity ordering (topo
 
 - [ ] Split into import-engine-parsing.test.ts, import-engine-ordering.test.ts, import-engine-checkpoint.test.ts, import-engine-persister.test.ts, import-engine-error-classification.test.ts
 - [ ] Extract shared setup into packages/import-core/src/**tests**/helpers/engine-fixtures.ts
-- [ ] Each resulting file ≤500 LOC
+- [ ] Each resulting file ≤500 LOC (stretch 350)
 - [ ] Every test case preserved
 
 ## Out of scope
@@ -31,3 +32,7 @@ import-core's engine covers several phases: input parsing, entity ordering (topo
 - pnpm vitest run --project import-core passes
 - Coverage unchanged or higher
 - Original file deleted
+
+## DRY pass
+
+While extracting engine fixtures, scan sibling tests in packages/import-core. Don't refactor the engine itself. Per 2026-04-29 re-scope spec.

--- a/.beans/ps-l2el--umbrella-split-remaining-16-test-files-over-1000-l.md
+++ b/.beans/ps-l2el--umbrella-split-remaining-16-test-files-over-1000-l.md
@@ -1,10 +1,11 @@
 ---
 # ps-l2el
 title: "Umbrella: split remaining 16 test files over 1,000 LOC"
-status: todo
+status: scrapped
 type: task
+priority: normal
 created_at: 2026-04-21T13:57:36Z
-updated_at: 2026-04-21T13:57:36Z
+updated_at: 2026-04-30T04:59:58Z
 parent: ps-36rg
 ---
 
@@ -37,3 +38,7 @@ Systematic split of the remaining 16 test files over 1,000 LOC, following the pa
 
 - File ≤600 LOC after split; every test preserved; relevant vitest project passes; coverage unchanged or higher
 - Umbrella bean completed only when all 16 boxes are checked and each underlying PR merged
+
+## Reasons for Scrapping
+
+Replaced by package-batched T2 beans per the 2026-04-29 re-scope spec (docs/superpowers/specs/2026-04-29-test-file-split-epic-design.md). The original 16-file umbrella structure didn't match the new tiered batching strategy. New T2 beans are direct children of ps-36rg, blocked-by the three T1 named-split beans.

--- a/.beans/ps-ro3q--t2-queue-test-split-bullmq-queueintegrationtestts.md
+++ b/.beans/ps-ro3q--t2-queue-test-split-bullmq-queueintegrationtestts.md
@@ -1,0 +1,25 @@
+---
+# ps-ro3q
+title: "T2 queue test split: bullmq-queue.integration.test.ts"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:13Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+One file in packages/queue.
+
+## Files
+
+- [ ] bullmq-queue.integration.test.ts (1,061)
+
+## Acceptance
+
+- pnpm vitest run --project queue-integration passes
+- Coverage unchanged or higher

--- a/.beans/ps-vrac--t2-import-sp-test-split-engineimport-enginetestts.md
+++ b/.beans/ps-vrac--t2-import-sp-test-split-engineimport-enginetestts.md
@@ -1,0 +1,30 @@
+---
+# ps-vrac
+title: "T2 import-sp test split: engine/import-engine.test.ts"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:02:07Z
+updated_at: 2026-04-30T05:02:12Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+One file in packages/import-sp.
+
+## Files
+
+- [ ] engine/import-engine.test.ts (1,150) — split by SP-specific phase (auth, fetch, mapping, persist)
+
+## Acceptance
+
+- pnpm vitest run --project import-sp passes
+- Coverage unchanged or higher
+
+## Out of scope
+
+- import-sp engine changes
+- Live API tests (gated behind SP_TEST_LIVE_API)

--- a/.beans/ps-y4tb--fleet-wide-type-sot-consolidation.md
+++ b/.beans/ps-y4tb--fleet-wide-type-sot-consolidation.md
@@ -1,11 +1,11 @@
 ---
 # ps-y4tb
 title: Encrypted-entity type SoT consolidation
-status: in-progress
+status: completed
 type: epic
 priority: normal
 created_at: 2026-04-25T07:48:01Z
-updated_at: 2026-04-25T09:34:38Z
+updated_at: 2026-04-30T03:40:02Z
 parent: ps-cd6x
 ---
 
@@ -82,3 +82,7 @@ Member → MemberEncryptedFields → MemberEncryptedInput
 11 commits across Class A (18), Class B (10), Class D (2) per plan. Class C (api-key, session, system-snapshot) tracked separately in `ps-qmyt`. Class E (webhook-delivery) tracked in `ps-f3ox`. Plaintext entities tracked in `ps-6phh`.
 
 Worktree to use: `/home/theprismsystem/git/ps-y4tb-fleet` from `origin/main` (post-merge).
+
+## Summary of Changes
+
+Encrypted-entity type SoT consolidation completed across the 34-entity fleet. Member pilot (PR #560) locked in the canonical chain (`X` → `XEncryptedFields` → `XEncryptedInput` → `XServerMetadata` → `XResult` → `XWire`), and all child tasks landed: ps-etbc (fleet rollout), types-yxgc (branded value labels), types-x61u/types-vmk9 (encrypted-keys hardening + brand pinHash + Relationship.label invariant), types-1spw (G4 anchored to data transforms), types-600s (CheckInRecord canonical chain), types-kk7a (JSDoc + ADR-023 cross-references). Class C tracked separately in ps-qmyt (completed); Class E in ps-f3ox (completed); plaintext sibling in ps-6phh (completed).

--- a/.beans/sync-96hx--split-post-merge-validatortestts-2728-loc-by-conce.md
+++ b/.beans/sync-96hx--split-post-merge-validatortestts-2728-loc-by-conce.md
@@ -3,8 +3,9 @@
 title: Split post-merge-validator.test.ts (2,728 LOC) by concern
 status: todo
 type: task
+priority: normal
 created_at: 2026-04-21T13:57:36Z
-updated_at: 2026-04-21T13:57:36Z
+updated_at: 2026-04-30T05:00:04Z
 parent: ps-36rg
 ---
 
@@ -18,7 +19,7 @@ Post-merge-validator.ts itself is ~1,011 LOC covering seven distinct responsibil
 
 - [ ] Split into post-merge-validator-tombstones.test.ts, -hierarchy.test.ts, -sort-order.test.ts, -check-in.test.ts, -friend-connection.test.ts, -fronting-sessions.test.ts, -fronting-comments.test.ts
 - [ ] Extract shared fixture setup into packages/sync/src/**tests**/helpers/validator-fixtures.ts
-- [ ] Each resulting test file ≤600 LOC (stretch 400)
+- [ ] Each resulting test file ≤500 LOC (stretch 350)
 - [ ] Preserve every existing test case — count before and after must match or increase
 
 ## Out of scope
@@ -31,4 +32,8 @@ Post-merge-validator.ts itself is ~1,011 LOC covering seven distinct responsibil
 - pnpm vitest run --project sync passes
 - Coverage for packages/sync unchanged or higher
 - Original post-merge-validator.test.ts deleted
-- Each new file ≤600 LOC
+- Each new file ≤500 LOC (stretch 350)
+
+## DRY pass
+
+While extracting fixtures, scan sibling tests in packages/sync for the same setup duplication and consolidate when clear. Don't refactor production code outside test files. Per 2026-04-29 re-scope spec.

--- a/.beans/sync-vmv4--t2-sync-test-splits-conflict-resolution-schemas-ws.md
+++ b/.beans/sync-vmv4--t2-sync-test-splits-conflict-resolution-schemas-ws.md
@@ -1,0 +1,36 @@
+---
+# sync-vmv4
+title: "T2 sync test splits: conflict-resolution, schemas, ws-client-adapter, document-lifecycle, sync-engine-runtime-hardening"
+status: todo
+type: task
+priority: normal
+created_at: 2026-04-30T05:01:01Z
+updated_at: 2026-04-30T05:02:12Z
+parent: ps-36rg
+blocked_by:
+  - sync-96hx
+  - db-5bu5
+  - ps-ga25
+---
+
+Five test files in packages/sync ≥750 LOC. See spec docs/superpowers/specs/2026-04-29-test-file-split-epic-design.md PR 4. Each split follows Standard Split Workflow.
+
+## Files (current LOC → target ≤500)
+
+- [ ] conflict-resolution.test.ts (1,548)
+- [ ] schemas.test.ts (1,087)
+- [ ] adapters/ws-client-adapter.test.ts (1,043)
+- [ ] document-lifecycle.test.ts (909)
+- [ ] sync-engine-runtime-hardening.test.ts (769)
+
+## Acceptance
+
+- pnpm vitest run --project sync passes
+- pnpm vitest run --project sync --coverage shows coverage unchanged or higher
+- Every new file ≤500 LOC (stretch 350)
+- Original files deleted
+
+## Out of scope
+
+- Refactoring sync engine, conflict resolver, or any production code
+- Files <750 LOC


### PR DESCRIPTION
## Summary

Bean-only changes preparing for execution of the M9a test-file-split epic (`ps-36rg`).

**T1 bean body refresh (sync-96hx, db-5bu5, ps-ga25):**
- Tighten resulting-file ceiling: 600 LOC → 500 LOC (stretch 350)
- Add DRY pass directive (extract repeated patterns to helpers, scope to test files only)

**ps-l2el** umbrella scrapped — replaced by 9 per-package T2 beans matching the 2026-04-29 re-scope (750-LOC threshold, 500-LOC ceiling, helpers in scope, 12 PRs total).

**9 new T2 beans** created, each `blocked-by` all 3 T1 beans:

| ID | Package | Files |
|---|---|---:|
| sync-vmv4 | packages/sync | 5 |
| db-oll6 | packages/db (sqlite) | 10 |
| db-im18 | packages/db (pg) | 12 |
| ps-vrac | packages/import-sp | 1 |
| ps-ro3q | packages/queue | 1 |
| crypto-mdzz | packages/crypto | 1 |
| api-rh0a | apps/api services | 16 |
| api-4cmq | apps/api ws+trpc | 4 |
| mobile-jxox | apps/mobile | 6 |

Also includes deferred completion markers for `ps-y4tb` (encrypted-entity SoT consolidation) and `ps-6phh` (plaintext SoT consolidation), both of which had their code work merged via PRs #560 + fleet rollout and #587 respectively.

## Test plan
- [x] `git status` shows only `.beans/*.md` changes
- [x] `beans query` confirms ps-36rg has 12 active children (3 T1 + 9 T2) plus 1 scrapped
- [x] All 9 T2 beans correctly blocked-by sync-96hx + db-5bu5 + ps-ga25
- [x] No code changes — CI remains green by default