### PR TITLE
chore(beans): apply M10 Phase 0 re-audit round 2

### DIFF
--- a/.beans/ps-472d--design-recoverykey-ceremony-pattern.md
+++ b/.beans/ps-472d--design-recoverykey-ceremony-pattern.md
@@ -3,8 +3,9 @@
 title: Design RecoveryKey ceremony pattern
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:30:59Z
-updated_at: 2026-05-17T06:30:59Z
+updated_at: 2026-05-17T19:06:46Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,10 @@ Design the RecoveryKey ceremony pattern: the three-screen composition (reveal + 
 ## Out of scope
 
 - RN code (M11), screen-level integration (Auth flow beans)
+
+## Mode coverage update (2026-05-17)
+
+Skip the Littles-mode variant for this pattern. Recovery-key ceremony
+happens during account setup and recovery — both predate Littles Mode
+configuration. Drop the earlier "littles skip-verification OR adult
+confirmation" decision; not needed.

--- a/.beans/ps-5iro--design-innerworldnode-primitive.md
+++ b/.beans/ps-5iro--design-innerworldnode-primitive.md
@@ -3,8 +3,9 @@
 title: Design InnerworldNode primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:29:42Z
-updated_at: 2026-05-17T06:29:42Z
+updated_at: 2026-05-17T19:06:46Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,24 @@ Design the InnerworldNode primitive: canvas node placed on the Innerworld 2D can
 ## Out of scope
 
 - RN code (M11), screen-level integration (System structure beans), the canvas pan/zoom chrome (separate Innerworld canvas screen bean)
+
+## Entity-type variants (2026-05-17)
+
+The audit's variant list (member / region / place / custom) was wrong.
+`InnerWorldEntityType` from
+`packages/types/src/entities/innerworld-entity.ts` has exactly three
+variants:
+
+- `member` — represents a system member's presence in the innerworld
+  (composes the member's avatar + display name)
+- `landmark` — a named location or fixture in the innerworld (a free
+  user-named node with description)
+- `structure-entity` — linked to a system structure entity (composes
+  the structure entity's name + visual properties)
+
+InnerworldRegions are a separate entity — they're containing zones, not
+nodes — and live in their own primitive (out of scope here).
+
+Sizes (sm / md / lg), states (default, selected, dragging, dimmed) and
+mode coverage per SKILL.md. Connection-point hit areas on the node
+boundary feed RelationshipEdge (ps-jtn3) wiring.

--- a/.beans/ps-gml0--design-entitytypepicker-primitive.md
+++ b/.beans/ps-gml0--design-entitytypepicker-primitive.md
@@ -3,8 +3,9 @@
 title: Design EntityTypePicker primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:30:52Z
-updated_at: 2026-05-17T06:30:52Z
+updated_at: 2026-05-17T19:06:46Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,26 @@ Design the EntityTypePicker primitive: pick a system-defined structure entity ty
 ## Out of scope
 
 - RN code (M11), screen-level integration (System structure beans)
+
+## Entity-type scope (2026-05-17)
+
+The audit's variant list was wrong. The picker chooses from
+**user-defined** `system_structure_entity_types`, not a fixed canonical
+enum. Each system creates its own entity types (e.g. caretaker,
+protector, host, source, anchor) via the structure-entity-types
+settings; the picker renders that list dynamically.
+
+Therefore the preview should show:
+
+- Empty-system state (no custom types defined yet — affordance to
+  create the first one)
+- Typical-system state (4–8 types listed, each with the system's chosen
+  color/icon)
+- Many-types state (12+, demonstrating the scroll behavior and search)
+- With-create-new affordance (opens the structure-entity-type creator)
+- Read-only variant (no create affordance)
+
+There are NO global / built-in entity types — every name and visual
+property comes from the system. Do not hardcode "member" or "custom
+front" as defaults; those are separate entity tables, not structure
+entity types.

--- a/.beans/ps-i6n1--design-bucketpill-primitive.md
+++ b/.beans/ps-i6n1--design-bucketpill-primitive.md
@@ -5,7 +5,7 @@ status: todo
 type: task
 priority: normal
 created_at: 2026-05-17T06:29:14Z
-updated_at: 2026-05-17T08:50:23Z
+updated_at: 2026-05-17T19:06:46Z
 parent: ps-udt1
 ---
 
@@ -43,3 +43,10 @@ a fail-closed visual treatment for the special "Nobody" bucket.
 
 Bean kept. Design produces `components-bucket-pill.html` with the 8 states
 and 4 mode variants per SKILL.md §7-8.
+
+## Wave promotion (2026-05-17)
+
+Moved to Wave 1 from Wave 2 Domain chips. Reason: BucketPicker (ps-s9r6,
+Wave 1) composes on BucketPill in its selected-buckets row. BucketPill
+should be designed before or in parallel with BucketPicker so the
+picker can reference the canonical chip form rather than a placeholder.

--- a/.beans/ps-jtvw--design-proxychip-primitive.md
+++ b/.beans/ps-jtvw--design-proxychip-primitive.md
@@ -1,10 +1,11 @@
 ---
 # ps-jtvw
 title: Design ProxyChip primitive
-status: todo
+status: scrapped
 type: task
+priority: normal
 created_at: 2026-05-17T06:29:24Z
-updated_at: 2026-05-17T06:29:24Z
+updated_at: 2026-05-17T19:06:45Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,13 @@ Design the ProxyChip primitive: currently-selected proxy member shown in the cha
 ## Out of scope
 
 - RN code (M11), screen-level integration (Communication beans)
+
+## Reasons for Scrapping
+
+Re-audit round 2 (2026-05-17): ProxyChip is not needed. The PluralKit /
+SimplyPlural proxy concept is data-import-time only — system members and
+their identifying patterns surface in the existing MemberPicker and
+mention flows. There is no surface in the M10 design scope where a
+distinct "proxy" affordance is meaningful.
+
+If a proxy-specific UI is ever required, the bean can be re-opened then.

--- a/.beans/ps-o1zp--design-recoverykeyfield-primitive.md
+++ b/.beans/ps-o1zp--design-recoverykeyfield-primitive.md
@@ -3,8 +3,9 @@
 title: Design RecoveryKeyField primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:07Z
-updated_at: 2026-05-17T06:27:07Z
+updated_at: 2026-05-17T19:06:45Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,11 @@ Design the RecoveryKeyField primitive: a paste-friendly multi-segment input for 
 ## Out of scope
 
 - RN code (M11), screen-level integration (Auth flow beans)
+
+## Mode coverage update (2026-05-17)
+
+Skip the Littles-mode variant for this primitive. Recovery-key flows
+happen during account setup and account recovery — both of those run
+before Littles Mode is configurable, so a Littles variant is never
+rendered in production. Cover default, low-sensory, and high-contrast
+only.

--- a/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
+++ b/.beans/ps-sg8k--m10-audit-primitive-coverage-gap-analysis.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: high
 created_at: 2026-05-17T05:49:37Z
-updated_at: 2026-05-17T08:50:23Z
+updated_at: 2026-05-17T19:06:46Z
 parent: ps-udt1
 ---
 
@@ -103,3 +103,30 @@ Empty-state canon clarified: `illustrations.html` is the system's
 Domestic Interiors illustration vocabulary (12 motifs, 3-ink palette,
 6 canonical applied empty states). `components-display.html:378-410`
 shows the structural pattern. The EmptyState primitive composes both.
+
+## Re-audit addendum round 2 (2026-05-17)
+
+Second round of corrections after stakeholder review:
+
+- Scrapped 2 additional beans:
+  - `ps-jtvw` ProxyChip — no surface in M10 scope needs a distinct
+    proxy affordance; member identity flows cover the use cases.
+  - `ps-xts0` SaturationPicker — the "saturation" field is not color
+    saturation; no picker needed.
+- Dropped Littles mode coverage from RecoveryKey trio (`ps-o1zp`,
+  `ps-xthc`, `ps-472d`) — those flows run before Littles Mode is
+  configurable.
+- Entity-type variant lists clarified against the canonical types from
+  `packages/types`:
+  - `ps-ywtb` EntityRefPicker now scoped to `BucketContentEntityType`
+    (21 variants) with surface-specific subsets
+  - `ps-gml0` EntityTypePicker corrected — picks from user-defined
+    `system_structure_entity_types`, not a fixed enum
+  - `ps-5iro` InnerworldNode variants corrected to the actual three:
+    member, landmark, structure-entity
+- `ps-i6n1` BucketPill promoted to Wave 1 (composition dep of
+  BucketPicker).
+
+Updated totals: 18 from-scratch design sessions + 2 scope-clarify kept
+in scope + 14 extract tasks + 3 scrapped (`ps-gfhz`, `ps-jtvw`,
+`ps-xts0`) = 37.

--- a/.beans/ps-xthc--design-recoverykeydisplay-primitive.md
+++ b/.beans/ps-xthc--design-recoverykeydisplay-primitive.md
@@ -3,8 +3,9 @@
 title: Design RecoveryKeyDisplay primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:27:22Z
-updated_at: 2026-05-17T06:27:22Z
+updated_at: 2026-05-17T19:06:45Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,11 @@ Design the RecoveryKeyDisplay primitive: the big readable key-reveal surface use
 ## Out of scope
 
 - RN code (M11), screen-level integration (Auth flow beans)
+
+## Mode coverage update (2026-05-17)
+
+Skip the Littles-mode variant for this primitive. Recovery-key flows
+happen during account setup and account recovery — both of those run
+before Littles Mode is configurable, so a Littles variant is never
+rendered in production. Cover default, low-sensory, and high-contrast
+only.

--- a/.beans/ps-xts0--design-saturationpicker-primitive.md
+++ b/.beans/ps-xts0--design-saturationpicker-primitive.md
@@ -1,10 +1,11 @@
 ---
 # ps-xts0
 title: Design SaturationPicker primitive
-status: todo
+status: scrapped
 type: task
+priority: normal
 created_at: 2026-05-17T06:30:44Z
-updated_at: 2026-05-17T06:30:44Z
+updated_at: 2026-05-17T19:06:45Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,9 @@ Design the SaturationPicker primitive: pick a member's saturation (elaboration) 
 ## Out of scope
 
 - RN code (M11), screen-level integration (Member management beans)
+
+## Reasons for Scrapping
+
+Re-audit round 2 (2026-05-17): the audit misread the requirement. The
+"saturation" field is not color saturation — it does not need its own
+picker. No new design work is required.

--- a/.beans/ps-ywtb--design-entityrefpicker-primitive.md
+++ b/.beans/ps-ywtb--design-entityrefpicker-primitive.md
@@ -3,8 +3,9 @@
 title: Design EntityRefPicker primitive
 status: todo
 type: task
+priority: normal
 created_at: 2026-05-17T06:30:23Z
-updated_at: 2026-05-17T06:30:23Z
+updated_at: 2026-05-17T19:06:46Z
 parent: ps-udt1
 ---
 
@@ -25,3 +26,27 @@ Design the EntityRefPicker primitive: polymorphic picker returning an `EntityRef
 ## Out of scope
 
 - RN code (M11), screen-level integration (Phase 1 / 2)
+
+## Entity-type scope (2026-05-17)
+
+The canonical set of referenceable entities is
+`BucketContentEntityType` from `packages/types/src/entities/bucket.ts`,
+which currently lists 21 variants: member, group, channel, message, note,
+poll, relationship, structure-entity-type, structure-entity,
+journal-entry, wiki-page, custom-front, fronting-session, board-message,
+acknowledgement, innerworld-entity, innerworld-region, field-definition,
+field-value, member-photo, fronting-comment.
+
+EntityRefPicker should NOT show all 21 by default — most surfaces only
+need a subset. Expose a `scope` prop that takes a subset of
+`BucketContentEntityType`:
+
+- Mention insertion: ["member", "custom-front", "structure-entity"]
+- Fronting reference: ["member", "custom-front", "structure-entity"]
+- Journal entry tagging: ["member", "custom-front", "structure-entity",
+  "group", "wiki-page", "journal-entry"]
+- Privacy-bucket attachment: full set
+
+Sectioned results in the picker should group by category (people,
+content, structure). Custom systems may not have all 21 enabled —
+filter the displayed set to what the system actually has data for.


### PR DESCRIPTION
## Summary

Second round of M10 Phase 0 bean corrections after stakeholder review.

- 2 additional scraps: `ps-jtvw` ProxyChip (no M10 surface needs a distinct proxy affordance) and `ps-xts0` SaturationPicker (the "saturation" field is not color saturation; no picker needed).
- Drop Littles mode coverage on the RecoveryKey trio (`ps-o1zp`, `ps-xthc`, `ps-472d`). Those flows run before Littles Mode is configurable, so the variant never renders in production.
- Entity-type variant lists corrected against canonical types in `packages/types`:
  - `ps-ywtb` EntityRefPicker scoped to `BucketContentEntityType` (21 variants) with surface-specific subsets.
  - `ps-gml0` EntityTypePicker corrected to read from user-defined `system_structure_entity_types` (no fixed enum).
  - `ps-5iro` InnerworldNode variants corrected to the canonical three: member, landmark, structure-entity.
- `ps-i6n1` BucketPill promoted to Wave 1 (composition dep of BucketPicker).
- `ps-sg8k` audit bean addended with round-2 changes.

Net Phase 0 disposition: 18 from-scratch design sessions + 2 scope-clarify + 14 extract + 3 scrapped = 37.

## Test plan

- [ ] `beans show ps-jtvw` and `beans show ps-xts0` show status `scrapped` with `## Reasons for Scrapping` sections.
- [ ] `beans show ps-o1zp`, `ps-xthc`, `ps-472d` each include a `## Mode coverage update` noting Littles is skipped.
- [ ] `beans show ps-ywtb` includes an `## Entity-type scope` section listing the 21 `BucketContentEntityType` variants and per-surface scopes.
- [ ] `beans show ps-gml0` clarifies the picker reads from `system_structure_entity_types` (user-defined, no fixed enum).
- [ ] `beans show ps-5iro` lists the three canonical variants: member, landmark, structure-entity.
- [ ] `beans show ps-i6n1` notes the Wave 1 promotion.
- [ ] `beans show ps-sg8k` has a `## Re-audit addendum round 2` section with the new totals.