### PR TITLE
chore(beans): apply M10 Phase 0 re-audit dispositions

### DIFF
--- a/.beans/ps-00b4--design-confirmgesture-primitive.md
+++ b/.beans/ps-00b4--design-confirmgesture-primitive.md
@@ -3,8 +3,9 @@
 title: Design ConfirmGesture primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:36Z
-updated_at: 2026-05-17T06:27:36Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,19 @@ Design the ConfirmGesture primitive: hold-to-confirm circular-progress affordanc
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Already designed in `components-feedback.html:336-377`. Hold-to-confirm
+with a 1.2s ring fill, 3 states rendered (idle, holding-0.7s, confirmed).
+Used for irreversible actions in distress contexts (panic deletion,
+immediate sign-out everywhere) where a tap could be accidental. Releases
+early → cancels.
+
+Updated scope: extract into `components-confirm-gesture.html`. Add: the
+8 acceptance states (focus-visible matters here for keyboard users — Space
+holds, releasing within 1.2s cancels), 4 mode variants (littles likely
+disables this entirely; high-contrast doubles the ring; low-sensory
+removes the pulse), 7-section doc.
+
+Extraction task.

--- a/.beans/ps-217e--design-drawer-primitive.md
+++ b/.beans/ps-217e--design-drawer-primitive.md
@@ -3,8 +3,9 @@
 title: Design Drawer primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:28:30Z
-updated_at: 2026-05-17T06:28:30Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,17 @@ Design the Drawer primitive: side-drawer chrome for web and tablet ≥1024px vie
 ## Out of scope
 
 - RN code (M11), screen-level integration (Home & Nav beans)
+
+## Re-audit disposition (2026-05-17)
+
+Mentioned in `components-nav-chrome.html` but without detailed state or
+mode coverage. Less coverage than the other EXTRACT beans — closer to
+"flesh out + extract" than pure extraction.
+
+Updated scope: read the existing nav-chrome treatment, design the missing
+state coverage (collapsed/expanded, dragging, dismissing), produce
+`components-drawer.html` with the 8 acceptance states and 4 mode variants
+(littles is the key one — drawer may need wider hit targets and simpler
+contents). 7-section doc.
+
+Partial-extraction + light design task.

--- a/.beans/ps-3m01--design-progressbar-and-progressring-primitives.md
+++ b/.beans/ps-3m01--design-progressbar-and-progressring-primitives.md
@@ -3,8 +3,9 @@
 title: Design ProgressBar and ProgressRing primitives
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:52Z
-updated_at: 2026-05-17T06:27:52Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,17 @@ Design the ProgressBar (linear) and ProgressRing (circular) primitives together 
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Already designed in `components-display.html:359-376` — determinate bar
+(65% width example), indeterminate bar, and ring (44px, dashoffset for
+65%) rendered with usage notes (determinate for import progress / key
+rotation, indeterminate for export queued, ring inline with status text).
+
+Updated scope: extract into `components-progress.html`. Add: small/medium/
+large size tokens, stalled/error variants, the 8 acceptance states, 4 mode
+variants (low-sensory removes any glow/pulse; high-contrast promotes the
+fill color), 7-section doc.
+
+Extraction task.

--- a/.beans/ps-458i--design-frontingchip-primitive.md
+++ b/.beans/ps-458i--design-frontingchip-primitive.md
@@ -3,8 +3,9 @@
 title: Design FrontingChip primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:28:55Z
-updated_at: 2026-05-17T06:28:55Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,24 @@ Design the FrontingChip primitive: per-member or per-custom-front active-fronter
 ## Out of scope
 
 - RN code (M11), screen-level integration (Fronting beans)
+
+## Scope clarification (2026-05-17)
+
+Re-audit (ps-sg8k) noted FrontingTimeline already renders fronting state
+as colored bars (not chips), which raised the question of whether a
+distinct FrontingChip primitive is needed.
+
+It is. FrontingChip is for non-timeline surfaces where a compact
+"this member is fronting" badge is more useful than a timeline bar:
+
+- App header / status bar — "Rowan is fronting" at a glance
+- Quick-switch sheet preview rows
+- Member cards — "currently fronting" inline badge
+- Mention previews — "@Rowan (fronting)"
+- Notification context — "Rowan was fronting when this fired"
+
+These surfaces need a single-pill component, not a timeline lane.
+
+Bean kept. Variants per the original bean body (member / custom-front /
+structure-entity, sm/md/lg, with co-fronting / primary-front /
+ended-recently / live state indicators).

--- a/.beans/ps-5lr6--design-keyvaluerow-primitive.md
+++ b/.beans/ps-5lr6--design-keyvaluerow-primitive.md
@@ -3,8 +3,9 @@
 title: Design KeyValueRow primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:28:01Z
-updated_at: 2026-05-17T06:28:01Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,17 @@ Design the KeyValueRow primitive: a label + value row for details screens, audit
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Already designed in `components-display.html:314-321`. Renders the
+standard key/value row with mono variant for IDs and keys, plus the
+`plaintext` tag variant that marks server-visible-as-cleartext fields
+(timestamps, record IDs, sync metadata). The doc meta explicitly notes
+the T1/T2 policy (see ps-gfhz scrap reason).
+
+Updated scope: extract into `components-keyvalue-row.html`. Add: copy-on-tap
+variant for IDs, sensitive-value masked variant, the 8 acceptance states,
+4 mode variants, 7-section doc.
+
+Extraction task.

--- a/.beans/ps-a5ee--design-errorstate-primitive.md
+++ b/.beans/ps-a5ee--design-errorstate-primitive.md
@@ -3,8 +3,9 @@
 title: Design ErrorState primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:26:58Z
-updated_at: 2026-05-17T06:26:58Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,19 @@ Design the ErrorState primitive: a first-class screen-level error display with r
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Original audit (ps-sg8k) classified ErrorState as missing. Re-audit found
+it paired with EmptyState in `components-display.html:378-410` with one
+example: "Couldn't send invite — check your connection, retry automatically,
+your draft is saved." Tone rules from GOVERNANCE §7.
+
+Updated scope: extract into `components-error-state.html`. Show the
+distinction from EmptyState (errors only fire on actions that can actually
+fail — sends, sync, exports — because the product is offline-first and a
+generic "load failed" surface is wrong). Add: retry affordance variant,
+permanent-failure variant (no retry possible), the 8 acceptance states,
+4 mode variants, 7-section doc.
+
+Extraction task, not from-scratch.

--- a/.beans/ps-a5pt--design-systemswitcher-primitive.md
+++ b/.beans/ps-a5pt--design-systemswitcher-primitive.md
@@ -3,8 +3,9 @@
 title: Design SystemSwitcher primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:28:40Z
-updated_at: 2026-05-17T06:28:40Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,17 @@ Design the SystemSwitcher primitive: account → system pick surface reachable f
 ## Out of scope
 
 - RN code (M11), screen-level integration (Home & Nav beans)
+
+## Re-audit disposition (2026-05-17)
+
+Dropdown shown in `components-nav-chrome.html` but with limited state
+coverage.
+
+Updated scope: read the existing nav-chrome treatment, design missing
+states (loading systems list, error fetching, system-being-switched
+intermediate), produce `components-system-switcher.html` with full state
+
+- mode coverage. The littles-mode variant should be simpler (system
+  switching is a power-user affordance).
+
+Partial-extraction + light design task.

--- a/.beans/ps-bydy--design-destructiveconfirmdialog-primitive.md
+++ b/.beans/ps-bydy--design-destructiveconfirmdialog-primitive.md
@@ -3,8 +3,9 @@
 title: Design DestructiveConfirmDialog primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:31Z
-updated_at: 2026-05-17T06:27:31Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,24 @@ Design the DestructiveConfirmDialog primitive: typed-phrase confirmation extendi
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+The bean's canonical name in the design system is `ConfirmDestructive`,
+not `DestructiveConfirmDialog`. Already designed:
+
+- `docs/design-system/ui_kits/mobile/ConfirmDestructive.jsx` — full React
+  component, all 3 friction tiers (confirm / typed-the-name / cooldown),
+  consequences list, recoverable flag, cooldown seconds, callbacks
+- `docs/design-system/preview/patterns.html:137-166` — live demo with
+  all three tiers and the "Delete Rowan" scenario
+
+GOVERNANCE §6 explicitly requires Littles mode to hide Critical tier and
+soften Medium tier copy.
+
+Updated scope: extract into `components-confirm-destructive.html` (using
+the canonical name). Add: explicit Littles-mode rendering showing the
+hidden Critical and softened Medium, the 8 acceptance states (many N/A
+for a transient dialog — mark them), 4 mode variants, 7-section doc.
+
+Extraction task.

--- a/.beans/ps-djqo--design-memberpicker-and-multimemberpicker-primitiv.md
+++ b/.beans/ps-djqo--design-memberpicker-and-multimemberpicker-primitiv.md
@@ -3,8 +3,9 @@
 title: Design MemberPicker and MultiMemberPicker primitives
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:30:18Z
-updated_at: 2026-05-17T06:30:18Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,24 @@ Design the MemberPicker (single-pick) and MultiMemberPicker (multi-pick) primiti
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Already designed in `components-pickers.html:227-300`. Full bottom-sheet
+composite: search input → selected-tokens row → grouped result rows
+(Recently fronted / Everyone else) → footer with named count action
+("Add 2 members"). Composes on BottomSheet, TextField, MemberRow, and
+token chips — already covered primitives.
+
+Updated scope: extract into `components-member-picker.html`. The existing
+preview already shows the multi-select case; add:
+
+- Single-select variant (no tokens row, single-row commit)
+- Zero-results state (composes with EmptyState)
+- Selection-cap-reached state (e.g., "max 8 fronters")
+- `includes-self` toggle for fronting check-in use
+- `data-includes` variant that surfaces custom fronts and structure
+  entities alongside members
+- The 8 acceptance states, 4 mode variants, 7-section doc
+
+Extraction + small additions, not from-scratch.

--- a/.beans/ps-ecpl--design-accordion-primitive.md
+++ b/.beans/ps-ecpl--design-accordion-primitive.md
@@ -3,8 +3,9 @@
 title: Design Accordion primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:57Z
-updated_at: 2026-05-17T06:27:57Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,16 @@ Design the Accordion primitive: expandable section with header + chevron + colla
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Already designed in `components-display.html` (Accordion section). Open
+and closed states rendered.
+
+Updated scope: extract into `components-accordion.html`. Add the 8
+acceptance states, 4 mode variants, 7-section doc. Specifically cover:
+keyboard navigation (Space/Enter to toggle, Arrow keys to move between
+panels), `aria-expanded` and `aria-controls` wiring, animated open/close
+that collapses cleanly under reduced motion.
+
+Extraction task.

--- a/.beans/ps-gfhz--design-encryptiontierbadge-primitive.md
+++ b/.beans/ps-gfhz--design-encryptiontierbadge-primitive.md
@@ -1,10 +1,11 @@
 ---
 # ps-gfhz
 title: Design EncryptionTierBadge primitive
-status: todo
+status: scrapped
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:26Z
-updated_at: 2026-05-17T06:27:26Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,19 @@ Design the EncryptionTierBadge primitive: small lock indicator with T1 / T2 / T3
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Reasons for Scrapping
+
+Re-audit (2026-05-17) found this bean contradicts the existing design system.
+`docs/design-system/preview/components-display.html:320` states explicitly:
+"We never display a 'T1/T2' tier label — every field is T1; T2 is just the
+privacy-bucket-keyed subset and is functionally still T1 to the user."
+
+The only encryption-tier indicator that surfaces in UI is the T3 (plaintext)
+tag, which is already designed in two places:
+
+- `components-feedback.html:298-318` — Popover form with "Server-visible
+  metadata" explainer
+- `components-display.html:316-318` — inline `plaintext` tag in KeyValueRow
+
+No new badge is needed.

--- a/.beans/ps-gnkq--design-syncindicator-primitive.md
+++ b/.beans/ps-gnkq--design-syncindicator-primitive.md
@@ -3,8 +3,9 @@
 title: Design SyncIndicator primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:03Z
-updated_at: 2026-05-17T06:27:03Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,21 @@ Design the SyncIndicator primitive: small inline indicator surfacing the 9 canon
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Original audit (ps-sg8k) misnamed this — the existing component is
+`SyncState`, not `SyncIndicator`. Already designed in two places:
+
+- `docs/design-system/ui_kits/mobile/SyncState.jsx` — full React component
+- `docs/design-system/preview/patterns.html` "State of data" section —
+  renders all 10 state variants: savedLocal, syncing, synced, offline,
+  syncFailed, conflict, encrypted, keyUnavailable, exportReady, importPending
+
+Each variant carries a screen-reader-only sentence and the right
+`aria-live` politeness already.
+
+Updated scope: extract into `components-sync-state.html` (renaming the bean
+target from SyncIndicator to SyncState to match the canonical name).
+Add the 8 acceptance states and 4 mode variants per primitive. Verify the
+aria-live politeness is correctly tiered.

--- a/.beans/ps-i6n1--design-bucketpill-primitive.md
+++ b/.beans/ps-i6n1--design-bucketpill-primitive.md
@@ -3,8 +3,9 @@
 title: Design BucketPill primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:29:14Z
-updated_at: 2026-05-17T06:29:14Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,20 @@ Design the BucketPill primitive: small visual privacy-bucket indicator — color
 ## Out of scope
 
 - RN code (M11), screen-level integration (Privacy & Social beans)
+
+## Scope clarification (2026-05-17)
+
+Re-audit (ps-sg8k) found that `PrivacyBucket.jsx` (the bucket editor)
+already exists, but BucketPill is a distinct primitive: the compact
+chip-form representation of a bucket assignment, used in:
+
+- Content metadata rows (e.g., "Visible to: Close friends, Strangers")
+- BucketPicker (ps-s9r6) selection state — picked buckets render as pills
+- KeyValueRow value cells where the value is a list of buckets
+
+BucketPill is NOT the editor and should not be confused with PrivacyBucket.jsx.
+It's a tiny pill with the bucket name, optional audience-count badge, and
+a fail-closed visual treatment for the special "Nobody" bucket.
+
+Bean kept. Design produces `components-bucket-pill.html` with the 8 states
+and 4 mode variants per SKILL.md §7-8.

--- a/.beans/ps-oylh--design-searchheader-primitive.md
+++ b/.beans/ps-oylh--design-searchheader-primitive.md
@@ -3,8 +3,9 @@
 title: Design SearchHeader primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:28:44Z
-updated_at: 2026-05-17T06:28:44Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,16 @@ Design the SearchHeader primitive: inline search bar header used in pickers (Mem
 ## Out of scope
 
 - RN code (M11), screen-level integration (Search beans)
+
+## Re-audit disposition (2026-05-17)
+
+JSX implementation exists in `docs/design-system/ui_kits/mobile/LibraryComponents.jsx`
+and is used in `Screen_Library.jsx`, but no dedicated preview file.
+
+Updated scope: extract the JSX implementation into a dedicated
+`components-search-header.html` preview. Add: focused/blurred states,
+clear-button affordance, voice-search affordance (if applicable),
+recent-searches popover, the 8 acceptance states, 4 mode variants,
+7-section doc.
+
+Extraction task.

--- a/.beans/ps-rgrw--design-popover-primitive.md
+++ b/.beans/ps-rgrw--design-popover-primitive.md
@@ -3,8 +3,9 @@
 title: Design Popover primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:47Z
-updated_at: 2026-05-17T06:27:47Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,17 @@ Design the Popover primitive: anchored tap/hover explanation surface, distinct f
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Already designed in `components-feedback.html:298-318` paired with Tooltip.
+Anchored popover with rich content (the existing demo is the "Server-visible
+metadata" plaintext explainer), plus tooltip variant for ephemeral
+single-line content.
+
+Updated scope: extract into `components-popover.html`. Add: anchor-side
+variants (top/bottom/left/right), dismiss-on-outside-tap behavior, the
+8 acceptance states (focus-visible matters — Esc dismisses, Tab moves to
+contents), 4 mode variants, 7-section doc.
+
+Extraction task.

--- a/.beans/ps-ruwi--design-emptystate-primitive.md
+++ b/.beans/ps-ruwi--design-emptystate-primitive.md
@@ -3,8 +3,9 @@
 title: Design EmptyState primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:26:53Z
-updated_at: 2026-05-17T06:26:53Z
+updated_at: 2026-05-17T08:50:22Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,27 @@ Design the EmptyState primitive: preview HTML + spec doc per `docs/design-system
 ## Out of scope
 
 - React Native code (M11), screen-level integration (Phase 1 / 2)
+
+## Re-audit disposition (2026-05-17)
+
+Original audit (ps-sg8k) classified EmptyState as missing. Re-audit found
+the canon is already established:
+
+- `docs/design-system/preview/illustrations.html` is the canonical empty-state
+  system: Domestic Interiors line vignettes, 12-motif vocabulary, 3-ink
+  palette, six applied canonical empty states (Empty journal, Empty fronting
+  log, No friends, First run, Empty notes, Offline) with Caveat-italic
+  annotations.
+- `docs/design-system/preview/components-display.html:378-410` shows the
+  structural pattern (vignette + title + body + CTA) paired with ErrorState.
+
+Updated scope: extract the structural EmptyState component into a dedicated
+preview at `components-empty-state.html` that composes a Domestic Interiors
+vignette with the structural pattern, adds the 8 acceptance states from
+SKILL.md §7 (default, hover, pressed, disabled, focus-visible, loading,
+error, screen-reader — most are N/A for a static state surface; mark them
+explicitly), 4 mode variants (default, low-sensory flattens the vignette,
+high-contrast promotes the body text contrast, littles uses simpler copy
+and a larger CTA), and the 7-section doc contract.
+
+This is an extraction + doc task, not a from-scratch design.

--- a/.beans/ps-sal4--design-frontingtimelinelane-primitive.md
+++ b/.beans/ps-sal4--design-frontingtimelinelane-primitive.md
@@ -3,8 +3,9 @@
 title: Design FrontingTimelineLane primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:29:08Z
-updated_at: 2026-05-17T06:29:08Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,24 @@ Design the FrontingTimelineLane primitive: one member's track within the multi-l
 ## Out of scope
 
 - RN code (M11), screen-level integration (Fronting beans)
+
+## Re-audit disposition (2026-05-17)
+
+The lane primitive is implicit inside the `FrontingTimeline` parent
+component, not yet separated as its own primitive. Existing assets:
+
+- `docs/design-system/ui_kits/mobile/FrontingTimeline.jsx` — full editable
+  timeline with drag boundary handles, focus + ←/→ for 5-min steps,
+  co-fronting overlays, screen-reader segment announcements
+- `docs/design-system/preview/patterns.html:238-242` — demo
+- `docs/design-system/preview/components-fronting-history.html` — fronting
+  history screen layout using lanes (vertical + horizontal views)
+
+Updated scope: extract the **lane sub-component** as a standalone primitive
+in `components-fronting-timeline-lane.html`. Variants to render: ongoing
+(no end time, fade), ended, micro-session (under 5min collapsed), co-fronting
+(overlapping translucent ranges). Document the composition contract so the
+parent FrontingTimeline can consume it without restructuring. Add the 8
+acceptance states, 4 mode variants, 7-section doc.
+
+Extraction-with-decomposition task.

--- a/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
+++ b/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: high
 created_at: 2026-05-17T05:49:37Z
-updated_at: 2026-05-17T06:31:39Z
+updated_at: 2026-05-17T08:50:23Z
 parent: ps-udt1
 ---
 
@@ -69,3 +69,37 @@ Patterns: RecoveryKey ceremony (ps-472d), WizardStepper (ps-rhno)
 **Audit report**: not written as a separate file — `docs/design-system/audits/` is gitignored. The summary above captures the same gap data inline so the spawned bean IDs are traceable in the committed bean files.
 
 **Blocks-pilot primitives** (Phase 1 Fronting beans should declare blocked_by on these): FrontingChip (ps-458i), FrontingTimelineLane (ps-sal4), AvatarStack already covered, EmptyState (ps-ruwi), DestructiveConfirmDialog (ps-bydy), CheckInPrompt (ps-7to1), BucketPicker (ps-s9r6), MemberPicker+Multi (ps-djqo).
+
+## Re-audit addendum (2026-05-17)
+
+A definitive cross-reference of the 37 spawned beans against every file
+in `docs/design-system/preview/*.html` and `docs/design-system/ui_kits/mobile/*.jsx`
+found that the original audit was too aggressive in declaring primitives
+"missing":
+
+- **20 confirmed missing** — design from scratch via Claude Design
+- **14 already designed** — bean scope changed to "extract to standalone
+  preview + add missing 8 acceptance states + 4 mode variants + 7-section
+  doc contract" (a Claude Code task, not a Claude Design task):
+  EmptyState (ps-ruwi), ErrorState (ps-a5ee), SyncIndicator/SyncState
+  (ps-gnkq), ProgressBar+Ring (ps-3m01), Accordion (ps-ecpl),
+  KeyValueRow (ps-5lr6), DestructiveConfirmDialog/ConfirmDestructive
+  (ps-bydy), ConfirmGesture (ps-00b4), Popover (ps-rgrw),
+  MemberPicker+Multi (ps-djqo), FrontingTimelineLane (ps-sal4),
+  Drawer (ps-217e), SystemSwitcher (ps-a5pt), SearchHeader (ps-oylh)
+- **1 scrapped** — EncryptionTierBadge (ps-gfhz): contradicts existing
+  design policy (no T1/T2 tier labels surface in UI; T3 plaintext
+  indicator already exists)
+- **2 scope-clarified** — BucketPill (ps-i6n1) distinguished from the
+  PrivacyBucket editor; FrontingChip (ps-458i) confirmed as needed for
+  non-timeline surfaces
+
+Naming corrections discovered during re-audit:
+
+- DestructiveConfirmDialog → canonical name is `ConfirmDestructive`
+- SyncIndicator → canonical name is `SyncState`
+
+Empty-state canon clarified: `illustrations.html` is the system's
+Domestic Interiors illustration vocabulary (12 motifs, 3-ink palette,
+6 canonical applied empty states). `components-display.html:378-410`
+shows the structural pattern. The EmptyState primitive composes both.


### PR DESCRIPTION
## Summary

- Re-audited the 37 Phase 0 primitive beans against existing previews and `ui_kits/mobile` JSX. The original `ps-sg8k` audit was too aggressive in declaring primitives missing.
- 1 scrapped (`ps-gfhz` EncryptionTierBadge contradicts existing policy; T3 plaintext indicator already exists in `components-feedback.html` and `components-display.html`).
- 14 rescoped from "design from scratch" to "extract from existing assets + add missing states/modes/doc contract" (EmptyState, ErrorState, SyncState, Progress, Accordion, KeyValueRow, ConfirmDestructive, ConfirmGesture, Popover, MemberPicker, FrontingTimelineLane, Drawer, SystemSwitcher, SearchHeader).
- 2 scope-clarified: `ps-i6n1` BucketPill (distinct from the PrivacyBucket editor) and `ps-458i` FrontingChip (needed for non-timeline surfaces).
- Naming corrections discovered: DestructiveConfirmDialog -> canonical `ConfirmDestructive`; SyncIndicator -> canonical `SyncState`.
- `ps-sg8k` audit bean got a `## Re-audit addendum` with the corrected counts.

Net: ~14 fewer from-scratch design sessions needed in Phase 0.

## Test plan

- [ ] `beans show ps-gfhz` returns status `scrapped` with a `## Reasons for Scrapping` section.
- [ ] `beans show ps-ruwi` body includes `## Re-audit disposition` referencing `illustrations.html` as canon and `components-display.html:378-410` as the structural example.
- [ ] `beans show ps-sg8k` body includes `## Re-audit addendum` with the 20/14/1/2 breakdown.
- [ ] Spot-check 3 rescoped beans (e.g., `ps-djqo`, `ps-bydy`, `ps-gnkq`) — each has a `## Re-audit disposition` section pointing to specific source files.
- [ ] `beans list --json --ready` does not surface any of the rescoped Phase 0 primitives (they remain blocked by the same parent epic).