### PR TITLE
docs(design-system): refresh package docs and expand planned a11y gates

### DIFF
--- a/.beans/ps-2r3p--refresh-design-system-package-docs.md
+++ b/.beans/ps-2r3p--refresh-design-system-package-docs.md
@@ -1,0 +1,39 @@
+---
+# ps-2r3p
+title: Refresh design-system package docs
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-10T19:25:05Z
+updated_at: 2026-05-10T19:31:49Z
+---
+
+Update design-system docs to reflect current state and add upcoming a11y CI gates.
+
+## Scope
+
+- README.md: align theme list with actual ThemeMode (default, static, reduced-motion, high-contrast, littles)
+- tokens/README.md: complete file listing (breakpoints/gradients/illustration/pairings.json, build.mjs); refresh mode table to current names; correct build command
+- docs/GOVERNANCE.md: small accuracy pass
+- docs/cross-platform-parity.md: drop dead SKILL.md reference; point to GOVERNANCE.md §2; clarify font stack
+- docs/A11Y_GATES.md: add planned gates (heading order, label association, focus trap, Esc-closes-overlays, lang attribute, image alts, duration ceilings per mode, autocomplete, error-message association, Reduced-motion coverage as its own row)
+
+## Todo
+
+- [x] README.md aligned with src/index.ts and ThemeMode
+- [x] tokens/README.md layout matches tokens/ directory; mode table current
+- [x] GOVERNANCE.md verified for accuracy and tone
+- [x] cross-platform-parity.md verified for accuracy and tone
+- [x] A11Y_GATES.md expanded with planned gates
+
+## Summary of Changes
+
+**README.md** — public API list expanded to include every export; theme list aligned with the actual `ThemeMode` (5 modes — `default`, `static`, `reduced-motion`, `high-contrast`, `littles`). Tooling table added.
+
+**tokens/README.md** — layout block now lists every file (`breakpoints`, `gradients`, `illustration`, `pairings`, `build.mjs` were missing). Mode table now uses the current names; the `low-sensory` row is replaced by separate `static` and `reduced-motion` rows. Build command corrected to `pnpm tokens:build`. Notes both production and preview outputs.
+
+**docs/GOVERNANCE.md** — small accuracy pass on §2: clarified that the package ships RN atoms plus HTML previews, not just HTML.
+
+**docs/cross-platform-parity.md** — dropped the dead `SKILL.md` reference and pointed at `docs/GOVERNANCE.md` §2 instead. Type-ramp row corrected: package ships DM Sans Variable as the canonical face, with a fallback chain. Reduced-motion / high-contrast OS mappings spelled out per platform; explicit note that OS reduced-motion preference maps to `reduced-motion`, not `static`.
+
+**docs/A11Y_GATES.md** — section A reorganized into five subsections (lint, token/contrast, component contract, motion/mode, render/document). New planned gates: per-mode contrast, touch-target spacing (2.5.8), focus trap, Esc-closes-overlays, form-label association, error-message association, autocomplete attribute (1.3.5), duration ceiling per mode, no-motion-only-signal, live-region etiquette, heading order (1.3.1), image alt-text, lang attribute, skip-to-content link, Lighthouse a11y score. Manual section gained a color-blindness simulation row.

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -1,6 +1,6 @@
 # @pluralscape/design-system
 
-The Inner Horizons design system: typed tokens, RN atoms, brand assets, and binding specs that govern Pluralscape's mobile, web, and marketing surfaces.
+The Inner Horizons design system: typed tokens, RN atoms, brand assets, and the binding specs that govern Pluralscape's mobile, web, and marketing surfaces.
 
 ## Public API
 
@@ -12,31 +12,62 @@ import {
   themes,
   type Theme,
   type ThemeMode,
-  Button,
-  IconButton,
-  Badge,
+  type ThemeProviderProps,
   Avatar,
-  Input,
-  Switch,
+  type AvatarProps,
+  Badge,
+  type BadgeProps,
+  Button,
+  type ButtonProps,
   Icon,
+  type IconName,
+  type IconProps,
+  IconButton,
+  type IconButtonProps,
+  Input,
+  type InputProps,
   PluralscapeLogo,
+  type PluralscapeLogoProps,
+  Switch,
+  type SwitchProps,
 } from "@pluralscape/design-system";
 ```
 
-Atoms read tokens via `useTheme()`. Components never branch on mode — they read resolved tokens.
+Atoms read tokens via `useTheme()`. Components never branch on mode — they read the resolved tokens for the active theme and render.
 
 ## Source of truth
 
-- **Tokens:** `tokens/*.json`. Edit JSON, then run `pnpm tokens:build` to regenerate `src/tokens.generated.ts` and `src/themes.generated.ts`.
-- **Atom visual fidelity:** `docs/design-system/preview/components-*.html` (gitignored — request the bundle if missing).
-- **Governance / cross-platform parity / accessibility:** `packages/design-system/docs/`.
+- **Tokens:** `tokens/*.json`. Edit JSON, then run `pnpm tokens:build` to regenerate `src/tokens.generated.ts` and `src/themes.generated.ts`. Both generated files are committed.
+- **Atom visual fidelity:** `docs/design-system/preview/components-*.html` (gitignored bundle — request it if missing).
+- **Governance, cross-platform parity, accessibility:** `packages/design-system/docs/`.
 
 ## Themes
 
-Four fully-merged themes ship: `default`, `low-sensory`, `high-contrast`, `littles`. `ThemeProvider` accepts `mode` + `onModeChange` props (persistence is the consumer's responsibility — wired in M10).
+Five fully-merged themes ship today:
+
+| Mode             | Purpose                                                    |
+| ---------------- | ---------------------------------------------------------- |
+| `default`        | Inner Horizons aesthetic — gradients, ambient motion, glow |
+| `static`         | Strictest sensory accommodation — flat fills, motion off   |
+| `reduced-motion` | Vestibular accommodation — visuals untouched, motion ≤50ms |
+| `high-contrast`  | Brighter text, stronger borders, no surface tint           |
+| `littles`        | Littles Safe Mode — softer accent, larger targets          |
+
+`ThemeProvider` accepts `mode` and `onModeChange` props. Persistence is the consumer's job — wired in M10. The full mode contracts live in `docs/GOVERNANCE.md` §3.
 
 ## Package boundaries
 
-- ≤150 LOC per atom (ESLint enforced).
-- No inline color, spacing, radius, motion, or elevation literals — all flow through `useTheme()`.
+- ≤150 LOC per atom (ESLint enforced via the `loc-ceilings` rule).
+- No inline color, spacing, radius, motion, or elevation literals — every semantic value flows through `useTheme()`.
 - Atoms compose tokens; tokens never reach into atoms.
+
+## Tooling
+
+| Script                                                  | Purpose                                                          |
+| ------------------------------------------------------- | ---------------------------------------------------------------- |
+| `pnpm --filter @pluralscape/design-system tokens:build` | Regenerate `src/tokens.generated.ts` + `src/themes.generated.ts` |
+| `pnpm --filter @pluralscape/design-system tokens:check` | Validate tokens (forbidden-pair check) without writing outputs   |
+| `pnpm --filter @pluralscape/design-system typecheck`    | TypeScript type-check                                            |
+| `pnpm --filter @pluralscape/design-system lint`         | ESLint (zero warnings enforced)                                  |
+
+Tests run from the repo root: `pnpm vitest run --project design-system`.

--- a/packages/design-system/docs/A11Y_GATES.md
+++ b/packages/design-system/docs/A11Y_GATES.md
@@ -1,27 +1,68 @@
-# Mobile accessibility test gates — proposed
+# Mobile and web accessibility gates — proposed
 
 > **Status: design-system spec, not yet wired to CI.**
-> This file specifies the gates that should run before any Pluralscape surface ships to users. The gates below are **planned** — they live as a contract between design and engineering. None of them currently execute in CI on this kit (the kit is HTML-only). When the production monorepo adopts this system, the engineering team owns moving each row from "planned" to "running" and updating the status column.
+> This file specifies the gates that should run before any Pluralscape surface ships to users. The gates below are **planned** — they live as a contract between design and engineering. None of them currently execute in CI on this kit; the production monorepo owns moving each row from "planned" to "running" and updating the status column.
 
 The intent: nothing merges to `main` without section A passing; nothing ships to the App Store / Play Store without section B logged in the release record.
 
-The gates exist because the PDF audit (Apr 2026) flagged that our docs claimed full WCAG 2.2 AA conformance while several primitives lacked accessible names, focus styles, or dialog semantics. These gates make the claim falsifiable when implemented.
+The gates exist because the Apr 2026 audit flagged that earlier docs claimed full WCAG 2.2 AA conformance while several primitives lacked accessible names, focus styles, or dialog semantics. These gates make the claim falsifiable when implemented.
 
 ---
 
 ## A. Automated — to wire into CI
 
-| Gate                         | Tool                                                                                                                                                                                                 | Where                   | Status  | Failing means |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------- | ------------- |
-| **Web a11y lint**            | [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) `recommended` ruleset, no rule allowed below `error`                                                                | `apps/web/.eslintrc`    | planned | block PR      |
-| **RN a11y lint**             | [`eslint-plugin-react-native-a11y`](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y) `all` ruleset                                                                                 | `apps/mobile/.eslintrc` | planned | block PR      |
-| **Token contrast**           | `tests/tokens/contrast.test.ts` — iterates `tokens/pairings.json` (C2). Each `allowed` pair must clear its declared min; no `forbidden` pair may resolve as fg+bg in any `semantic.<mode>` mapping.  | `tokens/` package CI    | planned | block PR      |
-| **Hit-area floor**           | `tests/components/hit-area.test.tsx` — renders every primitive in default mode, asserts bounding box ≥ 44×44                                                                                         | components package      | planned | block PR      |
-| **Mode coverage**            | `tests/tokens/mode-coverage.test.ts` — every override key in `tokens/colors.json` modes must reference an existing default token; every primitive must render under all three modes without crashing | tokens + components     | planned | block PR      |
-| **axe-core in render tests** | [`jest-axe`](https://github.com/nickcolley/jest-axe) on every screen/component test, no violations allowed                                                                                           | components + screens    | planned | block PR      |
-| **Focus-visible coverage**   | `tests/components/focus-visible.test.tsx` — every interactive primitive shows `box-shadow` matching `--focus-ring` when focused via keyboard                                                         | components              | planned | block PR      |
+The gates split into five categories. Each row gets its own test or lint rule; gates without a concrete test obligation belong in section C, not here.
 
-### Forbidden-pair tests (C2)
+### A.1 Lint gates
+
+| Gate                    | Tool                                                                                                                                                                                 | Where                   | Status  | Failing means |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------- | ------------- |
+| **Web a11y lint**       | [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) `recommended` ruleset, no rule allowed below `error`                                                | `apps/web/.eslintrc`    | planned | block PR      |
+| **RN a11y lint**        | [`eslint-plugin-react-native-a11y`](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y) `all` ruleset                                                                 | `apps/mobile/.eslintrc` | planned | block PR      |
+| **Inline-literal lint** | Custom rule extending `pluralscape/no-design-token-literals` to interactive props (`accessibilityLabel`, `aria-label`) — values must come from `i18n` keys, never hard-coded strings | `tooling/eslint-config` | planned | block PR      |
+
+### A.2 Token and contrast gates
+
+| Gate                             | Tool                                                                                                                                                                                           | Where                       | Status  | Failing means |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ------- | ------------- |
+| **Token contrast (default)**     | `tests/tokens/contrast.test.ts` — iterates `tokens/pairings.json`. Every `allowed` pair must clear its declared min; no `forbidden` pair may resolve as fg+bg in any `semantic.<mode>` mapping | `packages/design-system` CI | planned | block PR      |
+| **Token contrast (per mode)**    | `tests/tokens/contrast-modes.test.ts` — re-runs the contrast iteration for every active theme (`static`, `reduced-motion`, `high-contrast`, `littles`); high-contrast text must clear ≥7:1     | `packages/design-system` CI | planned | block PR      |
+| **Mode coverage**                | `tests/tokens/mode-coverage.test.ts` — every override key in `tokens/*.json` modes blocks must reference a default token; every primitive must render under all five modes without crashing    | tokens + components         | planned | block PR      |
+| **Forbidden-pair short-circuit** | The `tokens/build.mjs` script runs the pairings validator before emitting any output, so a forbidden pair never reaches a generated artifact even if Vitest hasn't run                         | `pnpm tokens:build`         | live    | block build   |
+
+### A.3 Component contract gates
+
+| Gate                          | Tool                                                                                                                                                                                            | Where              | Status  | Failing means |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | ------------- |
+| **Hit-area floor**            | `tests/components/hit-area.test.tsx` — renders every primitive in default mode, asserts bounding box ≥ 44×44; in `littles` mode asserts ≥56×56                                                  | components package | planned | block PR      |
+| **Touch-target spacing**      | `tests/components/touch-target-spacing.test.tsx` — adjacent interactive primitives must have ≥10px clear space per WCAG 2.5.8                                                                   | components package | planned | block PR      |
+| **Focus-visible coverage**    | `tests/components/focus-visible.test.tsx` — every interactive primitive shows a `box-shadow` or RN `accessibilityState` change matching `--focus-ring` when focused via keyboard                | components         | planned | block PR      |
+| **Focus trap (overlays)**     | `tests/components/focus-trap.test.tsx` — `Dialog`, `BottomSheet`, `Popover` keep focus inside the surface; `Tab` / `Shift-Tab` cycle the surface's focusable elements only                      | components         | planned | block PR      |
+| **Esc closes overlays**       | `tests/components/escape-closes.test.tsx` — every overlay primitive responds to `Escape` (web) and the OS back gesture (mobile) by closing                                                      | components         | planned | block PR      |
+| **Form-label association**    | `tests/components/labels.test.tsx` — every `Input`, `TextArea`, `Select`, `Checkbox`, `Radio`, `Switch` exposes an accessible name via `<label htmlFor>`, `aria-label`, or `accessibilityLabel` | components         | planned | block PR      |
+| **Error-message association** | `tests/components/error-association.test.tsx` — input components render `aria-describedby` (web) / `accessibilityHint` (RN) pointing at the error text whenever the `error` prop is set         | components         | planned | block PR      |
+| **Autocomplete attribute**    | `tests/components/autocomplete.test.tsx` — every `Input` whose semantics map to a known `autocomplete` token (email, current-password, given-name, etc.) sets it; per WCAG 1.3.5                | components         | planned | block PR      |
+
+### A.4 Motion and mode contracts
+
+| Gate                          | Tool                                                                                                                                                                                                              | Where               | Status  | Failing means |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------- | ------------- |
+| **Duration ceiling per mode** | `tests/tokens/duration-ceiling.test.ts` — for every animated primitive, the resolved duration is ≤400ms in `default`, ≤50ms in `reduced-motion`, 0ms in `static`                                                  | tokens + components | planned | block PR      |
+| **No motion-only signal**     | `tests/components/motion-signal.test.tsx` — primitives that animate state changes (`Switch`, `Toast`, `Progress`) also expose the change via text or `aria-live`; verified by snapshotting the static-mode render | components          | planned | block PR      |
+| **Live-region etiquette**     | `tests/components/live-regions.test.tsx` — `aria-live="assertive"` (web) / `LiveRegion` priority `high` (RN) used only on `danger`/`critical` tone surfaces; `polite` is the default                              | components          | planned | block PR      |
+
+### A.5 Render and document gates
+
+| Gate                         | Tool                                                                                                                                                                                       | Where                  | Status  | Failing means           |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------- | ------- | ----------------------- |
+| **axe-core in render tests** | [`jest-axe`](https://github.com/nickcolley/jest-axe) on every screen and component render test, no violations allowed                                                                      | components + screens   | planned | block PR                |
+| **Heading order**            | `tests/screens/heading-order.test.tsx` — every screen's rendered DOM has a single `<h1>` and no skipped heading levels per WCAG 1.3.1                                                      | screens                | planned | block PR                |
+| **Image alt-text**           | `tests/components/image-alt.test.tsx` — every `<img>` / RN `Image` has either an `alt` / `accessibilityLabel` or is explicitly marked decorative (`alt=""`, `accessibilityElementsHidden`) | components + screens   | planned | block PR                |
+| **Lang attribute**           | `tests/screens/lang.test.tsx` — every web screen renders `<html lang="…">` matching the active i18n locale                                                                                 | apps/web               | planned | block PR                |
+| **Skip-to-content**          | `tests/screens/skip-link.test.tsx` — every web screen exposes a focusable "Skip to content" link as the first tab stop                                                                     | apps/web               | planned | block PR                |
+| **Lighthouse a11y score**    | CI Lighthouse run against the marketing site and primary product screens; a11y score ≥95 required                                                                                          | CI nightly + PR labels | planned | warn PR / block release |
+
+### Forbidden-pair tests
 
 The test iterates the explicit `pairings.json` registry rather than guessing
 implied pairings from the shape of `semantic.default`. Every `allowed` pair
@@ -54,9 +95,8 @@ test.each(pairings.forbidden)("forbidden: $id never resolves in any semantic mod
 });
 ```
 
-The `tokens/build.mjs` script runs this same validation as a CI gate before
-emitting any platform output, so a forbidden pair never reaches the CSS/JS
-artifacts even if jest hasn't run yet.
+The same validation runs as a build-time gate in `tokens/build.mjs` so a
+forbidden pair never reaches the generated CSS/JS even if Vitest hasn't run.
 
 ### Contrast helper signature
 
@@ -71,14 +111,15 @@ export function passesAAA(fg: string, bg: string, large?: boolean): boolean;
 
 ## B. Manual — to run each release candidate
 
-These are **not** automatable; they require devices and humans. **None have been run yet against this kit** — the kit ships HTML previews, not a built mobile app. Log results in the release record (`releases/<version>/a11y.md`) with date, tester, and tool versions when the production app exists.
+These are **not** automatable; they require devices and humans. **None have been run yet against this kit** — there is no built mobile app to test against. Log results in the release record (`releases/<version>/a11y.md`) with date, tester, and tool versions when the production app exists.
 
-- [ ] **VoiceOver iOS** — entire app traversable; every screen reaches Sign Out without losing focus. Form fields announce label + value + state.
+- [ ] **VoiceOver iOS** — every screen traversable; every screen reaches Sign Out without losing focus. Form fields announce label + value + state.
 - [ ] **TalkBack Android** — same coverage as iOS. Custom views announce role.
-- [ ] **External keyboard / Switch Control** — every action reachable in ≤ 6 swipes from the home screen. No keyboard traps. `Esc` closes every dialog.
+- [ ] **External keyboard / Switch Control** — every action reachable in ≤6 swipes from the home screen. No keyboard traps. `Esc` closes every dialog.
 - [ ] **Dynamic Type / Font Scaling at 200%** — no text clipped, no overlapping containers. The Today, Members, Chat, and Settings tabs are the canonical screens to verify.
-- [ ] **Reduced Motion** — verify both `<html data-mode="reduced-motion">` (visuals untouched, durations clamped to 50ms) and `<html data-mode="static">` (visuals flatten, durations clamp to 0). Either mode applied via OS `prefers-reduced-motion` should match the CSS-driven version.
-- [ ] **Low-vision contrast review** — set `<html data-mode="high-contrast">` and verify every interactive border is distinguishable from its surface at arm's length.
+- [ ] **Reduced Motion** — verify both `data-mode="reduced-motion"` (visuals untouched, durations clamped to 50ms) and `data-mode="static"` (visuals flatten, durations clamp to 0). OS `prefers-reduced-motion` should map to `reduced-motion`, not `static`.
+- [ ] **Low-vision contrast review** — set `data-mode="high-contrast"` and verify every interactive border is distinguishable from its surface at arm's length.
+- [ ] **Color-blindness simulation** — run the marketing site and primary product screens through deuteranopia, protanopia, and tritanopia simulators. No interactive element should depend on hue alone for state.
 - [ ] **Panic / dissociation walkthrough** — a tester unfamiliar with the app should be able to: (a) change who's fronting, (b) send a chat message, (c) sign out — using only first-pass guesses, in under 60 seconds total. This proxies low-capacity users.
 - [ ] **Offline path** — turn on airplane mode, exercise every data-modifying screen. Every action shows a `SyncState` badge and survives the app being relaunched.
 
@@ -91,6 +132,7 @@ These need separate processes; flag them in design review:
 - **Cognitive load** — there is no automated test for "is this copy gentle enough." Voice review is part of design crit.
 - **Cultural fit of terminology** — community language drift is monitored in the `terminology.json` change log, not in CI.
 - **Trauma-informed flow design** — destructive-action confirmation, account deletion, and crisis-mode flows go through a community advisory review before release.
+- **Reading level** — automated readability scoring is unreliable for the voice the docs target. Crit is the gate.
 
 ---
 

--- a/packages/design-system/docs/A11Y_GATES.md
+++ b/packages/design-system/docs/A11Y_GATES.md
@@ -15,10 +15,10 @@ The gates split into five categories. Each row gets its own test or lint rule; g
 
 ### A.1 Lint gates
 
-| Gate                    | Tool                                                                                                                                                                                 | Where                   | Status  | Failing means |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------- | ------------- |
-| **Web a11y lint**       | [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) `recommended` ruleset, no rule allowed below `error`                                                | `apps/web/.eslintrc`    | planned | block PR      |
-| **RN a11y lint**        | [`eslint-plugin-react-native-a11y`](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y) `all` ruleset                                                                 | `apps/mobile/.eslintrc` | planned | block PR      |
+| Gate                    | Tool                                                                                                                                                                              | Where                   | Status  | Failing means |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------- | ------------- |
+| **Web a11y lint**       | [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) `recommended` ruleset, no rule allowed below `error`                                             | `apps/web/.eslintrc`    | planned | block PR      |
+| **RN a11y lint**        | [`eslint-plugin-react-native-a11y`](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y) `all` ruleset                                                              | `apps/mobile/.eslintrc` | planned | block PR      |
 | **Inline-literal lint** | New custom rule under the `pluralscape/*` namespace covering interactive props (`accessibilityLabel`, `aria-label`) — values must come from `i18n` keys, never hard-coded strings | `tooling/eslint-config` | planned | block PR      |
 
 ### A.2 Token and contrast gates

--- a/packages/design-system/docs/A11Y_GATES.md
+++ b/packages/design-system/docs/A11Y_GATES.md
@@ -19,7 +19,7 @@ The gates split into five categories. Each row gets its own test or lint rule; g
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | ------- | ------------- |
 | **Web a11y lint**       | [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) `recommended` ruleset, no rule allowed below `error`                                                | `apps/web/.eslintrc`    | planned | block PR      |
 | **RN a11y lint**        | [`eslint-plugin-react-native-a11y`](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y) `all` ruleset                                                                 | `apps/mobile/.eslintrc` | planned | block PR      |
-| **Inline-literal lint** | Custom rule extending `pluralscape/no-design-token-literals` to interactive props (`accessibilityLabel`, `aria-label`) — values must come from `i18n` keys, never hard-coded strings | `tooling/eslint-config` | planned | block PR      |
+| **Inline-literal lint** | New custom rule under the `pluralscape/*` namespace covering interactive props (`accessibilityLabel`, `aria-label`) — values must come from `i18n` keys, never hard-coded strings | `tooling/eslint-config` | planned | block PR      |
 
 ### A.2 Token and contrast gates
 

--- a/packages/design-system/docs/GOVERNANCE.md
+++ b/packages/design-system/docs/GOVERNANCE.md
@@ -37,17 +37,17 @@ Every component, pattern, token, mode and accessibility claim in this kit carrie
 
 ## 2. Accessibility — what the system actually claims
 
-**WCAG 2.2 AA is the target baseline.** That is the only conformance claim this kit makes. Stronger phrasings ("fully meets," "every criterion verified," "zero failures," "every component is accessible") are not used because the kit ships HTML previews — not a built application against which an audit can run.
+**WCAG 2.2 AA is the target baseline.** That is the only conformance claim the design system makes. Stronger phrasings ("fully meets," "every criterion verified," "zero failures," "every component is accessible") are not used because the production Pluralscape app is not yet built. The package ships RN atoms and HTML previews; an end-to-end audit needs a running app, screens, and the full navigation surface.
 
 What canonical components must include:
 
 - An **accessible name** for every interactive element.
 - A **visible focus state** that meets 1.4.11 (3:1 against adjacent colors) and 2.4.13 (≥2px perimeter, encloses the element).
-- **Sufficient text contrast** (4.5:1 normal text, 3:1 large + non-text).
-- A **clear touch target** (≥24×24 visual with ≥10px spacing per 2.5.8 AA; ≥44×44 hit area for primary actions per 2.5.5 AAA).
-- **Color is never the only signal** — pair with icon, label, shape, or position.
+- **Sufficient text contrast** (4.5:1 normal text, 3:1 large and non-text).
+- A **clear touch target** — ≥24×24 visual with ≥10px spacing per 2.5.8 AA, ≥44×44 hit area for primary actions per 2.5.5 AAA.
+- **Color is never the only signal** — pair it with an icon, label, shape, or position.
 
-Known accessibility risks (as of last audit, Apr 2026) are documented in `preview/accessibility.html` under "Known risks" and should be reviewed before any production adoption of this kit. The CI gates in `packages/design-system/docs/A11Y_GATES.md` are the mechanism by which "designed in" becomes "verified" — they are exploratory until a production app wires them up.
+Known accessibility risks (as of last audit, Apr 2026) are documented in `preview/accessibility.html` under "Known risks" and must be reviewed before any production adoption. The planned CI gates in `packages/design-system/docs/A11Y_GATES.md` are the mechanism by which "designed in" becomes "verified" — they are exploratory until a production app wires them up.
 
 ### Phrasing rules
 

--- a/packages/design-system/docs/cross-platform-parity.md
+++ b/packages/design-system/docs/cross-platform-parity.md
@@ -1,12 +1,12 @@
 # Cross-platform parity — design contract
 
-Pluralscape ships on **iOS**, **Android**, and **web** from one design system. This document is the **design-level contract** that says what stays the same across platforms and what is allowed to differ. Engineering pipeline details (build, framework, API references) live in the monorepo; this file is for the design decisions that govern parity.
+Pluralscape ships on **iOS**, **Android**, and **web** from one design system. This document is the **design-level contract** that says what stays the same across platforms and what is allowed to differ. Engineering pipeline details — build, framework, API references — live in the monorepo; this file is for the design decisions that govern parity.
 
 ## Core principle
 
 **Identical mental model. Native execution.**
 
-A user who learns the app on iPhone and then signs in on the web should never have to relearn where things are or what they mean. On each platform, the design uses the right primitive for that platform — sheets are sheets on iOS, bottom sheets on Android, modals on the web; system controls (date pickers, file pickers, share sheets) are always native.
+A user who learns the app on iPhone and then signs in on the web should never have to relearn where things are or what they mean. On each platform, the design uses the right primitive for that platform — sheets are sheets on iOS, bottom sheets on Android, modals on the web. System controls (date pickers, file pickers, share sheets) are always native.
 
 ---
 
@@ -27,7 +27,7 @@ These are the parity rules a design must hold to. They are **canonical for the c
 
 ## What SHOULD differ — platform-native presentation
 
-These are presentation differences the design intentionally allows so each platform feels native. Implementation specifics (which framework, which API) are documented separately in the monorepo; this table lists only the design-level differences.
+These are presentation differences the design intentionally allows so each platform feels native. Implementation specifics — which framework, which API — are documented separately in the monorepo; this table lists only the design-level differences.
 
 | Concern             | iOS                                               | Android                                         | Web                                                                                          |
 | ------------------- | ------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
@@ -37,23 +37,27 @@ These are presentation differences the design intentionally allows so each platf
 | Date / time picker  | iOS native picker                                 | Material date picker                            | Native `<input type="date">`                                                                 |
 | File picker / share | UIDocumentPicker, ShareLink                       | SAF, Android share intent                       | `<input type="file">`, Web Share API where available                                         |
 | Haptics             | Subtle confirmation on switch / save              | Subtle confirmation on switch / save            | None (no equivalent — fall back to subtle motion if `prefers-reduced-motion: no-preference`) |
-| Type ramp           | SF / SF Pro Display                               | Roboto Flex / system                            | Inter (web), system fallback                                                                 |
+| Type ramp           | DM Sans (system fallback: SF Pro)                 | DM Sans (system fallback: Roboto)               | DM Sans (system fallback: Inter / system)                                                    |
 | Scroll bounce       | iOS rubber-band                                   | Android over-scroll glow                        | Browser default                                                                              |
+
+**Type ramp note:** the package ships DM Sans Variable as the canonical product face (see `assets/fonts/`). The fallback chain in `tokens/typography.json` is `'DM Sans', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` so an unloaded font on any platform degrades gracefully.
 
 ---
 
 ## Accessibility parity contract
 
-Every primitive in `SKILL.md`'s acceptance-criteria table must be true on **all three** platforms before that primitive is considered shipped. Specifically:
+Every primitive in the **canonical accessibility checklist** (see `docs/GOVERNANCE.md` §2 — accessible name, visible focus, sufficient contrast, clear touch target, color-never-only) must be true on **all three** platforms before that primitive is considered shipped. Specifically:
 
-| Requirement               | iOS                                                                      | Android                                      | Web                                    |
-| ------------------------- | ------------------------------------------------------------------------ | -------------------------------------------- | -------------------------------------- |
-| Hit area ≥ 44×44 pt       | Yes                                                                      | Yes (≥48dp)                                  | Yes (≥44px)                            |
-| Focus-visible indicator   | VoiceOver focus ring                                                     | TalkBack focus ring + visible focus          | Custom 2px focus ring (`--focus-ring`) |
-| Screen reader label       | `accessibilityLabel`                                                     | `contentDescription`                         | `aria-label` / labeled control         |
-| Live region announcements | `UIAccessibility.post`                                                   | `announceForAccessibility`                   | `aria-live` / `role="status"`          |
-| Reduced motion respected  | `UIAccessibility.isReduceMotionEnabled`                                  | `Settings.Global.TRANSITION_ANIMATION_SCALE` | `prefers-reduced-motion`               |
-| High-contrast mode        | iOS Increase Contrast → switch to `data-mode="high-contrast"` equivalent | Android High contrast text                   | `[data-mode="high-contrast"]`          |
+| Requirement               | iOS                                                                    | Android                                                                     | Web                                                     |
+| ------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Hit area ≥ 44×44 pt       | Yes                                                                    | Yes (≥48dp)                                                                 | Yes (≥44px)                                             |
+| Focus-visible indicator   | VoiceOver focus ring                                                   | TalkBack focus ring + visible focus                                         | Custom 2px focus ring (`--focus-ring`)                  |
+| Screen reader label       | `accessibilityLabel`                                                   | `contentDescription`                                                        | `aria-label` / labeled control                          |
+| Live region announcements | `UIAccessibility.post`                                                 | `announceForAccessibility`                                                  | `aria-live` / `role="status"`                           |
+| Reduced motion respected  | `UIAccessibility.isReduceMotionEnabled` → `data-mode="reduced-motion"` | `Settings.Global.TRANSITION_ANIMATION_SCALE` → `data-mode="reduced-motion"` | `prefers-reduced-motion` → `data-mode="reduced-motion"` |
+| High-contrast mode        | iOS Increase Contrast → switch to `data-mode="high-contrast"`          | Android High contrast text → `data-mode="high-contrast"`                    | `prefers-contrast: more` → `data-mode="high-contrast"`  |
+
+OS reduced-motion preferences map to the **`reduced-motion`** mode, not to `static`. `static` is the broader sensory-load accommodation and only activates when the user opts in explicitly. The two-mode split is canonical (`docs/GOVERNANCE.md` §3.1, §3.1b); platform-level mapping must not collapse them.
 
 ---
 
@@ -63,8 +67,8 @@ For design-system purposes, the rules above are sufficient. Concrete implementat
 
 ## What's NOT covered yet
 
-- Watch / wearable surfaces (deferred — not part of the v1 plan).
-- Tablet split-view layout rules beyond "treat as web ≥768px" (needs design pass).
-- Offline conflict resolution UX on small screens — `ImportConflictResolver` is a desktop-density layout; mobile variant is open work.
+- Watch and wearable surfaces (deferred — not part of the v1 plan).
+- Tablet split-view layout rules beyond "treat as web ≥768px" (needs a design pass).
+- Offline conflict resolution UX on small screens — `ImportConflictResolver` is a desktop-density layout; the mobile variant is open work.
 
 This document is meant to be edited as the platforms reveal disagreements. When you find one, update the table — don't paper it over.

--- a/packages/design-system/tokens/README.md
+++ b/packages/design-system/tokens/README.md
@@ -1,51 +1,60 @@
 # Pluralscape design tokens
 
-This folder is the **single source of truth** for Pluralscape design tokens. The PDF audit called out token drift across `colors_and_type.css`, the preview HTML, `theme.js`, inline JSX, and the per-package CSS — this directory replaces the "edit it everywhere" workflow.
+This folder is the **single source of truth** for Pluralscape design tokens. The Apr 2026 audit flagged token drift across `colors_and_type.css`, the preview HTML, `theme.js`, inline JSX, and per-package CSS — this directory replaces the "edit it everywhere" workflow with one JSON tree and a build script.
 
 ## Layout
 
 ```
 tokens/
-  colors.json       Primary/extended palette + semantic mapping + mode overrides
-  typography.json   Font stacks + type scale + responsive overrides + mode overrides
-  spacing.json      Spacing scale + touch-target floors per mode
-  radii.json        Radius scale
-  motion.json       Easing + duration scale + mode overrides
-  elevation.json    Shadows + glow (default disables glow under low-sensory + HC)
-  README.md         This file
+  breakpoints.json   Responsive breakpoints (sm/md/lg/xl) consumed by responsive scales
+  build.mjs          Style Dictionary build — emits tokens.generated.ts + themes.generated.ts
+  colors.json        Primary / extended palette + semantic mapping + per-mode overrides
+  elevation.json     Shadows + glow (default disables glow under static + high-contrast)
+  gradients.json     Hand-painted aurora variants + grain overlay
+  illustration.json  Illustration vocabulary (constellations, drift, atmospheric SVG)
+  motion.json        Easing + duration scale + per-mode overrides
+  pairings.json      Allowed / forbidden fg+bg pair registry — drives the contrast gate
+  radii.json         Radius scale
+  README.md          This file
+  spacing.json       Spacing scale + touch-target floors per mode
+  typography.json    Font stacks + type scale + responsive overrides + mode overrides
 ```
 
 ## Modes
 
-`colors.json`, `typography.json`, `spacing.json`, `motion.json`, and `elevation.json` each define a default and a set of overrides under `modes.*`. The current modes are:
+`colors.json`, `typography.json`, `spacing.json`, `motion.json`, `elevation.json`, and `gradients.json` each define a default and a set of overrides under `modes.*`. The active modes are:
 
-| Mode            | Selector                      | Purpose                                                       |
-| --------------- | ----------------------------- | ------------------------------------------------------------- |
-| Default         | (none)                        | Inner Horizons aesthetic                                      |
-| `low-sensory`   | `[data-mode="low-sensory"]`   | Flat fills, no glow, motion clamped                           |
-| `high-contrast` | `[data-mode="high-contrast"]` | Brighter text, stronger borders, no surface tint              |
-| `littles`       | `[data-mode="littles"]`       | Littles Safe Mode — softer accent, no Crimson, larger targets |
+| Mode             | Selector                       | Purpose                                                            |
+| ---------------- | ------------------------------ | ------------------------------------------------------------------ |
+| Default          | (none)                         | Inner Horizons aesthetic                                           |
+| `static`         | `[data-mode="static"]`         | Flat fills, no glow, motion clamped to 0                           |
+| `reduced-motion` | `[data-mode="reduced-motion"]` | Visuals untouched, every duration ≤50ms (vestibular accommodation) |
+| `high-contrast`  | `[data-mode="high-contrast"]`  | Brighter text, stronger borders, no surface tint                   |
+| `littles`        | `[data-mode="littles"]`        | Littles Safe Mode — softer accent, no Crimson, ≥56×56 hit targets  |
 
 Each override **merges** onto the default. Anything not listed inherits.
 
+The `static` and `reduced-motion` modes used to be one mode called `low-sensory`. They are now separate — vestibular sensitivity (motion) is independent from broader sensory load (gradients, glow, atmosphere). The `gradients.json` `low-sensory` block is the last stale reference to that name and is on the cleanup queue.
+
 ## Generating downstream artifacts
 
-The build script (`node tokens/build.mjs` using [Style Dictionary](https://amzn.github.io/style-dictionary/)) generates production outputs:
+The build script (`pnpm tokens:build`, which runs `node tokens/build.mjs` under [Style Dictionary](https://amzn.github.io/style-dictionary/)) produces both production and preview outputs:
 
-- `src/tokens.generated.ts` (TypeScript type-safe token object)
-- `src/themes.generated.ts` (theme objects for each mode)
+- `src/tokens.generated.ts` — type-safe primitive scales (production source)
+- `src/themes.generated.ts` — fully-merged theme objects per mode (production source)
+- `docs/design-system/preview/colors_and_type.generated.css` — CSS custom properties + `[data-mode]` overrides (preview only)
+- `docs/design-system/ui_kits/mobile/theme.generated.js` — `window.PS_THEME` + `applyMode(name)` helper (preview only)
 
-Preview artifacts are still emitted to the gitignored bundle at `docs/design-system/` for development:
+The preview outputs land in the gitignored `docs/design-system/` bundle. The two `*.generated.ts` files are committed and consumed by the Atom layer.
 
-- `colors_and_type.css` (CSS custom properties + mode `[data-mode]` overrides)
-- `ui_kits/mobile/theme.js` (`window.PS_THEME` + `applyMode(name)` helper)
+A pairings validator runs first and short-circuits the build if any forbidden pair is reachable through `semantic.<mode>`. A forbidden pair never reaches downstream consumers, even if Vitest hasn't run.
 
-The rule is:
+The rule:
 
-> **Edit JSON first, then run `pnpm tokens:build`.** Production outputs carry a `/* DO NOT EDIT — regenerate from /tokens */` banner; reviewers can flag direct edits.
+> **Edit JSON first, then run `pnpm tokens:build`.** Generated files carry a `/* DO NOT EDIT — regenerate from /tokens */` banner; reviewers can flag direct edits.
 
 ## What does not belong here
 
-- **Component-level rules.** Buttons, switches, etc. compose tokens — they don't define new ones. If you reach for a value that doesn't exist in `tokens/`, add it here first.
+- **Component-level rules.** Buttons, switches, cards compose tokens — they don't define new ones. If you need a value the tokens don't have, add it here first.
 - **One-off colors.** Avoid alpha-blended overlays as new tokens. Use existing primaries with documented opacity in component code.
 - **Per-page tweaks.** Preview pages and screens reference tokens; they never override them.

--- a/packages/design-system/tokens/README.md
+++ b/packages/design-system/tokens/README.md
@@ -24,12 +24,12 @@ tokens/
 
 `colors.json`, `typography.json`, `spacing.json`, `motion.json`, `elevation.json`, and `gradients.json` each define a default and a set of overrides under `modes.*`. The active modes are:
 
-| Mode             | Selector                       | Purpose                                                            |
-| ---------------- | ------------------------------ | ------------------------------------------------------------------ |
-| Default          | (none)                         | Inner Horizons aesthetic                                           |
-| `static`         | `[data-mode="static"]`         | Flat fills, no glow, motion clamped to 0                           |
-| `reduced-motion` | `[data-mode="reduced-motion"]` | Visuals untouched, every duration ≤50ms (vestibular accommodation) |
-| `high-contrast`  | `[data-mode="high-contrast"]`  | Brighter text, stronger borders, no surface tint                   |
+| Mode             | Selector                       | Purpose                                                                   |
+| ---------------- | ------------------------------ | ------------------------------------------------------------------------- |
+| Default          | (none)                         | Inner Horizons aesthetic                                                  |
+| `static`         | `[data-mode="static"]`         | Flat fills, no glow, motion clamped to 0                                  |
+| `reduced-motion` | `[data-mode="reduced-motion"]` | Visuals untouched, every duration ≤50ms (vestibular accommodation)        |
+| `high-contrast`  | `[data-mode="high-contrast"]`  | Brighter text, stronger borders, no surface tint                          |
 | `littles`        | `[data-mode="littles"]`        | Littles Safe Mode — softer accent, desaturated danger, ≥56×56 hit targets |
 
 Each override **merges** onto the default. Anything not listed inherits.

--- a/packages/design-system/tokens/README.md
+++ b/packages/design-system/tokens/README.md
@@ -30,7 +30,7 @@ tokens/
 | `static`         | `[data-mode="static"]`         | Flat fills, no glow, motion clamped to 0                           |
 | `reduced-motion` | `[data-mode="reduced-motion"]` | Visuals untouched, every duration ≤50ms (vestibular accommodation) |
 | `high-contrast`  | `[data-mode="high-contrast"]`  | Brighter text, stronger borders, no surface tint                   |
-| `littles`        | `[data-mode="littles"]`        | Littles Safe Mode — softer accent, no Crimson, ≥56×56 hit targets  |
+| `littles`        | `[data-mode="littles"]`        | Littles Safe Mode — softer accent, desaturated danger, ≥56×56 hit targets |
 
 Each override **merges** onto the default. Anything not listed inherits.
 


### PR DESCRIPTION
## Summary

- Aligns design-system docs with current code: theme list (5 modes, not 4), tokens layout (5 files were missing), build commands, and a dropped dead `SKILL.md` cross-reference.
- Reorganizes `A11Y_GATES.md` section A into five categories and adds 15+ planned gates we want wired into CI before the production app ships (touch-target spacing, focus trap, Esc-closes-overlays, form-label / error-message association, autocomplete, duration ceiling per mode, heading order, lang attribute, skip-to-content, Lighthouse, etc.).
- Small accuracy passes on `GOVERNANCE.md` §2 and `cross-platform-parity.md` (DM Sans is the canonical face; OS reduced-motion maps to `reduced-motion`, not `static`).

## Files changed

- `packages/design-system/README.md`
- `packages/design-system/tokens/README.md`
- `packages/design-system/docs/GOVERNANCE.md`
- `packages/design-system/docs/cross-platform-parity.md`
- `packages/design-system/docs/A11Y_GATES.md`
- `.beans/ps-2r3p--refresh-design-system-package-docs.md`

## Test plan

- [x] `pnpm prettier --check` passes on all five doc files
- [x] Cross-references verified — `docs/GOVERNANCE.md §2`, `tokens/*.json` filenames, `tokens/build.mjs`, `pnpm tokens:build`
- [x] Mode list matches `ThemeMode` in `src/theme.tsx` and `themes.generated.ts`
- [x] Public API list matches `src/index.ts` exports
- [ ] Reviewer sanity-check that the planned a11y gate list is the right scope before any of the rows move from "planned" to "live"

Closes ps-2r3p.