### PR TITLE
chore(beans): seed M10 bean structure (3 epics + topology + Phase 0 + 10 Fronting pilot beans)

### DIFF
--- a/.beans/ps-00b4--design-confirmgesture-primitive.md
+++ b/.beans/ps-00b4--design-confirmgesture-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-00b4
+title: Design ConfirmGesture primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:36Z
+updated_at: 2026-05-17T06:27:36Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the ConfirmGesture primitive: hold-to-confirm circular-progress affordance for irreversible actions in distress contexts (e.g., the in-the-moment "end fronting now" action in Littles-safe mode). Provides physical friction without dialog overhead.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-confirm-gesture.html` showing variants (small/medium/large), progress states (0 / 25 / 50 / 75 / 100%), and the released-too-early reset state
+- [ ] Spec doc per SKILL.md §8, with explicit note: must remain accessible via keyboard equivalent (long-press is touch-only)
+
+## Tokens / references
+
+- Tokens: `tokens/motion.json`, `tokens/colors.json`
+- Reference: GOVERNANCE.md §3 (reduced-motion mode disables animation; provide tap-twice fallback)
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-07l7--member-management-screen-designs.md
+++ b/.beans/ps-07l7--member-management-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:12:49Z
-updated_at: 2026-03-31T23:12:53Z
+updated_at: 2026-05-17T05:49:09Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Member list, member detail/edit, photo gallery, custom fields, group list, group detail, member duplication flow

--- a/.beans/ps-0yt2--settings-webhooks-list-createedit-secret-rotate-de.md
+++ b/.beans/ps-0yt2--settings-webhooks-list-createedit-secret-rotate-de.md
@@ -1,0 +1,51 @@
+---
+# ps-0yt2
+title: "Settings: Webhooks (list + create/edit + secret rotate + delivery log)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:46:41Z
+updated_at: 2026-05-17T06:46:41Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the webhook surfaces — list of configured endpoints, create / edit form, secret rotate modal, per-webhook delivery log.
+
+## Surfaces
+
+- List: `(app)/settings/integrations/webhooks/index.tsx`
+- New: `(app)/settings/integrations/webhooks/new.tsx`
+- Edit: `(app)/settings/integrations/webhooks/[id]/edit.tsx`
+- Secret rotate: `(modals)/webhook-secret-rotate.tsx`
+- Delivery log: `(app)/settings/integrations/webhooks/[id]/deliveries.tsx`
+
+## Required states per surface
+
+- list: empty, populated (with last-delivery success / failure indicator per row), archived view, error
+- create/edit: URL + per-event-kind toggles + secret (generated) + payload encryption Switch + test-ping affordance, invalid, submitting
+- secret rotate: warning (existing-secret will-stop-validating), new-secret reveal-once with copy, ack-complete, success
+- delivery log: empty, populated (paginated with status badge per delivery), filtered (by-status, by-event-kind), per-row expand-for-payload, with-retry affordance for failed
+
+## Mode notes
+
+- Littles: hidden entirely
+- High-contrast: delivery status uses icon + label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), FAB, Card (webhook tile), TextField, Switch (per-event-kind), Button (test-ping), Banner (rotate warning), RecoveryKeyField (ps-o1zp, re-skinned secret display), KeyValueRow (ps-5lr6, delivery row), Badge (delivery status), Accordion (ps-ecpl, payload expand), DestructiveConfirmDialog (ps-bydy), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/webhook-config.ts` CRUD + rotate + test-ping
+- `apps/api/src/trpc/routers/webhook-delivery.ts` list, retry
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-webhooks.html with all surfaces + states
+- [ ] Rationale on the test-ping placement and the delivery-log row density
+
+## Out of scope
+
+- RN code (M11), data wiring (M12)

--- a/.beans/ps-0yt2--settings-webhooks-list-createedit-secret-rotate-de.md
+++ b/.beans/ps-0yt2--settings-webhooks-list-createedit-secret-rotate-de.md
@@ -3,9 +3,12 @@
 title: "Settings: Webhooks (list + create/edit + secret rotate + delivery log)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:46:41Z
-updated_at: 2026-05-17T06:46:41Z
+updated_at: 2026-05-17T07:42:00Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-107o--design-imagecropper-primitive.md
+++ b/.beans/ps-107o--design-imagecropper-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-107o
+title: Design ImageCropper primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:13Z
+updated_at: 2026-05-17T06:28:13Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the ImageCropper primitive: in-app crop and resize affordance for member avatars and gallery photos. Square + free-form crop, resize sliders, rotate. Loaded after ImagePickerLauncher returns a source. Required by features.md §1 "Image editing — built-in crop and resize when uploading avatars or gallery photos (no external tool needed)".
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-image-cropper.html` showing variants (square crop, free-form, with rotate, with zoom) and states (loaded, cropping, applying, error)
+- [ ] Spec doc per SKILL.md §8 (gesture handling: pinch-zoom, drag-pan, rotate-handle)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/radii.json` (crop frame), `tokens/motion.json` (drag feedback)
+- Reference: features.md §1
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Member management beans)

--- a/.beans/ps-1mui--search-global-friend-data-no-results-states.md
+++ b/.beans/ps-1mui--search-global-friend-data-no-results-states.md
@@ -3,9 +3,12 @@
 title: "Search: Global + friend-data + no-results states"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:45:34Z
-updated_at: 2026-05-17T06:45:34Z
+updated_at: 2026-05-17T07:42:00Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-1mui--search-global-friend-data-no-results-states.md
+++ b/.beans/ps-1mui--search-global-friend-data-no-results-states.md
@@ -1,0 +1,48 @@
+---
+# ps-1mui
+title: "Search: Global + friend-data + no-results states"
+status: todo
+type: feature
+created_at: 2026-05-17T06:45:34Z
+updated_at: 2026-05-17T06:45:34Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the global search screen and the friend-data search screen, including shared no-results state.
+
+## Surfaces
+
+- Global search: `(app)/search/index.tsx`
+- Friend-data search: `(app)/search/friend/[friendId].tsx`
+- No-results: shared state
+
+## Required states per surface
+
+- global: idle (recent queries), typing, results (grouped per entity kind: members, fronting sessions, notes, board messages, journal, wiki), no-results, with-filter chips, error, loading
+- friend-data: idle (bucket-scoped query), typing, results (grouped per shared entity kind), no-results-because-no-share-permission, no-results-because-no-match, error
+- no-results: shared empty-state copy variants per context
+
+## Mode notes
+
+- Littles: search limited to member names only (no rich-data search)
+- High-contrast: result-row icons indicate entity-kind disambiguation
+
+## Primitives required
+
+- ScreenScaffold, SearchHeader (ps-oylh), InfiniteList (ps-hijf), Card (per-entity result row), Chip (filter, entity-kind), EmptyState (ps-ruwi, no-results variant), Banner (no-share-permission), KeyValueRow (ps-5lr6)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/account.ts` search
+- friend-data uses bucket-filtered client-side search (per features.md §4)
+
+## Required output
+
+- [ ] docs/design-system/preview/search-all.html with all surfaces + states
+- [ ] Rationale on entity-kind grouping order and filter affordance placement
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the SearchHeader primitive (Phase 0)

--- a/.beans/ps-1v9l--design-relationshiptypepicker-primitive.md
+++ b/.beans/ps-1v9l--design-relationshiptypepicker-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-1v9l
+title: Design RelationshipTypePicker primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:30:48Z
+updated_at: 2026-05-17T06:30:48Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the RelationshipTypePicker primitive: pick a relationship type when creating an edge between two members. Bundled types per features.md §6: split-from, fused-from, sibling, partner, parent-child, protector-of, caretaker-of, gatekeeper-of, source, plus user-defined custom types. Indicates bidirectional vs directional.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-relationship-type-picker.html` showing variants (well-known list, custom-type create, with-direction-indicator) and required states
+- [ ] Spec doc per SKILL.md §8
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md §6 relationship data model
+
+## Out of scope
+
+- RN code (M11), screen-level integration (System structure beans)

--- a/.beans/ps-1yh1--settings-privacy-default-visibility.md
+++ b/.beans/ps-1yh1--settings-privacy-default-visibility.md
@@ -1,0 +1,43 @@
+---
+# ps-1yh1
+title: "Settings: Privacy & default-visibility"
+status: todo
+type: feature
+created_at: 2026-05-17T06:46:21Z
+updated_at: 2026-05-17T06:46:21Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the privacy & default-visibility settings — fail-closed defaults per entity type, default bucket assignment for new entities, anti-enumeration toggles.
+
+## Surfaces
+
+- Privacy & defaults: `(app)/settings/privacy.tsx`
+
+## Required states per surface
+
+- default with section per entity type (members, custom fronts, groups, fronting sessions, journal, wiki, channels), each with default-bucket selector + "private by default" Switch, with-anti-enumeration-toggles section, save / reset affordances
+
+## Mode notes
+
+- Littles: simplified — single "Who can see your things?" preset pick (private / trusted friends / everyone)
+- High-contrast: per-section card uses border + label
+
+## Primitives required
+
+- ScreenScaffold, Section (per entity type), Switch, BucketPicker (ps-s9r6), Banner, Button, KeyValueRow (ps-5lr6)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/system.ts` settings.privacy
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-privacy-defaults.html with all states
+- [ ] Rationale on the preset-vs-granular UX trade
+
+## Out of scope
+
+- RN code (M11), data wiring (M12)

--- a/.beans/ps-1yh1--settings-privacy-default-visibility.md
+++ b/.beans/ps-1yh1--settings-privacy-default-visibility.md
@@ -3,9 +3,12 @@
 title: "Settings: Privacy & default-visibility"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:46:21Z
-updated_at: 2026-05-17T06:46:21Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-217e--design-drawer-primitive.md
+++ b/.beans/ps-217e--design-drawer-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-217e
+title: Design Drawer primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:30Z
+updated_at: 2026-05-17T06:28:30Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the Drawer primitive: side-drawer chrome for web and tablet ≥1024px viewports. Mobile uses a bottom-tab "More" surface instead — the Drawer is not shown on phone. Hosts secondary navigation, system switcher, and settings entry on larger viewports.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-drawer.html` showing variants (collapsed-rail, expanded, expanded-with-system-switcher-open) and required states
+- [ ] Spec doc per SKILL.md §8 documenting the ≥1024px breakpoint rule and the keyboard-trap behavior when in mobile sheet mode
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`, `tokens/breakpoints.json`, `tokens/elevation.json`
+- Reference: `packages/design-system/docs/cross-platform-parity.md` (tab bar bottom <1024, drawer left ≥1024)
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Home & Nav beans)

--- a/.beans/ps-21dn--settings-tools-sync-diagnostics-storage-background.md
+++ b/.beans/ps-21dn--settings-tools-sync-diagnostics-storage-background.md
@@ -1,0 +1,49 @@
+---
+# ps-21dn
+title: "Settings: Tools (sync diagnostics + storage + background jobs)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:46:58Z
+updated_at: 2026-05-17T06:46:58Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the three diagnostic / tool surfaces — sync diagnostics (live sync state + recent events), storage / quota (used vs quota with per-category breakdown), background jobs viewer (queue inspector with retry / cancel).
+
+## Surfaces
+
+- Sync: `(app)/settings/tools/sync.tsx`
+- Storage: `(app)/settings/tools/storage.tsx`
+- Jobs: `(app)/settings/tools/jobs.tsx`
+
+## Required states per surface
+
+- sync: live (with WebSocket / SSE indicator, last-sync timestamp, conflict count badge), with-paused warning, with-recent-events log, with-force-resync affordance, offline, error
+- storage: usage bar (used / quota), per-category breakdown (members, photos, journal, snapshots, sync metadata), with-cleanup affordances per category, near-quota warning, over-quota error
+- jobs: active jobs list (with progress), queued jobs list, recently-completed list, with-retry affordance for failed, with-cancel for active, empty (no jobs ever)
+
+## Mode notes
+
+- Littles: hidden
+- High-contrast: bars / charts use border + label
+
+## Primitives required
+
+- ScreenScaffold, KeyValueRow (ps-5lr6), Banner, ProgressBar (ps-3m01), Card (per-job tile), Badge (status), Button, EmptyState (ps-ruwi), SyncIndicator (ps-gnkq), Accordion (ps-ecpl, recent events log)
+
+## Data refs (informational)
+
+- Local sync engine state (no router)
+- `apps/api/src/trpc/routers/account.ts` storage usage
+- Background queue inspection (local + server-side jobs)
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-tools.html with all surfaces + states
+- [ ] Rationale on the cleanup affordance UX (per-category vs free-form scan)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12)

--- a/.beans/ps-21dn--settings-tools-sync-diagnostics-storage-background.md
+++ b/.beans/ps-21dn--settings-tools-sync-diagnostics-storage-background.md
@@ -3,9 +3,12 @@
 title: "Settings: Tools (sync diagnostics + storage + background jobs)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:46:58Z
-updated_at: 2026-05-17T06:46:58Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-3bdr--auth-app-boot-welcome-carousel.md
+++ b/.beans/ps-3bdr--auth-app-boot-welcome-carousel.md
@@ -1,0 +1,45 @@
+---
+# ps-3bdr
+title: "Auth: App boot + welcome carousel"
+status: todo
+type: feature
+created_at: 2026-05-17T06:33:03Z
+updated_at: 2026-05-17T06:33:03Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the first-paint surfaces: splash boot gate and welcome carousel (privacy / your-terms / your-community pillars + sign-in vs sign-up fork).
+
+## Surfaces
+
+- Splash: `(boot)/index.tsx` — decision tree (logged-in → home, locked → PIN/biometric, fresh → welcome)
+- Welcome carousel: `(auth)/welcome.tsx` — 3-slide pillars + final CTA pair
+
+## Required states per surface
+
+- splash: bootstrapping, fork-decision (each branch shown briefly), error-fallback
+- carousel: each slide, paginator dots, language switcher visible
+
+## Mode notes
+
+- Littles: simplified single-screen welcome, no carousel slides — direct "Sign in" / "Get started" buttons
+- Static / reduced-motion: shimmer animation disabled
+
+## Primitives required
+
+- ScreenScaffold, PluralscapeLogo, Button, Pagination dots (Skeleton variant or its own atom)
+
+## Data refs (informational)
+
+- None — splash uses local session + key derivation gate; welcome is i18n-only
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-boot-welcome.html with all states
+- [ ] Rationale notes on first-paint decision tree
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond above (Phase 3)

--- a/.beans/ps-3bdr--auth-app-boot-welcome-carousel.md
+++ b/.beans/ps-3bdr--auth-app-boot-welcome-carousel.md
@@ -3,9 +3,12 @@
 title: "Auth: App boot + welcome carousel"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:33:03Z
-updated_at: 2026-05-17T06:33:03Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-3d9b--settings-help-about.md
+++ b/.beans/ps-3d9b--settings-help-about.md
@@ -3,9 +3,12 @@
 title: "Settings: Help + About"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:47:06Z
-updated_at: 2026-05-17T06:47:06Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-3d9b--settings-help-about.md
+++ b/.beans/ps-3d9b--settings-help-about.md
@@ -1,0 +1,47 @@
+---
+# ps-3d9b
+title: "Settings: Help + About"
+status: todo
+type: feature
+created_at: 2026-05-17T06:47:06Z
+updated_at: 2026-05-17T06:47:06Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the Help & support surface (FAQ accordions, contact link, send-diagnostics button) and the About page (version, license, attribution, links).
+
+## Surfaces
+
+- Help: `(app)/settings/help.tsx`
+- About: `(app)/settings/about.tsx`
+
+## Required states per surface
+
+- help: default (FAQ accordions), with-search, with-contact-form expanded, with-diagnostic-bundle-pending, with-diagnostic-sent confirmation
+- about: default (version, build, commit hash, license, links to ToS / Privacy / Open-source notices), with-update-available banner
+
+## Mode notes
+
+- Littles: simplified — single "Get help" entry pointing to a caregiver-curated resource list
+- High-contrast: FAQ accordions use border + label
+
+## Primitives required
+
+- ScreenScaffold, Accordion (ps-ecpl, FAQ), SearchHeader (ps-oylh), TextArea (contact form), Button (send diagnostic), KeyValueRow (ps-5lr6, about metadata), Banner (update available), Link
+
+## Data refs (informational)
+
+- Local app version + build metadata
+- Help content: bundled static + remote-overridable
+- Diagnostic bundle: local (logs + sync state)
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-help-about.html with both surfaces + states
+- [ ] Rationale on diagnostic-bundle UX (what's included, opt-in for system data)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the contact backend

--- a/.beans/ps-3m01--design-progressbar-and-progressring-primitives.md
+++ b/.beans/ps-3m01--design-progressbar-and-progressring-primitives.md
@@ -1,0 +1,27 @@
+---
+# ps-3m01
+title: Design ProgressBar and ProgressRing primitives
+status: todo
+type: task
+created_at: 2026-05-17T06:27:52Z
+updated_at: 2026-05-17T06:27:52Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the ProgressBar (linear) and ProgressRing (circular) primitives together — they share semantics (determinate / indeterminate) and tokens. Used for import jobs, key rotation, blob upload, fronting-report generation.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-progress.html` showing ProgressBar + ProgressRing with variants (determinate, indeterminate, success, error) and sizes (sm, md, lg)
+- [ ] Spec doc per SKILL.md §8 (one doc covering both primitives with shared rules)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/motion.json` (animation), `tokens/radii.json`
+- Reference: GOVERNANCE.md §3 (reduced-motion: spinner replaces indeterminate animation; static: bar with no transition)
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-458i--design-frontingchip-primitive.md
+++ b/.beans/ps-458i--design-frontingchip-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-458i
+title: Design FrontingChip primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:55Z
+updated_at: 2026-05-17T06:28:55Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the FrontingChip primitive: per-member or per-custom-front active-fronter mini-card showing avatar + name + duration + optional status text. Used in the AppHeader (current fronter badge), Front overview, and AvatarStack expanded view.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-fronting-chip.html` showing variants (compact, expanded with status, co-fronting badge, custom-front variant, structure-entity variant) and required states
+- [ ] Spec doc per SKILL.md §8 covering: identity pairing rule (color + shape + initial per GOVERNANCE.md §4), duration format (live-updating clock), status-text truncation (50 char per features.md §2)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/typography.json`
+- Reference: features.md §2, GOVERNANCE.md §4
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Fronting beans)

--- a/.beans/ps-472d--design-recoverykey-ceremony-pattern.md
+++ b/.beans/ps-472d--design-recoverykey-ceremony-pattern.md
@@ -1,0 +1,27 @@
+---
+# ps-472d
+title: Design RecoveryKey ceremony pattern
+status: todo
+type: task
+created_at: 2026-05-17T06:30:59Z
+updated_at: 2026-05-17T06:30:59Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the RecoveryKey ceremony pattern: the three-screen composition (reveal + ack-checkboxes → confirmation challenge → reminder modal) that surrounds the RecoveryKeyDisplay and RecoveryKeyField primitives during sign-up and post-reset. Pattern-level beats: introduce, reveal, demand-engagement, periodic-verify.
+
+## Required output
+
+- [ ] `docs/design-system/preview/patterns-recovery-key-ceremony.html` showing the three screens as a composition with state transitions documented
+- [ ] Spec doc per SKILL.md §8 (composition-level — when to break out vs reuse the pattern; copy contract per GOVERNANCE.md §7)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (warning palette), `tokens/typography.json`
+- Reference: ADR 011, features.md §14 security, the primitive beans for RecoveryKeyDisplay and RecoveryKeyField
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Auth flow beans)

--- a/.beans/ps-47zn--cross-cutting-image-picker-launcher-permission-flo.md
+++ b/.beans/ps-47zn--cross-cutting-image-picker-launcher-permission-flo.md
@@ -1,0 +1,59 @@
+---
+# ps-47zn
+title: "Cross-cutting: Image picker launcher + permission flow"
+status: todo
+type: feature
+created_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T06:50:29Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the image picker launcher used across avatar upload, journal attachments, member proxy images: action sheet → permission prompt → picker → cropper → upload progress.
+
+## Surfaces
+
+- Launcher action sheet (camera / photo library / cancel).
+- Permission-pre-prompt (rationale before OS prompt).
+- Permission-denied empty state with deep-link to OS settings.
+- Cropper (1:1 square + freeform).
+- Upload progress overlay.
+- Upload error.
+
+## Required states per surface
+
+- Default.
+- Permission pending.
+- Permission granted.
+- Permission denied permanently.
+- Crop in-progress.
+- Uploading.
+- Upload error with retry.
+
+## Mode notes
+
+- Default mode only.
+- High-contrast: cropper handles must remain visible — noted for Phase 3.
+
+## Primitives required
+
+- Bottom-sheet (launcher).
+- Permission-explainer card.
+- Image cropper primitive.
+- Progress overlay.
+
+## Data refs (informational)
+
+- packages/storage upload pipeline.
+- E2E encryption handled transparently; no UI surface.
+
+## Required output
+
+- HTML mockup of the full flow in docs/design-system/preview/cross-cutting/image-picker.html.
+- Decision notes: pre-prompt rationale copy, retry behavior.
+
+## Out of scope
+
+- RN implementation (M11).
+- Native plugin selection (M11).

--- a/.beans/ps-47zn--cross-cutting-image-picker-launcher-permission-flo.md
+++ b/.beans/ps-47zn--cross-cutting-image-picker-launcher-permission-flo.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Image picker launcher + permission flow"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:50:29Z
-updated_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-48g4--journaling-journal-hub.md
+++ b/.beans/ps-48g4--journaling-journal-hub.md
@@ -3,9 +3,12 @@
 title: "Journaling: Journal hub"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:44:09Z
-updated_at: 2026-05-17T06:44:09Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-djgs
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-48g4--journaling-journal-hub.md
+++ b/.beans/ps-48g4--journaling-journal-hub.md
@@ -1,0 +1,44 @@
+---
+# ps-48g4
+title: "Journaling: Journal hub"
+status: todo
+type: feature
+created_at: 2026-05-17T06:44:09Z
+updated_at: 2026-05-17T06:44:09Z
+parent: ps-djgs
+---
+
+## Goal
+
+Design the Journal hub — landing for personal entries + collaborative wiki, with recent activity summary.
+
+## Surfaces
+
+- Journal hub: `(app)/journal/index.tsx`
+
+## Required states per surface
+
+- default (with both sections populated), empty per section, with-search affordance, with-fronting-context indicator (if currently fronting), error
+
+## Mode notes
+
+- Littles: simplified — single "My journal" entry only; wiki hidden
+- High-contrast: section cards use border-strong
+
+## Primitives required
+
+- ScreenScaffold, Card (section tile), Badge, ListItem (recent activity), FrontingChip (ps-458i, current-fronter context), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/journal.ts` recent entries, recent wiki pages
+- `apps/api/src/trpc/routers/fronting-session.ts` activeFronters (context)
+
+## Required output
+
+- [ ] docs/design-system/preview/journal-hub.html with all states
+- [ ] Rationale on the journal-vs-wiki split
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), individual sub-area screens (separate beans)

--- a/.beans/ps-491k--home-notifications-inbox.md
+++ b/.beans/ps-491k--home-notifications-inbox.md
@@ -1,0 +1,46 @@
+---
+# ps-491k
+title: "Home: Notifications inbox"
+status: todo
+type: feature
+created_at: 2026-05-17T06:35:38Z
+updated_at: 2026-05-17T06:35:38Z
+parent: ps-divy
+---
+
+## Goal
+
+Design the Notifications inbox — system-side surface for received push notifications (friend front alerts, mandatory acknowledgements, device-transfer requests, webhook failures, recovery-key reminders).
+
+## Surfaces
+
+- Notifications: `(app)/notifications.tsx`
+
+## Required states per surface
+
+- default (mixed-kind list), empty (no notifications ever), filtered (by-kind chip), unread-only toggle, archived view, error, loading
+
+## Mode notes
+
+- Littles: hides device-transfer + webhook-failure notification kinds
+- High-contrast: per-kind icon is the disambiguator (color tier is supplemental)
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), ListItem, Badge, Chip (filter), EmptyState (ps-ruwi)
+- LifecycleEventChip (ps-v3e9) for system-event notifications
+- BucketPill (ps-i6n1) for friend-related notifications
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/notification-config.ts`
+- SSE notification stream (local subscription)
+
+## Required output
+
+- [ ] docs/design-system/preview/home-notifications.html with all states
+- [ ] Rationale on notification grouping rules (per-kind, per-time-bucket)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), notification-config screen (Privacy & Social bean)

--- a/.beans/ps-491k--home-notifications-inbox.md
+++ b/.beans/ps-491k--home-notifications-inbox.md
@@ -3,9 +3,12 @@
 title: "Home: Notifications inbox"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:35:38Z
-updated_at: 2026-05-17T06:35:38Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-divy
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-4lhb--cross-cutting-pin-biometric-foreground-re-auth-ove.md
+++ b/.beans/ps-4lhb--cross-cutting-pin-biometric-foreground-re-auth-ove.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: PIN / biometric foreground re-auth overlay"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:51:15Z
-updated_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-4lhb--cross-cutting-pin-biometric-foreground-re-auth-ove.md
+++ b/.beans/ps-4lhb--cross-cutting-pin-biometric-foreground-re-auth-ove.md
@@ -1,0 +1,57 @@
+---
+# ps-4lhb
+title: "Cross-cutting: PIN / biometric foreground re-auth overlay"
+status: todo
+type: feature
+created_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T06:51:15Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the foreground re-authentication overlay shown when app resumes from background after the configured timeout.
+
+## Surfaces
+
+- Re-auth overlay (PIN input).
+- Re-auth overlay (biometric prompt — face / touch).
+- Re-auth fallback (biometric failed → PIN).
+- Re-auth lockout (N failed attempts → cooldown).
+
+## Required states per surface
+
+- Default (PIN: empty input).
+- Typing PIN.
+- Biometric pending.
+- Biometric succeeded.
+- Biometric failed → PIN fallback.
+- Lockout countdown.
+- Lockout cleared.
+
+## Mode notes
+
+- Default mode only.
+- Static mode: no biometric animation — noted for Phase 3.
+
+## Primitives required
+
+- Modal overlay (full-screen).
+- PIN input primitive.
+- Biometric prompt placeholder.
+- Countdown timer.
+
+## Data refs (informational)
+
+- Settings → Privacy (lock timeout config — ps-1yh1).
+- packages/crypto secret-key unlock flow.
+
+## Required output
+
+- HTML mockup of all states in docs/design-system/preview/cross-cutting/reauth-overlay.html.
+- Decision notes: lockout policy (attempts × cooldown).
+
+## Out of scope
+
+- RN implementation (M11).
+- Secret-key derivation UI (lives in onboarding ps-\* auth bean).

--- a/.beans/ps-4rf4--privacy-privacy-hub-audit-log-viewer.md
+++ b/.beans/ps-4rf4--privacy-privacy-hub-audit-log-viewer.md
@@ -1,0 +1,47 @@
+---
+# ps-4rf4
+title: "Privacy: Privacy hub + audit log viewer"
+status: todo
+type: feature
+created_at: 2026-05-17T06:40:22Z
+updated_at: 2026-05-17T06:40:22Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the Privacy hub (landing for buckets / friends / devices / notifications) and the security audit log viewer (login timestamps, IP addresses, failed attempts, data exports).
+
+## Surfaces
+
+- Privacy hub: `(app)/privacy/index.tsx`
+- Audit log: `(app)/settings/security/audit-log.tsx`
+
+## Required states per surface
+
+- hub: default (with-pending-rotations banner if any), empty (first-time, no friends yet), with-bucket-count summary, error
+- audit log: empty, populated with various event kinds, filtered (by-kind, by-date-range), with-IP-tracking-disabled notice, error
+
+## Mode notes
+
+- Littles: audit log hidden; hub simplified to buckets only
+- High-contrast: per-event-kind chip uses icon + label
+
+## Primitives required
+
+- ScreenScaffold, Card (hub sub-area tile), Badge, Banner (pending rotations / data-loss warnings), InfiniteList (ps-hijf), KeyValueRow (ps-5lr6, audit-log rows), Chip (filter), EmptyState (ps-ruwi), EncryptionTierBadge (ps-gfhz)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/bucket.ts` summary
+- `apps/api/src/trpc/routers/friend.ts` count
+- `apps/api/src/trpc/routers/account.ts` audit-log subroute
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-hub-audit.html with all states
+- [ ] Rationale on the audit-log row layout (one-line vs two-line per event)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), individual bucket/friend/device sub-screens (separate beans)

--- a/.beans/ps-4rf4--privacy-privacy-hub-audit-log-viewer.md
+++ b/.beans/ps-4rf4--privacy-privacy-hub-audit-log-viewer.md
@@ -3,9 +3,12 @@
 title: "Privacy: Privacy hub + audit log viewer"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:40:22Z
-updated_at: 2026-05-17T06:40:22Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-4yum--fronting-reports-list-config-createedit-generate.md
+++ b/.beans/ps-4yum--fronting-reports-list-config-createedit-generate.md
@@ -1,0 +1,56 @@
+---
+# ps-4yum
+title: "Fronting: Reports — list + config create/edit + generate"
+status: todo
+type: feature
+created_at: 2026-05-17T05:51:00Z
+updated_at: 2026-05-17T05:51:00Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the fronting report system: list of saved report configs, create/edit config form, generate flow (client-side generation since server is encryption-blind).
+
+## Surfaces
+
+- Report list: `(app)/fronting/reports/index.tsx` — saved FrontingReport configs.
+- Report config create/edit: `(app)/fronting/reports/new.tsx`, `[id]/edit.tsx` — name, scope (members + bucket filter), date range, format (PDF / CSV / share-friendly).
+- Report generate: `(app)/fronting/reports/[id]/generate.tsx` — initiates client-side generation with progress and download.
+
+## Required states per surface
+
+- list: empty, populated, archived view
+- config form: valid, invalid, submitting, conflict
+- generate: queued, generating (with progress), ready (download CTA), error (retry CTA)
+
+## Mode notes
+
+- Client-side generation can be slow on lower-end devices (littles target audience); progress indicator must be clear.
+- Reduced-motion: spinner replaces progress animation. Static mode: bar with no transition.
+
+## Primitives required
+
+- ListItem
+- FAB (add new)
+- TextField (report name)
+- DateRangePicker
+- MultiMemberPicker (scope filter)
+- BucketPicker (scope filter)
+- ProgressBar (generation)
+- EmptyState
+- Dialog (delete config — DestructiveConfirmDialog variant)
+- Button (download, share)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/fronting-report.ts` — list, get, create, update, delete (generation happens client-side; no server endpoint)
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-reports.html with all states
+- [ ] Layout / interaction rationale including the client-side generation UX decision
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage (Phase 3 sweep), actual report content layout (separate bean: "Fronting history report content design" under M13 ancillary).

--- a/.beans/ps-4yum--fronting-reports-list-config-createedit-generate.md
+++ b/.beans/ps-4yum--fronting-reports-list-config-createedit-generate.md
@@ -3,9 +3,12 @@
 title: "Fronting: Reports — list + config create/edit + generate"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:51:00Z
-updated_at: 2026-05-17T05:51:00Z
+updated_at: 2026-05-17T07:42:01Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-54nf--closeout-m10-milestone-closeout-close-ps-9cca.md
+++ b/.beans/ps-54nf--closeout-m10-milestone-closeout-close-ps-9cca.md
@@ -5,7 +5,7 @@ status: todo
 type: task
 priority: normal
 created_at: 2026-05-17T06:53:15Z
-updated_at: 2026-05-17T06:53:31Z
+updated_at: 2026-05-17T07:40:53Z
 parent: ps-l9fv
 blocked_by:
   - ps-oqs8
@@ -27,7 +27,8 @@ Close M10 milestone bean ps-9cca with a comprehensive `## Summary of Changes` se
    - Final design system surface count (primitives + screens).
    - Reference to docs/design-system/handoff-m11.md.
    - Open known gaps (deferred to M11 or later milestones).
-4. Body-append to ps-9cca, then `beans update ps-9cca -s completed`.
+4. Verify no open M10 descendants: walk every bean parented (transitively) to `ps-9cca` and confirm status is `completed` or `scrapped`. If any are open — including audit-spawned follow-ups under `ps-z1og` — STOP and finish them first. The milestone cannot close with open children.
+5. Body-append to ps-9cca, then `beans update ps-9cca -s completed`.
 
 ## Required output
 

--- a/.beans/ps-54nf--closeout-m10-milestone-closeout-close-ps-9cca.md
+++ b/.beans/ps-54nf--closeout-m10-milestone-closeout-close-ps-9cca.md
@@ -1,0 +1,39 @@
+---
+# ps-54nf
+title: "Closeout: M10 milestone closeout (close ps-9cca)"
+status: todo
+type: task
+priority: normal
+created_at: 2026-05-17T06:53:15Z
+updated_at: 2026-05-17T06:53:31Z
+parent: ps-l9fv
+blocked_by:
+  - ps-oqs8
+  - ps-z1og
+  - ps-hkdf
+---
+
+## Goal
+
+Close M10 milestone bean ps-9cca with a comprehensive `## Summary of Changes` section.
+
+## Method
+
+1. Run `beans list --parent ps-9cca` recursively (every epic + every grandchild).
+2. Group by phase: Phase 0 primitives, Phase 1 Fronting, Phase 2 domain epics, Phase 3 audits, Phase 4 closeout.
+3. Produce summary covering:
+   - Count of beans completed in each phase.
+   - Count of follow-up beans spawned by audits.
+   - Final design system surface count (primitives + screens).
+   - Reference to docs/design-system/handoff-m11.md.
+   - Open known gaps (deferred to M11 or later milestones).
+4. Body-append to ps-9cca, then `beans update ps-9cca -s completed`.
+
+## Required output
+
+- ps-9cca status = completed with full `## Summary of Changes` block.
+- This bean's own `## Summary of Changes` is brief: "Closed ps-9cca."
+
+## Out of scope
+
+- New design work — that's why this is the last bean in M10.

--- a/.beans/ps-5920--fronting-screen-designs.md
+++ b/.beans/ps-5920--fronting-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:12:53Z
-updated_at: 2026-03-31T23:12:57Z
+updated_at: 2026-05-17T05:48:58Z
 parent: ps-9cca
+blocked_by:
+  - ps-udt1
 ---
 
 Quick-switch UI, fronting timeline, co-fronting display, session detail/edit, fronting comments, analytics/charts, timer config, check-in prompts

--- a/.beans/ps-5fc5--communication-screen-designs.md
+++ b/.beans/ps-5fc5--communication-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:12:57Z
-updated_at: 2026-03-31T23:13:01Z
+updated_at: 2026-05-17T05:49:09Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Chat channel list, message thread, board messages, private notes, poll creation/voting/results, acknowledgement flow

--- a/.beans/ps-5gzc--journaling-wiki-pages-list-detail.md
+++ b/.beans/ps-5gzc--journaling-wiki-pages-list-detail.md
@@ -3,9 +3,12 @@
 title: "Journaling: Wiki pages (list + detail)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:44:35Z
-updated_at: 2026-05-17T06:44:35Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-djgs
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-5gzc--journaling-wiki-pages-list-detail.md
+++ b/.beans/ps-5gzc--journaling-wiki-pages-list-detail.md
@@ -1,0 +1,45 @@
+---
+# ps-5gzc
+title: "Journaling: Wiki pages (list + detail)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:44:35Z
+updated_at: 2026-05-17T06:44:35Z
+parent: ps-djgs
+---
+
+## Goal
+
+Design the wiki pages list and page detail view. Wiki is collaborative (multi-member authorship) while journal entries are typically single-author.
+
+## Surfaces
+
+- Wiki list: `(app)/journal/wiki/index.tsx`
+- Wiki detail: `(app)/journal/wiki/[id]/index.tsx`
+
+## Required states per surface
+
+- list: empty, populated, with-categories grouping, with-search, archived view, error
+- detail: default (with-multi-author chip stack, last-edited indicator), with-edit affordance, with-page-history popover (changelog), archived
+
+## Mode notes
+
+- Littles: simplified — single-page format, no categories
+- High-contrast: per-page-card uses border + label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (page tile), FAB, Accordion (ps-ecpl, for categories), AvatarStack (multi-author chip), KeyValueRow (ps-5lr6), Popover (ps-rgrw, page history), EmptyState (ps-ruwi), Button
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/journal.ts` wiki list, get, history
+
+## Required output
+
+- [ ] docs/design-system/preview/journal-wiki-list-detail.html with all states
+- [ ] Rationale on category visualization (left rail vs accordion vs top tabs)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), editor (separate bean), destructive flows (separate bean)

--- a/.beans/ps-5iro--design-innerworldnode-primitive.md
+++ b/.beans/ps-5iro--design-innerworldnode-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-5iro
+title: Design InnerworldNode primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:42Z
+updated_at: 2026-05-17T06:29:42Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the InnerworldNode primitive: canvas node placed on the Innerworld 2D canvas. Three variants — member, landmark, structure-entity — each with visual properties (color, shape, image source, external URL).
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-innerworld-node.html` showing the 3 variants (member, landmark, structure-entity) with each visual property type (color-only, image, external-url) and required states (idle, selected, dragging, editing-meta-popover-open)
+- [ ] Spec doc per SKILL.md §8 (drag-to-reposition gesture, snap-to-grid optional, accessibility: keyboard arrow keys reposition by 1px increments)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/radii.json`, `tokens/motion.json`
+- Reference: features.md §6 innerworld mapping, `apps/api/src/trpc/routers/innerworld.ts`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (System structure beans), the canvas pan/zoom chrome (separate Innerworld canvas screen bean)

--- a/.beans/ps-5lr6--design-keyvaluerow-primitive.md
+++ b/.beans/ps-5lr6--design-keyvaluerow-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-5lr6
+title: Design KeyValueRow primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:01Z
+updated_at: 2026-05-17T06:28:01Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the KeyValueRow primitive: a label + value row for details screens, audit-log entries, settings descriptions. Often grouped inside Section. Supports truncation rules, copy-to-clipboard affordance, inline edit hint.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-key-value-row.html` showing variants (single-line, wrapped, with-copy-button, with-edit-pencil, long-value-truncated) and required states
+- [ ] Spec doc per SKILL.md §8
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (fg-muted for keys, fg for values), `tokens/typography.json`
+- Reference: `components-display.html` if a KeyValueRow variant already exists; extend rather than duplicate
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-6a3x--search-settings-screen-designs.md
+++ b/.beans/ps-6a3x--search-settings-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:13:13Z
-updated_at: 2026-03-31T23:13:16Z
+updated_at: 2026-05-17T05:49:10Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Global search, settings panels (system settings, account settings, API key management, device management)

--- a/.beans/ps-6g36--audit-screen-trpc-router-parity-41-routers.md
+++ b/.beans/ps-6g36--audit-screen-trpc-router-parity-41-routers.md
@@ -3,9 +3,20 @@
 title: "Audit: Screen → tRPC router parity (41 routers)"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:52:27Z
-updated_at: 2026-05-17T06:52:27Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-oqs8
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
 ---
 
 ## Goal
@@ -14,7 +25,7 @@ Audit Phase 1 + Phase 2 design coverage against every tRPC router in apps/api/sr
 
 ## Method
 
-1. Enumerate routers: `ls apps/api/src/trpc/routers/*.ts` → 41 entries.
+1. Enumerate routers: `find apps/api/src/trpc/routers -name '*.ts'` → 41 entries (top-level glob misses `account/device-transfer.ts` and `structure/links.ts`).
 2. For each router, list the procedures and classify each:
    - **User-facing** (needs UI design).
    - **Backend-internal** (used by sync, server-to-server — no UI needed).

--- a/.beans/ps-6g36--audit-screen-trpc-router-parity-41-routers.md
+++ b/.beans/ps-6g36--audit-screen-trpc-router-parity-41-routers.md
@@ -1,0 +1,35 @@
+---
+# ps-6g36
+title: "Audit: Screen → tRPC router parity (41 routers)"
+status: todo
+type: task
+created_at: 2026-05-17T06:52:27Z
+updated_at: 2026-05-17T06:52:27Z
+parent: ps-oqs8
+---
+
+## Goal
+
+Audit Phase 1 + Phase 2 design coverage against every tRPC router in apps/api/src/trpc/routers/ (41 routers). Every router's user-facing operations must map to at least one designed surface. Every undesigned operation either spawns a bean or is documented as backend-only.
+
+## Method
+
+1. Enumerate routers: `ls apps/api/src/trpc/routers/*.ts` → 41 entries.
+2. For each router, list the procedures and classify each:
+   - **User-facing** (needs UI design).
+   - **Backend-internal** (used by sync, server-to-server — no UI needed).
+   - **Devtools-only** (debug routes — no design required).
+3. For each user-facing procedure, map to the designed surface (or note "no surface — gap").
+4. For every gap, create a follow-up bean.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-router-screen-parity.md.
+- Mapping table: rows = procedures, columns = classification + designed-surface-bean-id.
+- For each gap: a new bean titled "Surface: <router>.<procedure>" parented to the most-relevant Phase 2 domain epic.
+- This bean's `## Summary of Changes` includes the full mapping table + spawned bean IDs.
+
+## Out of scope
+
+- REST parity (separate concern — `pnpm trpc:parity` covers this).
+- RN implementation (M11).

--- a/.beans/ps-6n3q--auth-sign-up-flow-account-type-password-recovery-k.md
+++ b/.beans/ps-6n3q--auth-sign-up-flow-account-type-password-recovery-k.md
@@ -1,0 +1,54 @@
+---
+# ps-6n3q
+title: "Auth: Sign-up flow (account-type + password + recovery key)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:33:20Z
+updated_at: 2026-05-17T06:33:20Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the complete sign-up flow: account-type pick (system vs viewer per ADR 021) → master password create with strength meter → terms ack → recovery key ceremony (reveal + confirm + initial reminder schedule).
+
+## Surfaces
+
+- Account-type pick: `(auth)/register/account-type.tsx`
+- Password create: `(auth)/register/password.tsx`
+- Terms ack: inline within password screen or sibling
+- Recovery key reveal: `(auth)/register/recovery.tsx`
+- Recovery key confirm challenge: `(auth)/register/recovery-confirm.tsx`
+
+## Required states per surface
+
+- account-type: idle, system selected, viewer selected, with "What's the difference?" tooltip
+- password: weak / fair / strong, confirm-mismatch, terms-unchecked, submitting
+- reveal: revealed, ack-pending (3 checkboxes), all-acked
+- confirm: idle, mismatch, success, skip-dialog visible
+
+## Mode notes
+
+- Littles: account-type pick hidden (default to system); password screen simplified language ("a key word only you know"); recovery key ceremony preserved (safety-critical)
+- High-contrast / static: strength meter uses bar segments + text label (not color-only)
+
+## Primitives required
+
+- WizardStepper (pattern, ps-rhno)
+- RecoveryKey ceremony (pattern, ps-472d)
+- RecoveryKeyDisplay (ps-xthc), RecoveryKeyField (ps-o1zp)
+- TextField, Button, Switch, Checkbox, Banner
+
+## Data refs (informational)
+
+- REST `/v1/auth/register`
+- Client-side recovery key generation before POST
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-sign-up.html with all surfaces + states
+- [ ] Rationale notes on hard-ack copy per GOVERNANCE.md §6 / §7
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage variants beyond above (Phase 3 sweep), the recovery key ceremony pattern itself (Phase 0)

--- a/.beans/ps-6n3q--auth-sign-up-flow-account-type-password-recovery-k.md
+++ b/.beans/ps-6n3q--auth-sign-up-flow-account-type-password-recovery-k.md
@@ -3,9 +3,12 @@
 title: "Auth: Sign-up flow (account-type + password + recovery key)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:33:20Z
-updated_at: 2026-05-17T06:33:20Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-7nrg--structure-relationship-graph-edit-modal.md
+++ b/.beans/ps-7nrg--structure-relationship-graph-edit-modal.md
@@ -3,9 +3,12 @@
 title: "Structure: Relationship graph + edit modal"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:43:03Z
-updated_at: 2026-05-17T06:43:03Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-7nrg--structure-relationship-graph-edit-modal.md
+++ b/.beans/ps-7nrg--structure-relationship-graph-edit-modal.md
@@ -1,0 +1,46 @@
+---
+# ps-7nrg
+title: "Structure: Relationship graph + edit modal"
+status: todo
+type: feature
+created_at: 2026-05-17T06:43:03Z
+updated_at: 2026-05-17T06:43:03Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the relationship graph view — member-to-member typed edges visualized as a pan/zoom canvas — plus the inline relationship create / edit modal.
+
+## Surfaces
+
+- Graph: `(app)/structure/relationships/index.tsx`
+- Edit modal: `(modals)/relationship-edit.tsx`
+
+## Required states per surface
+
+- graph: empty (no relationships), small graph (3-10 nodes), large graph (with-clustering), with-filter-by-type chip, with-selected-edge highlighted, error
+- edit: pick relationship-type, pick endpoints (member A + member B), bidirectional toggle, submitting, success
+
+## Mode notes
+
+- Littles: hidden
+- High-contrast: graph edges use both color and pattern (dashed for one direction, solid for bidirectional)
+- Reduced-motion: pan / zoom transitions clamped
+
+## Primitives required
+
+- ScreenScaffold, Canvas primitive (or wrapper), RelationshipEdge (ps-jtn3), Avatar (nodes), Chip (filter), BottomSheet (edit host), RelationshipTypePicker (ps-1v9l), MemberPicker (ps-djqo), Switch (bidirectional), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/relationship.ts` list, create, update, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-relationships.html with all surfaces + states
+- [ ] Rationale on graph layout algorithm (force-directed vs radial vs circular)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the RelationshipEdge primitive (Phase 0)

--- a/.beans/ps-7to1--design-checkinprompt-primitive.md
+++ b/.beans/ps-7to1--design-checkinprompt-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-7to1
+title: Design CheckInPrompt primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:47Z
+updated_at: 2026-05-17T06:29:47Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the CheckInPrompt primitive: dissociation check-in card hosted in a modal or bottom sheet when a timer fires. Soft non-punitive copy per GOVERNANCE.md §7. Three primary actions: respond, dismiss, archive (Littles mode hides dismiss).
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-check-in-prompt.html` showing variants (default, Littles-mode simplified, with response-compose-open, with offline-queued banner) and required states
+- [ ] Spec doc per SKILL.md §8 (copy contract: gentle question variants; voice rules from GOVERNANCE.md §7)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`, `tokens/typography.json`
+- Reference: features.md §2 (dissociation check-ins), `apps/api/src/trpc/routers/check-in-record.ts`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (the Fronting check-ins screen bean, ps-f0qp)

--- a/.beans/ps-7vlc--settings-api-keys-list-create-wizard-detailrevoke.md
+++ b/.beans/ps-7vlc--settings-api-keys-list-create-wizard-detailrevoke.md
@@ -1,0 +1,47 @@
+---
+# ps-7vlc
+title: "Settings: API keys (list + create wizard + detail/revoke)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:46:31Z
+updated_at: 2026-05-17T06:46:31Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the API key surfaces — list of issued keys, create wizard (name + scopes + expiry), detail with reveal once / revoke.
+
+## Surfaces
+
+- List: `(app)/settings/integrations/api-keys/index.tsx`
+- Create wizard: `(app)/settings/integrations/api-keys/new.tsx`
+- Detail / revoke: `(app)/settings/integrations/api-keys/[id].tsx`
+
+## Required states per surface
+
+- list: empty, populated (with last-used indicator), with-near-expiry warning, archived view, error
+- create wizard: step 1 name + purpose label, step 2 scope-pick (read / write / sync, per-resource), step 3 expiry (60d / 1y / never), step 4 reveal-once key with copy / save / never-show-again ack
+- detail: post-creation read-only metadata, with-revoke affordance, revoked-state
+
+## Mode notes
+
+- Littles: hidden entirely
+- High-contrast: key reveal monospace + segmented
+
+## Primitives required
+
+- ScreenScaffold, WizardStepper (pattern, ps-rhno), InfiniteList (ps-hijf), FAB, Card (key tile), TextField, Select (expiry preset), Switch (per-scope), RecoveryKeyField (ps-o1zp, re-skinned for key display + copy), KeyValueRow (ps-5lr6), DestructiveConfirmDialog (ps-bydy), Banner (near-expiry), Button, EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/api-key.ts` list, get, create (returns reveal-once key), revoke
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-api-keys.html with all surfaces + states
+- [ ] Rationale on scope-pick UX (per-resource grid vs preset role)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the actual scope schema (server-defined)

--- a/.beans/ps-7vlc--settings-api-keys-list-create-wizard-detailrevoke.md
+++ b/.beans/ps-7vlc--settings-api-keys-list-create-wizard-detailrevoke.md
@@ -3,9 +3,12 @@
 title: "Settings: API keys (list + create wizard + detail/revoke)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:46:31Z
-updated_at: 2026-05-17T06:46:31Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-7wf6--system-structure-screen-designs.md
+++ b/.beans/ps-7wf6--system-structure-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:13:05Z
-updated_at: 2026-03-31T23:13:09Z
+updated_at: 2026-05-17T05:49:10Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Structure entity list/detail, hierarchy visualization, entity links, member associations

--- a/.beans/ps-7xno--members-list-filter-sheet.md
+++ b/.beans/ps-7xno--members-list-filter-sheet.md
@@ -1,0 +1,45 @@
+---
+# ps-7xno
+title: "Members: List + filter sheet"
+status: todo
+type: feature
+created_at: 2026-05-17T06:36:20Z
+updated_at: 2026-05-17T06:36:20Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the Members list — primary tab destination — and its filter sheet (by tag, by group, by saturation, by archived state, by bucket).
+
+## Surfaces
+
+- Members list: `(app)/(tabs)/members/index.tsx`
+- Filter sheet: `(modals)/member-filter.tsx`
+
+## Required states per surface
+
+- list: empty system (no members ever), small system (1–3 members), large system (search-required), with-archived-toggle, with-filter-chips active, loading, error
+- filter: idle, filters applied, reset
+
+## Mode notes
+
+- Littles: simplified — alphabetical grid only, no advanced filters
+- High-contrast: member identity rows pair color + shape + initial (GOVERNANCE.md §4)
+
+## Primitives required
+
+- ScreenScaffold, AppHeader, FAB (add new), InfiniteList (ps-hijf), MemberCard, Chip (filter), EmptyState (ps-ruwi), BottomSheet (filter host), TagPicker (ps-jleu) inline, MultiMemberPicker (ps-djqo, for group filter), BucketPicker (ps-s9r6, for bucket filter)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/member.ts` list with filters
+
+## Required output
+
+- [ ] docs/design-system/preview/members-list-filter.html with all states
+- [ ] Rationale on which filters are surfaced inline vs deep in the sheet
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), member detail (separate bean)

--- a/.beans/ps-7xno--members-list-filter-sheet.md
+++ b/.beans/ps-7xno--members-list-filter-sheet.md
@@ -3,9 +3,12 @@
 title: "Members: List + filter sheet"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:36:20Z
-updated_at: 2026-05-17T06:36:20Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-82u6--members-duplicate-flow-archive-delete-confirms.md
+++ b/.beans/ps-82u6--members-duplicate-flow-archive-delete-confirms.md
@@ -3,9 +3,12 @@
 title: "Members: Duplicate flow + archive + delete confirms"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:36:51Z
-updated_at: 2026-05-17T06:36:51Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-82u6--members-duplicate-flow-archive-delete-confirms.md
+++ b/.beans/ps-82u6--members-duplicate-flow-archive-delete-confirms.md
@@ -1,0 +1,47 @@
+---
+# ps-82u6
+title: "Members: Duplicate flow + archive + delete confirms"
+status: todo
+type: feature
+created_at: 2026-05-17T06:36:51Z
+updated_at: 2026-05-17T06:36:51Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the three destructive / semi-destructive member operations as a cohesive set: duplicate modal (semi-destructive — creates new entity), archive confirm dialog (reversible), delete confirm dialog (permanent, requires DestructiveConfirmDialog tier).
+
+## Surfaces
+
+- Duplicate: `(modals)/member-duplicate.tsx`
+- Archive confirm: `(modals)/member-archive.tsx`
+- Delete confirm: `(modals)/member-delete.tsx`
+
+## Required states per surface
+
+- duplicate: copy-options-pick (name override, copy-photos toggle, copy-fields toggle, copy-group-memberships toggle, copy-structure-links toggle), submitting, success-redirect-to-new
+- archive: warning + ack, submitting, success, undo-toast surfaced after dismiss
+- delete: warning, dependent-409 (cannot delete with active fronting / lifecycle event references), typed-confirm "DELETE [member name]", submitting, success-redirect-to-list
+
+## Mode notes
+
+- Littles: delete hidden entirely; archive copy softened ("Put away")
+- High-contrast: every destructive dialog uses icon + label (not color-only)
+
+## Primitives required
+
+- Dialog or BottomSheet (host), DestructiveConfirmDialog (ps-bydy), Switch (copy toggles), TextField (typed-confirm), Banner (409 warning), Button, Toast (undo affordance after archive)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/member.ts` duplicate, archive, restore, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/members-destructive-flows.html with all three flows + states
+- [ ] Copy decisions per GOVERNANCE.md §6 destructive tiers
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), undo handling logic

--- a/.beans/ps-8363--structure-innerworld-canvas-regionplaceredit-sheet.md
+++ b/.beans/ps-8363--structure-innerworld-canvas-regionplaceredit-sheet.md
@@ -3,9 +3,12 @@
 title: "Structure: Innerworld canvas + region/placer/edit sheets"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:43:22Z
-updated_at: 2026-05-17T06:43:22Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-8363--structure-innerworld-canvas-regionplaceredit-sheet.md
+++ b/.beans/ps-8363--structure-innerworld-canvas-regionplaceredit-sheet.md
@@ -1,0 +1,50 @@
+---
+# ps-8363
+title: "Structure: Innerworld canvas + region/placer/edit sheets"
+status: todo
+type: feature
+created_at: 2026-05-17T06:43:22Z
+updated_at: 2026-05-17T06:43:22Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the Innerworld 2D canvas — pan / zoom, drag-and-drop nodes, region overlays — plus the region create/edit sheet, the entity placer sheet, and the inline node edit popover.
+
+## Surfaces
+
+- Innerworld canvas: `(app)/structure/innerworld/index.tsx`
+- Region create/edit: `(sheets)/innerworld-region.tsx`
+- Entity placer: `(sheets)/innerworld-place.tsx`
+- Inline node edit: popover within canvas
+
+## Required states per surface
+
+- canvas: empty (no entities placed), populated, with-region-overlay, with-selected-node, dragging-node, zoomed-out (overview), zoomed-in (detail), with-canvas-state-save indicator (auto vs manual), offline
+- region sheet: name + color + gatekeeper-pick + access-rule (open vs gatekept), submitting
+- placer sheet: pick kind (member / landmark / structure-entity), pick target, pick position (snap-to-grid optional)
+- node edit popover: rename, color, image source override, link-to-structure-entity, delete
+
+## Mode notes
+
+- Littles: simplified — single-region "Headspace" only, no advanced canvas
+- High-contrast: region overlays use pattern + label
+- Reduced-motion: pan / zoom snap (no smooth transitions)
+
+## Primitives required
+
+- ScreenScaffold, Canvas primitive, InnerworldNode (ps-5iro), BottomSheet, TextField, ColorSwatchPicker, EmojiPicker, ImagePickerLauncher, MemberPicker (ps-djqo), EntityTypePicker (ps-gml0), Banner (offline), SyncIndicator (ps-gnkq), Button, Popover (ps-rgrw)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/innerworld.ts` regions, entities, canvas-state, save
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-innerworld.html with all surfaces + states
+- [ ] Rationale on the snap-to-grid affordance and auto-save trigger threshold
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the InnerworldNode primitive (Phase 0)

--- a/.beans/ps-85ha--cross-cutting-toast-snackbar-feedback-layer.md
+++ b/.beans/ps-85ha--cross-cutting-toast-snackbar-feedback-layer.md
@@ -1,0 +1,55 @@
+---
+# ps-85ha
+title: "Cross-cutting: Toast / snackbar feedback layer"
+status: todo
+type: feature
+created_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T06:50:29Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the global toast/snackbar feedback layer: position rules, stacking behavior, action affordances, severity variants, dismissal.
+
+## Surfaces
+
+- Bottom-anchored toast (mobile primary).
+- Top-anchored toast (web header context).
+- Snackbar with action button (single action).
+- Toast stack (multiple in-flight).
+
+## Required states per surface
+
+- Default (info).
+- Success.
+- Warning.
+- Error (persistent until dismissed).
+- With action.
+- Dismissing animation.
+- Stack-overflow (>3 toasts).
+
+## Mode notes
+
+- Default mode only.
+- Reduced-motion variant noted but not designed here (Phase 3 sweep).
+
+## Primitives required
+
+- Toast primitive.
+- Icon (severity glyph).
+- Button (action).
+
+## Data refs (informational)
+
+- No tRPC routers — UI-only ephemeral state.
+
+## Required output
+
+- HTML mockup of all variants × states in docs/design-system/preview/cross-cutting/toast-snackbar.html.
+- Decision notes: timeout per severity, stack cap.
+
+## Out of scope
+
+- RN implementation (M11).
+- Telemetry / observability of toast events.

--- a/.beans/ps-85ha--cross-cutting-toast-snackbar-feedback-layer.md
+++ b/.beans/ps-85ha--cross-cutting-toast-snackbar-feedback-layer.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Toast / snackbar feedback layer"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:50:29Z
-updated_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-8hob--privacy-buckets-list-create.md
+++ b/.beans/ps-8hob--privacy-buckets-list-create.md
@@ -3,9 +3,12 @@
 title: "Privacy: Buckets list + create"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:40:29Z
-updated_at: 2026-05-17T06:40:29Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-8hob--privacy-buckets-list-create.md
+++ b/.beans/ps-8hob--privacy-buckets-list-create.md
@@ -1,0 +1,45 @@
+---
+# ps-8hob
+title: "Privacy: Buckets list + create"
+status: todo
+type: feature
+created_at: 2026-05-17T06:40:29Z
+updated_at: 2026-05-17T06:40:29Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the privacy bucket list (with per-bucket friend count + content count) and the bucket-create form.
+
+## Surfaces
+
+- Bucket list: `(app)/privacy/buckets/index.tsx`
+- New: `(app)/privacy/buckets/new.tsx`
+
+## Required states per surface
+
+- list: empty (first-time), populated, with-rotation-needed badge per bucket, archived view, error
+- create: empty/populated (name, color, description, optional emoji), invalid (name conflict), submitting
+
+## Mode notes
+
+- Littles: simplified — single "Friends I trust" preset bucket only; create flow hidden
+- High-contrast: bucket color tile uses dot + emoji + label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), FAB, Card (bucket tile), BucketPill (ps-i6n1), Badge (rotation needed), EmptyState (ps-ruwi), TextField, TextArea, ColorSwatchPicker, EmojiPicker
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/bucket.ts` list, get, create with rotation-status summary
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-buckets-list-create.html with all states
+- [ ] Rationale on rotation-needed surfacing
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), bucket detail tabs (separate bean)

--- a/.beans/ps-8j2i--cross-cutting-encryption-tier-badge-explainer.md
+++ b/.beans/ps-8j2i--cross-cutting-encryption-tier-badge-explainer.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Encryption tier badge + explainer"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:51:15Z
-updated_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T07:42:02Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-8j2i--cross-cutting-encryption-tier-badge-explainer.md
+++ b/.beans/ps-8j2i--cross-cutting-encryption-tier-badge-explainer.md
@@ -1,0 +1,53 @@
+---
+# ps-8j2i
+title: "Cross-cutting: Encryption tier badge + explainer"
+status: todo
+type: feature
+created_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T06:51:15Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the encryption tier badge surfaced on data-bearing entities (member, journal, comm message, etc.) plus the explainer screen reachable from the badge.
+
+## Surfaces
+
+- Inline badge (E2E / TLS-only / unencrypted) on entity headers.
+- Tap-target → explainer card (what the tier means, who can read, where keys live).
+- Full explainer screen (linked from settings → help).
+- Tier-downgrade warning toast (rare path).
+
+## Required states per surface
+
+- E2E encrypted (default for member/journal/comm).
+- TLS-only (server can read — applies to non-secret metadata).
+- Unencrypted (applies to public profile, opted-in).
+- Mixed (entity contains fields in multiple tiers).
+
+## Mode notes
+
+- Default mode only.
+- High-contrast: tier color tokens must remain distinguishable — noted for Phase 3.
+
+## Primitives required
+
+- Badge primitive.
+- Card.
+- Icon (lock / shield / open variants).
+
+## Data refs (informational)
+
+- packages/crypto bucket/tier model.
+- packages/types entity tier classifications.
+
+## Required output
+
+- HTML mockup of badge + explainer in docs/design-system/preview/cross-cutting/encryption-tier.html.
+- Decision notes: per-tier color, copy register, where badge appears vs. hides.
+
+## Out of scope
+
+- RN implementation (M11).
+- Settings → Privacy & default-visibility (lives in ps-1yh1).

--- a/.beans/ps-8n3j--cross-cutting-empty-error-loading-state-catalog.md
+++ b/.beans/ps-8n3j--cross-cutting-empty-error-loading-state-catalog.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Empty / error / loading state catalog"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:51:15Z
-updated_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-8n3j--cross-cutting-empty-error-loading-state-catalog.md
+++ b/.beans/ps-8n3j--cross-cutting-empty-error-loading-state-catalog.md
@@ -1,0 +1,50 @@
+---
+# ps-8n3j
+title: "Cross-cutting: Empty / error / loading state catalog"
+status: todo
+type: feature
+created_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T06:51:15Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Produce a catalog screen showing every canonical empty / error / loading variant used across the app, so Phase 3 state-coverage audit has a reference.
+
+## Surfaces
+
+- Empty-list variants (first-time empty, search-no-results, filter-no-results, offline-empty).
+- Loading variants (skeleton list, skeleton card, spinner full-screen, inline spinner).
+- Error variants (network, server 5xx, permission 403, not-found 404, conflict 409, validation 422).
+- Maintenance / forced-upgrade states (linked from ps-\* system-banners bean).
+
+## Required states per surface
+
+- N/A — this bean IS the state catalog.
+
+## Mode notes
+
+- Default mode only.
+- All other modes will reference this catalog in their Phase 3 sweep.
+
+## Primitives required
+
+- Card primitive.
+- Skeleton primitive.
+- Spinner primitive.
+- Icon (per state).
+
+## Data refs (informational)
+
+- N/A — UI catalog only.
+
+## Required output
+
+- HTML mockup with every variant labeled in docs/design-system/preview/cross-cutting/state-catalog.html.
+- Decision notes: copy register per error class, illustration vs. icon choice per empty class.
+
+## Out of scope
+
+- RN implementation (M11).
+- Per-screen error mapping (lives in each screen bean).

--- a/.beans/ps-90fj--structure-entity-hierarchy-view.md
+++ b/.beans/ps-90fj--structure-entity-hierarchy-view.md
@@ -3,9 +3,12 @@
 title: "Structure: Entity hierarchy view"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:42:33Z
-updated_at: 2026-05-17T06:42:33Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-90fj--structure-entity-hierarchy-view.md
+++ b/.beans/ps-90fj--structure-entity-hierarchy-view.md
@@ -1,0 +1,43 @@
+---
+# ps-90fj
+title: "Structure: Entity hierarchy view"
+status: todo
+type: feature
+created_at: 2026-05-17T06:42:33Z
+updated_at: 2026-05-17T06:42:33Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the recursive entity hierarchy view — entities-within-entities, depth-capped at 50 levels per features.md §6. Tree visualization with expand / collapse + per-row entity-detail entry.
+
+## Surfaces
+
+- Entity hierarchy: `(app)/structure/entities/index.tsx`
+
+## Required states per surface
+
+- empty (no entities), shallow tree (1-2 levels), deep tree (collapsed), with-search-filter, with-archived-toggle, error
+
+## Mode notes
+
+- Littles: hidden
+- High-contrast: tree connector lines use border-strong + label per row
+
+## Primitives required
+
+- ScreenScaffold, Tree (existing in components-rows-tree.html), Accordion (ps-ecpl, alternate render), FAB, Card (entity row), Icon, Badge, EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/structure.ts` entities + hierarchy
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-hierarchy.html with all states
+- [ ] Rationale on tree-vs-accordion render at depth ≥3
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), entity detail / create (separate beans)

--- a/.beans/ps-92nh--audit-mode-coverage-sweep-reduced-motion.md
+++ b/.beans/ps-92nh--audit-mode-coverage-sweep-reduced-motion.md
@@ -3,9 +3,20 @@
 title: "Audit: Mode coverage sweep — reduced-motion"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:52:03Z
-updated_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-oqs8
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
 ---
 
 ## Goal

--- a/.beans/ps-92nh--audit-mode-coverage-sweep-reduced-motion.md
+++ b/.beans/ps-92nh--audit-mode-coverage-sweep-reduced-motion.md
@@ -1,0 +1,33 @@
+---
+# ps-92nh
+title: "Audit: Mode coverage sweep — reduced-motion"
+status: todo
+type: task
+created_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T06:52:03Z
+parent: ps-oqs8
+---
+
+## Goal
+
+Audit every Phase 2 screen for reduced-motion coverage per GOVERNANCE.md §3. Reduced-motion preserves layout and gestures but removes or shortens animations.
+
+## Method
+
+1. Walk every HTML mockup under docs/design-system/preview/ produced by Phase 1 + Phase 2.
+2. For each animation, classify:
+   - **Decorative** (purely aesthetic — remove entirely).
+   - **Informational** (signals state change — replace with instant state swap).
+   - **Disorienting** (parallax, slide-from-edge, scale — must be neutralized).
+3. For every animation that requires a non-trivial reduced-motion variant, create a follow-up bean.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-reduced-motion-sweep.md.
+- For each gap: a new bean titled "Reduced-motion: <surface>" parented to the relevant Phase 2 domain epic, blocked-by this audit bean.
+- This bean's `## Summary of Changes` lists every spawned bean ID.
+
+## Out of scope
+
+- Redesign of surfaces — gaps spawn beans, not handled inline.
+- RN implementation (M11).

--- a/.beans/ps-99lr--journaling-journal-entries-list-detail.md
+++ b/.beans/ps-99lr--journaling-journal-entries-list-detail.md
@@ -1,0 +1,45 @@
+---
+# ps-99lr
+title: "Journaling: Journal entries (list + detail)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:44:17Z
+updated_at: 2026-05-17T06:44:17Z
+parent: ps-djgs
+---
+
+## Goal
+
+Design the journal entries list and entry detail view.
+
+## Surfaces
+
+- Entries list: `(app)/journal/entries/index.tsx`
+- Entry detail: `(app)/journal/entries/[id]/index.tsx`
+
+## Required states per surface
+
+- list: empty, populated, filtered (by-member-author, by-date-range, by-bucket), archived view, with-search-active, error
+- detail: default (with author + date + bucket pill + fronting-context-at-time-of-entry), with-edit affordance, archived
+
+## Mode notes
+
+- Littles: entries by trauma-marker authors hidden by default; simplified detail layout
+- High-contrast: per-entry-card uses border-strong
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (entry tile), FAB, ProxyChip (ps-jtvw, author), BucketPill (ps-i6n1), KeyValueRow (ps-5lr6), FrontingChip (ps-458i, snapshot at time), EmptyState (ps-ruwi), Button
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/journal.ts` list, get, archive, restore
+
+## Required output
+
+- [ ] docs/design-system/preview/journal-entries-list-detail.html with all states
+- [ ] Rationale on entry-card density (compact vs expanded preview)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), editor (separate bean)

--- a/.beans/ps-99lr--journaling-journal-entries-list-detail.md
+++ b/.beans/ps-99lr--journaling-journal-entries-list-detail.md
@@ -3,9 +3,12 @@
 title: "Journaling: Journal entries (list + detail)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:44:17Z
-updated_at: 2026-05-17T06:44:17Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-djgs
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-9bdx--audit-mode-coverage-sweep-static.md
+++ b/.beans/ps-9bdx--audit-mode-coverage-sweep-static.md
@@ -1,0 +1,34 @@
+---
+# ps-9bdx
+title: "Audit: Mode coverage sweep — static"
+status: todo
+type: task
+created_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T06:52:03Z
+parent: ps-oqs8
+---
+
+## Goal
+
+Audit every Phase 2 screen for static-mode coverage per GOVERNANCE.md §3. Static mode removes all animation, gestures, transitions — everything is tap-only and instant.
+
+## Method
+
+1. Walk every HTML mockup under docs/design-system/preview/ produced by Phase 1 + Phase 2.
+2. For each surface, identify any animation, gesture, or transition (slide-in, fade, spring, drag, swipe, hold).
+3. Categorize each:
+   - **Already covered** (mockup notes static-mode behavior).
+   - **Trivially derived** (no design needed — animation simply removed).
+   - **Needs static variant** (gesture must be replaced — e.g., bottom-sheet drag becomes full-screen modal; hold-to-confirm becomes typed-match).
+4. For every "needs static variant" gap, create a follow-up bean blocked by this audit.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-static-mode-sweep.md (local-only — folder is gitignored).
+- For each gap: a new bean titled "Static mode: <surface>" parented to the relevant Phase 2 domain epic, blocked-by this audit bean.
+- This bean's `## Summary of Changes` lists every spawned bean ID.
+
+## Out of scope
+
+- Redesign of surfaces — gaps spawn beans, not handled inline.
+- RN implementation (M11).

--- a/.beans/ps-9bdx--audit-mode-coverage-sweep-static.md
+++ b/.beans/ps-9bdx--audit-mode-coverage-sweep-static.md
@@ -3,9 +3,20 @@
 title: "Audit: Mode coverage sweep — static"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:52:03Z
-updated_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-oqs8
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
 ---
 
 ## Goal

--- a/.beans/ps-9cca--milestone-10-uiux-design.md
+++ b/.beans/ps-9cca--milestone-10-uiux-design.md
@@ -6,9 +6,6 @@ type: milestone
 priority: normal
 created_at: 2026-03-31T23:10:04Z
 updated_at: 2026-04-21T14:00:40Z
-blocked_by:
-  - ps-h2gl
-  - ps-cd6x
 ---
 
 Stitch-generated HTML mockups for every screen family, establishing visual language, interaction patterns, and layout decisions

--- a/.beans/ps-9xue--privacy-social-screen-designs.md
+++ b/.beans/ps-9xue--privacy-social-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:13:01Z
-updated_at: 2026-03-31T23:13:04Z
+updated_at: 2026-05-17T05:49:10Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Privacy bucket management, field visibility controls, friend list, friend code flow, friend dashboard, push notification preferences

--- a/.beans/ps-9yhh--design-richtextfield-primitive.md
+++ b/.beans/ps-9yhh--design-richtextfield-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-9yhh
+title: Design RichTextField primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:24Z
+updated_at: 2026-05-17T06:28:24Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the RichTextField primitive: block-aware single-message rich-text input for chat composer, board-message composer, and notes. Lighter than BlockEditor — inline formatting only (bold/italic, member @mentions, member-link, emoji), no block-type switching.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-rich-text-field.html` showing variants (empty, typing, with-mention-picker open, with-formatting-toolbar) and required states
+- [ ] Spec doc per SKILL.md §8 covering: @-mention picker invocation, formatting toolbar layout, paste-handling rules (strip foreign formatting)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`, `tokens/typography.json`
+- Reference: features.md §3
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Communication beans), MemberPicker / member-link target picker (separate)

--- a/.beans/ps-a200--home-webtablet-layout-adaptation-drawer-content.md
+++ b/.beans/ps-a200--home-webtablet-layout-adaptation-drawer-content.md
@@ -1,0 +1,44 @@
+---
+# ps-a200
+title: "Home: Web/tablet layout adaptation (Drawer + content)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:35:46Z
+updated_at: 2026-05-17T06:35:46Z
+parent: ps-divy
+---
+
+## Goal
+
+Design the ≥1024px responsive layout — Drawer rail on the left, content on the right. Drawer hosts what the mobile More tab hosts plus the bottom-tab nav.
+
+## Surfaces
+
+- Web/tablet adapted shell: applies to every `(app)` route at ≥1024px viewport
+
+## Required states per surface
+
+- default (drawer expanded), collapsed-rail (icons only), with-system-switcher-expanded, with-section-active-highlight
+
+## Mode notes
+
+- Littles: web mode still applies but with fewer drawer entries; collapsed-rail disabled (always-expanded for clarity)
+- High-contrast: drawer separation from content uses 2px border with `--border-strong`
+
+## Primitives required
+
+- Drawer (ps-217e), SystemSwitcher (ps-a5pt), ScreenScaffold, ListItem (drawer entries), Badge, Icon
+
+## Data refs (informational)
+
+- Viewport breakpoint detection — local state, not server data
+- Same section enablement as More hub
+
+## Required output
+
+- [ ] docs/design-system/preview/home-web-layout.html showing the layout at both 1024px and ~1600px widths
+- [ ] Rationale on the rail / expanded breakpoint thresholds
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the Drawer primitive itself (Phase 0)

--- a/.beans/ps-a200--home-webtablet-layout-adaptation-drawer-content.md
+++ b/.beans/ps-a200--home-webtablet-layout-adaptation-drawer-content.md
@@ -3,9 +3,12 @@
 title: "Home: Web/tablet layout adaptation (Drawer + content)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:35:46Z
-updated_at: 2026-05-17T06:35:46Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-divy
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-a2a6--settings-data-import-hub-sp-wizard-pk-wizard-job-d.md
+++ b/.beans/ps-a2a6--settings-data-import-hub-sp-wizard-pk-wizard-job-d.md
@@ -1,0 +1,51 @@
+---
+# ps-a2a6
+title: "Settings: Data import (hub + SP wizard + PK wizard + job detail)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:47:18Z
+updated_at: 2026-05-17T06:47:18Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the data import surfaces — the hub (pick source: SP / PK), the SP import wizard, the PK import wizard, and the per-job detail (progress + result + conflict resolution).
+
+## Surfaces
+
+- Import hub: `(app)/settings/data/import.tsx`
+- SP wizard: `(app)/settings/data/import/sp/index.tsx`
+- PK wizard: `(app)/settings/data/import/pk/index.tsx`
+- Job detail: `(app)/settings/data/import/[jobId].tsx`
+
+## Required states per surface
+
+- hub: default (with-active-job banner if in-progress), with-recent-imports list, error
+- SP wizard: source pick (file upload vs API token), token entry (with-phishing-warning per import-sp hardening bean), preview-of-counts, dedup-options (against existing Pluralscape buckets), confirm + import, in-progress, complete
+- PK wizard: source pick (file upload only — PK has no live API in scope), preview-of-counts, mapping-options, confirm + import, in-progress, complete
+- job detail: live progress per category, conflict-resolution surfaces (one-by-one or batch-apply), result summary, retry-from-failed-chunk
+
+## Mode notes
+
+- Littles: import hidden entirely
+- High-contrast: progress bars use border + label
+
+## Primitives required
+
+- ScreenScaffold, Card (source tile), WizardStepper (pattern, ps-rhno), TextField, Switch (per-mapping option), KeyValueRow (ps-5lr6), ProgressBar (ps-3m01), Banner (warnings), Button, EmptyState (ps-ruwi), DestructiveConfirmDialog (ps-bydy, cancel mid-import)
+- ImportConflictResolver pattern (existing in patterns.html)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/import-job.ts` create, list, get, cancel, retry
+- `apps/api/src/trpc/routers/import-entity-ref.ts` conflict-resolution batch ops
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-data-import.html with all surfaces + states
+- [ ] Rationale on conflict-resolution UX (per-conflict review vs batch-apply)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the actual import engines (already exist in `packages/import-*`)

--- a/.beans/ps-a2a6--settings-data-import-hub-sp-wizard-pk-wizard-job-d.md
+++ b/.beans/ps-a2a6--settings-data-import-hub-sp-wizard-pk-wizard-job-d.md
@@ -3,9 +3,12 @@
 title: "Settings: Data import (hub + SP wizard + PK wizard + job detail)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:47:18Z
-updated_at: 2026-05-17T06:47:18Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-a46t--audit-mode-coverage-sweep-high-contrast.md
+++ b/.beans/ps-a46t--audit-mode-coverage-sweep-high-contrast.md
@@ -3,9 +3,20 @@
 title: "Audit: Mode coverage sweep — high-contrast"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:52:03Z
-updated_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-oqs8
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
 ---
 
 ## Goal

--- a/.beans/ps-a46t--audit-mode-coverage-sweep-high-contrast.md
+++ b/.beans/ps-a46t--audit-mode-coverage-sweep-high-contrast.md
@@ -1,0 +1,34 @@
+---
+# ps-a46t
+title: "Audit: Mode coverage sweep — high-contrast"
+status: todo
+type: task
+created_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T06:52:03Z
+parent: ps-oqs8
+---
+
+## Goal
+
+Audit every Phase 2 screen for high-contrast mode coverage per GOVERNANCE.md §3 and packages/design-system/docs/A11Y_GATES.md contrast requirements.
+
+## Method
+
+1. Walk every HTML mockup under docs/design-system/preview/ produced by Phase 1 + Phase 2.
+2. Run contrast checks on each token-pair used (text on background, icon on background, focus ring on background).
+3. For each surface, classify:
+   - **Passes high-contrast at default tokens** (no work).
+   - **Passes via high-contrast token theme** (covered by theme swap).
+   - **Needs surface-specific override** (e.g., subtle dividers must become solid lines; tier badges need different hue mapping).
+4. For every surface needing an override, create a follow-up bean.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-high-contrast-sweep.md.
+- For each gap: a new bean titled "High-contrast: <surface>" parented to the relevant Phase 2 domain epic, blocked-by this audit bean.
+- This bean's `## Summary of Changes` lists every spawned bean ID and a contrast-ratio summary table.
+
+## Out of scope
+
+- Token-theme work (lives in packages/design-system — already in scope for design system).
+- RN implementation (M11).

--- a/.beans/ps-a4fd--communication-acknowledgements-list-detail-create.md
+++ b/.beans/ps-a4fd--communication-acknowledgements-list-detail-create.md
@@ -3,9 +3,12 @@
 title: "Communication: Acknowledgements (list + detail + create)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:39:42Z
-updated_at: 2026-05-17T06:39:42Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-a4fd--communication-acknowledgements-list-detail-create.md
+++ b/.beans/ps-a4fd--communication-acknowledgements-list-detail-create.md
@@ -1,0 +1,47 @@
+---
+# ps-a4fd
+title: "Communication: Acknowledgements (list + detail + create)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:39:42Z
+updated_at: 2026-05-17T06:39:42Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the mandatory-acknowledgement surfaces — targeted alerts persisting until a specific member confirms. List of pending + resolved, detail with confirm action, create form.
+
+## Surfaces
+
+- Ack list: `(app)/communicate/acks/index.tsx`
+- Ack detail: `(app)/communicate/acks/[id].tsx`
+- New: `(app)/communicate/acks/new.tsx`
+
+## Required states per surface
+
+- list: empty, with-pending-on-me (highlighted), with-pending-on-others, resolved view, archived view, error
+- detail: pending-on-me (with confirm CTA), pending-on-others (read-only with target chip), resolved (with confirmation timestamp + by-whom), archived
+- create: empty/populated, with target-member picker, with-bucket-picker, with optional response-deadline, submitting
+
+## Mode notes
+
+- Littles: acks hidden (caregiver-only); Littles members surfaced via simplified prompt instead
+- High-contrast: pending vs resolved use icon + label (not color-only)
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (ack tile), FAB, Banner (pending-on-me CTA), RichTextField (ps-9yhh), MemberPicker (ps-djqo), BucketPicker (ps-s9r6), DateTimePicker (deadline), Button (confirm), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/acknowledgement.ts` list, get, create, confirm, archive, restore, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-acknowledgements.html with all surfaces + states
+- [ ] Copy decisions on the "this needs you" framing (per GOVERNANCE.md §7)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), push notification delivery surfaces (Privacy & Social beans)

--- a/.beans/ps-a5ee--design-errorstate-primitive.md
+++ b/.beans/ps-a5ee--design-errorstate-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-a5ee
+title: Design ErrorState primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:26:58Z
+updated_at: 2026-05-17T06:26:58Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the ErrorState primitive: a first-class screen-level error display with retry CTA and optional error-code reveal. Distinct from inline Banner — ErrorState replaces a list's content, Banner adorns the top.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-error-state.html` showing variants (recoverable with retry, terminal without retry, with-code-reveal) and states (default, retrying, retry-failed)
+- [ ] Spec doc per SKILL.md §8
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (semantic danger), `tokens/typography.json`
+- Reference: existing `state state--error` in `components-display.html`; reuse pattern
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-a5pt--design-systemswitcher-primitive.md
+++ b/.beans/ps-a5pt--design-systemswitcher-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-a5pt
+title: Design SystemSwitcher primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:40Z
+updated_at: 2026-05-17T06:28:40Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the SystemSwitcher primitive: account → system pick surface reachable from the AppHeader. Shows the `SystemListItem[]` for the current account (features.md §6 multi-system support). On mobile invoked as a BottomSheet; on web ≥1024px as a Drawer panel or header dropdown.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-system-switcher.html` showing variants (single system — no switcher), 2-5 systems, many systems with search, and required states
+- [ ] Spec doc per SKILL.md §8 (search threshold ~5 systems, sort order, "current" indicator)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md §6, `SystemListItem` type in `packages/types/`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Home & Nav beans)

--- a/.beans/ps-ag15--settings-nomenclature-editor.md
+++ b/.beans/ps-ag15--settings-nomenclature-editor.md
@@ -1,0 +1,43 @@
+---
+# ps-ag15
+title: "Settings: Nomenclature editor"
+status: todo
+type: feature
+created_at: 2026-05-17T06:45:51Z
+updated_at: 2026-05-17T06:45:51Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the per-system nomenclature editor — every term in features.md (System, Member, Fronting, Switch, Co-fronting, Headspace, Host, Structure, Dormancy, Body, Amnesia, Saturation) has an editable override, organized by category.
+
+## Surfaces
+
+- Nomenclature: `(app)/settings/system/nomenclature.tsx`
+
+## Required states per surface
+
+- default (all canonical terms with overrides visible), with-preset-pick (alters / headmates / parts / custom), per-term-edit (with conflict warning if term collides), submitting, success, with-undo affordance after save
+
+## Mode notes
+
+- Littles: simplified — only "What do you call yourselves?" single term editable
+- High-contrast: per-row form uses border + label
+
+## Primitives required
+
+- ScreenScaffold, RadioGroup (preset pick), TextField (per-term override), Section (term categories), KeyValueRow (ps-5lr6), Banner (preview applied), Button
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/system.ts` nomenclature get, update
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-nomenclature.html with all states
+- [ ] Rationale on preset-vs-custom UX
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the per-term application across the app (rendered via i18n at runtime)

--- a/.beans/ps-ag15--settings-nomenclature-editor.md
+++ b/.beans/ps-ag15--settings-nomenclature-editor.md
@@ -3,9 +3,12 @@
 title: "Settings: Nomenclature editor"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:45:51Z
-updated_at: 2026-05-17T06:45:51Z
+updated_at: 2026-05-17T07:42:03Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-awhm--structure-structure-overview.md
+++ b/.beans/ps-awhm--structure-structure-overview.md
@@ -1,0 +1,44 @@
+---
+# ps-awhm
+title: "Structure: Structure overview"
+status: todo
+type: feature
+created_at: 2026-05-17T06:42:19Z
+updated_at: 2026-05-17T06:42:19Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the Structure overview screen — landing for system structure with cards for entity-type counts, hierarchy depth, snapshot count, and quick-jump tiles.
+
+## Surfaces
+
+- Structure overview: `(app)/structure/index.tsx`
+
+## Required states per surface
+
+- default (with entity-type counts + recent snapshots), empty (no entity types defined), with-many-entity-types (scrollable), error
+
+## Mode notes
+
+- Littles: simplified — only "Members and groups" entry visible; advanced structure hidden
+- High-contrast: per-section card uses border-strong, not surface tint
+
+## Primitives required
+
+- ScreenScaffold, Card (section tile), KeyValueRow (ps-5lr6), Badge, EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/structure.ts` summary
+- `apps/api/src/trpc/routers/snapshot.ts` recent
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-overview.html with all states
+- [ ] Rationale on what's surfaced vs hidden behind sub-screens
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), individual sub-screens

--- a/.beans/ps-awhm--structure-structure-overview.md
+++ b/.beans/ps-awhm--structure-structure-overview.md
@@ -3,9 +3,12 @@
 title: "Structure: Structure overview"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:42:19Z
-updated_at: 2026-05-17T06:42:19Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-bflw--journaling-journal-entry-editor-with-fronting-snap.md
+++ b/.beans/ps-bflw--journaling-journal-entry-editor-with-fronting-snap.md
@@ -1,0 +1,48 @@
+---
+# ps-bflw
+title: "Journaling: Journal entry editor (with fronting snapshot insert)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:44:28Z
+updated_at: 2026-05-17T06:44:28Z
+parent: ps-djgs
+---
+
+## Goal
+
+Design the journal entry editor (block-based per features.md §7) plus the fronting snapshot insert affordance (inserts a frozen snapshot block referencing the active fronting state at insert time).
+
+## Surfaces
+
+- New: `(app)/journal/entries/new.tsx`
+- Edit: `(app)/journal/entries/[id]/edit.tsx`
+- Fronting snapshot insert: inline within editor
+
+## Required states per surface
+
+- editor: empty (new), populated (edit), with-block-menu-open, with-slash-command-palette, with-image-upload-pending, with-fronting-snapshot-block, with-member-link-block, save-status indicator (saving / saved / offline-queued)
+- snapshot insert: idle (with current fronting preview), inserted (as immutable block), error (key-unavailable for older snapshot)
+
+## Mode notes
+
+- Littles: simplified — paragraph + image blocks only; no slash-commands, no fronting snapshot
+- High-contrast: block boundaries use border-strong on hover
+
+## Primitives required
+
+- ScreenScaffold, BlockEditor (ps-zpyu), ProxyChip (ps-jtvw, author at top), BucketPicker (ps-s9r6), FrontingChip (ps-458i, current state preview), ImagePickerLauncher, ImageCropper (ps-107o), MemberPicker (ps-djqo, member-link target), Button, Banner (offline notice), SyncIndicator (ps-gnkq)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/journal.ts` create, update
+- `apps/api/src/trpc/routers/fronting-session.ts` snapshot (frozen reference at insert time)
+- `apps/api/src/trpc/routers/blob.ts` upload
+
+## Required output
+
+- [ ] docs/design-system/preview/journal-entry-editor.html with all states
+- [ ] Rationale on snapshot-block visual (read-only mini-card vs inline text)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the BlockEditor primitive (Phase 0)

--- a/.beans/ps-bflw--journaling-journal-entry-editor-with-fronting-snap.md
+++ b/.beans/ps-bflw--journaling-journal-entry-editor-with-fronting-snap.md
@@ -3,9 +3,12 @@
 title: "Journaling: Journal entry editor (with fronting snapshot insert)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:44:28Z
-updated_at: 2026-05-17T06:44:28Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-djgs
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-bydy--design-destructiveconfirmdialog-primitive.md
+++ b/.beans/ps-bydy--design-destructiveconfirmdialog-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-bydy
+title: Design DestructiveConfirmDialog primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:31Z
+updated_at: 2026-05-17T06:27:31Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the DestructiveConfirmDialog primitive: typed-phrase confirmation extending the base Dialog. Required for the Critical tier of destructive actions per GOVERNANCE.md §6 — account purge, recovery-key regenerate, system delete, friend block, snapshot delete.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-destructive-confirm.html` showing variants (typed-phrase, hold-to-confirm fallback, multi-step) and required states per SKILL.md §7
+- [ ] Spec doc per SKILL.md §8 including the GOVERNANCE.md §6 tier mapping
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (danger palette)
+- Reference: GOVERNANCE.md §6 destructive-action tiers, `patterns.html` "Destructive-action confirmation" pattern
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-ctnx--members-detail-with-6-tabs-overview-photos-relatio.md
+++ b/.beans/ps-ctnx--members-detail-with-6-tabs-overview-photos-relatio.md
@@ -3,9 +3,12 @@
 title: "Members: Detail with 6 tabs (overview / photos / relationships / fields / groups / lifecycle)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:36:34Z
-updated_at: 2026-05-17T06:36:34Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-ctnx--members-detail-with-6-tabs-overview-photos-relatio.md
+++ b/.beans/ps-ctnx--members-detail-with-6-tabs-overview-photos-relatio.md
@@ -1,0 +1,59 @@
+---
+# ps-ctnx
+title: "Members: Detail with 6 tabs (overview / photos / relationships / fields / groups / lifecycle)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:36:34Z
+updated_at: 2026-05-17T06:36:34Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the member detail screen with 6 tabbed sub-views. Tabs share a scaffold: header (avatar + name + pronouns + tags), tab bar, content. The 6 tabs are: overview (description, color, custom front status, structure entity membership), photos (gallery), relationships (graph edges to other members), fields (custom-field values), groups (group memberships), lifecycle (event log filtered to this member).
+
+## Surfaces
+
+- Member detail: `(app)/members/[memberId]/index.tsx` (overview, default tab)
+- Photos: `(app)/members/[memberId]/photos.tsx`
+- Relationships: `(app)/members/[memberId]/relationships.tsx`
+- Fields: `(app)/members/[memberId]/fields.tsx`
+- Groups: `(app)/members/[memberId]/groups.tsx`
+- Lifecycle: `(app)/members/[memberId]/lifecycle.tsx`
+
+## Required states per surface
+
+- header: default, archived, currently-fronting (badge), with-saturation-level
+- overview: rich description with member-link previews, color swatch, tags
+- photos: gallery (1, multi, empty), upload-pending, error
+- relationships: list of edges + visual mini-graph; empty
+- fields: ordered field-value list, empty if none defined
+- groups: list of group memberships, empty
+- lifecycle: timeline of events, empty
+
+## Mode notes
+
+- Littles: photos tab hidden if any contain trauma-marker content (per system setting); lifecycle simplified to last-N events
+- High-contrast: tabs use underline indicator (not background-fill)
+
+## Primitives required
+
+- ScreenScaffold, Avatar, Tabs (existing), KeyValueRow (ps-5lr6), BucketPill (ps-i6n1), LifecycleEventChip (ps-v3e9), Accordion (ps-ecpl), MarkdownRenderer, MentionRenderer, RelationshipEdge (ps-jtn3), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/member.ts` get
+- `apps/api/src/trpc/routers/member-photo.ts` list
+- `apps/api/src/trpc/routers/relationship.ts` byMember
+- `apps/api/src/trpc/routers/field.ts` valuesForMember
+- `apps/api/src/trpc/routers/group.ts` byMember
+- `apps/api/src/trpc/routers/lifecycle-event.ts` byMember
+
+## Required output
+
+- [ ] docs/design-system/preview/members-detail-tabs.html with all 6 tabs + their states
+- [ ] Rationale on tab order and which gets primary action button (header right slot)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), edit form (separate bean), photo gallery management modal (separate bean)

--- a/.beans/ps-d5bg--fronting-timer-configs-list-createedit.md
+++ b/.beans/ps-d5bg--fronting-timer-configs-list-createedit.md
@@ -1,0 +1,51 @@
+---
+# ps-d5bg
+title: "Fronting: Timer configs — list + create/edit"
+status: todo
+type: feature
+created_at: 2026-05-17T05:51:05Z
+updated_at: 2026-05-17T05:51:05Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the dissociation check-in timer configuration screens.
+
+## Surfaces
+
+- Timer config list: `(app)/timers/index.tsx`
+- Timer config create/edit: `(app)/timers/new.tsx`, `[id]/edit.tsx` — interval, waking-hours window, member scope, notification preferences.
+
+## Required states per surface
+
+- list: empty, populated, archived view (separate filter)
+- config form: valid, invalid (e.g. interval too short), submitting, conflict
+
+## Mode notes
+
+- Waking-hours picker must support both 12h and 24h locale formats — design both.
+- Littles mode: hides "waking hours" complexity (single all-day interval option only).
+
+## Primitives required
+
+- ListItem
+- FAB
+- DurationPicker (interval: every N minutes / hours)
+- TimePicker (waking-hours start / end)
+- Switch (enable/disable, notification toggle)
+- MultiMemberPicker (member scope — which members get the check-in)
+- EmptyState
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/timer-config.ts` — list, get, create, update, archive, restore, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-timers.html with all states
+- [ ] Layout / interaction rationale
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage (Phase 3 sweep), actual check-in prompt UI (separate bean D9).

--- a/.beans/ps-d5bg--fronting-timer-configs-list-createedit.md
+++ b/.beans/ps-d5bg--fronting-timer-configs-list-createedit.md
@@ -3,9 +3,12 @@
 title: "Fronting: Timer configs — list + create/edit"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:51:05Z
-updated_at: 2026-05-17T05:51:05Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-divy--home-navigation-design.md
+++ b/.beans/ps-divy--home-navigation-design.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:12:47Z
-updated_at: 2026-03-31T23:12:49Z
+updated_at: 2026-05-17T05:49:09Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Tab bar, home dashboard (active fronters, recent activity), app shell chrome

--- a/.beans/ps-djgs--journaling-screen-designs.md
+++ b/.beans/ps-djgs--journaling-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:13:09Z
-updated_at: 2026-03-31T23:13:13Z
+updated_at: 2026-05-17T05:49:10Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Journal entry list, entry creation/edit

--- a/.beans/ps-djqo--design-memberpicker-and-multimemberpicker-primitiv.md
+++ b/.beans/ps-djqo--design-memberpicker-and-multimemberpicker-primitiv.md
@@ -1,0 +1,27 @@
+---
+# ps-djqo
+title: Design MemberPicker and MultiMemberPicker primitives
+status: todo
+type: task
+created_at: 2026-05-17T06:30:18Z
+updated_at: 2026-05-17T06:30:18Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the MemberPicker (single-pick) and MultiMemberPicker (multi-pick) primitives together — they share the search + member-row pattern and identity rendering rules. Used for poll voters, mention targets, group assignment, fronting member selection.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-member-picker.html` showing both primitives with variants (empty system, small system, large system with search, with-archived-toggle) and required states
+- [ ] Spec doc per SKILL.md §8 (single doc covering both — note where behavior diverges)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: GOVERNANCE.md §4 member identity rules, `apps/api/src/trpc/routers/member.ts`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-dlf0--structure-entity-create-edit-form.md
+++ b/.beans/ps-dlf0--structure-entity-create-edit-form.md
@@ -3,9 +3,12 @@
 title: "Structure: Entity create / edit form"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:42:54Z
-updated_at: 2026-05-17T06:42:54Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-dlf0--structure-entity-create-edit-form.md
+++ b/.beans/ps-dlf0--structure-entity-create-edit-form.md
@@ -1,0 +1,44 @@
+---
+# ps-dlf0
+title: "Structure: Entity create / edit form"
+status: todo
+type: feature
+created_at: 2026-05-17T06:42:54Z
+updated_at: 2026-05-17T06:42:54Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the entity create / edit form — pick type, name, color, image, emoji, parent entity, member-link affordance.
+
+## Surfaces
+
+- New: `(app)/structure/entities/new.tsx`
+- Edit: `(app)/structure/entities/[id]/edit.tsx`
+
+## Required states per surface
+
+- form: empty (new), populated (edit), with-parent-picker open (cycle-warning if invalid), invalid, submitting, conflict
+- with-member-links pre-populated (for edit)
+
+## Mode notes
+
+- Littles: hidden
+- High-contrast: per-field labels are top-aligned + bold
+
+## Primitives required
+
+- ScreenScaffold, EntityTypePicker (ps-gml0), TextField, ColorSwatchPicker, EmojiPicker, ImagePickerLauncher, MultiMemberPicker (ps-djqo, member-links), Banner (cycle warning), Button
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/structure.ts` entity create, update, parent change
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-entity-create-edit.html with all states
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), entity detail (separate bean)

--- a/.beans/ps-dq5i--auth-setup-wizard-6-steps.md
+++ b/.beans/ps-dq5i--auth-setup-wizard-6-steps.md
@@ -3,9 +3,12 @@
 title: "Auth: Setup wizard (6 steps)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:34:08Z
-updated_at: 2026-05-17T06:34:08Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-dq5i--auth-setup-wizard-6-steps.md
+++ b/.beans/ps-dq5i--auth-setup-wizard-6-steps.md
@@ -1,0 +1,52 @@
+---
+# ps-dq5i
+title: "Auth: Setup wizard (6 steps)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:34:08Z
+updated_at: 2026-05-17T06:34:08Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the 6-step initial setup wizard run after sign-up + recovery key acknowledgement. All steps use the WizardStepper pattern.
+
+## Surfaces
+
+- Status check: `(setup)/index.tsx`
+- System profile: `(setup)/profile.tsx`
+- Nomenclature pick: `(setup)/nomenclature.tsx`
+- Privacy primer: `(setup)/privacy.tsx`
+- First member (optional): `(setup)/first-member.tsx`
+- Import offer: `(setup)/import-offer.tsx`
+- Complete: `(setup)/complete.tsx`
+
+## Required states per surface
+
+- per-step: idle, submitting, validation-failed, back / next / skip affordances
+- final: success summary with deep-link to home
+
+## Mode notes
+
+- Littles: wizard shortened to profile + nomenclature + complete; primer + first-member + import-offer hidden
+- All modes: step indicator (top progress) visible across the flow
+
+## Primitives required
+
+- WizardStepper (pattern, ps-rhno)
+- TextField, RadioGroup (nomenclature preset), Button, Banner, MemberCard (first-member preview), Accordion (privacy primer expandable sections)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/system.ts` setup wizard endpoints (status check, profile, nomenclature, complete)
+- `apps/api/src/trpc/routers/member.ts` (first member create)
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-setup-wizard.html with all 6 steps + states
+- [ ] Rationale on which steps are skippable and which are required
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond above (Phase 3 sweep), the WizardStepper pattern itself (Phase 0)

--- a/.beans/ps-e11x--privacy-friend-destructive-flows-block-remove-dash.md
+++ b/.beans/ps-e11x--privacy-friend-destructive-flows-block-remove-dash.md
@@ -1,0 +1,47 @@
+---
+# ps-e11x
+title: "Privacy: Friend destructive flows (block / remove + dashboard export)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:41:17Z
+updated_at: 2026-05-17T06:41:17Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the friend block / remove confirm dialogs and the dashboard export flow (one-shot snapshot of what a friend currently sees from this system).
+
+## Surfaces
+
+- Block confirm: invoked from friend detail
+- Remove confirm: invoked from friend detail
+- Dashboard export: `(app)/privacy/friends/[friendId]/export.tsx`
+
+## Required states per surface
+
+- block: warning (consequences), typed-confirm, submitting, success
+- remove: warning, typed-confirm "REMOVE [friend name]", submitting, success-redirect-to-list
+- dashboard export: idle (manifest of what's included), generating with progress, ready (download + share), error
+
+## Mode notes
+
+- Littles: all hidden
+- High-contrast: destructive states pair icon + label
+
+## Primitives required
+
+- DestructiveConfirmDialog (ps-bydy), Button, TextField (typed-confirm), ProgressBar (ps-3m01), KeyValueRow (ps-5lr6, manifest), Banner
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/friend.ts` block, remove, exportDashboard
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-friend-destructive.html with all flows + states
+- [ ] Copy decisions per GOVERNANCE.md §6 / §7
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the friend detail tabs (separate bean)

--- a/.beans/ps-e11x--privacy-friend-destructive-flows-block-remove-dash.md
+++ b/.beans/ps-e11x--privacy-friend-destructive-flows-block-remove-dash.md
@@ -3,9 +3,12 @@
 title: "Privacy: Friend destructive flows (block / remove + dashboard export)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:41:17Z
-updated_at: 2026-05-17T06:41:17Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-e8ly--audit-mode-coverage-sweep-littles.md
+++ b/.beans/ps-e8ly--audit-mode-coverage-sweep-littles.md
@@ -1,0 +1,34 @@
+---
+# ps-e8ly
+title: "Audit: Mode coverage sweep — littles"
+status: todo
+type: task
+created_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T06:52:03Z
+parent: ps-oqs8
+---
+
+## Goal
+
+Audit every Phase 2 screen for Littles Safe Mode coverage per GOVERNANCE.md §3. Littles mode is a simplified UI for child alters: bigger touch targets, simpler copy register, hidden destructive actions, restricted navigation.
+
+## Method
+
+1. Walk every HTML mockup under docs/design-system/preview/ produced by Phase 1 + Phase 2.
+2. For each surface, classify:
+   - **Hidden in littles mode** (e.g., API keys, webhooks, data import/export, account deletion — gated).
+   - **Simplified in littles mode** (smaller-vocabulary copy, single-action layout).
+   - **Identical** (already passes).
+3. For every simplified or hidden surface, create a follow-up bean.
+4. Document the gate list (which surfaces vanish entirely) as a deliverable.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-littles-mode-sweep.md.
+- For each gap: a new bean titled "Littles mode: <surface>" parented to the relevant Phase 2 domain epic, blocked-by this audit bean.
+- This bean's `## Summary of Changes` includes the full gate list (surfaces hidden in littles mode) plus every spawned bean ID.
+
+## Out of scope
+
+- Mode-switching mechanics (lives in onboarding + settings beans).
+- RN implementation (M11).

--- a/.beans/ps-e8ly--audit-mode-coverage-sweep-littles.md
+++ b/.beans/ps-e8ly--audit-mode-coverage-sweep-littles.md
@@ -3,14 +3,25 @@
 title: "Audit: Mode coverage sweep — littles"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:52:03Z
-updated_at: 2026-05-17T06:52:03Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-oqs8
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
 ---
 
 ## Goal
 
-Audit every Phase 2 screen for Littles Safe Mode coverage per GOVERNANCE.md §3. Littles mode is a simplified UI for child alters: bigger touch targets, simpler copy register, hidden destructive actions, restricted navigation.
+Audit every Phase 2 screen for Littles Safe Mode coverage per GOVERNANCE.md §3. Littles mode is a simplified UI for littles: bigger touch targets, simpler copy register, hidden destructive actions, restricted navigation.
 
 ## Method
 

--- a/.beans/ps-ecpl--design-accordion-primitive.md
+++ b/.beans/ps-ecpl--design-accordion-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-ecpl
+title: Design Accordion primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:57Z
+updated_at: 2026-05-17T06:27:57Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the Accordion primitive: expandable section with header + chevron + collapsible body. Used for FAQ, setup-wizard recap, audit-log grouped entries, advanced settings.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-accordion.html` showing variants (single, multi-open, with leading icon, with trailing badge) and required states per SKILL.md §7
+- [ ] Spec doc per SKILL.md §8 (keyboard a11y: arrow keys move between headers, Enter / Space toggles, focus stays on header)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/motion.json` (expand animation), `tokens/spacing.json`
+- Reference: existing `components-rows-tree.html` as visual baseline
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-eifq--settings-accessibility-language-picker.md
+++ b/.beans/ps-eifq--settings-accessibility-language-picker.md
@@ -1,0 +1,46 @@
+---
+# ps-eifq
+title: "Settings: Accessibility + Language picker"
+status: todo
+type: feature
+created_at: 2026-05-17T06:46:13Z
+updated_at: 2026-05-17T06:46:13Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the accessibility settings (font-scale recap + system-level overrides for color contrast / motion / haptics) and the language picker (locale + per-system terminology). Bundled because both are localization / accommodation concerns.
+
+## Surfaces
+
+- Accessibility: `(app)/settings/accessibility.tsx`
+- Language: `(app)/settings/language.tsx`
+
+## Required states per surface
+
+- accessibility: default with toggles (reduce-motion, increase-contrast, haptics, screen-reader hints), each with-OS-override-detected indicator, with-reset
+- language: idle (current locale highlighted), pick with-preview, with-RTL-warning if RTL locale picked, submitting
+
+## Mode notes
+
+- Littles: settings show fewer toggles
+- High-contrast: this screen itself must look correct under all modes (eat your own dog food)
+
+## Primitives required
+
+- ScreenScaffold, Switch, RadioGroup (locale), KeyValueRow (ps-5lr6), Banner (OS override), Button (reset), Card (preview tile)
+
+## Data refs (informational)
+
+- Local app settings (synced to system.settings)
+- `apps/api/src/trpc/routers/system.ts` settings.locale
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-accessibility-language.html with both surfaces + states
+- [ ] Rationale on the OS-override-detected affordance (banner vs inline)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the i18n implementation (already exists in `packages/i18n`)

--- a/.beans/ps-eifq--settings-accessibility-language-picker.md
+++ b/.beans/ps-eifq--settings-accessibility-language-picker.md
@@ -3,9 +3,12 @@
 title: "Settings: Accessibility + Language picker"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:46:13Z
-updated_at: 2026-05-17T06:46:13Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-f0qp--fronting-check-ins-prompt-modal-history-detail.md
+++ b/.beans/ps-f0qp--fronting-check-ins-prompt-modal-history-detail.md
@@ -3,9 +3,12 @@
 title: "Fronting: Check-ins — prompt modal + history + detail"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:51:18Z
-updated_at: 2026-05-17T05:51:18Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-f0qp--fronting-check-ins-prompt-modal-history-detail.md
+++ b/.beans/ps-f0qp--fronting-check-ins-prompt-modal-history-detail.md
@@ -1,0 +1,54 @@
+---
+# ps-f0qp
+title: "Fronting: Check-ins — prompt modal + history + detail"
+status: todo
+type: feature
+created_at: 2026-05-17T05:51:18Z
+updated_at: 2026-05-17T05:51:18Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the dissociation check-in surfaces: the prompt modal that fires from a timer, the history list of past check-ins, and the single-record detail view.
+
+## Surfaces
+
+- Check-in prompt: `(modals)/check-in.tsx` — modal that surfaces when a timer fires; respond / dismiss / archive.
+- History list: `(app)/check-ins/index.tsx` — past check-ins with response state.
+- Record detail: `(app)/check-ins/[id].tsx` — single check-in view.
+
+## Required states per surface
+
+- prompt: idle (initial), responding (compose answer), dismissing, archiving, error
+- history: empty, populated, mixed response states (responded / dismissed / unresponded)
+- detail: responded, dismissed, archived, error
+
+## Mode notes
+
+- Critical UX surface for dissociation context: gentle copy, never punitive (per GOVERNANCE.md §7 voice rules).
+- Littles mode: hide "dismiss" action by default; reframe as "I'm OK, ask me later".
+- Static mode: prompt appears instantly (no slide-up animation). Reduced-motion: 50ms fade instead.
+
+## Primitives required
+
+- CheckInPrompt (Phase 0 must produce — domain primitive; block on it)
+- Dialog or BottomSheet (prompt host)
+- TextArea (response compose)
+- ListItem (history rows)
+- KeyValueRow (detail metadata)
+- EmptyState
+- Banner (offline notice — response queued)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/check-in-record.ts` — list, get, create (from timer fire), respond, dismiss, archive, restore, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-checkins.html with all surfaces and states
+- [ ] Copy decisions (prompt question variants, response affordances) per GOVERNANCE.md §7
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond structural notes (Phase 3 sweep).

--- a/.beans/ps-fyin--auth-biometric-enrollment-unlock-prompt.md
+++ b/.beans/ps-fyin--auth-biometric-enrollment-unlock-prompt.md
@@ -3,9 +3,12 @@
 title: "Auth: Biometric enrollment + unlock prompt"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:34:00Z
-updated_at: 2026-05-17T06:34:00Z
+updated_at: 2026-05-17T07:42:04Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-fyin--auth-biometric-enrollment-unlock-prompt.md
+++ b/.beans/ps-fyin--auth-biometric-enrollment-unlock-prompt.md
@@ -1,0 +1,45 @@
+---
+# ps-fyin
+title: "Auth: Biometric enrollment + unlock prompt"
+status: todo
+type: feature
+created_at: 2026-05-17T06:34:00Z
+updated_at: 2026-05-17T06:34:00Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the biometric enrollment and unlock prompts. Native OS biometric APIs handle the actual auth — these screens explain, opt in, and surface the OS prompt.
+
+## Surfaces
+
+- Biometric enrollment: `(auth)/biometric/enroll.tsx`
+- Biometric unlock: `(lock)/biometric.tsx`
+
+## Required states per surface
+
+- enroll: idle, OS-prompt-pending, success, denied, unavailable (no hardware / not enrolled in OS), skip
+- unlock: prompt-pending, success (instant transition), failed, fallback-to-PIN
+
+## Mode notes
+
+- Littles: biometric flow hidden by default; opt-in only via parent/caregiver settings
+- Static / reduced-motion: no pulsing-fingerprint animation
+
+## Primitives required
+
+- ScreenScaffold, Button, Banner, Icon (biometric kind: fingerprint, face, etc.)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/account.ts` biometric token enrollment endpoints
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-biometric.html with all states
+- [ ] Copy on what biometric means for security (does NOT replace master password)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond above (Phase 3 sweep)

--- a/.beans/ps-fykx--auth-forgot-password-fork-3-recovery-paths.md
+++ b/.beans/ps-fykx--auth-forgot-password-fork-3-recovery-paths.md
@@ -3,9 +3,12 @@
 title: "Auth: Forgot password fork + 3 recovery paths"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:33:29Z
-updated_at: 2026-05-17T06:33:29Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-fykx--auth-forgot-password-fork-3-recovery-paths.md
+++ b/.beans/ps-fykx--auth-forgot-password-fork-3-recovery-paths.md
@@ -1,0 +1,50 @@
+---
+# ps-fykx
+title: "Auth: Forgot password fork + 3 recovery paths"
+status: todo
+type: feature
+created_at: 2026-05-17T06:33:29Z
+updated_at: 2026-05-17T06:33:29Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the forgot-password entry fork and its three downstream paths: recovery key entry, device-transfer initiate, and data-loss confirmation.
+
+## Surfaces
+
+- Fork entry: `(auth)/forgot/index.tsx`
+- Recovery-key entry: `(auth)/forgot/recovery-key.tsx`
+- Device-transfer initiate: `(auth)/forgot/device-transfer/initiate.tsx`
+- Data-loss confirmation: `(auth)/forgot/data-loss.tsx`
+
+## Required states per surface
+
+- fork: pick-path idle, hovering option (web), expanded explainer
+- recovery-key entry: idle, validating, decrypted (set new password), submitting, error (invalid key)
+- device-transfer initiate: generating-code, awaiting-approval (countdown), approved, expired (5min TTL), denied
+- data-loss: warning, typed-confirm ("DELETE MY DATA"), final-warning, submitting
+
+## Mode notes
+
+- Littles: data-loss path hidden (safety — destructive); fork shows only recovery-key + device-transfer options
+- High-contrast: countdown / error states use icon + label
+
+## Primitives required
+
+- ScreenScaffold, Button, RecoveryKeyField (ps-o1zp), TextField (typed-confirm), Banner, DestructiveConfirmDialog (ps-bydy)
+
+## Data refs (informational)
+
+- REST recovery-key challenge endpoint
+- `apps/api/src/trpc/routers/account.ts` deviceTransfer subrouter
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-forgot-password.html with all surfaces + states
+- [ ] Rationale on the data-loss copy (must be unmistakable per ADR 011)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond above (Phase 3 sweep)

--- a/.beans/ps-gfhz--design-encryptiontierbadge-primitive.md
+++ b/.beans/ps-gfhz--design-encryptiontierbadge-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-gfhz
+title: Design EncryptionTierBadge primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:26Z
+updated_at: 2026-05-17T06:27:26Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the EncryptionTierBadge primitive: small lock indicator with T1 / T2 / T3 variants. Tap or long-press reveals an explainer popover describing what the tier means for visibility (T1 zero-knowledge, T2 per-bucket, T3 server-visible metadata).
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-encryption-tier.html` showing T1 / T2 / T3 variants with the explainer popover open
+- [ ] Spec doc per SKILL.md §8
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md encryption tier definitions; `docs/design-system/uploads/SCREENS.md` §12.7
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-gi8z--privacy-bucket-export.md
+++ b/.beans/ps-gi8z--privacy-bucket-export.md
@@ -1,0 +1,44 @@
+---
+# ps-gi8z
+title: "Privacy: Bucket export"
+status: todo
+type: feature
+created_at: 2026-05-17T06:40:46Z
+updated_at: 2026-05-17T06:40:46Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the bucket export flow — bundle bucket-scoped data for a friend (manifest counts + key grants per entity type).
+
+## Surfaces
+
+- Bucket export: `(app)/privacy/buckets/[bucketId]/export.tsx`
+
+## Required states per surface
+
+- idle (with manifest preview — counts per entity-type), generating (with progress), ready (with download + share affordances), error (with retry)
+
+## Mode notes
+
+- Littles: feature hidden
+- Reduced-motion: progress animation replaced by static counter
+- Static: progress bar with no transition
+
+## Primitives required
+
+- ScreenScaffold, KeyValueRow (ps-5lr6, manifest), Button, ProgressBar (ps-3m01), Banner, EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/bucket.ts` export endpoint + manifest counts
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-bucket-export.html with all states
+- [ ] Rationale on the share-vs-download presentation
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), client-side export generation logic

--- a/.beans/ps-gi8z--privacy-bucket-export.md
+++ b/.beans/ps-gi8z--privacy-bucket-export.md
@@ -3,9 +3,12 @@
 title: "Privacy: Bucket export"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:40:46Z
-updated_at: 2026-05-17T06:40:46Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-gml0--design-entitytypepicker-primitive.md
+++ b/.beans/ps-gml0--design-entitytypepicker-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-gml0
+title: Design EntityTypePicker primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:30:52Z
+updated_at: 2026-05-17T06:30:52Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the EntityTypePicker primitive: pick a system-defined structure entity type when creating a structure entity. Sources from the per-system list of `system_structure_entity_types` (e.g. "Subsystem", "Side System", "Layer"). Inline "+ create new type" affordance shortcuts to entity-type create.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-entity-type-picker.html` showing variants (single-type system, many-type system, with "+ create" affordance, empty — first entity ever) and required states
+- [ ] Spec doc per SKILL.md §8
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md §6 generic structure entity model
+
+## Out of scope
+
+- RN code (M11), screen-level integration (System structure beans)

--- a/.beans/ps-gnkq--design-syncindicator-primitive.md
+++ b/.beans/ps-gnkq--design-syncindicator-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-gnkq
+title: Design SyncIndicator primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:03Z
+updated_at: 2026-05-17T06:27:03Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the SyncIndicator primitive: small inline indicator surfacing the 9 canonical data-state values from GOVERNANCE.md §5 (saved-local, syncing, synced, conflict, offline, import-pending, export-ready, failed, key-unavailable). Used in headers, list rows, and detail screens.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-sync-indicator.html` showing all 9 data-state variants with their canonical icon + color + label per GOVERNANCE.md §5
+- [ ] Spec doc per SKILL.md §8 (with explicit note that color is never the only signal — icon + label always accompany)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (semantic mapping per data-state)
+- Reference: GOVERNANCE.md §5 (canonical), `patterns.html` "State of data" pattern, `ui_kits/mobile/SyncState.jsx`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-h97n--privacy-friends-list.md
+++ b/.beans/ps-h97n--privacy-friends-list.md
@@ -1,0 +1,43 @@
+---
+# ps-h97n
+title: "Privacy: Friends list"
+status: todo
+type: feature
+created_at: 2026-05-17T06:40:59Z
+updated_at: 2026-05-17T06:40:59Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the friend list — system-side roster of all friend connections, with per-friend bucket count and last-sync time.
+
+## Surfaces
+
+- Friend list: `(app)/privacy/friends/index.tsx`
+
+## Required states per surface
+
+- empty (no friends), populated with mixed statuses (active, blocked, archived), filtered (by bucket, by sync state), with-pending-incoming-requests banner, error
+
+## Mode notes
+
+- Littles: hidden if account has no parent / caregiver opt-in
+- High-contrast: per-friend status badge uses icon + label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), FAB (add friend → friend code redeem), Card (friend row), Avatar, Badge (status), BucketPill (ps-i6n1, stacked), SyncIndicator (ps-gnkq), EmptyState (ps-ruwi), Banner (pending requests)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/friend.ts` list
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-friends-list.html with all states
+- [ ] Rationale on row content (avatar + name vs avatar + name + bucket-summary)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), friend detail tabs (separate bean), friend codes (separate bean)

--- a/.beans/ps-h97n--privacy-friends-list.md
+++ b/.beans/ps-h97n--privacy-friends-list.md
@@ -3,9 +3,12 @@
 title: "Privacy: Friends list"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:40:59Z
-updated_at: 2026-05-17T06:40:59Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-hijf--design-infinitelist-primitive.md
+++ b/.beans/ps-hijf--design-infinitelist-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-hijf
+title: Design InfiniteList primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:50Z
+updated_at: 2026-05-17T06:28:50Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the InfiniteList primitive: cursor-paginated list with bottom-of-list loading sentinel and pull-to-refresh integration. Every list screen uses it. Coordinates with the tRPC cursor pattern. Provides empty / loading-initial / loading-tail / error / end-of-list states.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-infinite-list.html` showing variants (idle with items, loading-initial, loading-tail spinner row, end-of-list marker, error-at-tail) and required states
+- [ ] Spec doc per SKILL.md §8 (cursor exhaustion behavior, retry-tail behavior, scroll-preservation on data update)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/motion.json` (loading spinner)
+- Reference: `apps/api/src/trpc/routers/*.ts` cursor pattern, existing `components-rows-tree.html`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-hkdf--closeout-m11-engineering-handoff-document.md
+++ b/.beans/ps-hkdf--closeout-m11-engineering-handoff-document.md
@@ -1,0 +1,38 @@
+---
+# ps-hkdf
+title: "Closeout: M11 engineering handoff document"
+status: todo
+type: task
+priority: normal
+created_at: 2026-05-17T06:53:15Z
+updated_at: 2026-05-17T06:53:31Z
+parent: ps-l9fv
+blocked_by:
+  - ps-oqs8
+  - ps-z1og
+---
+
+## Goal
+
+Produce the engineering-facing M11 handoff document at docs/design-system/handoff-m11.md covering everything an RN engineer needs to start the M11 buildout without re-reading every bean.
+
+## Required sections
+
+1. **Primitive index** — every primitive bean ID + file under docs/design-system/preview/primitives/ + token dependencies.
+2. **Surface index** — every screen/flow bean ID + file under docs/design-system/preview/<domain>/ + primitives consumed.
+3. **Mode coverage matrix** — surfaces × 5 modes, cells = covered / spawned-bean.
+4. **State coverage matrix** — surfaces × empty/loading/error variants, cells = covered / spawned-bean.
+5. **Router parity table** — tRPC routers ↔ designed surfaces (from ps-6g36 audit output).
+6. **Decision log** — every non-obvious design call made during M10 (e.g., "destructive confirms use typed-match", "co-fronting visualized as parallel bars", "encryption tier badge color spec").
+7. **Known gaps** — every spawned-but-unresolved follow-up bean.
+8. **Recommended buildout order for M11** — vertical-slice-first: Fronting → Members → Comm → Privacy → Journal → Structure → Auth → Home → Search & Settings → Cross-cutting.
+
+## Required output
+
+- docs/design-system/handoff-m11.md (committed).
+- This bean's `## Summary of Changes` summarizes the doc.
+
+## Out of scope
+
+- Implementation suggestions (RN libraries, navigation, state management) — leave to M11 brainstorm.
+- ADR-style decisions that don't affect design (e.g., test framework choice).

--- a/.beans/ps-i0y2--settings-root-account-hub-system-hub.md
+++ b/.beans/ps-i0y2--settings-root-account-hub-system-hub.md
@@ -3,9 +3,12 @@
 title: "Settings: Root + account hub + system hub"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:45:42Z
-updated_at: 2026-05-17T06:45:42Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-i0y2--settings-root-account-hub-system-hub.md
+++ b/.beans/ps-i0y2--settings-root-account-hub-system-hub.md
@@ -1,0 +1,48 @@
+---
+# ps-i0y2
+title: "Settings: Root + account hub + system hub"
+status: todo
+type: feature
+created_at: 2026-05-17T06:45:42Z
+updated_at: 2026-05-17T06:45:42Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the top-level Settings root screen and its two main hubs (account-level settings, system-level settings).
+
+## Surfaces
+
+- Settings root: `(app)/settings/index.tsx`
+- Account hub: `(app)/settings/account/index.tsx`
+- System hub: `(app)/settings/system/index.tsx`
+
+## Required states per surface
+
+- root: default (with both hubs visible + Tools + Help entries), with-recovery-key-reminder badge, with-storage-warning badge, error
+- account hub: default (email, password, recovery, devices, audit log entries), with-multi-system-switcher visible
+- system hub: default (nomenclature, privacy defaults, theme, accessibility, language, notifications)
+
+## Mode notes
+
+- Littles: Settings simplified — only Help / About + a parent-controlled "Adult settings" gated section
+- High-contrast: hub-section card uses border + label
+
+## Primitives required
+
+- ScreenScaffold, ListItem (settings rows), Section (grouped), Badge (reminder / warning), Card (hub-section tile), Icon
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/account.ts` settings
+- `apps/api/src/trpc/routers/system.ts` settings
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-root-hubs.html with all surfaces + states
+- [ ] Rationale on the account-vs-system split (which settings belong where)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), individual settings sub-screens (separate beans)

--- a/.beans/ps-i6n1--design-bucketpill-primitive.md
+++ b/.beans/ps-i6n1--design-bucketpill-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-i6n1
+title: Design BucketPill primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:14Z
+updated_at: 2026-05-17T06:29:14Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the BucketPill primitive: small visual privacy-bucket indicator — color dot + name + optional friend-count hint. Used inline on member detail, fronting session header, bucket selection sheets. Distinct from the BucketPicker primitive (which selects); BucketPill displays one assigned bucket.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-bucket-pill.html` showing variants (single, stacked-multi-pill row, with-friend-count, with-untagged-warning) and required states
+- [ ] Spec doc per SKILL.md §8 (fail-closed rule: untagged content displays a "Private" pill, not absence)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`, `tokens/radii.json`
+- Reference: GOVERNANCE.md §5b privacy-buckets canonical rules, `patterns.html` "Privacy buckets" pattern
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Privacy & Social beans)

--- a/.beans/ps-icxe--auth-device-transfer-approve-modal.md
+++ b/.beans/ps-icxe--auth-device-transfer-approve-modal.md
@@ -3,9 +3,12 @@
 title: "Auth: Device transfer approve modal"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:33:44Z
-updated_at: 2026-05-17T06:33:44Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-icxe--auth-device-transfer-approve-modal.md
+++ b/.beans/ps-icxe--auth-device-transfer-approve-modal.md
@@ -1,0 +1,45 @@
+---
+# ps-icxe
+title: "Auth: Device transfer approve modal"
+status: todo
+type: feature
+created_at: 2026-05-17T06:33:44Z
+updated_at: 2026-05-17T06:33:44Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the device-transfer approval modal (ADR 011 §Path 2) — invoked on an existing logged-in device when a new device initiates a transfer. Surfaces the pending code for side-by-side verification, with "This is me" and "I didn't request this" actions.
+
+## Surfaces
+
+- Approve modal: `(modals)/device-transfer/approve.tsx`
+
+## Required states per surface
+
+- prompt (verify code match), confirming, confirmed, denied, expired (5min TTL)
+- background: triggered by push notification or in-app banner
+
+## Mode notes
+
+- High-contrast: code display monospace + segmented (not color-only emphasis)
+- Static / reduced-motion: no countdown ring animation — text counter only
+- Littles: hide this flow entirely (security-sensitive)
+
+## Primitives required
+
+- Dialog or BottomSheet (host), Button, RecoveryKeyField (re-skinned for 8-digit code), Banner
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/account.ts` deviceTransfer.approveDeviceTransfer
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-device-transfer-approve.html with all states
+- [ ] Copy decisions per GOVERNANCE.md §7 (warning if code doesn't match)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the initiate side (covered by Auth: Forgot password)

--- a/.beans/ps-igb4--communication-channel-composer-proxy-switch-fly-ou.md
+++ b/.beans/ps-igb4--communication-channel-composer-proxy-switch-fly-ou.md
@@ -1,0 +1,48 @@
+---
+# ps-igb4
+title: "Communication: Channel composer + proxy switch fly-out + message actions sheet"
+status: todo
+type: feature
+created_at: 2026-05-17T06:38:54Z
+updated_at: 2026-05-17T06:38:54Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the composer surfaces inside a channel — message compose with proxy switching, the rapid proxy-switch fly-out (inline), and the message actions sheet (edit, delete, react, copy, reply).
+
+## Surfaces
+
+- Composer: footer of channel detail screen
+- Rapid proxy switch fly-out: inline within composer when proxy chip is tapped
+- Message actions: `(sheets)/message-actions.tsx`
+
+## Required states per surface
+
+- composer: idle, typing, with-mention-picker open, with-formatting-toolbar open, with-attachment-pending, send-disabled (empty), submitting, offline-queued
+- proxy fly-out: idle (current proxy + grid of options), with-recent-proxies, with-search, error-no-proxies
+- actions: per-message-state (own/other, recent/old, archived), reactions row, edit affordance, delete affordance, copy affordance, reply affordance
+
+## Mode notes
+
+- Littles: proxy switching hidden (default sender = current fronter); message actions limited to copy + reply
+- High-contrast: proxy chip uses icon + label
+
+## Primitives required
+
+- RichTextField (ps-9yhh), ProxyChip (ps-jtvw), MemberPicker (ps-djqo), BottomSheet, Button, IconButton, EmojiPicker (existing), Banner (offline notice), DestructiveConfirmDialog (ps-bydy)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/message.ts` create, update, delete
+- proxy state is local + per-channel preference
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-composer-proxy.html with all surfaces + states
+- [ ] Rationale on the rapid-proxy fly-out placement (above vs below the composer)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the channel list / detail screens (separate bean)

--- a/.beans/ps-igb4--communication-channel-composer-proxy-switch-fly-ou.md
+++ b/.beans/ps-igb4--communication-channel-composer-proxy-switch-fly-ou.md
@@ -3,9 +3,12 @@
 title: "Communication: Channel composer + proxy switch fly-out + message actions sheet"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:38:54Z
-updated_at: 2026-05-17T06:38:54Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-imfd--settings-data-export-hub.md
+++ b/.beans/ps-imfd--settings-data-export-hub.md
@@ -1,0 +1,44 @@
+---
+# ps-imfd
+title: "Settings: Data export hub"
+status: todo
+type: feature
+created_at: 2026-05-17T06:47:24Z
+updated_at: 2026-05-17T06:47:24Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the data export hub — pick what to export (whole system, bucket-scoped, single member subtree), pick format (JSON / SP-compatible / PK-compatible / PDF report), produce + download.
+
+## Surfaces
+
+- Export hub: `(app)/settings/data/export.tsx`
+
+## Required states per surface
+
+- idle (pick scope + format + bucket filter), with-preview-of-manifest, with-warning-if-includes-sensitive, generating (with progress), ready (download + share), error (with retry), success-history
+
+## Mode notes
+
+- Littles: hidden entirely
+- High-contrast: format tiles use icon + label
+
+## Primitives required
+
+- ScreenScaffold, RadioGroup (scope, format), BucketPicker (ps-s9r6), KeyValueRow (ps-5lr6, manifest), ProgressBar (ps-3m01), Button (download / share), Banner (sensitive warning), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- Client-side generation (T1 encrypted; server cannot decrypt)
+- `apps/api/src/trpc/routers/account.ts` export-history
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-data-export.html with all states
+- [ ] Rationale on format-pick UX
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the actual export generation

--- a/.beans/ps-imfd--settings-data-export-hub.md
+++ b/.beans/ps-imfd--settings-data-export-hub.md
@@ -3,9 +3,12 @@
 title: "Settings: Data export hub"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:47:24Z
-updated_at: 2026-05-17T06:47:24Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-j1wk--cross-cutting-confirmation-destructive-confirm-dia.md
+++ b/.beans/ps-j1wk--cross-cutting-confirmation-destructive-confirm-dia.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Confirmation + destructive-confirm dialogs"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:50:29Z
-updated_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-j1wk--cross-cutting-confirmation-destructive-confirm-dia.md
+++ b/.beans/ps-j1wk--cross-cutting-confirmation-destructive-confirm-dia.md
@@ -1,0 +1,55 @@
+---
+# ps-j1wk
+title: "Cross-cutting: Confirmation + destructive-confirm dialogs"
+status: todo
+type: feature
+created_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T06:50:29Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the two confirmation dialog variants per GOVERNANCE.md §6 destructive tiers: standard confirm (reversible action) and destructive confirm (irreversible — requires typed match or held-button gesture).
+
+## Surfaces
+
+- Standard confirm dialog (title, body, cancel + confirm buttons).
+- Destructive confirm dialog (title, body, danger affordance, typed-match input OR held-button gesture, cancel + destroy buttons).
+- Destructive confirm with dependent-blocker copy (e.g., delete member with active fronts → 409 with link to dependents).
+
+## Required states per surface
+
+- Default.
+- Typing in-progress (destructive — match not yet satisfied).
+- Match satisfied (destructive — destroy button enabled).
+- Holding-button progress (destructive variant 2).
+- Submitting (button disabled + spinner).
+- Error returned (inline error region above buttons).
+
+## Mode notes
+
+- Default mode only for this bean.
+- Holding-button variant must have a static-mode fallback (typed match).
+
+## Primitives required
+
+- Dialog primitive (modal overlay + focus trap).
+- Button + danger variant.
+- Text input.
+- Held-button progress ring.
+
+## Data refs (informational)
+
+- GOVERNANCE.md §6 destructive tiers.
+- packages/api-client error codes for 409 dependent-blocker.
+
+## Required output
+
+- HTML mockup of all 3 variants × 6 states in docs/design-system/preview/cross-cutting/confirm-dialogs.html.
+- Decision notes inline: which gesture for which destructive class.
+
+## Out of scope
+
+- RN implementation (M11).
+- Action wiring (M12).

--- a/.beans/ps-j21d--communication-poll-vote-sheet-results-visualizatio.md
+++ b/.beans/ps-j21d--communication-poll-vote-sheet-results-visualizatio.md
@@ -1,0 +1,45 @@
+---
+# ps-j21d
+title: "Communication: Poll vote sheet + results visualization"
+status: todo
+type: feature
+created_at: 2026-05-17T06:39:33Z
+updated_at: 2026-05-17T06:39:33Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the vote-cast sheet and the dedicated results visualization screen. Votes support optional comment + veto flag; null option = abstain.
+
+## Surfaces
+
+- Vote sheet: `(sheets)/poll-vote.tsx`
+- Results: `(app)/communicate/polls/[id]/results.tsx`
+
+## Required states per surface
+
+- vote sheet: idle, option-selected, with comment compose, with veto-toggle, abstain pick, submitting, already-voted (with update affordance), error
+- results: live (open poll), final (closed), with consensus-summary banner, per-option-breakdown, per-voter list (if visibility allows), with comments stream
+
+## Mode notes
+
+- Littles: vote sheet hidden (polls disabled by default)
+- High-contrast: chart segments use pattern + label (not color-only)
+
+## Primitives required
+
+- BottomSheet (vote host), RadioGroup (option pick), TextArea (comment), Switch (veto), Button, ScreenScaffold (results), Chart primitive (Phase 0 candidate; bar/donut), MemberCard (voter list), EntityRefPicker (ps-ywtb) for structure-entity voters, ListItem (comments), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/poll.ts` castVote, updateVote, deleteVote, listVotes, results
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-poll-vote-results.html with all states
+- [ ] Rationale on results-visualization choices (bar vs donut vs ranked-list)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the poll list / detail / CRUD (separate bean)

--- a/.beans/ps-j21d--communication-poll-vote-sheet-results-visualizatio.md
+++ b/.beans/ps-j21d--communication-poll-vote-sheet-results-visualizatio.md
@@ -3,9 +3,12 @@
 title: "Communication: Poll vote sheet + results visualization"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:39:33Z
-updated_at: 2026-05-17T06:39:33Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-jleu--design-tagpicker-primitive.md
+++ b/.beans/ps-jleu--design-tagpicker-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-jleu
+title: Design TagPicker primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:30:28Z
+updated_at: 2026-05-17T06:30:28Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the TagPicker primitive: well-known + custom tag chooser for member tagging. Well-known set per features.md §1: protector, gatekeeper, caretaker, little, age-slider, trauma-holder, host, persecutor, mediator, anp, memory-holder, symptom-holder, middle, introject, fictive, factive, non-human, custom.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-tag-picker.html` showing variants (well-known grid, with custom-tag input, with selected tags, search-filtered) and required states
+- [ ] Spec doc per SKILL.md §8 (Littles mode: trauma-holder and persecutor tags hidden by default; rationale per GOVERNANCE.md §3.3)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md §1 tag list
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Member management beans)

--- a/.beans/ps-jtn3--design-relationshipedge-primitive.md
+++ b/.beans/ps-jtn3--design-relationshipedge-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-jtn3
+title: Design RelationshipEdge primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:36Z
+updated_at: 2026-05-17T06:29:36Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the RelationshipEdge primitive: visual edge for the System structure relationship graph view. Carries a type label (split-from, fused-from, sibling, partner, parent-child, protector-of, caretaker-of, gatekeeper-of, source, custom) and a direction indicator (or bidirectional). Hover/long-press surfaces relationship metadata.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-relationship-edge.html` showing variants (directional, bidirectional, custom-type, with-metadata-popover-open) and required states
+- [ ] Spec doc per SKILL.md §8 (a11y: edges must be reachable in tab order; metadata available via popover)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/typography.json`
+- Reference: features.md §6, `apps/api/src/trpc/routers/relationship.ts`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (System structure beans)

--- a/.beans/ps-jtvw--design-proxychip-primitive.md
+++ b/.beans/ps-jtvw--design-proxychip-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-jtvw
+title: Design ProxyChip primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:24Z
+updated_at: 2026-05-17T06:29:24Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the ProxyChip primitive: currently-selected proxy member shown in the chat composer. Tappable to open the rapid proxy-switch fly-out. Distinct from FrontingChip — ProxyChip reflects who-is-sending-this-message, not who-is-fronting.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-proxy-chip.html` showing variants (member proxy, custom-front proxy, structure-entity proxy, no-proxy-default) and required states (default, active, fly-out-open, error-cannot-resolve)
+- [ ] Spec doc per SKILL.md §8 (visual disambiguation rule from FrontingChip; per-system terminology applies — "proxy" may be renamed via nomenclature settings)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/typography.json`
+- Reference: features.md §3 (proxy messaging), `apps/api/src/trpc/routers/message.ts`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Communication beans)

--- a/.beans/ps-k76m--home-bottom-tab-bar-appheader-chrome.md
+++ b/.beans/ps-k76m--home-bottom-tab-bar-appheader-chrome.md
@@ -1,0 +1,49 @@
+---
+# ps-k76m
+title: "Home: Bottom tab bar + AppHeader chrome"
+status: todo
+type: feature
+created_at: 2026-05-17T06:35:03Z
+updated_at: 2026-05-17T06:35:03Z
+parent: ps-divy
+---
+
+## Goal
+
+Design the persistent chrome surfaces — bottom tab bar (5 tabs) and the AppHeader bar (system name, active fronter chip, sync indicator, action slot).
+
+## Surfaces
+
+- Bottom tab bar: persistent below (app) routes
+- AppHeader: persistent above (app) routes
+
+## Required states per surface
+
+- tabs: idle, active-tab (filled icon + 4px Lavender dot per BRANDING), with unread-badge on Notifications, with Littles-mode reduced tab set
+- header: default, with-fronter-chip-pressed (opens FrontingChip detail popover), syncing indicator visible, with-action-button
+
+## Mode notes
+
+- Littles: fewer tabs (Members + Front + Communicate only); header simplified to system name
+- Web ≥1024px: tab bar replaced by Drawer (ps-217e); header stays
+- High-contrast: active tab uses underline + filled icon (not color-only)
+
+## Primitives required
+
+- BottomTabBar (existing), AppHeader (existing), FrontingChip (ps-458i), SyncIndicator (ps-gnkq), SystemSwitcher (ps-a5pt) entry point
+- Badge (unread count)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/fronting-session.ts` (activeFronters for chip)
+- Sync subscription state (local store)
+- `apps/api/src/trpc/routers/system.ts` (current system label)
+
+## Required output
+
+- [ ] docs/design-system/preview/home-chrome.html with both chrome surfaces in their states
+- [ ] Rationale for the 5-tab pick (Members / Front / Communicate / Privacy / More)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the actual screens those tabs lead to (separate beans)

--- a/.beans/ps-k76m--home-bottom-tab-bar-appheader-chrome.md
+++ b/.beans/ps-k76m--home-bottom-tab-bar-appheader-chrome.md
@@ -3,9 +3,12 @@
 title: "Home: Bottom tab bar + AppHeader chrome"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:35:03Z
-updated_at: 2026-05-17T06:35:03Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-divy
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-k8mz--cross-cutting-surface-designs.md
+++ b/.beans/ps-k8mz--cross-cutting-surface-designs.md
@@ -1,0 +1,26 @@
+---
+# ps-k8mz
+title: Cross-cutting surface designs
+status: todo
+type: epic
+created_at: 2026-05-17T05:48:10Z
+updated_at: 2026-05-17T05:48:10Z
+parent: ps-9cca
+blocked_by:
+  - ps-5920
+---
+
+Phase 2 epic for cross-cutting surfaces not bound to a single domain: confirmation dialog, destructive-confirm dialog, bottom-sheet primitive integration, toast/snackbar, image picker launcher, sync status overlay, encryption-tier badge + explainer, permission-request screens, update-available banner, offline/sync-paused banner, PIN/biometric foreground re-auth overlay, empty/error/loading catalog screens, mention-link preview card.
+
+Spec: docs/superpowers/specs/2026-05-16-m10-bean-buildout-design.md
+
+## Scope
+
+- 10–12 screen/flow beans under this epic.
+- Each follows the screen/flow body template from the spec.
+
+## Out of scope
+
+- RN code (M11).
+- Data wiring (M12).
+- Mode coverage variants (Phase 3 sweep).

--- a/.beans/ps-k95h--communication-notes-list-detail-createedit.md
+++ b/.beans/ps-k95h--communication-notes-list-detail-createedit.md
@@ -3,9 +3,12 @@
 title: "Communication: Notes (list + detail + create/edit)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:39:15Z
-updated_at: 2026-05-17T06:39:15Z
+updated_at: 2026-05-17T07:42:05Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-k95h--communication-notes-list-detail-createedit.md
+++ b/.beans/ps-k95h--communication-notes-list-detail-createedit.md
@@ -1,0 +1,48 @@
+---
+# ps-k95h
+title: "Communication: Notes (list + detail + create/edit)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:39:15Z
+updated_at: 2026-05-17T06:39:15Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the private notes surfaces — member-bound or system-wide notes with rich text, custom background colors, polymorphic authorship.
+
+## Surfaces
+
+- Note list: `(app)/communicate/notes/index.tsx`
+- Note detail: `(app)/communicate/notes/[id].tsx`
+- New: `(app)/communicate/notes/new.tsx`
+- Edit: `(app)/communicate/notes/[id]/edit.tsx`
+
+## Required states per surface
+
+- list: empty, populated (grid of color-cards), filtered by-member or system-wide, archived view, error
+- detail: default, with-archive-banner, edit affordance
+- create/edit: empty/populated, with-rich-text, with-color-background-picker, with-bucket-picker, with-member-target picker (or system-wide), submitting, conflict
+
+## Mode notes
+
+- Littles: simplified — no color backgrounds (white card only), no bucket scoping
+- Static: color backgrounds flatten to single shade
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (color-bg note tile), FAB, RichTextField (ps-9yhh), ColorSwatchPicker, BucketPicker (ps-s9r6), MemberPicker (ps-djqo, optional target), ProxyChip (ps-jtvw, author), EmptyState (ps-ruwi), DestructiveConfirmDialog (ps-bydy)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/note.ts` list, get, create, update, archive, restore, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-notes.html with all surfaces + states
+- [ ] Rationale on the color-card grid layout (masonry vs uniform)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12)

--- a/.beans/ps-ks6p--members-groups-list-detail.md
+++ b/.beans/ps-ks6p--members-groups-list-detail.md
@@ -1,0 +1,47 @@
+---
+# ps-ks6p
+title: "Members: Groups — list + detail"
+status: todo
+type: feature
+created_at: 2026-05-17T06:37:25Z
+updated_at: 2026-05-17T06:37:25Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the Groups list and group detail screens. Groups are hierarchical with multi-group membership; the detail screen shows members + sub-groups + group-level custom fields.
+
+## Surfaces
+
+- Group list: `(app)/groups/index.tsx`
+- Group detail: `(app)/groups/[groupId]/index.tsx`
+
+## Required states per surface
+
+- list: empty, populated (flat), populated (nested with expand/collapse), archived view, with-reorder-mode toggle, error
+- detail: default with members + sub-groups, empty (no members yet), archived, with custom-fields section
+
+## Mode notes
+
+- Littles: nested groups flattened (single level shown)
+- High-contrast: group color tile pairs color + emoji (not color-only)
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), FAB, Card (group tile), Accordion (ps-ecpl, for nesting), MemberCard, EmptyState (ps-ruwi), BucketPill (ps-i6n1) for visibility, ColorStrip
+- Tree primitive (existing in components-rows-tree.html) for nested groups
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/group.ts` list, get, byParent
+- `apps/api/src/trpc/routers/field.ts` valuesForGroup
+
+## Required output
+
+- [ ] docs/design-system/preview/members-groups-list-detail.html with all states
+- [ ] Rationale on nested group visualization (tree vs accordion)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), create / edit / move / member-add flows (separate bean)

--- a/.beans/ps-ks6p--members-groups-list-detail.md
+++ b/.beans/ps-ks6p--members-groups-list-detail.md
@@ -3,9 +3,12 @@
 title: "Members: Groups — list + detail"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:37:25Z
-updated_at: 2026-05-17T06:37:25Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-l13y--privacy-friend-detail-4-tabs-their-system-visibili.md
+++ b/.beans/ps-l13y--privacy-friend-detail-4-tabs-their-system-visibili.md
@@ -3,9 +3,12 @@
 title: "Privacy: Friend detail (4 tabs — their-system / visibility / notifications / buckets)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:41:10Z
-updated_at: 2026-05-17T06:41:10Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-l13y--privacy-friend-detail-4-tabs-their-system-visibili.md
+++ b/.beans/ps-l13y--privacy-friend-detail-4-tabs-their-system-visibili.md
@@ -1,0 +1,51 @@
+---
+# ps-l13y
+title: "Privacy: Friend detail (4 tabs — their-system / visibility / notifications / buckets)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:41:10Z
+updated_at: 2026-05-17T06:41:10Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the friend detail screen with 4 tabbed sub-views.
+
+## Surfaces
+
+- Friend detail: `(app)/privacy/friends/[friendId]/index.tsx` (visibility, default)
+- Their-system tab: `(app)/privacy/friends/[friendId]/their-system.tsx`
+- Visibility tab: `(app)/privacy/friends/[friendId]/visibility.tsx`
+- Notifications tab: `(app)/privacy/friends/[friendId]/notifications.tsx`
+- Buckets tab: `(app)/privacy/friends/[friendId]/buckets.tsx`
+
+## Required states per surface
+
+- header: default (with friend name + avatar + connection-age), blocked, archived
+- their-system: empty (they share nothing yet), populated (read-only friend dashboard snapshot), with-sync-pending, error (key-unavailable)
+- visibility: granular toggles per FriendVisibilitySettings — show me their fronters, show me their members, show me their custom fronts
+- notifications: per-event-kind toggles (their front changes, their lifecycle events)
+- buckets: assigned-buckets list with revoke-bucket affordance
+
+## Mode notes
+
+- Littles: their-system tab simplified to fronters only; notifications tab hidden
+- High-contrast: per-tab indicator uses underline + label
+
+## Primitives required
+
+- ScreenScaffold, Tabs, Avatar, FrontingChip (ps-458i, for their fronters), MemberCard, BucketPill (ps-i6n1), Switch, KeyValueRow (ps-5lr6), Banner (key-unavailable), EmptyState (ps-ruwi), Button
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/friend.ts` get, dashboard, visibility, notifications, buckets
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-friend-detail.html with all 4 tabs + states
+- [ ] Rationale on the their-system tab layout (mirror own home dashboard? or a more compact summary?)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), block / remove confirms (separate bean), dashboard export (separate bean)

--- a/.beans/ps-l83m--members-lifecycle-events-detail-create-global-log.md
+++ b/.beans/ps-l83m--members-lifecycle-events-detail-create-global-log.md
@@ -3,9 +3,12 @@
 title: "Members: Lifecycle events (detail + create + global log)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:38:00Z
-updated_at: 2026-05-17T06:38:00Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-l83m--members-lifecycle-events-detail-create-global-log.md
+++ b/.beans/ps-l83m--members-lifecycle-events-detail-create-global-log.md
@@ -1,0 +1,47 @@
+---
+# ps-l83m
+title: "Members: Lifecycle events (detail + create + global log)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:38:00Z
+updated_at: 2026-05-17T06:38:00Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the lifecycle event surfaces — detail view per event, create modal, and the global log spanning all members.
+
+## Surfaces
+
+- Event detail: `(app)/lifecycle/[eventId].tsx`
+- Event create: `(modals)/lifecycle-create.tsx`
+- Global log: `(app)/lifecycle/index.tsx`
+
+## Required states per surface
+
+- detail: per-event-type rendering (split, fusion, merge, unmerge, dormancy-start/end, discovery, archival, structure-formation, form-change, name-change, structure-move, innerworld-move), archived, edit affordance
+- create: pick-event-type, per-type form (e.g. split needs source-member + resulting-members; merge needs participating-members), submitting, validation-error
+- global log: empty, populated, filtered (by-member, by-type, by-date-range), archived view, error, loading
+
+## Mode notes
+
+- Littles: lifecycle log hidden by default (sensitive content per GOVERNANCE.md §3.3); create flow hidden
+- High-contrast: per-type chip uses icon + label (color is supplemental)
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), LifecycleEventChip (ps-v3e9), KeyValueRow (ps-5lr6), MultiMemberPicker (ps-djqo), Select (event-type pick), TextArea (note), DateTimePicker, EmptyState (ps-ruwi), Banner
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/lifecycle-event.ts` list, get, create, update, archive, restore, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/members-lifecycle.html with all surfaces + states
+- [ ] Rationale on per-event-type form rendering (single-form-with-conditional-fields vs per-type-screen)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), per-member lifecycle tab (covered by Members detail bean)

--- a/.beans/ps-l9fv--m10-closeout.md
+++ b/.beans/ps-l9fv--m10-closeout.md
@@ -1,0 +1,26 @@
+---
+# ps-l9fv
+title: M10 closeout
+status: todo
+type: epic
+created_at: 2026-05-17T05:48:39Z
+updated_at: 2026-05-17T05:48:39Z
+parent: ps-9cca
+blocked_by:
+  - ps-oqs8
+---
+
+Phase 4 epic for M10 milestone closeout, run after all Phase 3 audits complete.
+
+Spec: docs/superpowers/specs/2026-05-16-m10-bean-buildout-design.md
+
+## Beans under this epic (3 closeout beans)
+
+1. Feature coverage audit — verify every docs/planning/features.md feature has design coverage somewhere in docs/design-system/preview/.
+2. M11 handoff doc — produce engineering-facing handoff at docs/design-system/handoff-m11.md covering: primitive → file mapping, decision log, known gaps, recommended buildout order.
+3. M10 milestone closeout — close ps-9cca with a `## Summary of Changes` body-append summarizing all design artifacts produced.
+
+## Out of scope
+
+- Bug fixes uncovered in feature coverage audit — spawn follow-up beans, do not redesign within closeout.
+- Engineering work in M11 — the handoff doc references but does not implement.

--- a/.beans/ps-ljry--privacy-push-devices-notification-config.md
+++ b/.beans/ps-ljry--privacy-push-devices-notification-config.md
@@ -3,9 +3,12 @@
 title: "Privacy: Push devices + notification config"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:41:42Z
-updated_at: 2026-05-17T06:41:42Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-ljry--privacy-push-devices-notification-config.md
+++ b/.beans/ps-ljry--privacy-push-devices-notification-config.md
@@ -1,0 +1,46 @@
+---
+# ps-ljry
+title: "Privacy: Push devices + notification config"
+status: todo
+type: feature
+created_at: 2026-05-17T06:41:42Z
+updated_at: 2026-05-17T06:41:42Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the push-device list (registered devices with revoke affordance) and the per-system notification config (kind toggles + per-friend overrides).
+
+## Surfaces
+
+- Devices: `(app)/privacy/devices/index.tsx`
+- Notification config: `(app)/settings/notifications/index.tsx`
+
+## Required states per surface
+
+- devices: empty, populated (with current-device indicator, with-disabled-device row), with-permission-not-granted banner, error
+- notification config: per-event-kind toggles (friend front change, mandatory ack received, lifecycle event, recovery-key reminder, webhook failure), per-friend overrides (Accordion of friend × event-kind matrix), with-do-not-disturb scheduling, save / cancel
+
+## Mode notes
+
+- Littles: only "Caregiver alerts" toggle visible; everything else hidden
+- High-contrast: per-device status uses icon + label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (device row), KeyValueRow (ps-5lr6), Switch, Banner (permission notice), Button, Accordion (ps-ecpl, per-friend overrides), MultiMemberPicker (ps-djqo, scoped do-not-disturb), DestructiveConfirmDialog (ps-bydy, revoke device)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/device-token.ts` list, register, revoke
+- `apps/api/src/trpc/routers/notification-config.ts` get, update
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-devices-notifications.html with all surfaces + states
+- [ ] Rationale on the per-friend overrides UX (matrix vs nested-toggle)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the OS permission prompt surface (handled by OS)

--- a/.beans/ps-ln06--members-create-edit-form.md
+++ b/.beans/ps-ln06--members-create-edit-form.md
@@ -3,9 +3,12 @@
 title: "Members: Create / edit form"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:36:42Z
-updated_at: 2026-05-17T06:36:42Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-ln06--members-create-edit-form.md
+++ b/.beans/ps-ln06--members-create-edit-form.md
@@ -1,0 +1,45 @@
+---
+# ps-ln06
+title: "Members: Create / edit form"
+status: todo
+type: feature
+created_at: 2026-05-17T06:36:42Z
+updated_at: 2026-05-17T06:36:42Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the member create / edit form screens. New uses a single full-form flow; edit is the same form pre-populated.
+
+## Surfaces
+
+- New: `(app)/members/new.tsx`
+- Edit: `(app)/members/[memberId]/edit.tsx`
+
+## Required states per surface
+
+- form: empty (new), populated (edit), invalid (e.g. name required), submitting, conflict (concurrent edit on edit-form), success, with-image-crop-modal-open
+
+## Mode notes
+
+- Littles: simplified form — name + color + avatar only; tags / saturation / structure-entity-links collapsed into "More" disclosure
+- High-contrast: color-swatch picker pairs swatch + label
+
+## Primitives required
+
+- ScreenScaffold, TextField, TextArea, ColorSwatchPicker (existing), EmojiPicker (existing), TagPicker (ps-jleu), SaturationPicker (ps-xts0), ImagePickerLauncher (existing), ImageCropper (ps-107o), BucketPicker (ps-s9r6), Button, Banner
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/member.ts` create, update
+- `apps/api/src/trpc/routers/blob.ts` presigned upload
+
+## Required output
+
+- [ ] docs/design-system/preview/members-create-edit.html with all states
+- [ ] Rationale on field ordering and which fields are top-level vs disclosure
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the duplicate flow (separate bean), the photo gallery management (separate bean)

--- a/.beans/ps-m6ey--auth-account-management-email-password-recovery-ke.md
+++ b/.beans/ps-m6ey--auth-account-management-email-password-recovery-ke.md
@@ -3,9 +3,12 @@
 title: "Auth: Account management (email + password + recovery-key regen + deletion)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:34:22Z
-updated_at: 2026-05-17T06:34:22Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-m6ey--auth-account-management-email-password-recovery-ke.md
+++ b/.beans/ps-m6ey--auth-account-management-email-password-recovery-ke.md
@@ -1,0 +1,50 @@
+---
+# ps-m6ey
+title: "Auth: Account management (email + password + recovery-key regen + deletion)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:34:22Z
+updated_at: 2026-05-17T06:34:22Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the post-sign-in account management surfaces — email change with re-verify, password change, recovery-key regeneration (re-ceremony), and account deletion.
+
+## Surfaces
+
+- Email change: `(settings)/account/email/index.tsx` + verify `(settings)/account/email/verify.tsx`
+- Password change: `(settings)/account/password.tsx`
+- Recovery-key regenerate: `(settings)/account/recovery-key.tsx`
+- Account deletion: `(settings)/account/delete.tsx`
+
+## Required states per surface
+
+- email change: idle, submitting, pending-verify-email-sent, verified, error
+- password change: current+new+confirm valid/invalid, submitting, success, re-encrypt-pending
+- recovery-key regen: warning, ack, regenerating, new-key reveal (re-ceremony), confirm-challenge, success
+- account deletion: warning, typed-confirm, final-warning, purging (progress), completed-redirect-to-welcome
+
+## Mode notes
+
+- Littles: account deletion path requires switch out of Littles mode + parent re-auth
+- High-contrast: all destructive states use icon + label
+
+## Primitives required
+
+- RecoveryKey ceremony pattern (ps-472d), RecoveryKeyDisplay (ps-xthc)
+- TextField, Button, DestructiveConfirmDialog (ps-bydy), ProgressRing/Bar (ps-3m01), Banner
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/account.ts` (email change, password change, deletion, recovery-key regeneration)
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-account-management.html with all surfaces + states
+- [ ] Copy decisions for the four GOVERNANCE.md §6 destructive tier mappings
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond above (Phase 3 sweep)

--- a/.beans/ps-manc--settings-theme-appearance.md
+++ b/.beans/ps-manc--settings-theme-appearance.md
@@ -3,9 +3,12 @@
 title: "Settings: Theme & appearance"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:45:58Z
-updated_at: 2026-05-17T06:45:58Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-6a3x
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-manc--settings-theme-appearance.md
+++ b/.beans/ps-manc--settings-theme-appearance.md
@@ -1,0 +1,44 @@
+---
+# ps-manc
+title: "Settings: Theme & appearance"
+status: todo
+type: feature
+created_at: 2026-05-17T06:45:58Z
+updated_at: 2026-05-17T06:45:58Z
+parent: ps-6a3x
+---
+
+## Goal
+
+Design the theme & appearance settings — accommodation mode pick (default / static / reduced-motion / high-contrast / littles), accent-color override (within brand palette), font-scale slider, density toggle.
+
+## Surfaces
+
+- Theme & appearance: `(app)/settings/appearance.tsx`
+
+## Required states per surface
+
+- default (current selections + preview tile), mode pick with-preview (live), accent-color override with-preview, font-scale slider with-preview, density toggle (regular / dense), with-save indicator (auto on change), with-reset-to-default affordance
+
+## Mode notes
+
+- Littles: littles mode pick locked on; font scale + accent override hidden
+- High-contrast: mode tiles use icon + label (not color-only)
+
+## Primitives required
+
+- ScreenScaffold, RadioGroup (mode pick), ColorSwatchPicker (accent), Slider (font scale), Switch (density), Card (live preview tile), Button (reset), KeyValueRow (ps-5lr6)
+
+## Data refs (informational)
+
+- Local app settings (not network)
+- `apps/api/src/trpc/routers/system.ts` settings.theme (persisted for cross-device sync)
+
+## Required output
+
+- [ ] docs/design-system/preview/settings-theme.html with all states
+- [ ] Rationale on live-preview surface (always visible vs on-tap)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the actual mode tokens (already exist in `packages/design-system`)

--- a/.beans/ps-n0dl--communication-channels-list-detail-createedit-sett.md
+++ b/.beans/ps-n0dl--communication-channels-list-detail-createedit-sett.md
@@ -1,0 +1,51 @@
+---
+# ps-n0dl
+title: "Communication: Channels (list + detail + create/edit + settings)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:38:44Z
+updated_at: 2026-05-17T06:38:44Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the Channels surfaces — list with categories, channel detail (message stream), create/edit, and the channel settings sheet (rename, color, archive, delete).
+
+## Surfaces
+
+- Channel list: `(app)/communicate/channels/index.tsx`
+- Channel detail: `(app)/communicate/channels/[channelId]/index.tsx`
+- New: `(app)/communicate/channels/new.tsx`
+- Edit: `(app)/communicate/channels/[id]/edit.tsx`
+- Settings: `(sheets)/channel-settings.tsx`
+
+## Required states per surface
+
+- list: empty, categorized (with categories collapsed/expanded), filtered, archived view
+- detail: empty stream, populated, loading-tail, oldest-message reached, error, with-mention-highlight, with-pinned-message-banner, currently-typing-indicator
+- create/edit: empty/populated, invalid, submitting, conflict, with bucket assignment
+- settings sheet: rename, color, emoji, archive, delete, member-mute, notification settings
+
+## Mode notes
+
+- Littles: simplified — no categories, no proxy switching, single all-members channel only
+- High-contrast: per-channel color uses dot + label (not background fill)
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (channel row), Accordion (ps-ecpl, for categories), FAB, EmptyState (ps-ruwi), Banner (pinned-message), BucketPicker (ps-s9r6), ColorSwatchPicker, EmojiPicker, BottomSheet, DestructiveConfirmDialog (ps-bydy)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/channel.ts` list, get, create, update, archive, delete
+- `apps/api/src/trpc/routers/message.ts` listByChannel
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-channels.html with all surfaces + states
+- [ ] Rationale on category visualization
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the composer + actions sheet (separate bean)

--- a/.beans/ps-n0dl--communication-channels-list-detail-createedit-sett.md
+++ b/.beans/ps-n0dl--communication-channels-list-detail-createedit-sett.md
@@ -3,9 +3,12 @@
 title: "Communication: Channels (list + detail + create/edit + settings)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:38:44Z
-updated_at: 2026-05-17T06:38:44Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-n6cx--fronting-front-overview-screen.md
+++ b/.beans/ps-n6cx--fronting-front-overview-screen.md
@@ -1,0 +1,64 @@
+---
+# ps-n6cx
+title: "Fronting: Front overview screen"
+status: todo
+type: feature
+created_at: 2026-05-17T05:50:07Z
+updated_at: 2026-05-17T05:50:07Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the Fronting front-overview screen: preview HTML covering the active fronters panel, recent switches, and primary quick-switch entry point. This is the primary tab landing surface for the fronting domain.
+
+## Surfaces
+
+- Front overview: `(app)/(tabs)/front/index.tsx` — primary tab destination. Shows currently-fronting members + custom fronts + structure entities, recent switch activity, and the primary quick-switch CTA.
+
+## Required states per surface
+
+- default — single fronter
+- default — multiple co-fronters with overlapping time ranges
+- default — custom front active alongside members
+- default — structure entity fronting
+- empty — no one fronting, no fronting history at all
+- partial-empty — no one fronting, has prior history
+- loading
+- error (recoverable)
+- offline — last-known state shown with sync indicator
+
+## Mode notes
+
+- Littles mode simplifies hierarchy: larger "Who's fronting?" header, recent switches collapsed to a single summary line.
+- High-contrast mode pairs member identity color with shape glyph + initial per GOVERNANCE.md §4.
+
+## Primitives required
+
+- AvatarStack
+- FrontingChip
+- BottomTabBar
+- AppHeader
+- EmptyState (constellation variant)
+- ScreenScaffold
+- PullToRefresh
+- BucketPill
+- SyncIndicator
+
+If any are not in docs/design-system/preview/ at design time, block on the Phase 0 bean producing them.
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/fronting-session.ts` — activeFronters, list
+- `apps/api/src/trpc/routers/analytics.ts` — recent summary
+
+For understanding data shapes only. Not for wiring (M12).
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-overview.html with all states
+- [ ] Brief layout / interaction rationale notes (same file or sibling)
+
+## Out of scope
+
+- React Native code (M11), data wiring (M12), mode variants beyond the structural notes above (Phase 3 sweep).

--- a/.beans/ps-n6cx--fronting-front-overview-screen.md
+++ b/.beans/ps-n6cx--fronting-front-overview-screen.md
@@ -3,9 +3,12 @@
 title: "Fronting: Front overview screen"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:50:07Z
-updated_at: 2026-05-17T05:50:07Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-nsth--home-home-dashboard.md
+++ b/.beans/ps-nsth--home-home-dashboard.md
@@ -3,9 +3,12 @@
 title: "Home: Home dashboard"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:35:11Z
-updated_at: 2026-05-17T06:35:11Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-divy
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-nsth--home-home-dashboard.md
+++ b/.beans/ps-nsth--home-home-dashboard.md
@@ -1,0 +1,52 @@
+---
+# ps-nsth
+title: "Home: Home dashboard"
+status: todo
+type: feature
+created_at: 2026-05-17T06:35:11Z
+updated_at: 2026-05-17T06:35:11Z
+parent: ps-divy
+---
+
+## Goal
+
+Design the Home dashboard — the landing surface after auth. Composes active-fronters widget, recent activity feed, sync state, quick actions, optional check-in prompt slot.
+
+## Surfaces
+
+- Home dashboard: `(app)/(tabs)/index.tsx`
+
+## Required states per surface
+
+- default (active fronters present + recent activity)
+- empty (no one fronting + no activity ever)
+- partial-empty (no current activity but has history)
+- check-in pending (CheckInPrompt slot active)
+- offline (last-known with sync indicator)
+- loading (skeleton)
+- error
+
+## Mode notes
+
+- Littles: simplified — single "Who's fronting?" header + single primary action; activity feed hidden
+- High-contrast: widgets use boundary contrast not surface tint
+- Static: no shimmer / drift on empty-state constellation
+
+## Primitives required
+
+- ScreenScaffold, AvatarStack, FrontingChip (ps-458i), CheckInPrompt (ps-7to1), EmptyState (ps-ruwi), Card, SyncIndicator (ps-gnkq), Button (quick actions), InfiniteList (ps-hijf, for activity feed)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/fronting-session.ts` activeFronters
+- `apps/api/src/trpc/routers/lifecycle-event.ts` recent
+- `apps/api/src/trpc/routers/check-in-record.ts` pending
+
+## Required output
+
+- [ ] docs/design-system/preview/home-dashboard.html with all states
+- [ ] Rationale on what gets surfaced vs hidden, with Littles-mode reasoning
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), individual widget detail screens (separate beans)

--- a/.beans/ps-nwju--onboarding-auth-screen-designs.md
+++ b/.beans/ps-nwju--onboarding-auth-screen-designs.md
@@ -5,8 +5,10 @@ status: todo
 type: epic
 priority: normal
 created_at: 2026-03-31T23:12:43Z
-updated_at: 2026-03-31T23:12:46Z
+updated_at: 2026-05-17T05:49:09Z
 parent: ps-9cca
+blocked_by:
+  - ps-5920
 ---
 
 Login, registration, recovery key backup, device transfer, initial setup wizard

--- a/.beans/ps-nypl--audit-state-coverage-empty-loading-error-across-al.md
+++ b/.beans/ps-nypl--audit-state-coverage-empty-loading-error-across-al.md
@@ -1,0 +1,34 @@
+---
+# ps-nypl
+title: "Audit: State coverage — empty / loading / error across all surfaces"
+status: todo
+type: task
+created_at: 2026-05-17T06:52:27Z
+updated_at: 2026-05-17T06:52:27Z
+parent: ps-oqs8
+---
+
+## Goal
+
+Audit every list, grid, and detail surface for complete state coverage per the cross-cutting state catalog (ps-8n3j): every surface must designate one of each empty / loading / error variant.
+
+## Method
+
+1. Walk every HTML mockup under docs/design-system/preview/ produced by Phase 1 + Phase 2.
+2. For each list / grid / detail screen, check:
+   - Is the empty state designed? Which catalog variant?
+   - Is the loading state designed? Skeleton vs. spinner?
+   - Are the error states designed? Which catalog entries (network / 5xx / 403 / 404 / 409 / 422)?
+3. For every surface missing a state, create a follow-up bean.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-state-coverage.md.
+- Coverage matrix: rows = surfaces, columns = required states, cells = covered / spawned-bean-id.
+- For each gap: a new bean titled "States: <surface>" parented to the relevant Phase 2 domain epic, blocked-by this audit bean.
+- This bean's `## Summary of Changes` includes the matrix + spawned bean IDs.
+
+## Out of scope
+
+- Catalog itself (ps-8n3j).
+- RN implementation (M11).

--- a/.beans/ps-nypl--audit-state-coverage-empty-loading-error-across-al.md
+++ b/.beans/ps-nypl--audit-state-coverage-empty-loading-error-across-al.md
@@ -3,9 +3,20 @@
 title: "Audit: State coverage — empty / loading / error across all surfaces"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:52:27Z
-updated_at: 2026-05-17T06:52:27Z
+updated_at: 2026-05-17T07:42:06Z
 parent: ps-oqs8
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
 ---
 
 ## Goal

--- a/.beans/ps-o1zp--design-recoverykeyfield-primitive.md
+++ b/.beans/ps-o1zp--design-recoverykeyfield-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-o1zp
+title: Design RecoveryKeyField primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:07Z
+updated_at: 2026-05-17T06:27:07Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the RecoveryKeyField primitive: a paste-friendly multi-segment input for entering the XXXX-XXXX-XXXX-XXXX-XXXX-XXXX recovery key (ADR 011 §Path 1). Auto-formats on paste, supports per-segment editing, surfaces validation feedback.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-recovery-key-field.html` showing variants (empty, partial-fill, full, valid, invalid) and states (default, focused, error, success)
+- [ ] Spec doc per SKILL.md §8 (with auto-format and paste-handling rules documented)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/typography.json` (monospace variant)
+- Reference: ADR 011 recovery key format
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Auth flow beans)

--- a/.beans/ps-o5p5--audit-accessibility-intent-per-a11y-gatesmd-govern.md
+++ b/.beans/ps-o5p5--audit-accessibility-intent-per-a11y-gatesmd-govern.md
@@ -1,0 +1,38 @@
+---
+# ps-o5p5
+title: "Audit: Accessibility intent per A11Y_GATES.md + GOVERNANCE §8"
+status: todo
+type: task
+created_at: 2026-05-17T06:52:27Z
+updated_at: 2026-05-17T06:52:27Z
+parent: ps-oqs8
+---
+
+## Goal
+
+Audit every Phase 1 + Phase 2 surface for accessibility intent per packages/design-system/docs/A11Y_GATES.md and docs/design-system/GOVERNANCE.md §8 component documentation contract.
+
+## Method
+
+1. Walk every HTML mockup under docs/design-system/preview/.
+2. For each interactive element verify:
+   - Accessible name (label or aria-label intent documented).
+   - Role (button / link / heading / region / etc.).
+   - Focus order (tab sequence noted).
+   - Hit target size (min 44×44 mobile / 24×24 web per WCAG 2.2).
+   - Color is not sole conveyor (icon + text together).
+   - Live region usage for async state changes.
+3. For each surface, produce a pass/fail row per gate.
+4. For every fail, create a follow-up bean tagged with the failing gate.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-accessibility-intent.md.
+- Gate matrix: rows = surfaces, columns = A11Y_GATES sections, cells = pass/fail.
+- For each fail: a new bean titled "A11y: <surface> — <gate>" parented to the relevant Phase 2 domain epic.
+- This bean's `## Summary of Changes` includes the matrix + spawned bean IDs.
+
+## Out of scope
+
+- Automated a11y test wiring (M11+).
+- RN implementation (M11).

--- a/.beans/ps-o5p5--audit-accessibility-intent-per-a11y-gatesmd-govern.md
+++ b/.beans/ps-o5p5--audit-accessibility-intent-per-a11y-gatesmd-govern.md
@@ -3,9 +3,20 @@
 title: "Audit: Accessibility intent per A11Y_GATES.md + GOVERNANCE §8"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:52:27Z
-updated_at: 2026-05-17T06:52:27Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-oqs8
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
 ---
 
 ## Goal

--- a/.beans/ps-oipx--design-keyrotationstepper-primitive.md
+++ b/.beans/ps-oipx--design-keyrotationstepper-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-oipx
+title: Design KeyRotationStepper primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:52Z
+updated_at: 2026-05-17T06:29:52Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the KeyRotationStepper primitive: visual progress indicator for the chunked bucket-key rotation protocol (ADR 014). Shows initiate → progress (N of M chunks) → complete states, plus retry-from-failed-chunk path. Used inline on the bucket rotation tab.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-key-rotation-stepper.html` showing the steps (initiate, in-progress, retry-required, complete, error-terminal) and required states
+- [ ] Spec doc per SKILL.md §8 (estimated time display rules; resume-from-checkpoint affordance copy)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/motion.json`
+- Reference: ADR 014, features.md §4 bucket key rotation
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Privacy & Social beans)

--- a/.beans/ps-oqs8--m10-audits.md
+++ b/.beans/ps-oqs8--m10-audits.md
@@ -1,0 +1,40 @@
+---
+# ps-oqs8
+title: M10 audits
+status: todo
+type: epic
+created_at: 2026-05-17T05:48:31Z
+updated_at: 2026-05-17T05:48:31Z
+parent: ps-9cca
+blocked_by:
+  - ps-nwju
+  - ps-divy
+  - ps-07l7
+  - ps-5fc5
+  - ps-9xue
+  - ps-7wf6
+  - ps-djgs
+  - ps-6a3x
+  - ps-k8mz
+---
+
+Phase 3 epic for M10 horizontal coverage sweeps and audits, run after all Phase 2 domain epics complete.
+
+Spec: docs/superpowers/specs/2026-05-16-m10-bean-buildout-design.md
+
+## Beans under this epic (7 audit beans)
+
+1. Mode coverage sweep — static
+2. Mode coverage sweep — reduced-motion
+3. Mode coverage sweep — high-contrast
+4. Mode coverage sweep — littles
+5. State coverage audit — empty / loading / error across every list and detail screen
+6. Accessibility intent audit per packages/design-system/docs/A11Y_GATES.md and docs/design-system/SKILL.md §8.3
+7. Screen → router parity audit against the 41 tRPC routers in apps/api/src/trpc/routers/
+
+Each audit follows the audit body template from the spec.
+
+## Out of scope
+
+- Redesign of failing surfaces — gaps spawn new beans, not handled inside the audit.
+- RN code (M11).

--- a/.beans/ps-oylh--design-searchheader-primitive.md
+++ b/.beans/ps-oylh--design-searchheader-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-oylh
+title: Design SearchHeader primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:44Z
+updated_at: 2026-05-17T06:28:44Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the SearchHeader primitive: inline search bar header used in pickers (MemberPicker, BucketPicker) and the global Search screen. Distinct from AppHeader — SearchHeader replaces or augments the header in search-active contexts with the input expanded, cancel affordance visible.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-search-header.html` showing variants (idle, typing, with-results-count, no-results, with-active-filters chips) and required states
+- [ ] Spec doc per SKILL.md §8 covering: focus management on mount, clear-query button, cancel returns to underlying header
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md §15 search
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Search beans)

--- a/.beans/ps-p7ia--cross-cutting-permission-request-screens-camera-ph.md
+++ b/.beans/ps-p7ia--cross-cutting-permission-request-screens-camera-ph.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Permission request screens (camera, photos, notifications, biometrics)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:51:15Z
-updated_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-p7ia--cross-cutting-permission-request-screens-camera-ph.md
+++ b/.beans/ps-p7ia--cross-cutting-permission-request-screens-camera-ph.md
@@ -1,0 +1,53 @@
+---
+# ps-p7ia
+title: "Cross-cutting: Permission request screens (camera, photos, notifications, biometrics)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T06:51:15Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the pre-OS-prompt rationale screens for the four permission surfaces: camera, photo library, push notifications, biometrics (face/touch).
+
+## Surfaces
+
+- Camera rationale (used for: avatar photo).
+- Photo library rationale (used for: avatar / journal attachment).
+- Push notifications rationale (used for: switch reminders, comm DM, friend requests).
+- Biometric rationale (used for: foreground re-auth, secret-key unlock).
+
+## Required states per surface
+
+- Default rationale (pre-prompt).
+- Awaiting OS prompt.
+- Granted confirmation.
+- Denied with deep-link to OS settings.
+- Permanently-denied state.
+
+## Mode notes
+
+- Default mode only.
+- Static mode: same screens, no animation — noted for Phase 3.
+
+## Primitives required
+
+- Full-screen rationale card.
+- Button + secondary button.
+- Icon (permission-type illustration).
+
+## Data refs (informational)
+
+- N/A — UI-only.
+
+## Required output
+
+- HTML mockup of all 4 surfaces × 5 states in docs/design-system/preview/cross-cutting/permissions.html.
+- Decision notes: rationale copy register per permission.
+
+## Out of scope
+
+- RN implementation (M11).
+- Native plugin selection.

--- a/.beans/ps-pgrq--structure-entity-detail-3-tabs-members-association.md
+++ b/.beans/ps-pgrq--structure-entity-detail-3-tabs-members-association.md
@@ -1,0 +1,49 @@
+---
+# ps-pgrq
+title: "Structure: Entity detail (3 tabs — members / associations / fields)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:42:42Z
+updated_at: 2026-05-17T06:42:42Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the structure entity detail screen with 3 tabbed sub-views.
+
+## Surfaces
+
+- Entity detail: `(app)/structure/entities/[entityId]/index.tsx` (members, default)
+- Members tab: same path
+- Associations tab: `(app)/structure/entities/[entityId]/associations.tsx`
+- Fields tab: `(app)/structure/entities/[entityId]/fields.tsx`
+
+## Required states per surface
+
+- header: default (with type tag, parent chain breadcrumb, color, gatekeeper indicator)
+- members: empty, populated, with-add affordance
+- associations: empty, with-incoming edges, with-outgoing edges, with-create affordance
+- fields: scoped custom-field values, empty if no field defs scoped to this entity-type
+
+## Mode notes
+
+- Littles: hidden
+- High-contrast: tabs use underline indicator (not background-fill)
+
+## Primitives required
+
+- ScreenScaffold, Tabs (existing), Badge (entity-type), MemberCard, RelationshipEdge (ps-jtn3), KeyValueRow (ps-5lr6), EntityRefPicker (ps-ywtb, for association create), MultiMemberPicker (ps-djqo), EmptyState (ps-ruwi), Button
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/structure.ts` entity get, memberLinks, associations, fields-for-entity
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-entity-detail.html with all 3 tabs + states
+- [ ] Rationale on parent-chain breadcrumb format
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), create / edit form (separate bean)

--- a/.beans/ps-pgrq--structure-entity-detail-3-tabs-members-association.md
+++ b/.beans/ps-pgrq--structure-entity-detail-3-tabs-members-association.md
@@ -3,9 +3,12 @@
 title: "Structure: Entity detail (3 tabs — members / associations / fields)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:42:42Z
-updated_at: 2026-05-17T06:42:42Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-pp0e--members-custom-fields-manager.md
+++ b/.beans/ps-pp0e--members-custom-fields-manager.md
@@ -3,9 +3,12 @@
 title: "Members: Custom fields manager"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:37:52Z
-updated_at: 2026-05-17T06:37:52Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-pp0e--members-custom-fields-manager.md
+++ b/.beans/ps-pp0e--members-custom-fields-manager.md
@@ -1,0 +1,46 @@
+---
+# ps-pp0e
+title: "Members: Custom fields manager"
+status: todo
+type: feature
+created_at: 2026-05-17T06:37:52Z
+updated_at: 2026-05-17T06:37:52Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the custom-field manager: list of field definitions, create / edit form, per-field bucket visibility, per-field scope to specific structure entity types.
+
+## Surfaces
+
+- Fields manager: `(app)/fields/index.tsx`
+- New field: `(app)/fields/new.tsx`
+- Edit field: `(app)/fields/[fieldId]/edit.tsx`
+
+## Required states per surface
+
+- list: empty (no fields defined), populated, with-scope-filter chip, archived view, error
+- create/edit: empty/populated, with-validation-rules-section, with-bucket-visibility-section, with-entity-type-scoping-section, invalid, submitting, conflict
+
+## Mode notes
+
+- Littles: simplified — no validation rules section, no scoping
+- High-contrast: per-bucket visibility toggles use both Switch + tier label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), FAB, ListItem (field row), TextField, Select (field type — text / number / date / select / multi-select), Switch (required, archived), BucketPicker (ps-s9r6, multi), EntityTypePicker (ps-gml0, multi-scope), EmptyState (ps-ruwi), Dialog (delete confirm)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/field.ts` list, get, create, update, archive, delete; bucketVisibility sub-route; entityTypeScopes sub-route
+
+## Required output
+
+- [ ] docs/design-system/preview/members-custom-fields.html with all surfaces + states
+- [ ] Rationale on field-type taxonomy and the per-bucket visibility UI per features.md §1
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), how values get set on individual members (covered by Members detail tabs)

--- a/.beans/ps-pxsv--structure-system-duplicate-wizard.md
+++ b/.beans/ps-pxsv--structure-system-duplicate-wizard.md
@@ -1,0 +1,49 @@
+---
+# ps-pxsv
+title: "Structure: System duplicate wizard"
+status: todo
+type: feature
+created_at: 2026-05-17T06:43:36Z
+updated_at: 2026-05-17T06:43:36Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the system duplicate wizard — multi-step flow to duplicate the current system to a new system under the same account, with element-selection at each step.
+
+## Surfaces
+
+- Wizard: `(app)/system/duplicate.tsx` (multi-step within)
+
+## Required states per surface
+
+- step 1 (name + nomenclature pick): empty/populated, invalid (name conflict)
+- step 2 (element selection): toggle per category — members, custom fronts, groups, structure entities, fields, snapshots, innerworld, fronting history (with size hints per category)
+- step 3 (bucket assignment): per-bucket include/exclude
+- step 4 (confirm + estimated time): summary view
+- duplicating: progress per category
+- success: redirect to new system
+
+## Mode notes
+
+- Littles: hidden entirely
+- Reduced-motion: progress per category as static count
+- Static: bar with no transition
+
+## Primitives required
+
+- WizardStepper (pattern, ps-rhno), TextField, RadioGroup (nomenclature), Switch (per-category), KeyValueRow (ps-5lr6, size hints), BucketPicker (ps-s9r6), ProgressBar (ps-3m01), Banner
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/system.ts` duplicate endpoint with options
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-system-duplicate.html with all steps + states
+- [ ] Rationale on the element-selection grouping (per-category vs per-entity-type)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the WizardStepper pattern (Phase 0)

--- a/.beans/ps-pxsv--structure-system-duplicate-wizard.md
+++ b/.beans/ps-pxsv--structure-system-duplicate-wizard.md
@@ -3,9 +3,12 @@
 title: "Structure: System duplicate wizard"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:43:36Z
-updated_at: 2026-05-17T06:43:36Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-qbx9--fronting-quick-switch-sheet-co-front-variant.md
+++ b/.beans/ps-qbx9--fronting-quick-switch-sheet-co-front-variant.md
@@ -1,0 +1,57 @@
+---
+# ps-qbx9
+title: "Fronting: Quick switch sheet + co-front variant"
+status: todo
+type: feature
+created_at: 2026-05-17T05:50:12Z
+updated_at: 2026-05-17T05:50:12Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the quick-switch sheet: the primary action UI for ending the current fronting session and starting a new one, or adding a co-fronter alongside.
+
+## Surfaces
+
+- Quick switch: `(sheets)/quick-switch.tsx` — invoked from front-overview, member list, and header chip.
+- Co-front add: same sheet with an "Add alongside" toggle (`endPrevious=false`).
+
+## Required states per surface
+
+- idle — member list visible, no selection
+- selecting — member chosen, status text input visible
+- co-front toggle on
+- bucket selection visible (assign privacy bucket to the new session)
+- confirming — submit engaged
+- optimistic-update — sheet dismissing, fronting state already shows new fronter
+- error — offline → queued, with retry affordance
+
+## Mode notes
+
+- Littles mode: larger member tiles, "Add alongside" toggle hidden by default (single-action).
+- Static mode: removes gradient/glow on member tiles.
+
+## Primitives required
+
+- BottomSheet (host)
+- MemberCard (selection)
+- MultiMemberPicker (when adding co-fronters)
+- TextField (status text — 50 char cap per features.md §2)
+- Switch (co-front toggle, positionality flag)
+- Button
+- BucketPicker
+- Banner (offline notice)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/fronting-session.ts` — start, co-front, structure-entity-front
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-quick-switch.html with all states
+- [ ] Layout / interaction rationale
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage variants (Phase 3 sweep).

--- a/.beans/ps-qbx9--fronting-quick-switch-sheet-co-front-variant.md
+++ b/.beans/ps-qbx9--fronting-quick-switch-sheet-co-front-variant.md
@@ -3,9 +3,12 @@
 title: "Fronting: Quick switch sheet + co-front variant"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:50:12Z
-updated_at: 2026-05-17T05:50:12Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-qmnt--members-custom-fronts-list-createedit-detail.md
+++ b/.beans/ps-qmnt--members-custom-fronts-list-createedit-detail.md
@@ -1,0 +1,48 @@
+---
+# ps-qmnt
+title: "Members: Custom fronts (list + create/edit + detail)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:37:15Z
+updated_at: 2026-05-17T06:37:15Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the custom-front surfaces — abstract cognitive states logged like members (e.g. "Dissociated", "Blurry"). List, create/edit form, detail.
+
+## Surfaces
+
+- Custom-front list: `(app)/custom-fronts/index.tsx`
+- New: `(app)/custom-fronts/new.tsx`
+- Edit: `(app)/custom-fronts/[id]/edit.tsx`
+- Detail: `(app)/custom-fronts/[id]/index.tsx`
+
+## Required states per surface
+
+- list: empty, populated, archived view
+- create/edit form: empty/populated, invalid, submitting, conflict
+- detail: default, with-fronting-history sample, archived
+
+## Mode notes
+
+- Littles: custom-front feature disabled by default (parent / caregiver toggle)
+- High-contrast: custom-front visual differentiation from members uses icon + label (in addition to color)
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), FAB, MemberCard variant (custom-front), TextField, TextArea, ColorSwatchPicker, EmojiPicker, EmptyState (ps-ruwi), Dialog (delete confirm)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/custom-front.ts` CRUD + archive/restore
+
+## Required output
+
+- [ ] docs/design-system/preview/members-custom-fronts.html with all surfaces + states
+- [ ] Rationale on visual distinction from Members in list contexts
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), fronting integration for custom fronts (Fronting beans cover that)

--- a/.beans/ps-qmnt--members-custom-fronts-list-createedit-detail.md
+++ b/.beans/ps-qmnt--members-custom-fronts-list-createedit-detail.md
@@ -3,9 +3,12 @@
 title: "Members: Custom fronts (list + create/edit + detail)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:37:15Z
-updated_at: 2026-05-17T06:37:15Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-qv5s--fronting-timeline-visualization-filter-sheet.md
+++ b/.beans/ps-qv5s--fronting-timeline-visualization-filter-sheet.md
@@ -3,9 +3,12 @@
 title: "Fronting: Timeline visualization + filter sheet"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:50:33Z
-updated_at: 2026-05-17T05:50:33Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-qv5s--fronting-timeline-visualization-filter-sheet.md
+++ b/.beans/ps-qv5s--fronting-timeline-visualization-filter-sheet.md
@@ -1,0 +1,55 @@
+---
+# ps-qv5s
+title: "Fronting: Timeline visualization + filter sheet"
+status: todo
+type: feature
+created_at: 2026-05-17T05:50:33Z
+updated_at: 2026-05-17T05:50:33Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the multi-lane swimlane timeline visualization (color-coded per member with co-fronting overlap visible) and its filter sheet.
+
+## Surfaces
+
+- Timeline: `(app)/fronting/timeline.tsx` — vertical or horizontal swimlanes per member, time axis, co-fronting overlap rendered.
+- Filter sheet: `(sheets)/timeline-filter.tsx` — date range, member subset, bucket filter, period preset (day / week / month / custom).
+
+## Required states per surface
+
+- timeline: dense day (many switches), sparse week, empty (no sessions in range), loading-tail (paginated load), error
+- filter: idle, applying, applied (chip visible on timeline header), reset
+
+## Mode notes
+
+- High-contrast mode: member colors must pair with shape glyph or pattern fill — color-only swimlanes violate identity rules.
+- Reduced-motion: disable any scrub / scroll animation.
+- Static mode: flat lane fills (no gradient member color strips).
+- Littles mode: simplified day-view only; week/month hidden.
+
+## Primitives required
+
+- FrontingTimelineLane (Phase 0 must produce — block on it)
+- SegmentedControl (period preset)
+- DateRangePicker
+- MultiMemberPicker (filter)
+- BucketPicker (filter)
+- BottomSheet (filter host)
+- EmptyState
+- Chip (active-filter indicator on timeline header)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/fronting-session.ts` — list with cursor pagination
+- `apps/api/src/trpc/routers/analytics.ts` — period summaries
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-timeline.html with all states
+- [ ] Layout / interaction rationale (including swimlane direction decision: horizontal-time vs vertical-time)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond structural notes (Phase 3 sweep).

--- a/.beans/ps-r7ox--privacy-friend-codes-generate-list-redeem.md
+++ b/.beans/ps-r7ox--privacy-friend-codes-generate-list-redeem.md
@@ -1,0 +1,47 @@
+---
+# ps-r7ox
+title: "Privacy: Friend codes (generate + list + redeem)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:41:25Z
+updated_at: 2026-05-17T06:41:25Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the friend-code surfaces — generate a new XXXX-XXXX code, list active / archived codes, redeem an incoming code.
+
+## Surfaces
+
+- Generate: `(app)/privacy/friend-codes/new.tsx`
+- List: `(app)/privacy/friend-codes/index.tsx`
+- Redeem: `(app)/privacy/friend-codes/redeem.tsx`
+
+## Required states per surface
+
+- generate: with options (bucket auto-assign, code-purpose label), confirming, code-revealed (copy + share + QR), expired
+- list: empty, with-active-codes, archived view, with-revoke affordance per code
+- redeem: idle, code-entry, validating, matched (with friend preview), submitting, error (invalid, expired)
+
+## Mode notes
+
+- Littles: hidden
+- High-contrast: code display monospace + segmented
+
+## Primitives required
+
+- ScreenScaffold, RecoveryKeyField (ps-o1zp, re-skinned for XXXX-XXXX code entry), Button, BucketPicker (ps-s9r6), TextField, Banner, EmptyState (ps-ruwi), QR code primitive (or inline-svg, NEW), Avatar (friend preview)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/friend-code.ts` create, list, redeem, revoke, archive
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-friend-codes.html with all surfaces + states
+- [ ] Rationale on QR code presentation (default on / off)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12)

--- a/.beans/ps-r7ox--privacy-friend-codes-generate-list-redeem.md
+++ b/.beans/ps-r7ox--privacy-friend-codes-generate-list-redeem.md
@@ -3,9 +3,12 @@
 title: "Privacy: Friend codes (generate + list + redeem)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:41:25Z
-updated_at: 2026-05-17T06:41:25Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-rghj--privacy-bucket-detail-4-tabs-friends-content-rotat.md
+++ b/.beans/ps-rghj--privacy-bucket-detail-4-tabs-friends-content-rotat.md
@@ -1,0 +1,51 @@
+---
+# ps-rghj
+title: "Privacy: Bucket detail (4 tabs — friends / content / rotation / settings)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:40:40Z
+updated_at: 2026-05-17T06:40:40Z
+parent: ps-9xue
+---
+
+## Goal
+
+Design the bucket detail screen with 4 tabbed sub-views.
+
+## Surfaces
+
+- Bucket detail: `(app)/privacy/buckets/[bucketId]/index.tsx` (settings, default)
+- Friends tab: `(app)/privacy/buckets/[bucketId]/friends.tsx`
+- Content tab: `(app)/privacy/buckets/[bucketId]/content.tsx`
+- Rotation tab: `(app)/privacy/buckets/[bucketId]/rotation.tsx`
+- Settings tab: `(app)/privacy/buckets/[bucketId]/settings.tsx`
+
+## Required states per surface
+
+- header: default with name + color + count summaries
+- friends: empty (no friends assigned), populated, with-add-friend affordance, with-revoke confirm
+- content: empty (no entities tagged), populated grouped by entity-type, with-untagged-warning banner if everything is empty, search/filter
+- rotation: idle (no rotation in progress), in-progress with KeyRotationStepper (ps-oipx), failed-with-retry, complete-with-summary
+- settings: rename, color, emoji, description, archive, delete
+
+## Mode notes
+
+- Littles: rotation tab hidden (caregiver-only); settings tab hides delete
+- High-contrast: per-entity-type group headers use icon + label (color is supplemental)
+
+## Primitives required
+
+- ScreenScaffold, Tabs (existing), BucketPill (ps-i6n1), InfiniteList (ps-hijf), Card (friend / entity rows), KeyRotationStepper (ps-oipx), EmptyState (ps-ruwi), Banner (untagged-warning, rotation-needed), Button, DestructiveConfirmDialog (ps-bydy), KeyValueRow (ps-5lr6)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/bucket.ts` get, friends, tags (content), rotation routes, update, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/privacy-bucket-detail.html with all 4 tabs + states
+- [ ] Rationale on the content-tab grouping (per-entity-type vs flat)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the bucket export flow (separate bean), the KeyRotationStepper primitive (Phase 0)

--- a/.beans/ps-rghj--privacy-bucket-detail-4-tabs-friends-content-rotat.md
+++ b/.beans/ps-rghj--privacy-bucket-detail-4-tabs-friends-content-rotat.md
@@ -3,9 +3,12 @@
 title: "Privacy: Bucket detail (4 tabs — friends / content / rotation / settings)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:40:40Z
-updated_at: 2026-05-17T06:40:40Z
+updated_at: 2026-05-17T07:42:07Z
 parent: ps-9xue
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-rgrw--design-popover-primitive.md
+++ b/.beans/ps-rgrw--design-popover-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-rgrw
+title: Design Popover primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:47Z
+updated_at: 2026-05-17T06:27:47Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the Popover primitive: anchored tap/hover explanation surface, distinct from Tooltip (short text-only on hover/long-press) and BottomSheet (drag-up surface). Popover is anchored to a trigger and can hold rich content (icons, links, multi-line copy). On mobile, popovers anchored near screen edges flip orientation; on web, the Popover API + anchor positioning handles placement.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-popover.html` showing variants (top, bottom, left, right anchor) and required states per SKILL.md §7
+- [ ] Spec doc per SKILL.md §8 documenting the mobile-popover-becomes-bottom-sheet rule at narrow viewports
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (surface), `tokens/elevation.json`, `tokens/radii.json`
+- Reference: `packages/design-system/docs/cross-platform-parity.md` (popover-on-desktop = bottom-sheet-on-mobile)
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-rhno--design-wizardstepper-pattern.md
+++ b/.beans/ps-rhno--design-wizardstepper-pattern.md
@@ -1,0 +1,27 @@
+---
+# ps-rhno
+title: Design WizardStepper pattern
+status: todo
+type: task
+created_at: 2026-05-17T06:31:13Z
+updated_at: 2026-05-17T06:31:13Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the WizardStepper pattern: multi-step linear-flow composition. Used by the setup wizard (6 steps), sign-up (account-type → password → recovery), bucket-key rotation (initiate → progress → complete), system duplicate wizard, import wizards (SP and PK).
+
+## Required output
+
+- [ ] `docs/design-system/preview/patterns-wizard-stepper.html` showing the stepper chrome variants (top-progress, side-rail, minimal-counter) and the step transitions, plus the back / next / skip affordance rules
+- [ ] Spec doc per SKILL.md §8 (back-navigation rules per flow type: destructive flows disable back after a point; non-destructive flows allow free back-nav)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/motion.json`
+- Reference: existing setup wizard sketch in `ui_kits/mobile/Screen_*.jsx`, features.md §6 setup wizard
+
+## Out of scope
+
+- RN code (M11), screen-level integration of any specific wizard (those are separate Phase 2 beans)

--- a/.beans/ps-rjqk--journaling-wiki-page-editor.md
+++ b/.beans/ps-rjqk--journaling-wiki-page-editor.md
@@ -1,0 +1,44 @@
+---
+# ps-rjqk
+title: "Journaling: Wiki page editor"
+status: todo
+type: feature
+created_at: 2026-05-17T06:44:48Z
+updated_at: 2026-05-17T06:44:48Z
+parent: ps-djgs
+---
+
+## Goal
+
+Design the wiki page editor — block-based, multi-author collaborative with per-author edit attribution.
+
+## Surfaces
+
+- New: `(app)/journal/wiki/new.tsx`
+- Edit: `(app)/journal/wiki/[id]/edit.tsx`
+
+## Required states per surface
+
+- editor: empty (new), populated (edit), with-block-menu, with-other-author-typing indicator, with-conflict-banner (concurrent edit), save-status indicator (saving / saved / offline-queued), with-category-picker, with-bucket-picker
+
+## Mode notes
+
+- Littles: simplified — paragraph + image blocks only
+- High-contrast: other-author indicators use border-strong + initial
+
+## Primitives required
+
+- ScreenScaffold, BlockEditor (ps-zpyu), Avatar (other-author typing), BucketPicker (ps-s9r6), Select (category), MemberPicker (ps-djqo, member-link), Button, Banner (conflict), SyncIndicator (ps-gnkq)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/journal.ts` wiki create, update, sync-events
+
+## Required output
+
+- [ ] docs/design-system/preview/journal-wiki-editor.html with all states
+- [ ] Rationale on collaborative-edit attribution UX (inline marker vs gutter avatar)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the BlockEditor primitive (Phase 0)

--- a/.beans/ps-rjqk--journaling-wiki-page-editor.md
+++ b/.beans/ps-rjqk--journaling-wiki-page-editor.md
@@ -3,9 +3,12 @@
 title: "Journaling: Wiki page editor"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:44:48Z
-updated_at: 2026-05-17T06:44:48Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-djgs
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-rjuj--fronting-session-detail-edit-comments-thread.md
+++ b/.beans/ps-rjuj--fronting-session-detail-edit-comments-thread.md
@@ -3,9 +3,12 @@
 title: "Fronting: Session detail + edit + comments thread"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:50:25Z
-updated_at: 2026-05-17T05:50:25Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-rjuj--fronting-session-detail-edit-comments-thread.md
+++ b/.beans/ps-rjuj--fronting-session-detail-edit-comments-thread.md
@@ -1,0 +1,56 @@
+---
+# ps-rjuj
+title: "Fronting: Session detail + edit + comments thread"
+status: todo
+type: feature
+created_at: 2026-05-17T05:50:25Z
+updated_at: 2026-05-17T05:50:25Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the fronting session detail screen, its edit form, and the inline comments thread.
+
+## Surfaces
+
+- Session detail: `(app)/fronting/[sessionId]/index.tsx` — view single session, comments thread, lifecycle metadata.
+- Session edit: `(app)/fronting/[sessionId]/edit.tsx` — retroactive edit (time range, members, status text, positionality, outtrigger reason + sentiment).
+- Comments thread: inline within detail (not a separate route).
+
+## Required states per surface
+
+- detail: active session (no end_at), ended, archived, with comments, without comments, multi-member (co-fronting), loading, error
+- edit: form valid, form invalid (e.g. end before start), submitting, conflict (concurrent edit), success
+- comments: empty thread, populated thread, compose-new, editing-existing, delete confirm
+
+## Mode notes
+
+- Outtrigger sentiment editing (negative / neutral / positive) must not be color-only — include icon + label per GOVERNANCE.md §4.
+- Littles mode: hide outtrigger editing (sensitive content per GOVERNANCE.md §3.3); show comments simplified.
+
+## Primitives required
+
+- ScreenScaffold
+- KeyValueRow (lifecycle metadata)
+- AvatarStack
+- TextArea (status text, comment compose)
+- DateTimePicker (time range edit)
+- SegmentedControl (outtrigger sentiment)
+- Banner (offline notice, edit conflict notice)
+- Dialog (delete confirm — DestructiveConfirmDialog variant)
+- ListItem (comment row)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/fronting-session.ts` — get, update, delete
+- `apps/api/src/trpc/routers/fronting-comment.ts` — list, create, update, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-session-detail.html with all surfaces and states
+- [ ] Layout / interaction rationale
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond structural notes (Phase 3 sweep).

--- a/.beans/ps-ruwi--design-emptystate-primitive.md
+++ b/.beans/ps-ruwi--design-emptystate-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-ruwi
+title: Design EmptyState primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:26:53Z
+updated_at: 2026-05-17T06:26:53Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the EmptyState primitive: preview HTML + spec doc per `docs/design-system/SKILL.md` §8. Composes constellation illustration variant, copy line, and optional primary CTA. Used on every list screen with no data.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-empty-state.html` showing variants (constellation, sparse, illustrated) and states (default, with-CTA, no-CTA, with-secondary-action)
+- [ ] Spec doc covering §8.1 anatomy, §8.2 required states, §8.3 a11y intent, §8.4 mode behavior, §8.5 content rules, §8.6 usage rules, §8.7 bad example
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`, `tokens/typography.json`
+- Reference: existing `components-display.html` `state` class as starting point
+
+## Out of scope
+
+- React Native code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-s1ec--fronting-analytics-fronting-summary.md
+++ b/.beans/ps-s1ec--fronting-analytics-fronting-summary.md
@@ -3,9 +3,12 @@
 title: "Fronting: Analytics — fronting summary"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:50:43Z
-updated_at: 2026-05-17T05:50:43Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-s1ec--fronting-analytics-fronting-summary.md
+++ b/.beans/ps-s1ec--fronting-analytics-fronting-summary.md
@@ -1,0 +1,53 @@
+---
+# ps-s1ec
+title: "Fronting: Analytics — fronting summary"
+status: todo
+type: feature
+created_at: 2026-05-17T05:50:43Z
+updated_at: 2026-05-17T05:50:43Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the per-subject fronting summary analytics screen: cumulative duration, average session length, percentage breakdown.
+
+## Surfaces
+
+- Analytics summary: `(app)/fronting/analytics/index.tsx`
+
+## Required states per surface
+
+- default (3+ members)
+- small system (1–2 members) — different chart treatment
+- single fronter dominates (>80%)
+- empty (no fronting data in range)
+- loading
+- error
+
+## Mode notes
+
+- High-contrast mode: bar / donut charts need text labels alongside color segments.
+- Reduced-motion: chart entrance animations disabled.
+- Static mode: flat fills, no gradient chart segments.
+
+## Primitives required
+
+- SegmentedControl (period preset)
+- Chart primitive — donut + horizontal bar (Phase 0 candidate; block on it)
+- MemberCard (legend / detail rows)
+- KeyValueRow (summary stats: total duration, session count, avg length)
+- EmptyState
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/analytics.ts` — per-subject breakdown (members + custom fronts + structure entities)
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-analytics-summary.html with all states
+- [ ] Chart treatment decisions (donut vs bar, axis labels, member color → glyph fallback for accessibility)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage (Phase 3 sweep), per-co-fronting-pair analytics (separate bean).

--- a/.beans/ps-s9r6--design-bucketpicker-primitive.md
+++ b/.beans/ps-s9r6--design-bucketpicker-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-s9r6
+title: Design BucketPicker primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:30:33Z
+updated_at: 2026-05-17T06:30:33Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the BucketPicker primitive: privacy-bucket selection (single or multi). Distinct from BucketPill (display). Used everywhere a piece of data is bucket-scoped: member, custom field, fronting session, channel, board message, note, poll, friend assignment.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-bucket-picker.html` showing variants (single-pick, multi-pick with chips, with "+ create bucket" affordance, with untagged-warning explainer) and required states
+- [ ] Spec doc per SKILL.md §8 (fail-closed messaging: pre-select "Private" if no buckets exist for the entity)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: GOVERNANCE.md §5b privacy primitive, features.md §4
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Privacy & Social beans)

--- a/.beans/ps-sal4--design-frontingtimelinelane-primitive.md
+++ b/.beans/ps-sal4--design-frontingtimelinelane-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-sal4
+title: Design FrontingTimelineLane primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:08Z
+updated_at: 2026-05-17T06:29:08Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the FrontingTimelineLane primitive: one member's track within the multi-lane Timeline visualization. Single-color or gradient strip with session segments, status-text tooltip on hover/long-press, co-fronting overlap rendered as a stacked second lane.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-fronting-timeline-lane.html` showing variants (single member, with-status-tooltip-open, co-fronting overlap with neighbor) and required states (default, focused, dragging-edit, error)
+- [ ] Spec doc per SKILL.md §8 (color-only-not-allowed rule in high-contrast mode → pattern fill or text label; reduced-motion disables drag-edit animation)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (member palette), `tokens/motion.json`
+- Reference: GOVERNANCE.md §4 identity rules, existing `components-fronting-history.html` and `patterns.html` Fronting timeline pattern
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Fronting beans)

--- a/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
+++ b/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
@@ -1,11 +1,11 @@
 ---
 # ps-sg8k
 title: "M10 audit: Primitive coverage gap analysis"
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-05-17T05:49:37Z
-updated_at: 2026-05-17T05:49:37Z
+updated_at: 2026-05-17T06:31:39Z
 parent: ps-udt1
 ---
 
@@ -48,3 +48,24 @@ Gaps spawn new beans referencing this audit. The audit bean completes when the r
 - Designing the primitives themselves (separate per-primitive beans).
 - RN code (M11).
 - Atoms already shipped in @pluralscape/design-system (Avatar, Badge, Button, Icon, IconButton, Input, Switch, PluralscapeLogo) unless a variant or state is missing.
+
+## Summary of Changes
+
+Audit performed inline during M10 full-buildout. Existing `docs/design-system/preview/components-*.html` survey produced the following classification:
+
+**Covered** (no new bean needed): Button, IconButton, Badge, Chip, Card, Surface, Switch, FAB, TextField, PinPad, BottomTabBar, AppHeader, Tabs, NavBackButton, PullToRefresh, Avatar, AvatarStack, MemberCard, Skeleton, Toast/Snackbar, Banner, BottomSheet, Tooltip, LoadingOverlay, Timeline, Chart, ColorStrip, MarkdownRenderer, MentionRenderer, ListItem, Section, Tree, DatePicker, TimePicker, DateTimePicker, DurationPicker, Select, MultiSelect, ColorSwatchPicker, EmojiPicker, ImagePickerLauncher, SegmentedControl, Checkbox, Radio, Dialog. Member-identity, Privacy-buckets, State-of-data, Fronting-timeline, Import-conflict, Destructive-action, Custom-terminology patterns all in `patterns.html`.
+
+**Missing — spawned 37 follow-up beans under ps-udt1**:
+
+Foundation: EmptyState (ps-ruwi), ErrorState (ps-a5ee), SyncIndicator (ps-gnkq)
+Input: RecoveryKeyField (ps-o1zp), ImageCropper (ps-107o), BlockEditor (ps-zpyu), RichTextField (ps-9yhh)
+Display: RecoveryKeyDisplay (ps-xthc), EncryptionTierBadge (ps-gfhz), ProgressBar+ProgressRing (ps-3m01), Accordion (ps-ecpl), KeyValueRow (ps-5lr6)
+Feedback: DestructiveConfirmDialog (ps-bydy), ConfirmGesture (ps-00b4), Popover (ps-rgrw)
+Navigation: Drawer (ps-217e), SystemSwitcher (ps-a5pt), SearchHeader (ps-oylh), InfiniteList (ps-hijf)
+Domain: FrontingChip (ps-458i), FrontingTimelineLane (ps-sal4), BucketPill (ps-i6n1), LifecycleEventChip (ps-v3e9), ProxyChip (ps-jtvw), RelationshipEdge (ps-jtn3), InnerworldNode (ps-5iro), CheckInPrompt (ps-7to1), KeyRotationStepper (ps-oipx)
+Pickers: MemberPicker+Multi (ps-djqo), EntityRefPicker (ps-ywtb), TagPicker (ps-jleu), BucketPicker (ps-s9r6), SaturationPicker (ps-xts0), RelationshipTypePicker (ps-1v9l), EntityTypePicker (ps-gml0)
+Patterns: RecoveryKey ceremony (ps-472d), WizardStepper (ps-rhno)
+
+**Audit report**: not written as a separate file — `docs/design-system/audits/` is gitignored. The summary above captures the same gap data inline so the spawned bean IDs are traceable in the committed bean files.
+
+**Blocks-pilot primitives** (Phase 1 Fronting beans should declare blocked_by on these): FrontingChip (ps-458i), FrontingTimelineLane (ps-sal4), AvatarStack already covered, EmptyState (ps-ruwi), DestructiveConfirmDialog (ps-bydy), CheckInPrompt (ps-7to1), BucketPicker (ps-s9r6), MemberPicker+Multi (ps-djqo).

--- a/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
+++ b/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
@@ -1,0 +1,50 @@
+---
+# ps-sg8k
+title: "M10 audit: Primitive coverage gap analysis"
+status: todo
+type: task
+priority: high
+created_at: 2026-05-17T05:49:37Z
+updated_at: 2026-05-17T05:49:37Z
+parent: ps-udt1
+---
+
+## Goal
+
+Cross-reference every primitive named in docs/design-system/uploads/SCREENS.md §1.1–1.6 (foundations, inputs, display, feedback, navigation, domain primitives) and every primitive implied by docs/planning/features.md against existing preview HTML coverage in docs/design-system/preview/components-\*.html. Output a written gap list that drives the rest of Phase 0.
+
+Spec: docs/superpowers/specs/2026-05-16-m10-bean-buildout-design.md
+
+## Scope
+
+Files surveyed:
+
+- docs/design-system/preview/components-\*.html (existing coverage)
+- docs/design-system/preview/brand-\*.html (brand-affected primitives)
+- docs/design-system/uploads/SCREENS.md §1 (rough inventory, not contract)
+- docs/planning/features.md (canonical feature spec)
+- packages/design-system/src/components/ (already-ported atoms — out of scope unless a variant is missing)
+
+## Pass criteria
+
+- [ ] Every primitive named in SCREENS.md §1 classified as covered, partially covered, or missing.
+- [ ] Every primitive implied by features.md (bucket pill, lifecycle event chip, fronting timeline lane, etc.) classified the same way.
+- [ ] Composed patterns audited separately: member identity card, ConfirmDestructive tiers, ImportConflictResolver, SyncState, FrontingTimeline, RecoveryKey ceremony, PrivacyBucket primitive.
+- [ ] Each gap classified by phase dependency: blocks-pilot (Phase 1 Fronting), blocks-domain (specific Phase 2 epic), or general-purpose.
+
+## Required output
+
+- [ ] Audit report: docs/design-system/audits/2026-05-XX-primitive-coverage.md
+- [ ] One follow-up bean per missing primitive (parent ps-udt1)
+- [ ] One follow-up bean per missing composed pattern (parent ps-udt1)
+- [ ] Blocks-pilot primitives marked priority: high so Phase 1 Fronting beans can declare blocked_by on them
+
+## Disposition of failures
+
+Gaps spawn new beans referencing this audit. The audit bean completes when the report is written; follow-up bean creation and design work proceed independently.
+
+## Out of scope
+
+- Designing the primitives themselves (separate per-primitive beans).
+- RN code (M11).
+- Atoms already shipped in @pluralscape/design-system (Avatar, Badge, Button, Icon, IconButton, Input, Switch, PluralscapeLogo) unless a variant or state is missing.

--- a/.beans/ps-t9lx--members-photo-gallery-management.md
+++ b/.beans/ps-t9lx--members-photo-gallery-management.md
@@ -3,9 +3,12 @@
 title: "Members: Photo gallery management"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:37:08Z
-updated_at: 2026-05-17T06:37:08Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-t9lx--members-photo-gallery-management.md
+++ b/.beans/ps-t9lx--members-photo-gallery-management.md
@@ -1,0 +1,45 @@
+---
+# ps-t9lx
+title: "Members: Photo gallery management"
+status: todo
+type: feature
+created_at: 2026-05-17T06:37:08Z
+updated_at: 2026-05-17T06:37:08Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the member-photo gallery management surface — upload, reorder, set primary, delete, and crop/edit existing photos. Distinct from member detail's photos tab (display-only).
+
+## Surfaces
+
+- Gallery management: invoked from member detail photos tab or inline edit
+
+## Required states per surface
+
+- empty (no photos), with-photos (grid), reorder mode (drag handles visible), uploading (progress per file), upload-error per file, with-image-cropper-modal open, with-set-primary indicator, deleting with confirm
+
+## Mode notes
+
+- Littles: gallery management hidden if any photos contain trauma-marker content; viewer-only
+- High-contrast: drag-handle uses both icon + border-strong
+
+## Primitives required
+
+- BottomSheet (host), ImagePickerLauncher (existing), ImageCropper (ps-107o), ProgressBar (ps-3m01), Dialog (delete confirm), Button, Banner (offline queue notice)
+- Polymorphic ImageSource discriminated union per features.md §1 (blob ref vs external URL)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/member-photo.ts` list, create, update (reorder, set-primary), delete
+- `apps/api/src/trpc/routers/blob.ts` presigned upload + confirm
+
+## Required output
+
+- [ ] docs/design-system/preview/members-photo-gallery.html with all states
+- [ ] Rationale on the polymorphic ImageSource UI (when to surface "use external URL" affordance)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the ImagePickerLauncher / ImageCropper primitives (Phase 0)

--- a/.beans/ps-te2p--structure-entity-types-list-createedit.md
+++ b/.beans/ps-te2p--structure-entity-types-list-createedit.md
@@ -1,0 +1,46 @@
+---
+# ps-te2p
+title: "Structure: Entity types (list + create/edit)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:42:27Z
+updated_at: 2026-05-17T06:42:27Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the entity-type surfaces — list of user-defined types per system (e.g. "Subsystem", "Side System", "Layer"), and the create / edit form (name, color, image source, emoji, architecture type, gatekeeper).
+
+## Surfaces
+
+- Entity-type list: `(app)/structure/types/index.tsx`
+- New: `(app)/structure/types/new.tsx`
+- Edit: `(app)/structure/types/[id]/edit.tsx`
+
+## Required states per surface
+
+- list: empty, populated, archived view, error
+- create/edit: empty/populated, with all metadata fields (name, color, image source, emoji, architecture-type pick, gatekeeper member picker), invalid, submitting, conflict
+
+## Mode notes
+
+- Littles: hidden entirely
+- High-contrast: per-type tile uses border + label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), FAB, Card (type tile), TextField, TextArea, ColorSwatchPicker, EmojiPicker, ImagePickerLauncher, MemberPicker (ps-djqo, gatekeeper), Select (architecture type), EmptyState (ps-ruwi), DestructiveConfirmDialog (ps-bydy)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/structure.ts` types subrouter
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-entity-types.html with all surfaces + states
+- [ ] Rationale on architecture-type taxonomy and how it surfaces in entity detail
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), entity hierarchy / detail (separate beans)

--- a/.beans/ps-te2p--structure-entity-types-list-createedit.md
+++ b/.beans/ps-te2p--structure-entity-types-list-createedit.md
@@ -3,9 +3,12 @@
 title: "Structure: Entity types (list + create/edit)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:42:27Z
-updated_at: 2026-05-17T06:42:27Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-tmm6--fronting-pilot-slice-retrospective.md
+++ b/.beans/ps-tmm6--fronting-pilot-slice-retrospective.md
@@ -1,0 +1,34 @@
+---
+# ps-tmm6
+title: "Fronting: Pilot slice retrospective"
+status: todo
+type: task
+priority: high
+created_at: 2026-05-17T05:51:25Z
+updated_at: 2026-05-17T05:51:25Z
+parent: ps-5920
+---
+
+## Goal
+
+After the other Phase 1 Fronting beans complete, review every preview HTML + spec doc produced. Extract reusable patterns, fold discoveries back into Phase 0 spec docs, identify any new primitives or pattern needs surfaced by the pilot. Verifies that Phase 2 can proceed without rework of the design system foundation.
+
+## Pass criteria
+
+- [ ] Every Fronting preview HTML reviewed end-to-end against GOVERNANCE.md §3 (modes), §4 (member identity), §5 (data states), §7 (voice).
+- [ ] List of new primitives discovered during the slice (any not anticipated by Phase 0 audit) — file as Phase 0 follow-up beans.
+- [ ] List of pattern decisions that should propagate to other domains (e.g. "all list screens use this empty-state recipe", "all detail screens place the encryption-tier badge here").
+- [ ] Note any GOVERNANCE.md / SKILL.md / cross-platform-parity.md updates needed and apply them, or file beans for them.
+- [ ] Update docs/design-system/SKILL.md if a new pattern category emerged.
+
+## Required output
+
+- [ ] Retrospective report: docs/design-system/audits/2026-XX-XX-fronting-slice-retro.md
+- [ ] Follow-up beans for any newly-discovered primitives or pattern gaps.
+- [ ] Updated SKILL.md / GOVERNANCE.md if generalizable.
+- [ ] Sign-off comment on this bean: "Phase 2 unblocked".
+
+## Out of scope
+
+- Redesigning the Fronting screens themselves (any issues spawn new beans).
+- RN code (M11).

--- a/.beans/ps-tmm6--fronting-pilot-slice-retrospective.md
+++ b/.beans/ps-tmm6--fronting-pilot-slice-retrospective.md
@@ -5,8 +5,10 @@ status: todo
 type: task
 priority: high
 created_at: 2026-05-17T05:51:25Z
-updated_at: 2026-05-17T05:51:25Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-tpvx--cross-cutting-system-banners-update-available-main.md
+++ b/.beans/ps-tpvx--cross-cutting-system-banners-update-available-main.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: System banners (update-available, maintenance, breaking-change)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:51:15Z
-updated_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-tpvx--cross-cutting-system-banners-update-available-main.md
+++ b/.beans/ps-tpvx--cross-cutting-system-banners-update-available-main.md
@@ -1,0 +1,52 @@
+---
+# ps-tpvx
+title: "Cross-cutting: System banners (update-available, maintenance, breaking-change)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T06:51:15Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the top-of-app system banner surfaces for: update available, server maintenance, breaking-change advisory.
+
+## Surfaces
+
+- Update-available banner (with "update now" CTA → app store).
+- Forced-update gate (full-screen, no dismiss).
+- Maintenance window banner (with countdown).
+- Breaking-change advisory banner (with link to changelog).
+
+## Required states per surface
+
+- Default (dismissible).
+- Persistent (not dismissible).
+- With countdown.
+- Submitting (forced-update only — checking version).
+
+## Mode notes
+
+- Default mode only.
+- Reduced-motion: no banner slide-in — noted for Phase 3.
+
+## Primitives required
+
+- Banner primitive.
+- Modal overlay (forced-update only).
+- Button.
+
+## Data refs (informational)
+
+- packages/api-client `/system/status` endpoint (if exists; otherwise informational).
+
+## Required output
+
+- HTML mockup of all banner variants in docs/design-system/preview/cross-cutting/system-banners.html.
+- Decision notes: dismiss persistence rules, forced-update threshold.
+
+## Out of scope
+
+- RN implementation (M11).
+- App store deep-link plumbing (M11).

--- a/.beans/ps-u28x--structure-snapshots-list-detail-create-confirm.md
+++ b/.beans/ps-u28x--structure-snapshots-list-detail-create-confirm.md
@@ -3,9 +3,12 @@
 title: "Structure: Snapshots (list + detail + create confirm)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:43:11Z
-updated_at: 2026-05-17T06:43:11Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-7wf6
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-u28x--structure-snapshots-list-detail-create-confirm.md
+++ b/.beans/ps-u28x--structure-snapshots-list-detail-create-confirm.md
@@ -1,0 +1,47 @@
+---
+# ps-u28x
+title: "Structure: Snapshots (list + detail + create confirm)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:43:11Z
+updated_at: 2026-05-17T06:43:11Z
+parent: ps-7wf6
+---
+
+## Goal
+
+Design the system snapshot surfaces — list of point-in-time captures, detail viewer (read-only), create confirm modal.
+
+## Surfaces
+
+- Snapshot list: `(app)/structure/snapshots/index.tsx`
+- Snapshot detail: `(app)/structure/snapshots/[id]/index.tsx`
+- Create confirm: `(modals)/snapshot-create.tsx`
+
+## Required states per surface
+
+- list: empty, populated (with-creation-date sort), with-storage-warning if approaching quota, archived view, error
+- detail: snapshot preview rendered as read-only-mini-app (members list, structure entities, innerworld state), with-export affordance, with-delete affordance
+- create: confirm dialog with snapshot-includes summary, optional-label TextField, submitting, success
+
+## Mode notes
+
+- Littles: hidden
+- High-contrast: snapshot date uses monospace numerals
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (snapshot tile), KeyValueRow (ps-5lr6), Dialog (create + delete confirm), DestructiveConfirmDialog (ps-bydy), Button, EmptyState (ps-ruwi), Banner (storage warning), Tabs (detail sub-views)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/snapshot.ts` list, get, create, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/structure-snapshots.html with all surfaces + states
+- [ ] Rationale on detail-view layout (mirror current app vs custom layout)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), restoring from a snapshot (not supported — view-only per features.md §6)

--- a/.beans/ps-uck1--home-system-switcher-modal.md
+++ b/.beans/ps-uck1--home-system-switcher-modal.md
@@ -3,9 +3,12 @@
 title: "Home: System switcher modal"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:35:24Z
-updated_at: 2026-05-17T06:35:24Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-divy
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-uck1--home-system-switcher-modal.md
+++ b/.beans/ps-uck1--home-system-switcher-modal.md
@@ -1,0 +1,43 @@
+---
+# ps-uck1
+title: "Home: System switcher modal"
+status: todo
+type: feature
+created_at: 2026-05-17T06:35:24Z
+updated_at: 2026-05-17T06:35:24Z
+parent: ps-divy
+---
+
+## Goal
+
+Design the System switcher modal surface that wraps the SystemSwitcher primitive (ps-a5pt). Invoked from the AppHeader system-name tap.
+
+## Surfaces
+
+- System switcher: `(modals)/system-switcher.tsx`
+
+## Required states per surface
+
+- default (current system highlighted), single-system (no switcher needed — surface disabled or "Add system" CTA only), many-systems with search, currently-syncing transition
+
+## Mode notes
+
+- Littles: hidden if account has multiple systems with adult content (parent / caregiver setting)
+- High-contrast: current-system indicator uses both color AND label/icon
+
+## Primitives required
+
+- BottomSheet (mobile host), Dialog (web host ≥1024px), SystemSwitcher primitive (ps-a5pt), Button (+ Add system)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/account.ts` system list (returns `SystemListItem[]`)
+
+## Required output
+
+- [ ] docs/design-system/preview/home-system-switcher.html with all states
+- [ ] Rationale on transition affordance (instant vs slow)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the create-new-system flow (separate Auth or settings bean)

--- a/.beans/ps-v3e9--design-lifecycleeventchip-primitive.md
+++ b/.beans/ps-v3e9--design-lifecycleeventchip-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-v3e9
+title: Design LifecycleEventChip primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:29:18Z
+updated_at: 2026-05-17T06:29:18Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the LifecycleEventChip primitive: per-event-type icon + label chip used in member detail lifecycle tabs and the global lifecycle log. Event types per features.md §6: split, fusion, merge, unmerge, dormancy-start, dormancy-end, discovery, archival, structure-formation, form-change, name-change, structure-move, innerworld-move.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-lifecycle-chip.html` showing all 13 event-type variants with their distinct iconography + label + tone
+- [ ] Spec doc per SKILL.md §8 (color is not the only signal — every chip pairs icon + label per GOVERNANCE.md a11y rules)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md §6 lifecycle event list, `apps/api/src/trpc/routers/lifecycle-event.ts`
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Member management beans)

--- a/.beans/ps-v4cy--members-groups-create-edit-movecopy-reorder-member.md
+++ b/.beans/ps-v4cy--members-groups-create-edit-movecopy-reorder-member.md
@@ -1,0 +1,50 @@
+---
+# ps-v4cy
+title: "Members: Groups — create / edit + move/copy + reorder + member assignment"
+status: todo
+type: feature
+created_at: 2026-05-17T06:37:33Z
+updated_at: 2026-05-17T06:37:33Z
+parent: ps-07l7
+---
+
+## Goal
+
+Design the group management operations — create/edit form, move-or-copy modal (cross-folder), reorder mode, member assignment modal.
+
+## Surfaces
+
+- New: `(app)/groups/new.tsx`
+- Edit: `(app)/groups/[groupId]/edit.tsx`
+- Move/copy: `(modals)/group-move.tsx`
+- Reorder mode: `(app)/groups/reorder.tsx`
+- Add member: `(modals)/group-add-member.tsx`
+
+## Required states per surface
+
+- create/edit form: empty/populated, invalid, submitting, conflict
+- move/copy: pick-target-folder, move-vs-copy toggle, with-cycle-warning (cannot move group into its own descendant), submitting
+- reorder: drag-and-drop active, save / cancel affordances, conflict
+- add member: search + multi-pick, with-already-member chips, submitting
+
+## Mode notes
+
+- Littles: move/copy hidden; reorder uses up/down arrow buttons instead of drag
+- High-contrast: drag indicator uses border-strong handle
+
+## Primitives required
+
+- ScreenScaffold, TextField, ColorSwatchPicker, EmojiPicker, BucketPicker (ps-s9r6), MultiMemberPicker (ps-djqo), BottomSheet, Button, Banner (cycle warning), Switch (move vs copy)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/group.ts` create, update, move, copy, reorder, addMember, removeMember
+
+## Required output
+
+- [ ] docs/design-system/preview/members-groups-management.html with all surfaces + states
+- [ ] Rationale on the move-vs-copy affordance pattern (single sheet vs two screens)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), the list / detail screens (separate bean)

--- a/.beans/ps-v4cy--members-groups-create-edit-movecopy-reorder-member.md
+++ b/.beans/ps-v4cy--members-groups-create-edit-movecopy-reorder-member.md
@@ -3,9 +3,12 @@
 title: "Members: Groups — create / edit + move/copy + reorder + member assignment"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:37:33Z
-updated_at: 2026-05-17T06:37:33Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-07l7
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-vrk6--communication-polls-list-detail-createedit.md
+++ b/.beans/ps-vrk6--communication-polls-list-detail-createedit.md
@@ -1,0 +1,48 @@
+---
+# ps-vrk6
+title: "Communication: Polls (list + detail + create/edit)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:39:24Z
+updated_at: 2026-05-17T06:39:24Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the Polls surfaces — list, detail (with current results preview), create/edit. Poll kinds: standard or custom. Options can have color and emoji; voters can be members or structure entities (polymorphic EntityReference).
+
+## Surfaces
+
+- Poll list: `(app)/communicate/polls/index.tsx`
+- Poll detail: `(app)/communicate/polls/[id].tsx`
+- New: `(app)/communicate/polls/new.tsx`
+- Edit: `(app)/communicate/polls/[id]/edit.tsx`
+
+## Required states per surface
+
+- list: empty, open (with vote count), closed, archived view, filtered by-author, error
+- detail: open with-results-preview, ended with-final-results, with-veto warning, with-abstain count
+- create/edit: empty/populated, with kind toggle (standard / custom), with options builder (color + emoji per option), with abstain toggle, with veto toggle, with end-date picker, with bucket picker, with eligible-voters picker (polymorphic), submitting
+
+## Mode notes
+
+- Littles: polls feature disabled by default
+- High-contrast: option colors paired with emoji + label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (poll tile), FAB, TextField (question), TextField (option label), ColorSwatchPicker (per option), EmojiPicker (per option), DateTimePicker (end-date), BucketPicker (ps-s9r6), Switch (abstain, veto), EntityRefPicker (ps-ywtb, eligible voters), Banner (ended notice), EmptyState (ps-ruwi)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/poll.ts` list, get, create, update, close, archive, restore, delete
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-polls-list-crud.html with all surfaces + states
+- [ ] Rationale on option-builder UX (drag-reorder vs sequential add)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), vote + results visualization (separate bean)

--- a/.beans/ps-vrk6--communication-polls-list-detail-createedit.md
+++ b/.beans/ps-vrk6--communication-polls-list-detail-createedit.md
@@ -3,9 +3,12 @@
 title: "Communication: Polls (list + detail + create/edit)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:39:24Z
-updated_at: 2026-05-17T06:39:24Z
+updated_at: 2026-05-17T07:42:08Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-w4vp--auth-pin-setup-unlock-locked-state.md
+++ b/.beans/ps-w4vp--auth-pin-setup-unlock-locked-state.md
@@ -1,0 +1,48 @@
+---
+# ps-w4vp
+title: "Auth: PIN setup + unlock + locked state"
+status: todo
+type: feature
+created_at: 2026-05-17T06:33:53Z
+updated_at: 2026-05-17T06:33:53Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the PIN lock surfaces — set new PIN, enter PIN to unlock at app foreground, account-locked state after too many failures.
+
+## Surfaces
+
+- PIN setup: `(auth)/pin/setup.tsx` and reached from Settings → Security
+- PIN unlock: `(lock)/pin.tsx`
+- Account locked: `(auth)/locked.tsx`
+
+## Required states per surface
+
+- setup: idle, entering, confirming, mismatch, success, cancel
+- unlock: idle, entering (digit-by-digit feedback), submitting, error (wrong PIN with attempt-count), throttle warning
+- locked: countdown to retry, recovery alternates listed (use recovery key, use another device)
+
+## Mode notes
+
+- Littles: PIN setup hidden if account-type is "viewer"; unlock simplified copy ("Your PIN")
+- High-contrast: filled / empty dot indicators use shape difference (filled circle vs ring) not just color
+- Reduced-motion: shake-on-error animation collapses to brief tone
+
+## Primitives required
+
+- PinPad (existing in components-inputs.html), Banner, Button, KeyValueRow (attempt count)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/account.ts` PIN sub-resource (set, verify, remove)
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-pin-lock.html with all surfaces + states
+- [ ] Copy on lockout recovery options
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage beyond above (Phase 3 sweep)

--- a/.beans/ps-w4vp--auth-pin-setup-unlock-locked-state.md
+++ b/.beans/ps-w4vp--auth-pin-setup-unlock-locked-state.md
@@ -3,9 +3,12 @@
 title: "Auth: PIN setup + unlock + locked state"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:33:53Z
-updated_at: 2026-05-17T06:33:53Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-whkq--cross-cutting-bottom-sheet-integration-patterns.md
+++ b/.beans/ps-whkq--cross-cutting-bottom-sheet-integration-patterns.md
@@ -1,0 +1,55 @@
+---
+# ps-whkq
+title: "Cross-cutting: Bottom-sheet integration patterns"
+status: todo
+type: feature
+created_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T06:50:29Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the canonical bottom-sheet integration patterns showing how primitives compose into sheet layouts: form sheet, action sheet, picker sheet, scrollable detail sheet.
+
+## Surfaces
+
+- Action sheet (list of buttons).
+- Form sheet (single-step form).
+- Picker sheet (single/multi select).
+- Scrollable detail sheet (member detail summary, settings sub-page).
+- Half-sheet vs full-sheet snap points.
+
+## Required states per surface
+
+- Default.
+- Snap to half.
+- Snap to full.
+- Keyboard open (form sheet only).
+- Submitting.
+- Error.
+
+## Mode notes
+
+- Default mode only.
+- Static mode: sheet renders as full-page modal — noted but not designed here.
+
+## Primitives required
+
+- Bottom-sheet primitive.
+- All form primitives (input, select, button, switch, textarea).
+- Scrollable list primitive.
+
+## Data refs (informational)
+
+- N/A — pattern catalog only.
+
+## Required output
+
+- HTML mockup of all 4 sheet types × snap states in docs/design-system/preview/cross-cutting/bottom-sheets.html.
+- Decision notes: snap point %, drag-handle ergonomics, dismiss gesture.
+
+## Out of scope
+
+- RN implementation (M11).
+- Per-domain sheet content (lives with the owning screen bean).

--- a/.beans/ps-whkq--cross-cutting-bottom-sheet-integration-patterns.md
+++ b/.beans/ps-whkq--cross-cutting-bottom-sheet-integration-patterns.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Bottom-sheet integration patterns"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:50:29Z
-updated_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-xi6m--cross-cutting-mention-link-member-proxy-preview-ca.md
+++ b/.beans/ps-xi6m--cross-cutting-mention-link-member-proxy-preview-ca.md
@@ -1,0 +1,58 @@
+---
+# ps-xi6m
+title: "Cross-cutting: Mention link + member proxy preview card"
+status: todo
+type: feature
+created_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T06:51:15Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the inline mention chip + tap-to-expand preview card used across journal entries, comm messages, and structure docs to reference a member, custom front, or innerworld location.
+
+## Surfaces
+
+- Inline @member mention chip.
+- Inline #front mention chip.
+- Inline ~location mention chip.
+- Expanded preview card (member: avatar + pronouns + role).
+- Expanded preview card (front: badge + active-since).
+- Expanded preview card (location: icon + brief).
+- Mention picker (autocomplete dropdown).
+- Broken-mention state (entity deleted).
+
+## Required states per surface
+
+- Default (collapsed chip).
+- Tapped / expanded card.
+- Picker open (autocomplete results).
+- Picker — no results.
+- Broken-mention.
+
+## Mode notes
+
+- Default mode only.
+- Littles mode: simpler picker UI — noted for Phase 3.
+
+## Primitives required
+
+- Chip primitive.
+- Card primitive.
+- Autocomplete primitive.
+- Avatar primitive.
+
+## Data refs (informational)
+
+- members, custom-fronts, innerworld-locations routers (informational; no wiring here).
+
+## Required output
+
+- HTML mockup of all 3 mention types × states + picker in docs/design-system/preview/cross-cutting/mentions.html.
+- Decision notes: chip color per entity type, picker keyboard nav.
+
+## Out of scope
+
+- RN implementation (M11).
+- Markdown parser (M11/M12).

--- a/.beans/ps-xi6m--cross-cutting-mention-link-member-proxy-preview-ca.md
+++ b/.beans/ps-xi6m--cross-cutting-mention-link-member-proxy-preview-ca.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Mention link + member proxy preview card"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:51:15Z
-updated_at: 2026-05-17T06:51:15Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-xthc--design-recoverykeydisplay-primitive.md
+++ b/.beans/ps-xthc--design-recoverykeydisplay-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-xthc
+title: Design RecoveryKeyDisplay primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:27:22Z
+updated_at: 2026-05-17T06:27:22Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the RecoveryKeyDisplay primitive: the big readable key-reveal surface used during sign-up. Includes copy / save-as-PDF / save-to-file / print buttons and a hard-to-miss warning that the key will not be shown again.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-recovery-key-display.html` showing variants (reveal, post-copy ack, redacted-after-acknowledge) and required states per SKILL.md §7
+- [ ] Spec doc per SKILL.md §8
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json` (warning palette), `tokens/typography.json` (monospace)
+- Reference: ADR 011, GOVERNANCE.md §6 destructive-action tiers
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Auth flow beans)

--- a/.beans/ps-xts0--design-saturationpicker-primitive.md
+++ b/.beans/ps-xts0--design-saturationpicker-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-xts0
+title: Design SaturationPicker primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:30:44Z
+updated_at: 2026-05-17T06:30:44Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the SaturationPicker primitive: pick a member's saturation (elaboration) level — 4 known kinds (fragment, functional-fragment, partially-elaborated, highly-elaborated) plus optional user-defined custom level. Returns a `SaturationLevel` discriminated union with `kind`. Only visible when the system has `saturationLevelsEnabled` per features.md §1.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-saturation-picker.html` showing variants (4 well-known options, with custom-level affordance, with explainer popover) and required states
+- [ ] Spec doc per SKILL.md §8 (term explainer copy per level; per-system enablement check)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: features.md §1 saturation levels
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Member management beans)

--- a/.beans/ps-y8b5--journaling-journal-wiki-destructive-flows.md
+++ b/.beans/ps-y8b5--journaling-journal-wiki-destructive-flows.md
@@ -1,0 +1,47 @@
+---
+# ps-y8b5
+title: "Journaling: Journal + wiki destructive flows"
+status: todo
+type: feature
+created_at: 2026-05-17T06:44:55Z
+updated_at: 2026-05-17T06:44:55Z
+parent: ps-djgs
+---
+
+## Goal
+
+Design the archive + delete confirms for journal entries and wiki pages.
+
+## Surfaces
+
+- Journal entry archive confirm
+- Journal entry delete confirm
+- Wiki page archive confirm
+- Wiki page delete confirm (multi-author warning if applicable)
+
+## Required states per surface
+
+- archive: warning + ack, submitting, success, undo-toast affordance
+- delete: warning, typed-confirm, multi-author-confirmation (require co-author sign-off for multi-author wiki pages — optional design exploration), submitting, success-redirect-to-list
+
+## Mode notes
+
+- Littles: delete hidden entirely
+- High-contrast: destructive states use icon + label
+
+## Primitives required
+
+- Dialog or BottomSheet (host), DestructiveConfirmDialog (ps-bydy), TextField (typed-confirm), Banner, Button, Toast (undo affordance after archive), AvatarStack (co-authors)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/journal.ts` archive, restore, delete (entries + wiki)
+
+## Required output
+
+- [ ] docs/design-system/preview/journal-destructive.html with all flows + states
+- [ ] Open question to resolve: co-author sign-off for wiki page deletion — yes / no
+
+## Out of scope
+
+- RN code (M11), data wiring (M12)

--- a/.beans/ps-y8b5--journaling-journal-wiki-destructive-flows.md
+++ b/.beans/ps-y8b5--journaling-journal-wiki-destructive-flows.md
@@ -3,9 +3,12 @@
 title: "Journaling: Journal + wiki destructive flows"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:44:55Z
-updated_at: 2026-05-17T06:44:55Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-djgs
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-yfas--home-more-hub.md
+++ b/.beans/ps-yfas--home-more-hub.md
@@ -3,9 +3,12 @@
 title: "Home: More hub"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:35:18Z
-updated_at: 2026-05-17T06:35:18Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-divy
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-yfas--home-more-hub.md
+++ b/.beans/ps-yfas--home-more-hub.md
@@ -1,0 +1,45 @@
+---
+# ps-yfas
+title: "Home: More hub"
+status: todo
+type: feature
+created_at: 2026-05-17T06:35:18Z
+updated_at: 2026-05-17T06:35:18Z
+parent: ps-divy
+---
+
+## Goal
+
+Design the More hub — overflow tab for sections that don't fit in the primary tab bar. Settings entry, Innerworld, System structure, Journal, Search, Data import/export, Help.
+
+## Surfaces
+
+- More: `(app)/(tabs)/more.tsx`
+
+## Required states per surface
+
+- default (full grid of section cards)
+- with-badge on Settings (e.g. recovery-key reminder due)
+- offline (greyed-out sections that require network)
+
+## Mode notes
+
+- Littles: fewer sections — only Help and Settings shown
+- Web ≥1024px: this tab disappears entirely (Drawer hosts those sections)
+
+## Primitives required
+
+- ScreenScaffold, Card (section tiles), Icon, Badge, ListItem (variant)
+
+## Data refs (informational)
+
+- Section enablement comes from system settings + account flags (e.g. import disabled if `importsEnabled=false`)
+
+## Required output
+
+- [ ] docs/design-system/preview/home-more-hub.html with all states
+- [ ] Rationale on section ordering and grouping
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), individual section landing screens (separate beans)

--- a/.beans/ps-yfro--communication-board-messages-list-detail-createedi.md
+++ b/.beans/ps-yfro--communication-board-messages-list-detail-createedi.md
@@ -1,0 +1,48 @@
+---
+# ps-yfro
+title: "Communication: Board messages (list + detail + create/edit)"
+status: todo
+type: feature
+created_at: 2026-05-17T06:39:01Z
+updated_at: 2026-05-17T06:39:01Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the Board messages surfaces — persistent noticeboard with pin/unpin, drag-and-drop reorder, polymorphic authorship.
+
+## Surfaces
+
+- Board list: `(app)/communicate/board/index.tsx`
+- Board detail: `(app)/communicate/board/[id].tsx`
+- New: `(app)/communicate/board/new.tsx`
+- Edit: `(app)/communicate/board/[id]/edit.tsx`
+
+## Required states per surface
+
+- list: empty, populated, with-pinned-section, reorder mode active, archived view, with-filter chips, error
+- detail: default, with-archive-banner, edit affordance for owner
+- create/edit: empty/populated, with-rich-text composer, with-bucket-picker, with-pin toggle, submitting, conflict
+
+## Mode notes
+
+- Littles: pin/unpin hidden (caregiver-only); reorder uses up/down arrows instead of drag
+- High-contrast: pin indicator uses icon + "Pinned" text label
+
+## Primitives required
+
+- ScreenScaffold, InfiniteList (ps-hijf), Card (board-message tile), Badge (pinned), FAB, RichTextField (ps-9yhh), BucketPicker (ps-s9r6), ProxyChip (ps-jtvw), EmptyState (ps-ruwi), DestructiveConfirmDialog (ps-bydy)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/board-message.ts` list, get, create, update, archive, delete, pin, reorder
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-board.html with all surfaces + states
+- [ ] Rationale on pinned-section vs sticky-row treatment
+
+## Out of scope
+
+- RN code (M11), data wiring (M12)

--- a/.beans/ps-yfro--communication-board-messages-list-detail-createedi.md
+++ b/.beans/ps-yfro--communication-board-messages-list-detail-createedi.md
@@ -3,9 +3,12 @@
 title: "Communication: Board messages (list + detail + create/edit)"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:39:01Z
-updated_at: 2026-05-17T06:39:01Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-yih6--cross-cutting-sync-status-indicator-offline-banner.md
+++ b/.beans/ps-yih6--cross-cutting-sync-status-indicator-offline-banner.md
@@ -3,9 +3,12 @@
 title: "Cross-cutting: Sync status indicator + offline banner"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:50:29Z
-updated_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-k8mz
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-yih6--cross-cutting-sync-status-indicator-offline-banner.md
+++ b/.beans/ps-yih6--cross-cutting-sync-status-indicator-offline-banner.md
@@ -1,0 +1,55 @@
+---
+# ps-yih6
+title: "Cross-cutting: Sync status indicator + offline banner"
+status: todo
+type: feature
+created_at: 2026-05-17T06:50:29Z
+updated_at: 2026-05-17T06:50:29Z
+parent: ps-k8mz
+---
+
+## Goal
+
+Design the persistent sync indicator (header/footer chip) and the offline / sync-paused banner per offline-first architecture.
+
+## Surfaces
+
+- Header sync chip (synced / syncing / queued / offline / paused / error).
+- Offline banner (top-of-screen, dismissible per session).
+- Sync-paused banner (user paused — top-of-screen with resume button).
+- Sync-error banner with retry + diagnostics link.
+
+## Required states per surface
+
+- Synced (default — minimal/hidden chrome).
+- Syncing (animated indicator).
+- Queued N changes (chip shows count).
+- Offline.
+- Paused (user-initiated).
+- Error.
+
+## Mode notes
+
+- Default mode only.
+- Reduced-motion: syncing animation freezes — noted for Phase 3.
+
+## Primitives required
+
+- Chip/badge primitive.
+- Banner primitive.
+- Icon (sync states).
+
+## Data refs (informational)
+
+- packages/sync state machine.
+- Settings → Tools → sync diagnostics (ps-21dn).
+
+## Required output
+
+- HTML mockup of chip × 6 states + 3 banner variants in docs/design-system/preview/cross-cutting/sync-status.html.
+- Decision notes: banner dismiss persistence rules.
+
+## Out of scope
+
+- RN implementation (M11).
+- Sync engine UI (lives in Settings → Tools — ps-21dn).

--- a/.beans/ps-ywtb--design-entityrefpicker-primitive.md
+++ b/.beans/ps-ywtb--design-entityrefpicker-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-ywtb
+title: Design EntityRefPicker primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:30:23Z
+updated_at: 2026-05-17T06:30:23Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the EntityRefPicker primitive: polymorphic picker returning an `EntityReference` discriminated union (member, custom-front, or structure-entity). Used wherever a fronting subject, comment target, or polymorphic entity must be chosen.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-entity-ref-picker.html` showing variants (segmented filter for kind, all-kinds search, kind-restricted) and required states
+- [ ] Spec doc per SKILL.md §8 (visual disambiguation between the three entity kinds in result rows)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`
+- Reference: `EntityReference` type in `packages/types/`, features.md §2 (polymorphic subjects)
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Phase 1 / 2)

--- a/.beans/ps-z1og--closeout-feature-coverage-audit-featuresmd-design.md
+++ b/.beans/ps-z1og--closeout-feature-coverage-audit-featuresmd-design.md
@@ -1,0 +1,33 @@
+---
+# ps-z1og
+title: "Closeout: Feature coverage audit — features.md ↔ design coverage"
+status: todo
+type: task
+created_at: 2026-05-17T06:53:15Z
+updated_at: 2026-05-17T06:53:15Z
+parent: ps-l9fv
+blocked_by:
+  - ps-oqs8
+---
+
+## Goal
+
+Verify every entry in docs/planning/features.md has design coverage somewhere in docs/design-system/preview/. Last gate before M10 closeout.
+
+## Method
+
+1. Parse docs/planning/features.md into an enumerated feature list.
+2. For each feature, locate the designed surface(s) in docs/design-system/preview/ plus the owning bean.
+3. Produce a coverage matrix: rows = features, columns = "designed surface" + "owning bean".
+4. For every uncovered feature, create a follow-up bean parented to the most-relevant Phase 2 domain epic.
+
+## Required output
+
+- Audit report at docs/superpowers/audits/2026-XX-XX-feature-coverage.md.
+- This bean's `## Summary of Changes` includes the matrix + spawned bean IDs.
+- If zero gaps: explicit statement "100% feature coverage, no gaps."
+
+## Out of scope
+
+- Implementation work — gaps spawn beans only.
+- M11 handoff doc (ps-\* sibling bean).

--- a/.beans/ps-z1og--closeout-feature-coverage-audit-featuresmd-design.md
+++ b/.beans/ps-z1og--closeout-feature-coverage-audit-featuresmd-design.md
@@ -3,8 +3,9 @@
 title: "Closeout: Feature coverage audit — features.md ↔ design coverage"
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:53:15Z
-updated_at: 2026-05-17T06:53:15Z
+updated_at: 2026-05-17T07:40:55Z
 parent: ps-l9fv
 blocked_by:
   - ps-oqs8
@@ -31,3 +32,4 @@ Verify every entry in docs/planning/features.md has design coverage somewhere in
 
 - Implementation work — gaps spawn beans only.
 - M11 handoff doc (ps-\* sibling bean).
+- `apps/mobile/app/(app)/design-system-smoke.tsx` — dev harness route, not a user-facing feature; ignore if encountered.

--- a/.beans/ps-z6r9--communication-communicate-hub.md
+++ b/.beans/ps-z6r9--communication-communicate-hub.md
@@ -3,9 +3,12 @@
 title: "Communication: Communicate hub"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:38:34Z
-updated_at: 2026-05-17T06:38:34Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-5fc5
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal

--- a/.beans/ps-z6r9--communication-communicate-hub.md
+++ b/.beans/ps-z6r9--communication-communicate-hub.md
@@ -1,0 +1,47 @@
+---
+# ps-z6r9
+title: "Communication: Communicate hub"
+status: todo
+type: feature
+created_at: 2026-05-17T06:38:34Z
+updated_at: 2026-05-17T06:38:34Z
+parent: ps-5fc5
+---
+
+## Goal
+
+Design the Communicate hub — primary tab landing for chat, board, notes, polls, acknowledgements. Surfaces unread counts + latest activity per sub-area.
+
+## Surfaces
+
+- Communicate hub: `(app)/(tabs)/communicate/index.tsx`
+
+## Required states per surface
+
+- default (all 5 sub-areas with activity), empty per sub-area, unread-counts on each, with-mandatory-ack-pinned-top, offline, loading, error
+
+## Mode notes
+
+- Littles: only Chat and Board surfaces shown; Polls / Acks hidden
+- High-contrast: unread-count badges use icon + count (not pure dot)
+
+## Primitives required
+
+- ScreenScaffold, Card (per sub-area tile), Badge, ListItem (recent activity), EmptyState (ps-ruwi), Banner (mandatory ack notice)
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/channel.ts` unread summary
+- `apps/api/src/trpc/routers/board-message.ts` recent
+- `apps/api/src/trpc/routers/note.ts` recent
+- `apps/api/src/trpc/routers/poll.ts` open
+- `apps/api/src/trpc/routers/acknowledgement.ts` pending
+
+## Required output
+
+- [ ] docs/design-system/preview/comm-hub.html with all states
+- [ ] Rationale on tile order (most-recent vs most-active vs alphabetical)
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), individual sub-area screens (separate beans)

--- a/.beans/ps-zgpl--fronting-analytics-co-fronting-breakdown.md
+++ b/.beans/ps-zgpl--fronting-analytics-co-fronting-breakdown.md
@@ -3,9 +3,12 @@
 title: "Fronting: Analytics — co-fronting breakdown"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T05:50:48Z
-updated_at: 2026-05-17T05:50:48Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-5920
+blocked_by:
+  - ps-udt1
 ---
 
 ## Goal

--- a/.beans/ps-zgpl--fronting-analytics-co-fronting-breakdown.md
+++ b/.beans/ps-zgpl--fronting-analytics-co-fronting-breakdown.md
@@ -1,0 +1,51 @@
+---
+# ps-zgpl
+title: "Fronting: Analytics — co-fronting breakdown"
+status: todo
+type: feature
+created_at: 2026-05-17T05:50:48Z
+updated_at: 2026-05-17T05:50:48Z
+parent: ps-5920
+---
+
+## Goal
+
+Design the co-fronting pair analytics screen: pair matrix or chord visualization showing which members front together most often.
+
+## Surfaces
+
+- Co-fronting breakdown: `(app)/fronting/analytics/co-fronting.tsx`
+
+## Required states per surface
+
+- default (many co-fronting pairs)
+- few pairs (2–5)
+- single dominant pair
+- empty (no co-fronting history)
+- loading
+- error
+
+## Mode notes
+
+- Matrix visualization needs accessible reading order: screen-reader should announce row-by-row pairs with totals.
+- High-contrast mode: matrix cell intensity must use both opacity AND text labels — opacity-only violates color rules.
+
+## Primitives required
+
+- Heatmap / matrix primitive (Phase 0 candidate; block on it)
+- AvatarStack (pair display in legend)
+- SegmentedControl (period preset)
+- EmptyState
+
+## Data refs (informational)
+
+- `apps/api/src/trpc/routers/analytics.ts` — co-fronting pair analytics
+
+## Required output
+
+- [ ] docs/design-system/preview/fronting-analytics-cofronting.html with all states
+- [ ] Visualization decision (matrix vs chord vs bubble) with rationale
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage (Phase 3 sweep).

--- a/.beans/ps-zpyu--design-blockeditor-primitive.md
+++ b/.beans/ps-zpyu--design-blockeditor-primitive.md
@@ -1,0 +1,27 @@
+---
+# ps-zpyu
+title: Design BlockEditor primitive
+status: todo
+type: task
+created_at: 2026-05-17T06:28:19Z
+updated_at: 2026-05-17T06:28:19Z
+parent: ps-udt1
+---
+
+## Goal
+
+Design the BlockEditor primitive: block-based editor for journal entries and wiki pages. Block types per features.md §7: paragraph, heading, list, quote, code, divider, image, member-link, fronting-snapshot. Block insertion menu, drag-handle reorder, slash-command quick-insert.
+
+## Required output
+
+- [ ] `docs/design-system/preview/components-block-editor.html` showing each block type rendered, the block-insertion menu, drag-handle hover state, slash-command palette, and required interactive states
+- [ ] Spec doc per SKILL.md §8 covering: block menu anatomy, drag affordance, keyboard a11y (Tab indents, arrow keys move between blocks)
+
+## Tokens / references
+
+- Tokens: `tokens/colors.json`, `tokens/spacing.json`, `tokens/typography.json`
+- Reference: features.md §7
+
+## Out of scope
+
+- RN code (M11), screen-level integration (Journaling beans), member-link target picker (separate MemberPicker primitive)

--- a/.beans/ps-zx2p--auth-sign-in-flow.md
+++ b/.beans/ps-zx2p--auth-sign-in-flow.md
@@ -1,0 +1,45 @@
+---
+# ps-zx2p
+title: "Auth: Sign-in flow"
+status: todo
+type: feature
+created_at: 2026-05-17T06:33:09Z
+updated_at: 2026-05-17T06:33:09Z
+parent: ps-nwju
+---
+
+## Goal
+
+Design the sign-in surface and its quick-unlock variants (biometric prompt if previously enrolled, "use recovery key instead" link, "use another device" link).
+
+## Surfaces
+
+- Sign-in: `(auth)/login.tsx`
+- Biometric quick-unlock: inline within sign-in when enrolled
+
+## Required states per surface
+
+- idle, submitting, key-deriving (Argon2id local), error (invalid creds, throttled, network), 2-step (account locked → recover via PIN/recovery), biometric prompt visible
+
+## Mode notes
+
+- Littles: simplified — no biometric, no recovery alternates, just email/password
+- High-contrast: error states use icon + label (not color-only)
+
+## Primitives required
+
+- ScreenScaffold, TextField, Button, Banner (error), LoadingOverlay (key derive), Switch (show password)
+
+## Data refs (informational)
+
+- REST `/v1/auth/login` (auth predates tRPC session)
+- Local Argon2id key derivation
+
+## Required output
+
+- [ ] docs/design-system/preview/auth-sign-in.html with all states
+- [ ] Rationale for the "Unlocking your data…" indeterminate state copy
+
+## Out of scope
+
+- RN code (M11), data wiring (M12), mode coverage (Phase 3)

--- a/.beans/ps-zx2p--auth-sign-in-flow.md
+++ b/.beans/ps-zx2p--auth-sign-in-flow.md
@@ -3,9 +3,12 @@
 title: "Auth: Sign-in flow"
 status: todo
 type: feature
+priority: normal
 created_at: 2026-05-17T06:33:09Z
-updated_at: 2026-05-17T06:33:09Z
+updated_at: 2026-05-17T07:42:09Z
 parent: ps-nwju
+blocked_by:
+  - ps-5920
 ---
 
 ## Goal


### PR DESCRIPTION
## Summary

Seeds the full M10 (UI/UX Design) bean structure end-to-end so subsequent design work has a tracked hierarchy from milestone → epic → screen/primitive/audit. No code changes — pure `.beans/` content.

M10 produces HTML mockups + decision docs only. RN buildout is M11; data wiring is M12.

## Scope

Spec: `docs/superpowers/specs/2026-05-16-m10-bean-buildout-design.md` (gitignored — local-only).
Plan: `docs/superpowers/plans/2026-05-16-m10-bean-buildout.md` (gitignored — local-only).

### Epics created (3 new)

- **ps-k8mz** Cross-cutting surface designs (Phase 2 final)
- **ps-oqs8** M10 audits (Phase 3)
- **ps-l9fv** M10 closeout (Phase 4)

Plus topology wiring on the 10 pre-existing M10 epics.

### Bean counts per epic

| Phase | Epic | Children | Notes |
|---|---|---|---|
| 0 | ps-udt1 Design system foundation | 38 | 37 primitives + closeout audit |
| 1 | ps-5920 Fronting (pilot) | 10 | screens + flows |
| 2 | ps-nwju Onboarding & auth | 10 | |
| 2 | ps-divy Home & navigation | 6 | |
| 2 | ps-07l7 Member management | 10 | |
| 2 | ps-5fc5 Communication | 8 | |
| 2 | ps-9xue Privacy & social | 9 | |
| 2 | ps-7wf6 System structure | 9 | |
| 2 | ps-djgs Journaling | 6 | |
| 2 | ps-6a3x Search & settings | 12 | |
| 2 | ps-k8mz Cross-cutting | 11 | dialogs, toasts, sheets, sync chip, etc. |
| 3 | ps-oqs8 Audits | 7 | 4 mode sweeps + state + accessibility + router parity |
| 4 | ps-l9fv Closeout | 3 | feature coverage → M11 handoff → close ps-9cca |

Total: **139** child beans across **13** epics under milestone **ps-9cca**.

### Blocking topology

- Phase 0 (ps-udt1) blocks Phase 1 pilot (ps-5920).
- Phase 1 pilot (ps-5920) blocks all 9 Phase 2 horizontal epics.
- All 9 Phase 2 epics block Phase 3 audits (ps-oqs8).
- Phase 3 (ps-oqs8) blocks Phase 4 (ps-l9fv).
- Within Phase 4: feature coverage → handoff doc → milestone closeout.

### Bean body conventions

- **Primitives** (Phase 0): goal, required output, tokens/references, out of scope.
- **Screens/flows** (Phase 1 & 2): goal, surfaces, required states per surface, mode notes, primitives required, data refs (informational only), required output, out of scope.
- **Audits** (Phase 3): goal, method, required output, out of scope. Each audit spawns follow-up beans for every gap.

### Mode coverage strategy

Default mode in Phase 1 + Phase 2 screen beans. Static / reduced-motion / high-contrast / littles handled as per-mode audit sweeps in Phase 3 that spawn surface-specific follow-up beans only where the default design needs adaptation. Avoids 5× rework on every screen.

## Test plan

- [ ] `beans list --json | jq '[.[] | select(.parent == "ps-9cca")] | length'` reports 13 epics.
- [ ] `beans list --ready --json | jq 'map(select(.id == "ps-udt1")) | length'` reports 1 — Phase 0 is the only ready epic at start.
- [ ] Phase 0 audit bean `ps-sg8k` is `completed` with summary listing 37 spawned bean IDs.

## Review notes

Per request: please review and merge manually rather than auto-merging. The remaining ~150+ beans (mode sweep follow-ups, state audit follow-ups, etc.) accrue through the self-discovery loop as audits run during execution — they're explicitly out of seed scope.
