### PR TITLE
chore(deps): drop fast-xml-parser scoped pin, bump to ^5.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,7 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
 
       - name: Audit dependencies
-        # GHSA-gh4j-gqv2-49f6: fast-xml-parser XMLBuilder CDATA bug. Scoped to
-        # @aws-sdk/xml-builder@5.5.8 only (AWS SDK uses XMLParser, not XMLBuilder,
-        # so the injection path is unreachable). Pinned at 5.5.8 because 5.7.x
-        # rejects `&#xD;` numeric char refs that MinIO sends in error responses.
-        run: pnpm audit --audit-level=moderate --ignore-registry-errors --ignore GHSA-gh4j-gqv2-49f6
+        run: pnpm audit --audit-level=moderate --ignore-registry-errors
 
   openapi:
     name: OpenAPI Spec Reconciliation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,7 @@ overrides:
   better-sqlite3: npm:better-sqlite3-multiple-ciphers@^12.6.2
   ioredis: 5.10.1
   esbuild: '>=0.25.0'
-  fast-xml-parser: '>=5.7.0'
-  '@aws-sdk/xml-builder>fast-xml-parser': 5.5.12
+  fast-xml-parser: ^5.7.2
   postcss: '>=8.5.10'
   flatted: '>=3.4.2'
   picomatch: '>=4.0.4'
@@ -5009,10 +5008,6 @@ packages:
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.5.12:
-    resolution: {integrity: sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==}
-    hasBin: true
-
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
@@ -8156,7 +8151,7 @@ snapshots:
     dependencies:
       '@nodable/entities': 2.1.0
       '@smithy/types': 4.14.1
-      fast-xml-parser: 5.5.12
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -12270,12 +12265,6 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
       xml-naming: 0.1.0
-
-  fast-xml-parser@5.5.12:
-    dependencies:
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.3.0
 
   fast-xml-parser@5.7.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,8 +50,7 @@ overrides:
   better-sqlite3: "npm:better-sqlite3-multiple-ciphers@^12.6.2"
   ioredis: "5.10.1"
   esbuild: ">=0.25.0"
-  fast-xml-parser: ">=5.7.0"
-  "@aws-sdk/xml-builder>fast-xml-parser": "5.5.12"
+  fast-xml-parser: "^5.7.2"
   postcss: ">=8.5.10"
   flatted: ">=3.4.2"
   # brace-expansion override removed: pnpm overrides force a single version
@@ -70,9 +69,5 @@ overrides:
   axios: "^1.16.0"
   "@xmldom/xmldom": ">=0.8.13"
   uuid: ">=14.0.0"
-
-auditConfig:
-  ignoreCves:
-    - "GHSA-gh4j-gqv2-49f6"
 
 verifyDepsBeforeRun: true


### PR DESCRIPTION
## Summary

Clears the last open Dependabot alert (#41, fast-xml-parser).

The scoped `@aws-sdk/xml-builder>fast-xml-parser: 5.5.12` pin existed because fast-xml-parser 5.7.0 / 5.7.1 rejected the `&#xD;` numeric character references MinIO emits in S3 error responses — every storage integration test failed with `[EntityReplacer] Invalid character`.

Both sides have since fixed it:

| Source | Fix |
|---|---|
| **fast-xml-parser 5.7.2** | Release notes: *"allow numerical external entity for backward compatibility"* — restores `&#xD;` handling |
| **@aws-sdk/xml-builder** | Upstream now pins `fast-xml-parser: 5.7.2` itself, so AWS has validated the combination |
| **fast-xml-parser 5.7.1** | Adds CDATA sanitization to XMLBuilder — obsoletes the `GHSA-gh4j-gqv2-49f6` audit-ignore that backed the pin |

## Changes

- `pnpm-workspace.yaml`: drop scoped override, raise global `fast-xml-parser` floor from `>=5.7.0` to `^5.7.2`, remove `auditConfig.ignoreCves` block.
- `.github/workflows/ci.yml`: remove the matching `pnpm audit --ignore GHSA-gh4j-gqv2-49f6` flag and its rationale comment.
- `pnpm-lock.yaml`: regenerated — only `fast-xml-parser@5.7.3` (latest) remains.

## Test plan

- [x] `pnpm audit --audit-level=moderate` — clean, no ignores needed
- [x] `pnpm vitest run --project=storage-integration` — 26/26 pass against MinIO (the original failure mode)
- [x] `pnpm typecheck` — 23/23 green
- [ ] CI green
- [ ] Dependabot dashboard goes to 0 open