### PR TITLE
chore(beans): close out ps-36rg test-file-split epic

### DIFF
--- a/.beans/db-oll6--t2-db-sqlite-test-splits-9-schema-files-sqlite-hel.md
+++ b/.beans/db-oll6--t2-db-sqlite-test-splits-9-schema-files-sqlite-hel.md
@@ -1,11 +1,11 @@
 ---
 # db-oll6
 title: "T2 db sqlite test splits: 9 schema files + sqlite-helpers"
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-04-30T05:02:07Z
-updated_at: 2026-04-30T05:02:12Z
+updated_at: 2026-04-30T18:53:38Z
 parent: ps-36rg
 blocked_by:
   - sync-96hx
@@ -17,16 +17,16 @@ Ten files in packages/db (sqlite scope) ≥750 LOC. See spec PR 5.
 
 ## Files (current LOC → target ≤500)
 
-- [ ] helpers/sqlite-helpers.ts (1,893) — split by responsibility (schema init / fixture factory / transaction helpers)
-- [ ] schema-sqlite-structure.integration.test.ts (1,795)
-- [ ] schema-sqlite-communication.integration.test.ts (1,519)
-- [ ] schema-sqlite-custom-fields.integration.test.ts (1,386)
-- [ ] schema-sqlite-privacy.integration.test.ts (1,335)
-- [ ] schema-sqlite-fronting.integration.test.ts (1,171)
-- [ ] schema-sqlite-auth.integration.test.ts (1,106)
-- [ ] schema-sqlite-notifications.integration.test.ts (914)
-- [ ] schema-sqlite-import-export.integration.test.ts (911)
-- [ ] schema-sqlite-timers.integration.test.ts (859)
+- [x] helpers/sqlite-helpers.ts (1,893) — split by responsibility
+- [x] schema-sqlite-structure.integration.test.ts (1,795)
+- [x] schema-sqlite-communication.integration.test.ts (1,519)
+- [x] schema-sqlite-custom-fields.integration.test.ts (1,386)
+- [x] schema-sqlite-privacy.integration.test.ts (1,335)
+- [x] schema-sqlite-fronting.integration.test.ts (1,171)
+- [x] schema-sqlite-auth.integration.test.ts (1,106)
+- [x] schema-sqlite-notifications.integration.test.ts (914)
+- [x] schema-sqlite-import-export.integration.test.ts (911)
+- [x] schema-sqlite-timers.integration.test.ts (859)
 
 ## Acceptance
 
@@ -38,3 +38,7 @@ Ten files in packages/db (sqlite scope) ≥750 LOC. See spec PR 5.
 
 - Schema or migration changes
 - pg-side files (separate bean)
+
+## Summary of Changes
+
+Merged via PR #593. All 10 originally-oversized SQLite integration test files (and the sqlite-helpers.ts helper) split into smaller files (each ≤500 LOC). All db-integration tests pass.

--- a/.beans/ps-36rg--test-file-splits.md
+++ b/.beans/ps-36rg--test-file-splits.md
@@ -1,10 +1,11 @@
 ---
 # ps-36rg
 title: Test file splits
-status: in-progress
+status: completed
 type: epic
+priority: normal
 created_at: 2026-04-21T13:54:37Z
-updated_at: 2026-04-21T13:54:37Z
+updated_at: 2026-04-30T18:54:00Z
 parent: ps-cd6x
 ---
 
@@ -32,3 +33,30 @@ One child task covering the remaining 16 files >1,000 LOC with an internal check
 ## Spec reference
 
 docs/superpowers/specs/2026-04-21-m9a-closeout-hardening-design.md
+
+## Summary of Changes
+
+Epic completed across 12 child PRs (#588 bean restructuring + #589-600 splits) on 2026-04-30.
+
+### PRs merged
+
+- **Tier 1 (named-pattern, serial):** #589 sync-96hx (post-merge-validator), #590 db-5bu5 (rls-policies), #591 ps-ga25 (import-engine)
+- **Tier 2 Wave A:** #592 mobile-jxox, #593 db-oll6 (sqlite), #594 api-rh0a (services)
+- **Tier 2 Wave B:** #595 sync-vmv4, #596 api-4cmq (ws/trpc), #597 db-im18 (pg)
+- **Tier 2 Wave C:** #598 ps-vrac (import-sp), #599 ps-ro3q (queue), #600 crypto-mdzz (crypto)
+
+### Audit at completion
+
+- Zero `.test.ts`/`.test.tsx`/`.bench.ts` files ≥750 LOC remain in any `__tests__/` directory across the monorepo
+- All resulting files from the splits are ≤500 LOC (most under 350)
+- All test-only helper files are ≤500 LOC
+- Files originally between 500-749 LOC were below the epic's 750 threshold and remain unchanged (intentional out-of-scope per spec)
+- All packages' tests pass on green CI through merge of each PR
+
+### DRY consolidations across the epic
+
+Each PR extracted shared fixtures/setup into per-domain helpers — helper files include validator-fixtures, rls-test-helpers, engine-fixtures, conflict-resolution-fixtures, schema-fixtures, ws-client-adapter-fixtures, runtime-hardening-fixtures, schema-parity-fixtures, ws-handlers-fixtures, message-router-fixtures, structure-fixtures, bullmq-test-fixtures, key-lifecycle-fixtures, and others. These collapsed repeated boilerplate (sodium init, mock factories, harnesses, RLS context setup) across sibling tests.
+
+### Notable infra change
+
+PR #599 (queue) added `fileParallelism: false` for the `queue-integration` vitest project to preserve single-process semantics after the split — documented via a `SHARED_INFRA_INTEGRATION_PROJECTS` set in vitest.config.ts.


### PR DESCRIPTION
## Summary
- Mark `db-oll6` (Wave A db-sqlite) completed — missed during earlier merge cycle, now reflects merged PR #593 status
- Mark `ps-36rg` epic completed with full summary covering all 12 merged PRs, audit results, and DRY consolidations
- All 12 PRs (#588 bean restructure + #589-#600 splits) are already on main; this PR only updates bean status files

## Audit at completion
- Zero `*.test.ts` / `*.test.tsx` / `*.bench.ts` files ≥750 LOC remain in any `__tests__/` directory across the monorepo
- All resulting files from the splits are ≤500 LOC (most under 350)
- All test-only helper files are ≤500 LOC
- Files originally between 500-749 LOC were below the epic's 750 threshold and remain unchanged (intentional out-of-scope per spec)

## Test plan
- [x] No code changes — beans-only update